### PR TITLE
Adds calculated darkened hover color to link with reference to theme

### DIFF
--- a/components/src/Link/Link.js
+++ b/components/src/Link/Link.js
@@ -1,15 +1,23 @@
 
 import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
-import { color, space } from 'styled-system'
+import { color, space, themeGet } from 'styled-system'
 import theme from '../theme.js'
 import { darken } from 'polished'
+
+const getHoverColor = props =>{
+  return(
+    props.hover ?
+    themeGet("colors."+props.hover,props.hover) :
+    darken('0.1',themeGet("colors."+props.color,props.color)(props))
+  )
+}
 
 const Link = styled.a`
   ${color} ${space}
   text-decoration: ${props => props.underline ? 'underline' : 'none'}}
   &:hover {
-    color: ${props => props.hover ? props => props.hover : theme.colors.darkBlue}
+    color: ${props => getHoverColor(props)} 
   }
 `;
 


### PR DESCRIPTION
It seems that styled-system will handle translating colors to our theme automatically (eg. "red" becomes nulogy red) however props that use a similar datatype but are not part of styled system (eg. "hover" prop) will not automatically adopt theme. This can be handled by using themeGet(color,fallbackcolor) on each custom prop to have it automatically alias colors to our theme values.
*Note, themeGet returns a function that accepts props as an argument, so if you want to get the actual color value string you would type themeGet(color,fallbackcolor)(props)  