### PR TITLE
enables jest tests in components package

### DIFF
--- a/components/.jest/cssTransform.js
+++ b/components/.jest/cssTransform.js
@@ -1,0 +1,14 @@
+'use strict';
+
+// This is a custom Jest transformer turning style imports into empty objects.
+// http://facebook.github.io/jest/docs/en/webpack.html
+
+module.exports = {
+  process() {
+    return 'module.exports = {};';
+  },
+  getCacheKey() {
+    // The output is always the same.
+    return 'cssTransform';
+  },
+};

--- a/components/.jest/fileTransform.js
+++ b/components/.jest/fileTransform.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const path = require('path');
+
+// This is a custom Jest transformer turning file imports into filenames.
+// http://facebook.github.io/jest/docs/en/webpack.html
+
+module.exports = {
+  process(src, filename) {
+    return `module.exports = ${JSON.stringify(path.basename(filename))};`;
+  },
+};

--- a/components/package.json
+++ b/components/package.json
@@ -85,8 +85,8 @@
     "testURL": "http://localhost",
     "transform": {
       "^.+\\.(js|jsx|mjs)$": "<rootDir>/node_modules/babel-jest",
-      "^.+\\.css$": "<rootDir>/config/jest/cssTransform.js",
-      "^(?!.*\\.(js|jsx|mjs|css|json)$)": "<rootDir>/config/jest/fileTransform.js"
+      "^.+\\.css$": "<rootDir>/.jest/cssTransform.js",
+      "^(?!.*\\.(js|jsx|mjs|css|json)$)": "<rootDir>/.jest/fileTransform.js"
     },
     "transformIgnorePatterns": [
       "[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs)$"

--- a/components/src/index.test.js
+++ b/components/src/index.test.js
@@ -1,0 +1,3 @@
+it('runs tests', () => {
+  expect(true).toBeTruthy();
+});


### PR DESCRIPTION
# Problem

The Jest test config was broken in the @nulogy/components package.

# Solution

This PR restores some missing jest config files that were deleted from the CRA ejected config.

# To test

from the root run

```sh
yarn components test
```
There is a very basic test that should pass.