### PR TITLE
[bugfix] downgrades the use of shorthand prop names

### DIFF
--- a/tokens/index.js
+++ b/tokens/index.js
@@ -35,8 +35,8 @@ export const space = {
 };
 
 export default {
-  colours,
-  font,
-  space,
+  colours: colours,
+  font: font,
+  space: space,
   borderRadius: '0.4rem',
 };


### PR DESCRIPTION
# What?

The Netlify build was failing due to use of unsupported [shorthand object prop notation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#New_notations_in_ECMAScript_2015).

Shorthand prop notation is not yet supported in node. This change makes the tokens package usable without a build step.

# To test

pull the branch and run 

```sh
$ yarn build-docs
```