### PR TITLE
Nds 476 load stories dynamically

### DIFF
--- a/components/.storybook/config.js
+++ b/components/.storybook/config.js
@@ -6,13 +6,10 @@ import Box from '../src/Box/Box';
 import '../../css/src/nds-dev.css';
 // import ThemeProvider from '../src/ThemeProvider/ThemeProvider';
 
+const req = require.context('../src', true, /\.story\.js$/);
+
 function loadStories() {
-  require('../src/Box/Box.story.js');
-  require('../src/Button/Button.story.js');  
-  require('../src/Flex/Flex.story.js');
-  require('../src/Type/Headings.story.js');
-  require('../src/Link/Link.story.js');
-  require('../src/Type/Text.story.js');
+  req.keys().forEach(filename => req(filename));
 }
 
 addDecorator((story) => (

--- a/components/.storybook/config.js
+++ b/components/.storybook/config.js
@@ -10,16 +10,7 @@ import withStyles from "@sambego/storybook-styles";
 const req = require.context('../src', true, /\.story\.js$/);
 
 function loadStories() {
-<<<<<<< HEAD
   req.keys().forEach(filename => req(filename));
-=======
-  require('../src/Box/Box.story.js');
-  require('../src/Button/Button.story.js');
-  require('../src/Flex/Flex.story.js');
-  require('../src/Type/Headings.story.js');
-  require('../src/Link/Link.story.js');
-  require('../src/Type/Text.story.js');
->>>>>>> master
 }
 
 addDecorator(withStyles({

--- a/css/.storybook/config.js
+++ b/css/.storybook/config.js
@@ -1,16 +1,10 @@
 import { configure } from '@storybook/html';
 import '../src/nds-dev.css';
 
-  function loadStories() {
-    require('../src/scss/components/_buttons.story.js');
-    require('../src/scss/components/_type.story.js');
-    require('../src/scss/utilities/_borders.story.js');
-    require('../src/scss/utilities/_colors.story.js');
-    require('../src/scss/utilities/_helpers.story.js');
-    require('../src/scss/utilities/_layout.story.js');
-    require('../src/scss/utilities/_shadows.story.js');
-    require('../src/scss/utilities/_space.story.js');
-    require('../src/scss/utilities/_type.story.js');
-  }
+const req = require.context('../src/scss', true, /\.story\.js$/);
+
+function loadStories() {
+  req.keys().forEach(filename => req(filename));
+}
 
   configure(loadStories, module);


### PR DESCRIPTION
This makes changes to the css and component storybook config files so that all stories are loaded as long as they are in the correct path and names <name>.story.js 

This seems like a good solution for now so long as we are okay with all stories loading in alphabetical order, as that is the way the they are organized in the folder structure and therefore the order they are loaded. If we want to have more granular control we can either revert these changed and continue to add stories manually or we can look into a way to index the stories to appear in a desired order.