### PR TITLE
Nds 285 data mapping table component

### DIFF
--- a/components/src/Tables/Table.js
+++ b/components/src/Tables/Table.js
@@ -141,9 +141,9 @@ export const DataTable = ({ data, headers }) => (
 
     <Body>
     {data.map(row => (
-      <Row>
+      <Row key={`row${row}`}>
       {row.map(cell => (
-        <Cell>
+        <Cell key={`cell${row}${cell}`}>
           {cell}
         </Cell>
       ))}

--- a/components/src/Tables/Table.js
+++ b/components/src/Tables/Table.js
@@ -131,7 +131,7 @@ export const DataTable = ({ data, headers }) => (
     <Header>
       <Row>
       {headers.map(header => (
-        <HeaderCell>
+        <HeaderCell key={`DataTableHeader_${header}`}>
           {header}
         </HeaderCell>
       ))}
@@ -141,9 +141,9 @@ export const DataTable = ({ data, headers }) => (
 
     <Body>
     {data.map(row => (
-      <Row key={`row${row}`}>
+      <Row key={`DataTableHeaderRow_${row}`}>
       {row.map(cell => (
-        <Cell key={`cell${row}${cell}`}>
+        <Cell key={`DataTableHeaderCell_${row}_${cell}`}>
           {cell}
         </Cell>
       ))}

--- a/components/src/Tables/Table.js
+++ b/components/src/Tables/Table.js
@@ -123,3 +123,28 @@ export const Table = styled.table`
 `;
 
 Table.defaultProps = defaultProps;
+
+export const DataTable = ({ headers, data }) => (
+  <Table>
+    <Header>
+      <Row>
+      {headers.map(header => (
+        <HeaderCell>
+          {header}
+        </HeaderCell>
+      ))}
+      </Row>
+    </Header>
+    <Body>
+    {data.map(row => (
+      <Row>
+      {row.map(cell => (
+        <Cell>
+          {cell}
+        </Cell>
+      ))}
+      </Row>
+    ))}
+    </Body>
+  </Table>
+)

--- a/components/src/Tables/Table.js
+++ b/components/src/Tables/Table.js
@@ -127,6 +127,7 @@ Table.defaultProps = defaultProps;
 
 export const DataTable = ({ data, headers }) => (
   <Table>
+    { headers && 
     <Header>
       <Row>
       {headers.map(header => (
@@ -136,6 +137,8 @@ export const DataTable = ({ data, headers }) => (
       ))}
       </Row>
     </Header>
+    }
+
     <Body>
     {data.map(row => (
       <Row>

--- a/components/src/Tables/Table.js
+++ b/components/src/Tables/Table.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import tokens from '@nulogy/tokens';
 import QuietButton from '../Button/QuietButton';
@@ -124,7 +125,7 @@ export const Table = styled.table`
 
 Table.defaultProps = defaultProps;
 
-export const DataTable = ({ headers, data }) => (
+export const DataTable = ({ data, headers }) => (
   <Table>
     <Header>
       <Row>
@@ -147,4 +148,9 @@ export const DataTable = ({ headers, data }) => (
     ))}
     </Body>
   </Table>
-)
+);
+
+DataTable.propTypes = {
+  data: PropTypes.arrayOf(PropTypes.array).isRequired,
+  headers: PropTypes.array
+}

--- a/components/src/Tables/Table.story.js
+++ b/components/src/Tables/Table.story.js
@@ -5,7 +5,11 @@ import { DataTable, Table, Cell, ActionCell, Row, CreateRow, Body, Header, Heade
 storiesOf('Table/DataTable', module)
   .add('default', () => (
     <DataTable 
-      headers={['Header 1', 'Header 2', 'Header 3']} 
+      headers={[
+        'Header 1', 
+        'Header 2', 
+        'Header 3'
+      ]} 
       data={[
         [1, 2, 3],
         [11, 22, 33],

--- a/components/src/Tables/Table.story.js
+++ b/components/src/Tables/Table.story.js
@@ -12,6 +12,15 @@ storiesOf('Table/DataTable', module)
         [111, 222, 333]
       ]} />
   ))
+  .add('with no headers', () => (
+    <DataTable 
+      data={[
+        [1, 2, 3],
+        [11, 22, 33],
+        [111, 222, 333]
+      ]} />
+  ));
+
 storiesOf('Table/primitives', module)
   .add('Read Only', () => (
     <Table>

--- a/components/src/Tables/Table.story.js
+++ b/components/src/Tables/Table.story.js
@@ -1,8 +1,18 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { Table, Cell, ActionCell, Row, CreateRow, Body, Header, HeaderCell, Button, TemporaryTextInput } from './';
+import { DataTable, Table, Cell, ActionCell, Row, CreateRow, Body, Header, HeaderCell, Button, TemporaryTextInput } from './';
 
-storiesOf('Table', module)
+storiesOf('Table/DataTable', module)
+  .add('default', () => (
+    <DataTable 
+      headers={['Header 1', 'Header 2', 'Header 3']} 
+      data={[
+        [1, 2, 3],
+        [11, 22, 33],
+        [111, 222, 333]
+      ]} />
+  ))
+storiesOf('Table/primitives', module)
   .add('Read Only', () => (
     <Table>
       <Header>

--- a/components/src/Tables/__snapshots__/index.test.js.snap
+++ b/components/src/Tables/__snapshots__/index.test.js.snap
@@ -7,6 +7,7 @@ Object {
   "Button": [Function],
   "Cell": [Function],
   "CreateRow": [Function],
+  "DataTable": [Function],
   "Header": [Function],
   "HeaderCell": [Function],
   "Row": [Function],

--- a/components/src/__snapshots__/index.test.js.snap
+++ b/components/src/__snapshots__/index.test.js.snap
@@ -54,6 +54,7 @@ Object {
     "Button": [Function],
     "Cell": [Function],
     "CreateRow": [Function],
+    "DataTable": [Function],
     "Header": [Function],
     "HeaderCell": [Function],
     "Row": [Function],


### PR DESCRIPTION
# Problem

We need a component to tabular data which is all over our products.

# Solution

I built a data-table component that supports the following features:

1. Pass data via a 2D array: `data={[[ col1, col2, col33 ], [ col11, col22, col33 ], ... ]}` and it renders it!
2. pass headers as an array: `headers={['Header 1', 'Header 2', 'Header 3']}`
3. If you don't pass a `headers` prop then no header is rendered.

## The minimal api looks like: 

```jsx
<DataTable 
  headers={[
    'Header 1', 
    'Header 2', 
    'Header 3'
  ]} 
  data={[
    [1, 2, 3],
    [11, 22, 33],
    [111, 222, 333]
  ]} />
```

## Or with no headers

```jsx
<DataTable 
  data={[
    [1, 2, 3],
    [11, 22, 33],
    [111, 222, 333]
  ]} />
```
