### PR TITLE
Add language to html on catalog

### DIFF
--- a/docs/catalog/index.html
+++ b/docs/catalog/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
Catalog was missing `lang=en` on the `<html>` element which is a 👎for accessibility so I added it. 