### PR TITLE
Adds @nulogy/css package for global styles

### DIFF
--- a/css/package.json
+++ b/css/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@nulogy/css",
+  "version": "0.1.0",
+  "description": "Global Styles for Nulogy Design System",
+  "main": "index.js",
+  "repository": "https://github.com/nulogy/design-system",
+  "author": "Nulogy <info@nulogy.com> (https://github.com/nulogy)",
+  "license": "MIT",
+  "private": false
+}

--- a/css/package.json
+++ b/css/package.json
@@ -9,7 +9,8 @@
   "private": false,
   "scripts": {
     "start": "webpack --mode development",
-    "build": "webpack --mode production --config webpack.config.js"
+    "build": "webpack --mode production --config webpack.config.js",
+    "watch": "yarn build --watch"
   },
   "peerDependencies": {
     "react": "^16.3.2",
@@ -17,6 +18,7 @@
     "styled-components": "^3.2.6"
   },
   "devDependencies": {
+    "@nulogy/tokens": "^0.1",
     "babel-core": "^6.26.3",
     "babel-loader": "7.1.4",
     "babel-preset-env": "^1.7.0",

--- a/css/package.json
+++ b/css/package.json
@@ -11,13 +11,21 @@
     "start": "webpack --mode development",
     "build": "webpack --mode production --config webpack.config.js"
   },
+  "peerDependencies": {
+    "react": "^16.3.2",
+    "react-dom": "^16.3.2",
+    "styled-components": "^3.2.6"
+  },
   "devDependencies": {
     "babel-core": "^6.26.3",
     "babel-loader": "7.1.4",
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-1": "^6.24.1",
-    "webpack": "^4.8.3",
-    "webpack-cli": "^3.1.0"
+    "react-dom": "^16.3.2",
+    "react": "^16.3.2",
+    "styled-components": "^3.2.6",
+    "webpack-cli": "^3.1.0",
+    "webpack": "^4.8.3"
   }
 }

--- a/css/package.json
+++ b/css/package.json
@@ -2,9 +2,22 @@
   "name": "@nulogy/css",
   "version": "0.1.0",
   "description": "Global Styles for Nulogy Design System",
-  "main": "index.js",
+  "main": "dist/main.js",
   "repository": "https://github.com/nulogy/design-system",
   "author": "Nulogy <info@nulogy.com> (https://github.com/nulogy)",
   "license": "MIT",
-  "private": false
+  "private": false,
+  "scripts": {
+    "start": "webpack --mode development",
+    "build": "webpack --mode production --config webpack.config.js"
+  },
+  "devDependencies": {
+    "babel-core": "^6.26.3",
+    "babel-loader": "7.1.4",
+    "babel-preset-env": "^1.7.0",
+    "babel-preset-react": "^6.24.1",
+    "babel-preset-stage-1": "^6.24.1",
+    "webpack": "^4.8.3",
+    "webpack-cli": "^3.1.0"
+  }
 }

--- a/css/src/external.js
+++ b/css/src/external.js
@@ -7,10 +7,10 @@ injectGlobal`
 }
 `;
 
-// 2. this mixin just returns props
+// 3. this mixin just returns props
 export const mixin = css`color: red;`
 
-// 3. this returns an entire css string 
+// 4. this returns an entire css string 
 export default css`
 .nds--external {
   color: orange;

--- a/css/src/external.js
+++ b/css/src/external.js
@@ -1,0 +1,18 @@
+import {css, injectGlobal} from 'styled-components';
+
+injectGlobal`
+/* 1. this style is created by importing this module */
+.nds--externalInjected {
+  color: green;
+}
+`;
+
+// 2. this mixin just returns props
+export const mixin = css`color: red;`
+
+// 3. this returns an entire css string 
+export default css`
+.nds--external {
+  color: orange;
+}
+`

--- a/css/src/index.js
+++ b/css/src/index.js
@@ -1,3 +1,10 @@
-export default {
-  hi: "👋",
+import {injectGlobal} from 'styled-components';
+
+injectGlobal `
+
+.test {
+  color: red;
+  font-size: 10em;
 }
