### PR TITLE
moves jest and babel-jest out of direct deps

### DIFF
--- a/tokens/package.json
+++ b/tokens/package.json
@@ -17,11 +17,9 @@
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
-    "babel-preset-env": "^1.7.0",
-    "babel-preset-stage-1": "^6.24.1"
-  },
-  "dependencies": {
     "babel-jest": "22.4.4",
+    "babel-preset-env": "^1.7.0",
+    "babel-preset-stage-1": "^6.24.1",
     "jest": "22.4.4"
   },
   "jest": {


### PR DESCRIPTION
Quick fix to move Jest deps out of direct dependencies and into dev-dependencies to reduce bundle size.