### PR TITLE
Nds 461 finalize markdown implementation

### DIFF
--- a/gatsby/gatsby-node.js
+++ b/gatsby/gatsby-node.js
@@ -5,7 +5,7 @@ const path = require("path")
 exports.createPages = ({ actions, graphql }) => {
   const { createPage } = actions
 
-  const blogPostTemplate = path.resolve(`src/templates/component.js`)
+  const blogPostTemplate = path.resolve(`src/templates/markdown.js`)
 
   return graphql(`
     {

--- a/gatsby/src/components/layout.js
+++ b/gatsby/src/components/layout.js
@@ -42,7 +42,7 @@ export default ({ children }) => (
             </Nav>
             <Nav>
               <Text color='darkGrey' fontWeight={2}>Resources</Text>
-              <NavItem><Link href="/" underline={false}>Getting started</Link></NavItem>
+              <NavItem><Link href="/guides/get-started" underline={false}>Get started</Link></NavItem>
               <NavItem><Link href="https://github.com/nulogy/design-system" underline={false}>Github</Link></NavItem>
             </Nav>
         </Box>

--- a/gatsby/src/markdown/get-started.md
+++ b/gatsby/src/markdown/get-started.md
@@ -1,0 +1,6 @@
+---
+path: "/guides/get-started"
+title: "Get started"
+---
+
+This is where guides will live! In the `/src/markdown` folder. 

--- a/gatsby/src/markdown/text.md
+++ b/gatsby/src/markdown/text.md
@@ -1,9 +1,0 @@
----
-path: "/markdown/text"
-title: "Testing markdown"
-date: "12/12/12"
----
-
-Markdown test
-
-## Test heading

--- a/gatsby/src/templates/markdown.js
+++ b/gatsby/src/templates/markdown.js
@@ -1,5 +1,5 @@
-import React from "react"
-import { graphql } from "gatsby"
+import React from 'react'
+import {graphql} from "gatsby"
 import {Helmet} from 'react-helmet'
 import {Layout, DocSection} from '../components'
 import {Title} from '@nulogy/components'
@@ -16,11 +16,11 @@ export default function Template({
         </Helmet>
         <DocSection bg='whiteGrey' p={5} borderRadius={1}>
             <Title mb={0}>{frontmatter.title}</Title>
-          </DocSection>
-          <div
-          className="blog-post-content"
-          dangerouslySetInnerHTML={{ __html: html }}
-          />
+        </DocSection>
+        <div
+        className="blog-post-content"
+        dangerouslySetInnerHTML={{ __html: html }}
+        />
     </Layout>
   )
 }

--- a/gatsby/src/templates/markdown.js
+++ b/gatsby/src/templates/markdown.js
@@ -1,7 +1,7 @@
 import React from "react"
 import { graphql } from "gatsby"
-import Intro from '../components/Intro'
-import Layout from '../components/layout'
+import {Helmet} from 'react-helmet'
+import {Layout, DocSection} from '../components'
 import {Title} from '@nulogy/components'
 
 export default function Template({
@@ -11,16 +11,16 @@ export default function Template({
   const { frontmatter, html } = markdownRemark
   return (
       <Layout>
-        <div>
-        <div>
-            <Title>{frontmatter.title}</Title>
-            <Intro>{frontmatter.intro}</Intro>
-            <div
-            className="blog-post-content"
-            dangerouslySetInnerHTML={{ __html: html }}
-            />
-        </div>
-        </div>
+        <Helmet>
+            <title>{frontmatter.title} </title>
+        </Helmet>
+        <DocSection bg='whiteGrey' p={5} borderRadius={1}>
+            <Title mb={0}>{frontmatter.title}</Title>
+          </DocSection>
+          <div
+          className="blog-post-content"
+          dangerouslySetInnerHTML={{ __html: html }}
+          />
     </Layout>
   )
 }


### PR DESCRIPTION
This finishes adding markdown supported to Gatsby, allowing you to create .MD files in the `/src/markdown` that will be turned into HTML and inserted into the `Markdown.js` template. 