### PR TITLE
[NDS-536] fix webpack error

### DIFF
--- a/components/src/Button/IconicButton.js
+++ b/components/src/Button/IconicButton.js
@@ -6,67 +6,6 @@ import theme from "../theme";
 import Icon from "../Icon/Icon";
 import Text from "../Type/Text";
 import icons from "../../icons/icons.json";
-import { getTextWidth } from "../utils";
-
-/*
-BUG: the imposed width of the hidden label is slightly off and creates the look of
-increased horizontal padding - likely a calculation error in getMargin
-*/
-function getMargin(text, font, padding, maxWidth) {
-  const width = getTextWidth(text, font);
-  const paddingInt = parseInt(padding.replace(".px", ""), 10);
-  return (
-    (width + (2 * paddingInt)) > maxWidth
-      ? `-${maxWidth / 2}px`
-      : `-${(width / 2) + paddingInt}px`
-  );
-}
-
-
-const labelVisibilityText = props => {
-  switch (props.labelVisibility) {
-    case "always":
-      return {
-        display: "block",
-        fontWeight: props.theme.fontWeights[2],
-        textAlign: "left",
-      };
-    case "hover":
-      return {
-        display: "none",
-        position: "absolute",
-        fontSize: props.theme.fontSizes[0],
-        fontWeight: props.theme.fontWeights[1],
-        lineHeight: props.theme.lineHeights.smallTextCompressed,
-        padding: props.theme.space[1],
-        zIndex: "10",
-        top: "40px",
-        marginRight: getMargin(
-          props.label,
-          `${props.theme.fontSizes[0]} IBM Plex Sans`,
-          `${props.theme.space[1]}px`,
-          `${props.hiddlenLabelMaxWidth}`
-        ),
-        left: "25%",
-        right: "25%",
-        marginLeft: getMargin(
-          props.label,
-          `${props.theme.fontSizes[0]} IBM Plex Sans`,
-          `${props.theme.space[1]}px`,
-          `${props.hiddlenLabelMaxWidth}`
-        ),
-        borderRadius: props.theme.radii[0],
-        background: props.theme.colors.lightBlue,
-        pointerEvents: "none",
-      };
-    default:
-      return {
-        display: "block",
-        fontWeight: props.theme.fontWeights[2],
-        textAlign: "left",
-      };
-  }
-};
 
 const Wrapper = styled.button`
   ${space}
@@ -74,8 +13,7 @@ const Wrapper = styled.button`
   border: none;
   position: relative;
   display: inline-flex;
-  align-items: ${props => (props.labelVisibility ? "center" : null)};
-
+  align-items: center;
   padding: ${theme.space[1]} ${theme.space[0]};
   color: ${theme.colors.darkBlue};
   cursor: ${props => (props.disabled ? "arrow" : "pointer")};
@@ -86,14 +24,13 @@ const Wrapper = styled.button`
     min-width: 32px;
   }
   ${Text} {
-    ${labelVisibilityText}
+    display: "block",
+    fontWeight: props.theme.fontWeights[2],
+    textAlign: "left",
   }
   &:hover{
     ${Icon} {
         background ${theme.colors.lightBlue};
-    }
-    ${Text} {
-      display: ${props => (props.labelVisibility === "hover" ? "block" : null)};
     }
   }
   &:focus {outline: none;}
@@ -108,9 +45,6 @@ const Wrapper = styled.button`
       ${Icon} {
         background: none;
         transform: none;
-      }
-      ${Text} {
-        display: ${props => (props.labelVisibility === "hover" ? "none" : null)};
       }
     }
   }
@@ -136,15 +70,11 @@ IconicButton.propTypes = {
   children: PropTypes.node.isRequired,
   disabled: PropTypes.bool,
   theme: PropTypes.shape({}).isRequired,
-  labelVisibility: PropTypes.oneOf(["always", "hover"]),
   icon: PropTypes.oneOf(names).isRequired,
-  hiddlenLabelMaxWidth: PropTypes.number,
 };
 
 IconicButton.defaultProps = {
   disabled: false,
-  labelVisibility: "hover",
-  hiddlenLabelMaxWidth: "500",
 };
 
 export default IconicButton;

