### PR TITLE
[bugfix] 💚 fixes yarn version for all netlify builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,11 +2,11 @@
   command = "yarn run build-docs"
   publish = "docs/dist"
 
+[build.environment]
+  YARN_VERSION = "1.7.0"
+  
 # The following redirect is intended for use with most SPA's that handles routing internally.
 [[redirects]]
   from = "/*"
   to = "/index.html"
   status = 200
-  
-[context.production.environment]
-  YARN_VERSION = "1.7.0"


### PR DESCRIPTION
Netlify is configured to trigger a build on every PR, however, previously the `YARN_VERSION` was only applying to production environments. This change coirreclty sets the `YARN_VERSION` on on build environments.