### PR TITLE
Adds docs to Guides about `yarn components test:watch`

### DIFF
--- a/docs/catalog/guides/quickstart.md
+++ b/docs/catalog/guides/quickstart.md
@@ -1,6 +1,6 @@
 > This guide will help you get started on developing components or writing documentation.
 
-## To clone the project:
+## Clone the project
 
 ```code
 lang: sh
@@ -13,7 +13,7 @@ $ yarn install
 Note that `yarn install` will subsequently run `yarn build`. This will prepare the project for development using any dev server script below.
 ```
 
-## To develop React components for the [@nulogy/components](https://www.npmjs.com/package/@nulogy/components) package.
+## Develop React components for the [@nulogy/components](https://www.npmjs.com/package/@nulogy/components) package
 
 ### Start a dev server (Storybook)
 ```code
@@ -34,7 +34,7 @@ $ yarn components test:watch
 this will run [Jest](https://jestjs.io) in watch mode and report pass/failures via your OS's notification system (i.e. Notification Center on macOS).
 
 
-## To write documentation to appear on [nulogy.design](http://nulgoy.design)
+## Write documentation to appear on [nulogy.design](http://nulgoy.design)
 
 ```code
 lang: sh
@@ -44,7 +44,7 @@ $ yarn docs start
 
 This will start [Catalog](https://www.catalog.style/) in development mode on [port 9090](http://localhost:9090).
 
-### Further reading
+## Further reading
 
 For information on how to set-up the project see the [Set up guide](guides/setup).
 

--- a/docs/catalog/guides/quickstart.md
+++ b/docs/catalog/guides/quickstart.md
@@ -15,6 +15,7 @@ Note that `yarn install` will subsequently run `yarn build`. This will prepare t
 
 ## To develop React components for the [@nulogy/components](https://www.npmjs.com/package/@nulogy/components) package.
 
+### Start a dev server (Storybook)
 ```code
 lang: sh
 ---
@@ -22,6 +23,16 @@ $ yarn start
 ```
 
 This will start a [Storybook](https://storybook.js.org) on [port 8080](http://localhost:8080).
+
+### Run tests (Jest) 
+```code
+lang: sh
+---
+$ yarn components test:watch
+```
+
+this will run [Jest](https://jestjs.io) in watch mode and report pass/failures via your OS's notification system (i.e. Notification Center on macOS).
+
 
 ## To write documentation to appear on [nulogy.design](http://nulgoy.design)
 

--- a/docs/catalog/guides/scripts.md
+++ b/docs/catalog/guides/scripts.md
@@ -56,6 +56,9 @@ rows:
     1. Builds all the public npm modules (see **yarn build:public** below)  that have changed since master.
 
     2. Runs tests in any package with files that have changed since master.
+- Script: yarn components test:watch
+  Task: Test components while working on them.
+  Result: Runs the `@nulogy/components` [Jest](https://jestjs.io) tests in watch mode and report pass/failures via your OS's notification system (i.e. Notification Center on macOS).
 ```
 
 # Building


### PR DESCRIPTION
What it says on the tin. 

# To test

you can see the updated docs in the deploy preview here:

- [Quickstart](https://deploy-preview-38--nulogy-design-system.netlify.com/guides/quickstart)
- [Scripts](https://deploy-preview-38--nulogy-design-system.netlify.com/guides/scripts)