### PR TITLE
FIX: Standardize babel config

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -74,7 +74,7 @@
     "presets": [
       "env",
       "react",
-      "stage-2"
+      "stage-1"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     
     "build:all": "lerna run build --stream",
     "build": "yarn build:all --no-private",
-    "build:docs": "yarn build && yarn docs build",
+    "build:docs": "yarn docs build",
     "watch": "lerna run watch --no-private --stream --parallel",
     
     "prepublishOnly": "yarn pristine && yarn install",

--- a/tokens/package.json
+++ b/tokens/package.json
@@ -17,7 +17,8 @@
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
-    "babel-preset-env": "^1.7.0"
+    "babel-preset-env": "^1.7.0",
+    "babel-preset-stage-1": "^6.24.1"
   },
   "dependencies": {
     "babel-jest": "22.4.4",
@@ -28,14 +29,8 @@
   },
   "babel": {
     "presets": [
-      [
-        "env",
-        {
-          "targets": {
-            "node": "current"
-          }
-        }
-      ]
+      "env",
+      "stage-1"
     ]
   }
 }

--- a/tokens/src/tokens.js
+++ b/tokens/src/tokens.js
@@ -114,9 +114,9 @@ export const shadow = {
 
 export default {
   name: 'Nulogy Design System',
-  borderRadius: borderRadius,
-  colour: colour,
-  font: font,
-  space: space,
-  radius: radius,
+  borderRadius,
+  colour,
+  font,
+  space,
+  radius
 };


### PR DESCRIPTION
# Problem

Netlify builds are still failing!

# What I did

1. Standardizes all packages on babel present env and stage-1 (and preset-react where applicable)
2. removes  the build step from the `yarn build:docs` command, as all the deps are already built in the yarn `postinstall` lifecycle script. (this should speed up builds)
3. Minor update to syntax of the default export from `tokens.js to use object literal shorthand syntax.