+
+`

--- a/css/src/index.js
+++ b/css/src/index.js
@@ -1,10 +1,21 @@
 import {injectGlobal} from 'styled-components';
+import { font } from '@nulogy/tokens';
+// 1. you don't see it, but the .externalInjected class was created just by importing @nulogy/styles
+import external, { mixin } from "./external"
 
-injectGlobal `
+injectGlobal`
+.nds {
+  &--test {
+    color: pink;
+    font-size: ${font.size.smallest}px;
+  }
 
-.test {
-  color: red;
-  font-size: 10em;
+  &--mixin {
+    /* 2. */
+    ${mixin}
+  }
 }
 
+/* 3. */
+${external}
 `

--- a/css/src/index.js
+++ b/css/src/index.js
@@ -5,22 +5,23 @@ import external, { mixin } from "./external"
 
 injectGlobal`
 .nds {
-  &--test {
+  /* 2. this is your bread and butter pre-processed css */
+  &--global {
     color: pink;
     font-size: ${font.size.larger}px;
   }
 
   &--mixin {
-    /* 2. */
+    /* 3. */
     ${mixin}
   }
 }
 
-/* 3. */
+/* 4. */
 ${external}
 `
 
-// 4. here is an example of defining mixins and dynamically creating utility classes from them in a loop
+// 5. here is an example of defining mixins and dynamically creating utility classes from them in a loop
 const mx = {
   lineHeight: css`line-height: 1.5`,
   noMargin: css`margin: 0;`,

--- a/css/src/index.js
+++ b/css/src/index.js
@@ -7,7 +7,7 @@ injectGlobal`
 .nds {
   &--test {
     color: pink;
-    font-size: ${font.size.smallest}px;
+    font-size: ${font.size.larger}px;
   }
 
   &--mixin {

--- a/css/src/index.js
+++ b/css/src/index.js
@@ -1,0 +1,3 @@
+export default {
+  hi: "👋",
+}

--- a/css/src/index.js
+++ b/css/src/index.js
@@ -1,4 +1,4 @@
-import {injectGlobal} from 'styled-components';
+import {injectGlobal, css} from 'styled-components';
 import { font } from '@nulogy/tokens';
 // 1. you don't see it, but the .externalInjected class was created just by importing @nulogy/styles
 import external, { mixin } from "./external"
@@ -19,3 +19,14 @@ injectGlobal`
 /* 3. */
 ${external}
 `
+
+// 4. here is an example of defining mixins and dynamically creating utility classes from them in a loop
+const mx = {
+  lineHeight: css`line-height: 1.5`,
+  noMargin: css`margin: 0;`,
+  fontFamily: css`font-family: ${font.family.regular};`,
+  fontFamilyMono: css`font-family: ${font.family.mono};`,
+}
+// create global utility classes from those mixins
+Object.entries(mx)
+  .forEach(([className, rule]) => injectGlobal`.${className} { ${rule} }`);

--- a/css/webpack.config.js
+++ b/css/webpack.config.js
@@ -1,0 +1,21 @@
+module.exports = {
+  output: {
+    libraryTarget: "umd"
+  },
+  externals: [
+    "react",
+    "react-dom",
+    "styled-components"
+  ],
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: {
+          loader: "babel-loader"
+        }
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@nulogy/nucleus",
   "workspaces": [
-    "docs",
     "components",
-    "tokens",
-    "sandbox"
+    "css",
+    "docs",
+    "sandbox",
+    "tokens"
   ],
   "version": "0.1.0",
   "description": "Modern Enterprise Design for the Industrial Environment - http://nulogy.design",
@@ -34,10 +35,11 @@
     "start": "concurrently 'yarn components watch' 'yarn docs start'",
     "hack": "yarn sandbox hack",
     "build-docs": "yarn components build && yarn docs build",
-    "docs": "yarn workspace @nulogy/nulogy-design",
     "components": "yarn workspace @nulogy/components",
-    "tokens": "yarn workspace @nulogy/tokens",
-    "sandbox": "yarn workspace @nulogy/sandbox"
+    "css": "yarn workspace @nulogy/css",
+    "docs": "yarn workspace @nulogy/nulogy-design",
+    "sandbox": "yarn workspace @nulogy/sandbox",
+    "tokens": "yarn workspace @nulogy/tokens"
   },
   "devDependencies": {
     "concurrently": "^3.6.1"

--- a/sandbox/.storybook/config.js
+++ b/sandbox/.storybook/config.js
@@ -1,4 +1,5 @@
 import { configure } from '@storybook/react';
+import '@nulogy/css';
 
 const req = require.context(
   "../src",       // path where stories live

--- a/sandbox/package.json
+++ b/sandbox/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@nulogy/components": "^0.1",
+    "@nulogy/css": "^0.1",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
     "react-scripts": "1.1.4"

--- a/sandbox/package.json
+++ b/sandbox/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "start": "start-storybook -p 9009",
-    "hack": "concurrently 'yarn workspace @nulogy/components watch' 'yarn start'",
+    "hack": "concurrently 'yarn workspace @nulogy/components watch' 'yarn workspace @nulogy/css watch' 'yarn start'",
     "build": "build-storybook",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"

--- a/sandbox/src/globalCSS/globalCSS.story.js
+++ b/sandbox/src/globalCSS/globalCSS.story.js
@@ -4,7 +4,21 @@ import "@nulogy/css";
 
 storiesOf('Global CSS', module)
   .add('basic', () => (
-    <div className="test">
-      Hi there
-    </div>
+    <React.Fragment>
+      <div className="nds--test">
+        .test
+      </div>
+
+      <div className="nds--external">
+        .external
+      </div>
+
+      <div className="nds--externalInjected">
+        .externalInjected
+      </div>
+      
+      <div className="nds--mixin">
+        .mixin
+      </div>
+    </React.Fragment>
   ));

--- a/sandbox/src/globalCSS/globalCSS.story.js
+++ b/sandbox/src/globalCSS/globalCSS.story.js
@@ -21,5 +21,9 @@ storiesOf('Global CSS', module)
       <div className="nds--mixin">
         .mixin
       </div>
+
+      <p className="lineHeight noMargin fontFamilyMono">
+        This class has utility classes applied that were created dynamically
+      </p>
     </React.Fragment>
   ));

--- a/sandbox/src/globalCSS/globalCSS.story.js
+++ b/sandbox/src/globalCSS/globalCSS.story.js
@@ -5,25 +5,25 @@ import { storiesOf } from '@storybook/react';
 
 storiesOf('Global CSS', module)
   .add('basic', () => (
-    <React.Fragment>
-      <div className="nds--test">
-        .test
-      </div>
-
-      <div className="nds--external">
-        .external
-      </div>
-
-      <div className="nds--externalInjected">
+    <ol>
+      <li className="nds--externalInjected">
         .externalInjected
-      </div>
+      </li>
       
-      <div className="nds--mixin">
+      <li className="nds--global">
+        .test
+      </li>
+      
+      <li className="nds--mixin">
         .mixin
-      </div>
+      </li>
 
-      <p className="lineHeight noMargin fontFamilyMono">
+      <li className="nds--external">
+        .external
+      </li>    
+
+      <li className="lineHeight noMargin fontFamilyMono">
         This class has utility classes applied that were created dynamically
-      </p>
-    </React.Fragment>
+      </li>
+    </ol>
   ));

--- a/sandbox/src/globalCSS/globalCSS.story.js
+++ b/sandbox/src/globalCSS/globalCSS.story.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import "@nulogy/css";
+
+storiesOf('Global CSS', module)
+  .add('basic', () => (
+    <div className="test">
+      Hi there
+    </div>
+  ));

--- a/sandbox/src/globalCSS/globalCSS.story.js
+++ b/sandbox/src/globalCSS/globalCSS.story.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import "@nulogy/css";
+
+// @nulogy/css is imported in ../../.storybook/config.js
 
 storiesOf('Global CSS', module)
   .add('basic', () => (

--- a/tokens/package.json
+++ b/tokens/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@nulogy/tokens",
   "version": "0.1.0",
-  "description": "Design tokens for the Nulogy's Nucleus design system - http://nulody.design",
+  "description": "Design tokens for the Nulogy Design System - http://nulody.design",
   "main": "index.js",
-  "repository": "https://github.com/nulogy/nucleus.git",
-  "author": "\"Nulogy <info@nulogy.com> (https://github.com/nulogy)\"",
+  "repository": "https://github.com/nulogy/design-system.git",
+  "author": "Nulogy <info@nulogy.com> (https://github.com/nulogy)",
   "license": "MIT",
   "private": false
 }


### PR DESCRIPTION
# Why

We need a package to host vanilla CSS. There are a number of use-cases  where React components are not appropriate and this package will be usable in those circumstances.

# What I did

After the SPIKE I did in PR #8, we concluded that Stylis / Styled Components via `injectGlobal` is the best css-processor for our needs. This PR adds a `@nulogy/css` package and configures `styled-components injectGlobal` for the purpose of writing global styles.

The branch also includes some samples of how to work with `injectGlobal`, as well as some stories in the sandbox.