### PR TITLE
FIX: missing babel stanza in css/package.json

### DIFF
--- a/css/package.json
+++ b/css/package.json
@@ -35,5 +35,12 @@
     "styled-normalize": "^8.0.0",
     "webpack": "^4.8.3",
     "webpack-cli": "^3.1.0"
+  },
+  "babel": {
+    "presets": [
+      "env",
+      "react",
+      "stage-1"
+    ]
   }
 }


### PR DESCRIPTION
the babel config was missing in the css package. This PR restores it (?)

To test: the Netlify build was failing: it should pass now.