### PR TITLE
NDS-229 update build scripts

### DIFF
--- a/docs/catalog/guides/quickstart.md
+++ b/docs/catalog/guides/quickstart.md
@@ -9,6 +9,10 @@ $ git clone https://github.com/nulogy/design-system.git design-system
 $ yarn install
 ```
 
+```hint|neutral
+Note that `yarn install` will subsequently run `yarn build`. This will prepare the project for development using any dev server script below.
+```
+
 ## To develop React components for the [@nulogy/components](https://www.npmjs.com/package/@nulogy/components) package.
 
 ```code

--- a/docs/catalog/guides/quickstart.md
+++ b/docs/catalog/guides/quickstart.md
@@ -17,20 +17,20 @@ lang: sh
 $ yarn start
 ```
 
-This will start a [Storybook](https://storybook.js.org) on [port 9009](http://localhost:9009).
+This will start a [Storybook](https://storybook.js.org) on [port 8080](http://localhost:8080).
 
 ## To write documentation to appear on [nulogy.design](http://nulgoy.design)
 
 ```code
 lang: sh
 ---
-$ yarn document
+$ yarn docs start
 ```
 
-This will start [Catalog](https://www.catalog.style/) in development mode on [port 4000](http://localhost:4000).
+This will start [Catalog](https://www.catalog.style/) in development mode on [port 9090](http://localhost:9090).
 
 ### Further reading
 
 For information on how to set-up the project see the [Set up guide](guides/setup).
 
-For more information about other scripts available to you see the [Package Scripts guide](guides/scripts).
+For more information about scripts available to you see the [Package Scripts guide](guides/scripts).

--- a/docs/catalog/guides/scripts.md
+++ b/docs/catalog/guides/scripts.md
@@ -5,7 +5,11 @@
 The following scripts start dev servers for various packages.
 
 ```hint|neutral
-While developing, you may want to run `yarn watch` to build the rest of the project in watch mode. For more see below.
+Note that `yarn install` will subsequently run `yarn build`. This will prepare the project for development using the dev server scripts below.
+```
+
+```hint|neutral
+While developing, you may want to run `yarn watch` to build the rest of the project in watch mode. For more the [Building section](#building) below.
 ```
 
 ```table

--- a/docs/catalog/guides/scripts.md
+++ b/docs/catalog/guides/scripts.md
@@ -65,12 +65,16 @@ rows:
   Result: Uses Lerna to run the `watch` command in all workspaces concurrently. See `build:public` below for an explanation of what is considered a "library package".
  
 - Script: yarn build
-  Task: Build all packages.
+  Task: Build the library packages – not documentation and sandboxes.
+  Result: Build only dependency packages – where `pkg.private` is not set to `true`.
+
+- Script: yarn build:all
+  Task: Build all packages including the docs and sandbox.
   Result: Uses Lerna to build all workspaces.
 
-- Script: yarn build:public
-  Task: Build the library packages – not documentation and sandboxes.
-  Result: Build only packages where `pkg.private` is not set to `true`.
+- Script: yarn build:docs
+  Task: Used in CI to deploy the docs to http://nulogy.design.
+  Result: Builds the public packages, then builds the docs.
 
 - Script: yarn clean
   Task: Removes all build artifacts.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "yarn build"
+  command = "yarn build:docs"
   publish = "docs/dist"
 
 [build.environment]

--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
     "test": "lerna run test --stream --include-filtered-dependents --since master",
     "pretest": "yarn build:public --include-filtered-dependencies --since master",
     
-    "build": "lerna run build --stream",
-    "build:public": "yarn build --no-private",
+    "build:all": "lerna run build --stream",
+    "build": "yarn build:all --no-private",
+    "build:docs": "yarn build && yarn docs build",
     "watch": "lerna run watch --no-private --stream --parallel",
     
     "clean": "lerna exec 'rm -rf dist'",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build": "yarn build:all --no-private",
     "build:docs": "yarn build && yarn docs build",
     "watch": "lerna run watch --no-private --stream --parallel",
+    "prepare": "yarn build",
     
     "clean": "lerna exec 'rm -rf dist'",
     "pristine": "git clean -fdX .",


### PR DESCRIPTION
# What it is

A quick update to the npm scripts after working with them. These changes should make typical behaviour run faster. As well as automating the setup of the project to some extent.

# What I did

1. Updated the basic `yarn build` script to only build the library packages (not the sandbox or docks).
1. Added a script to build the libs and then build the docs - this is now used in the Netlify CI build to deploy http://nulogy.design.
1. Runs the `yarn build` script in the npm `prepare` lifecycle: thus the lib packages will be built after `yarn install` putting ht project in a workable state. This means that when you pull the project down for the first time, you should be able to just `yarn install` and the libs will be built and ready for your to start a dev server.
1. Updated the [Quickstart Guide](https://deploy-preview-33--nulogy-design-system.netlify.com/guides/quickstart) to replace the old `yarn document` command with `yarn docs start`
1. Added docs to the [Package scripts guide](https://deploy-preview-33--nulogy-design-system.netlify.com/guides/scripts) about the updates to `build` and `prepare` scripts.

# To test

1. Have a look at the [Updated guides](https://deploy-preview-33--nulogy-design-system.netlify.com/guides/)
1. run the scripts scripts. 
1. You could try to `yarn install` fresh checkout (or run `yarn pristine` / `yarn clean` then `yarn install`)
 