### PR TITLE
update components and tokens versions

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nulogy/components",
-  "version": "0.2.3",
+  "version": "0.2.5",
   "description": "Component library for the Nulogy Design System - http://nulogy.design",
   "private": false,
   "publishConfig": {

--- a/tokens/package.json
+++ b/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nulogy/tokens",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Design tokens for the Nulogy Design System - http://nulogy.design",
   "repository": "https://github.com/nulogy/design-system.git",
   "author": "Nulogy <info@nulogy.com> (https://github.com/nulogy)",


### PR DESCRIPTION
I think Netlify is failing on building our docs because it's referencing local packages. In an attempt to fix this I need to install our components and tokens from NPM. This updates our package versions so our latest code can be pushed. I skipped 0.2.4 in components because that version had already been uploaded somehow.