--- a/components/src/Button/IconicButton.story.js
+++ b/components/src/Button/IconicButton.story.js
@@ -4,14 +4,8 @@ import IconicButton from "./IconicButton";
 
 storiesOf("IconicButton", module)
   .add("With label", () => (
-    <IconicButton icon="delete" >Delete</IconicButton>
+    <IconicButton icon="delete">Delete</IconicButton>
   ))
-  // .add("With hidden label", () => (
-  //   <React.Fragment>
-  //     <IconicButton icon="edit">Edit</IconicButton>
-  //     <IconicButton icon="delete" >Delete</IconicButton>
-  //   </React.Fragment>
-  // ))
   .add("With a long label", () => (
     <React.Fragment>
       <IconicButton icon="user">

--- a/components/src/Button/IconicButton.story.js
+++ b/components/src/Button/IconicButton.story.js
@@ -3,35 +3,25 @@ import { storiesOf } from "@storybook/react";
 import IconicButton from "./IconicButton";
 
 storiesOf("IconicButton", module)
-  .add("With visible label", () => (
-    <IconicButton icon="delete" labelVisibility="always">Delete</IconicButton>
+  .add("With label", () => (
+    <IconicButton icon="delete" >Delete</IconicButton>
   ))
-  .add("With hidden label", () => (
-    <React.Fragment>
-      <IconicButton icon="edit">Edit</IconicButton>
-      <IconicButton icon="delete" labelVisibility="hover">Delete</IconicButton>
-    </React.Fragment>
-  ))
+  // .add("With hidden label", () => (
+  //   <React.Fragment>
+  //     <IconicButton icon="edit">Edit</IconicButton>
+  //     <IconicButton icon="delete" >Delete</IconicButton>
+  //   </React.Fragment>
+  // ))
   .add("With a long label", () => (
     <React.Fragment>
-      <IconicButton
-        icon="user"
-        labelVisibility="always"
-      >
-        I am an Iconic Button with a really really really long label
-      </IconicButton>
-      <IconicButton
-        ml={ 200 }
-        icon="user"
-        labelVisibility="hover"
-      >
+      <IconicButton icon="user">
         I am an Iconic Button with a really really really long label
       </IconicButton>
     </React.Fragment>
   ))
   .add("Disabled", () => (
     <React.Fragment>
-      <IconicButton icon="cancel" labelVisibility="always" disabled>Cancel</IconicButton>
-      <IconicButton icon="lock" labelVisibility="hover" disabled>Lock</IconicButton>
+      <IconicButton icon="cancel" disabled>Cancel</IconicButton>
+      <IconicButton icon="lock" disabled>Lock</IconicButton>
     </React.Fragment>
   ));

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   output: {
     libraryTarget: "umd",
-    globalObject: `(typeof self !== 'undefined' ? self : this)`    
+    globalObject: `(typeof self !== 'undefined' ? self : this)` // https://github.com/markdalgleish/static-site-generator-webpack-plugin/issues/130
   },
   externals: [
     "react",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,11 +24,11 @@ module.exports = {
         test: /\.stories\.jsx?$/,
         loaders: [require.resolve('@storybook/addon-storysource/loader')],
         enforce: 'pre',
-      },    
+      },
       {
         test: /\.svg$/,
         loader: 'svg-sprite-loader'
-      }  
+      }
     ]
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   output: {
-    libraryTarget: "umd"
+    libraryTarget: "umd",
+    globalObject: `(typeof self !== 'undefined' ? self : this)`    
   },
   externals: [
     "react",


### PR DESCRIPTION
The `window is not defined` error was actually coming from a Webpack 4 bug. It just required a one-line fix for now. More detail can be found [here](https://github.com/markdalgleish/static-site-generator-webpack-plugin/issues/130).

Clearing this up left us with a `document is not defined` error instead. Luckily this one was easy to trace as it was coming from `getTextWidth()` used inside `IconicButton.js`. 

I asked @coostenbrug about refactoring to not use a document check, and he informed me that that solution wasn't final, had a bug anyway, and was probably not worth updating at this time. He instead removed the references to it and added a ticket to the backlog [NDS-551] to solve the original issue a different way, probably by using a tooltip component. This means that IconicButton's hover variation is no longer working, but our component package won't error out when being used on a server. 