### PR TITLE
Nds 491 button with icon prop

### DIFF
--- a/components/src/Button/Button.js
+++ b/components/src/Button/Button.js
@@ -1,8 +1,9 @@
 import styled from 'styled-components';
 import { color, space, width, maxWidth, boxShadow, borderRadius, textAlign } from 'styled-system'
 import theme from '../theme'
-import {InlineIcon} from '../Icon/Icon.js'
+import {InlineIcon, names} from '../Icon/Icon.js'
 import React from 'react'
+import PropTypes from 'prop-types';
 
 const size = props => {
     switch (props.size) {
@@ -68,6 +69,13 @@ const Button = styled(BaseButton)`
     &:active {transform: scale(0.98); transition: .2s ease-in;}
     &:disabled {opacity: .5;}
 `
+Button.propTypes = {
+  size: PropTypes.oneOf(["small","medium","large"]),  
+  disabled: PropTypes.bool,
+  iconName: PropTypes.oneOf(names),
+  iconSide: PropTypes.oneOf(["left","right"]),
+  ...space.propTypes
+}
 
 Button.defaultProps = {
     theme: theme,

--- a/components/src/Button/Button.js
+++ b/components/src/Button/Button.js
@@ -1,6 +1,8 @@
 import styled from 'styled-components';
 import { color, space, width, maxWidth, boxShadow, borderRadius, textAlign } from 'styled-system'
 import theme from '../theme'
+import {InlineIcon} from '../Icon/Icon.js'
+import React from 'react'
 
 const size = props => {
     switch (props.size) {
@@ -30,7 +32,21 @@ const size = props => {
 
 const fullWidth = props => (props.fullWidth ? { width: '100%' } : null)
 
-const Button = styled.button`
+const BaseButton = (props) => {
+  return(
+    <button {...props}> 
+      {(props.iconName && props.iconSide === "left") &&
+        <InlineIcon mr={0} name={props.iconName}/>
+      }
+      {props.children}
+      {(props.iconName && props.iconSide === "right") &&
+        <InlineIcon ml={0} name={props.iconName}/>
+      }
+    </button>
+  )
+}
+
+const Button = styled(BaseButton)`
     -webkit-font-smoothing: antialiased;
     font-weight: 600;
     border: 0;
@@ -54,7 +70,8 @@ const Button = styled.button`
 `
 
 Button.defaultProps = {
-    theme: theme
+    theme: theme,
+    iconSide: "right"
 }
 
 export default Button

--- a/components/src/Button/Button.story.js
+++ b/components/src/Button/Button.story.js
@@ -5,7 +5,6 @@ import PrimaryButton from './PrimaryButton';
 import DangerButton from './DangerButton';
 import QuietButton from './QuietButton';
 
-
 storiesOf('Buttons', module)
   .add('Button', () => (
       <Button>Create project</Button>
@@ -26,6 +25,12 @@ storiesOf('Buttons', module)
      <Button size="large">Create project</Button>
    </React.Fragment>
   ))
+  .add('With a selected Icon', () => (
+    <React.Fragment>
+      <Button iconName="add" iconSide="left">Create project</Button>
+      <Button iconName="add" iconSide="right">Create project</Button>
+    </React.Fragment>
+  ))   
   .add('Set to full width', () => (
     <PrimaryButton fullWidth>Create project</PrimaryButton>
   )) 


### PR DESCRIPTION
This adds iconName and iconSide props to all components derived from Button.

iconName must be an existing icon name as provided by the Icon component
iconSide must be either "left" or "right"

Adds a story to demonstrate an Icon on either side of the button 