### PR TITLE
removes the static flag form the storybook command

### DIFF
--- a/sandboxes/package.json
+++ b/sandboxes/package.json
@@ -12,8 +12,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
-    "storybook": "start-storybook -p 9009 -s public",
-    "build-storybook": "build-storybook -s public"
+    "storybook": "start-storybook -p 9009",
+    "build-storybook": "build-storybook"
   },
   "devDependencies": {
     "@storybook/react": "^3.4.8",


### PR DESCRIPTION
We don't need a public folder for static assets in the sandbox as assets can be co-located with stories