### PR TITLE
Add accessibility features to icon

### DIFF
--- a/components/src/Icons/Icon.js
+++ b/components/src/Icons/Icon.js
@@ -61,14 +61,16 @@ export const Wrapper = styled.span`
 
 const Icon = ({ name, IconSvg = Icons[name], ...props }) => (
   <Wrapper {...props} >
-    <IconSvg />
+      <IconSvg title={props.title} aria-hidden={!props.title} />
   </Wrapper>
 );
 
 Icon.propTypes = {
-  name: PropTypes.oneOf(names).isRequired
+  name: PropTypes.oneOf(names).isRequired,
+  title: PropTypes.string
 }
 
 Icon.defaultProps = {}
 
 export default Icon;
+

--- a/components/src/Icons/Icon.story.js
+++ b/components/src/Icons/Icon.story.js
@@ -67,4 +67,10 @@ storiesOf("Icon", module)
         Quisque in tempus augue. Proin rhoncus, dolor sed. <Icon name="check" />
       </p>
     </React.Fragment>
+  ))
+  .add('Accessibility', () => (
+    <React.Fragment>
+      <p><Icon name="user" title="User account" /> This has a title attribute so it will be read by assistive devices.</p>
+      <p><Icon name="user"/> This doesn't have a title attribute, so it has aria-hidden set true instead.</p>
+    </React.Fragment>    
   ));

--- a/docs/catalog/components/icons.md
+++ b/docs/catalog/components/icons.md
@@ -1,23 +1,26 @@
 > Icons can be used alongside text to help assist users in finding certain actions on a page.
 
-Icons accept a prop for the name of the icon, which can be selected from the following list. They will be the same colour as their parent element, sized 25% larger than the text.
+Icons accept a prop for the name of the icon, which can be selected from the following list. They will be the same size and colour as their surrounding text.
 
 ```react
 showSource: true
 ---
 <div>
-  <Icon name="add" />
-  <Icon name="cancel" />
-  <Icon name="check" />
-  <Icon name="company" />
-  <Icon name="delete" />
-  <Icon name="edit" />
-  <Icon name="lock" />
-  <Icon name="menu" />
-  <Icon name="save" />
-  <Icon name="search" />
-  <Icon name="site" />
-  <Icon name="unlock" />
-  <Icon name="user" />
+    <Icon name="add" />
+    <Icon name="cancel" />
+    <Icon name="check" />
+    <Icon name="company" />
+    <Icon name="delete" />
+    <Icon name="edit" />
+    <Icon name="lock" />
+    <Icon name="menu" />
+    <Icon name="save" />
+    <Icon name="search" />
+    <Icon name="site" />
+    <Icon name="unlock" />
+    <Icon name="user" />
 </div>
 ```
+
+### Accessibility
+The icon also accepts an optional `title` prop. Use this when the icon stands on its own or has an interactive purpose. If you don't add a title, the icon will have `aria-hidden=true` and screenreaders will skip over it.


### PR DESCRIPTION
This pull request allows you to either set a title on your icon that screenreaders will read aloud or skip the icon entirely. 