### PR TITLE
defines breakpoints as an array

### DIFF
--- a/tokens/src/__snapshots__/tokens.test.js.snap
+++ b/tokens/src/__snapshots__/tokens.test.js.snap
@@ -3,11 +3,10 @@
 exports[`tokens matches snapshot 1`] = `
 Object {
   "borderRadius": "3px",
-  "breakpoints": Object {
-    "desktop": 1024,
-    "hd": 1920,
-    "mobile": 768,
-  },
+  "breakpoints": Array [
+    640,
+    1024,
+  ],
   "colour": Object {
     "base": "#0E77D2",
     "black": "#03101A",
@@ -91,6 +90,16 @@ Object {
       "bold": 700,
       "medium": 500,
       "normal": 400,
+    },
+  },
+  "mediaQueries": Object {
+    "max": Object {
+      "large": "@media screen and (max-width: 1024px)",
+      "medium": "@media screen and (max-width: 640px)",
+    },
+    "min": Object {
+      "large": "@media screen and (min-width: 1025px)",
+      "medium": "@media screen and (min-width: 641px)",
     },
   },
   "name": "Nulogy Design System",

--- a/tokens/src/tokens.js
+++ b/tokens/src/tokens.js
@@ -110,19 +110,19 @@ export const shadow = {
   far: '0 6px 15px 0 rgba(3,16,26, 0.33);'
 };
 
-export const breakpoints = {
-  medium: 640,
-  large: 1024,
-}
+export const breakpoints = [
+  640,
+  1024,
+]
 
 export const mediaQueries = {
   min: {
-    medium: `@media screen and (min-width: ${breakpoints.medium + 1}px)`,
-    large: `@media screen and (min-width: ${breakpoints.large + 1}px)`,
+    medium: `@media screen and (min-width: ${breakpoints[0] + 1}px)`,
+    large: `@media screen and (min-width: ${breakpoints[1] + 1}px)`,
   },
   max:  {
-    medium: `@media screen and (max-width: ${breakpoints.medium}px)`,
-    large: `@media screen and (max-width: ${breakpoints.large}px)`,
+    medium: `@media screen and (max-width: ${breakpoints[0]}px)`,
+    large: `@media screen and (max-width: ${breakpoints[1]}px)`,
   }
 }
 


### PR DESCRIPTION
styled systems expects breakpoints to be defined as an array. We are curtently using `rmdi` for icons whihc uses the styled system api. This was causing errors.

This chnage gets the Icons working again!