### PR TITLE
Update readmes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,33 @@
+This is a guide for Nulogy employees who wish to contribute to the Design System. 
 
-This is a WIP document for contributing to the Nulogy Design System. For now, if you have any questions or would like to get involved, please message somebody in the #design-systems slack channel.
+## Installation 
 
-## Prerequisits 
+### Prerequisites 
 1. Download and install the latest LTS version of [Node (10.15.0)](https://nodejs.org/en/)
 2. Download and install the package manager [Yarn](https://yarnpkg.com/en/docs/install#mac-stable)
 
-## Cloning the repo 
-3. In the directory you want to install the design system, run `git clone https://github.com/nulogy/design-system/`
-4. Run `yarn` to install dependencies 
+### Cloning the repo 
+1. In the directory you want to install the design system, run `git clone https://github.com/nulogy/design-system/ && cd design-system`
+2. Run `yarn` to install dependencies 
+
+## Adding tokens
+From the `/tokens/` directory: 
+
+* Add or update tokens in the `/src/` folder
+* Run `yarn build` to use [Style Dictionary](https://amzn.github.io/style-dictionary) to convert those tokens into `_variables.scss` for Sass and `exports.js` for React usage 
+
+New export formats can be added in `config.js`. 
 
 ## Writing components 
-_Coming soon_ 
+From the `/components/` directory: 
+* `yarn start` will run a storybook at [localhost:8080](localhost:8080) for local development. 
+* `yarn build` will rebuild the package exports for production.
+
+## Writing CSS 
+Our CSS package provides a way to access our tokens 
+From the `/css` directory: 
+* `yarn start` will watch `*.scss` files, compile them to `nds-dev.css` and launch a storybook dev environment at [http://localhost:8080](http://localhost:8080) 
+* `yarn build` will rebuild nds.css. 
 
 ## Coding standards
 _Coming soon_
@@ -21,11 +38,15 @@ _Coming soon_
 ## Testing
 _Coming soon_
 
-## Writing documentation 
-The main documentation can be found at http://nulogy.design. It's a static site  maanged in `@nulogy/docs`. 
+## Documentation 
+The main documentation can be found at [http://nulogy.design](http://nulogy.design). It's a static site created with [GatsbyJS](https://gatsbyjs.org) managed in `@nulogy/docs`. 
+Our component storybook can be found at [https://nulogy.github.io/design-system](https://nulogy.github.io/design-system)
 
 ## Publishing documentation 
 _Coming soon_ 
+
+## Resources
+* [#design-system on Slack](slack://channel?id=CBAFQ4X7X/)
 
 
 

--- a/components/README.md
+++ b/components/README.md
@@ -1,31 +1,37 @@
 # @nulogy/components
 Built with React, compononents make it easy to create interfaces that conform to the principles of the Nulogy Design System. Components are [styled-components](https://www.styled-components.com/) written using [styled-system](https://jxnblk.com/styled-system/). This makes it possible to write CSS directly in JS and pass props based on our design constraints. 
 
-## Development
-`$ yarn start` will run a storybook at [localhost:8080](localhost:8080) for local development. 
-
-`$ yarn build` will rebuild the package exports for production.
+## Installation 
+First, install the styled-components dependency: `yarn add styled-components`
+Then run `yarn add @nulogy/components`
 
 ## Usage
 
-### Theme Provider 
-Wrap your application in a ThemeProvider to access Nulogy's theme values and add typographic defaults. Components can then be imported for use in your application. 
+### 1. Wrap your appliction in our theme provider 
+Wrap your application in our ThemeProvider to access Nulogy's theme values and add typographic defaults. 
 
 ```
 import React from 'react'
-import { ThemeProvider, Box, Title } from '@nulogy/components'
+import { ThemeProvider } from '@nulogy/components'
 
 class App extends React.Component {
   render() {
     return (
       <ThemeProvider>
-        <Box pr={3}>
-          <Title>My App</Title>
-        </Box>
+        // your application 
       </ThemeProvider>
     )
   }
 }
 ```
 
-Please see the [documentation](http://nulogy.design/components) for instructions on how best to use each component. 
+### 2. Import desired components
+```
+import { Button } from '@nulogy/components'
+
+const SomeView = () => (
+  <Button>Click me</Button>
+)
+```
+
+Please see the [documentation](http://nulogy.design/components/buttons) for instructions on how best to use each component. 

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nulogy/components",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Component library for the Nulogy Design System - http://nulogy.design",
   "private": false,
   "publishConfig": {

--- a/css/package.json
+++ b/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nulogy/css",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "CSS for Nulogy Design System",
   "private": false,
   "publishConfig": {

--- a/css/readme.md
+++ b/css/readme.md
@@ -1,10 +1,16 @@
 # @nulogy/css
-This package provides sass variables and atomic CSS classes for writing CSS using Nulogy design tokens.
+Sass variables and atomic classes for writing CSS using Nulogy design tokens. These variables can be used to create CSS versions of our React components and the atomic classes can be 
+
+## Installation 
+`npm install @nulogy/css --save`
 
 ## Usage
+1. Include the CSS 
+`<link rel="stylesheet" href="'/node_modules/@nulogy/tokens/build/nds.css' />`
 
-### Development
-`yarn start` will watch `*.scss` files, compile them to `nds-dev.css` and launch a storybook dev environment at [http://localhost:8080](http://localhost:8080) 
+2. Use the utility classes as needed in your HTML
+`<p class='text--grey'>Grey text</p>`
 
-### Production
-`yarn build` will rebuild nds.css. 
+If you'd prefer to create your own classes using Scss variables, see [@nulogy/tokens](https://www.npmjs.com/package/@nulogy/tokens). 
+
+

--- a/tokens/package.json
+++ b/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nulogy/tokens",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Design tokens for the Nulogy Design System - http://nulogy.design",
   "repository": "https://github.com/nulogy/design-system.git",
   "author": "Nulogy <info@nulogy.com> (https://github.com/nulogy)",

--- a/tokens/readme.md
+++ b/tokens/readme.md
@@ -1,22 +1,19 @@
 # @nulogy/tokens
-This is where Nulogy's design tokens are stored and converted using [Style Dictionary](https://amzn.github.io/style-dictionary)
+This is where Nulogy's design tokens are stored and converted using [Style Dictionary](https://amzn.github.io/style-dictionary). Tokens are mostly used in our React components and CSS classes, but tokens can be imported directly into your application if needed. 
 
 ## What are tokens?
 > Design tokens are the visual design atoms of the design system — specifically, they are named entities that store visual design attributes. We use them in place of hard-coded values (such as hex values for color or pixel values for spacing) in order to maintain a scalable and consistent visual system for UI development.
 - [Salesforce](https://www.lightningdesignsystem.com/design-tokens/)
 
-## Adding tokens
-1. Add or update tokens in the `/src/` folder
-2. Run `yarn build` to convert those tokens into `_variables.scss` for Sass and `exports.js` for React usage
+## Installation
+`yarn add @nulogy/tokens`
 
-Your application can them import and use whichever format is required.
-
-New export formats can be added in `config.js`. 
-
-## Usage
-`$ yarn add @nulogy/tokens`
+## Usage 
 
 ### In JS 
 `import * as tokens from '@nulogy/tokens'`
-`Black is: {tokens.color_base_black}`
+`Blue is: {tokens.color_base_blue}`
 
+### In Sass
+`@import '/node_modules/@nulogy/tokens/build/variables.scss';`
+`.blue-thing {color: $color_base_blue}`


### PR DESCRIPTION
This PR splits out the instructions for how to use the design system and how to contribute to it. Each package README now provides instructions for how to install the package from NPM and use in an application, while CONTRIBUTING provides instructions for cloning the repo and doing work on the design system itself. I left coding standards/pr workflow/etc. out of the tickets as we have not decided on these things as a team yet. 