### PR TITLE
Fix readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,17 @@
 ## Visual Style
 Learn how to create consistent, beautiful interfaces using Nulogy's visual language.
 
-* [Colour](//nulogy.design/visual_style/colour)
-* [Typography](//nulogy.design/visual_style/typography)
-* [Spacing](//nulogy.design/visual_style/spacing)
-* [Iconography](//nulogy.design/visual_style/iconography)
+* [Colour](http://nulogy.design/visual_style/colour)
+* [Typography](http://nulogy.design/visual_style/typography)
+* [Spacing](http://nulogy.design/visual_style/spacing)
+* [Iconography](http://nulogy.design/visual_style/iconography)
 
 ## Components
 *Coming soon*. A set of React UI Components designed to allow fast and consistent development of Nulogy's interfaces.
 
 ## Guides
-* [Developing the Design System](//nulogy.design/getting_started/setup)
-* [Deploying to the web](//nulogy.design/getting_started/deploying)
+* [Developing the Design System](http://nulogy.design/getting_started/setup)
+* [Deploying to the web](http://nulogy.design/getting_started/deploying)
 
 
 

--- a/README.md
+++ b/README.md
@@ -3,17 +3,17 @@
 ## Visual Style
 Learn how to create consistent, beautiful interfaces using Nulogy's visual language.
 
-* [Colour](/visual_style/colour)
-* [Typography](/visual_style/typography)
-* [Spacing](/visual_style/spacing)
-* [Iconography](/visual_style/iconography)
+* [Colour](//nulogy.design/visual_style/colour)
+* [Typography](//nulogy.design/visual_style/typography)
+* [Spacing](//nulogy.design/visual_style/spacing)
+* [Iconography](//nulogy.design/visual_style/iconography)
 
 ## Components
 *Coming soon*. A set of React UI Components designed to allow fast and consistent development of Nulogy's interfaces.
 
 ## Guides
-* [Developing the Design System](/getting_started/setup)
-* [Deploying to the web](/getting_started/deploying)
+* [Developing the Design System](//nulogy.design/getting_started/setup)
+* [Deploying to the web](//nulogy.design/getting_started/deploying)
 
 
 


### PR DESCRIPTION
We have to use absolute URLs on the homepage because it's also used as our Github readme. This change will make the links work in both places. 