### PR TITLE
Nds 580 remove default margin from input components

### DIFF
--- a/components/spec/__snapshots__/Storyshots.spec.js.snap
+++ b/components/spec/__snapshots__/Storyshots.spec.js.snap
@@ -1539,13 +1539,47 @@ exports[`Storyshots Field Field 1`] = `
       }
     >
       <div
-        className="sc-cSHVUG CAuLq sc-jzJRlG idGKfE"
+        className="sc-cSHVUG bubdaT sc-jzJRlG iplBh"
       >
         <label
           className="sc-fjdhpX iOYorM"
         >
           Default label
         </label>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Field With Input 1`] = `
+<div
+  className="sc-bdVaJa iITmcr"
+>
+  <div
+    className="sc-bwzfXH ehOaqE"
+  >
+    <div
+      style={
+        Object {
+          "backgroundImage": "linear-gradient(to right, transparent 7px, #F0F2F5 8px, transparent 9px, transparent 14px, #F0F2F5 15px, transparent 16px, transparent 23px, #C0C8D1 24px), linear-gradient(to bottom, transparent 7px, #F0F2F5 8px, transparent 9px, transparent 15px, #F0F2F5 16px, transparent 16px, transparent 23px, #C0C8D1 24px)",
+          "backgroundSize": "24px 24px",
+          "minHeight": "calc(100vh - 32px)",
+        }
+      }
+    >
+      <div
+        className="sc-cSHVUG bubdaT sc-jzJRlG iplBh"
+      >
+        <label
+          className="sc-fjdhpX iOYorM"
+        >
+          Default label
+        </label>
+        <input
+          className="sc-kAzzGY czbVBA"
+          disabled={false}
+        />
       </div>
     </div>
   </div>
@@ -1569,7 +1603,7 @@ exports[`Storyshots Field With Input and InlineValidation 1`] = `
       }
     >
       <div
-        className="sc-cSHVUG CAuLq sc-jzJRlG idGKfE"
+        className="sc-cSHVUG bubdaT sc-jzJRlG iplBh"
       >
         <label
           className="sc-fjdhpX iOYorM"
@@ -1577,11 +1611,11 @@ exports[`Storyshots Field With Input and InlineValidation 1`] = `
           Default label
         </label>
         <input
-          className="sc-kAzzGY cKRvcT"
+          className="sc-kAzzGY czbVBA"
           disabled={false}
         />
         <div
-          className="sc-bwzfXH sc-chPdSV fogYWs"
+          className="sc-bwzfXH sc-chPdSV OPDIN"
           color="#cc1439"
         >
           <svg
@@ -1606,7 +1640,7 @@ exports[`Storyshots Field With Input and InlineValidation 1`] = `
             />
           </svg>
           <div
-            className="sc-bwzfXH crzhMj"
+            className="sc-kgoBCf jnnrjv"
           >
             <p
               className="sc-dnqmqq iUIAHX"
@@ -1641,7 +1675,7 @@ exports[`Storyshots Field With Label for Input 1`] = `
       }
     >
       <div
-        className="sc-cSHVUG CAuLq sc-jzJRlG idGKfE"
+        className="sc-cSHVUG bubdaT sc-jzJRlG iplBh"
         for="thisInput"
       >
         <label
@@ -1650,12 +1684,12 @@ exports[`Storyshots Field With Label for Input 1`] = `
           Default label
         </label>
         <input
-          className="sc-kAzzGY cKRvcT"
+          className="sc-kAzzGY czbVBA"
           disabled={false}
           id="thisInput"
         />
         <div
-          className="sc-bwzfXH sc-chPdSV fogYWs"
+          className="sc-bwzfXH sc-chPdSV OPDIN"
           color="#cc1439"
         >
           <svg
@@ -1680,7 +1714,7 @@ exports[`Storyshots Field With Label for Input 1`] = `
             />
           </svg>
           <div
-            className="sc-bwzfXH crzhMj"
+            className="sc-kgoBCf jnnrjv"
           >
             <p
               className="sc-dnqmqq iUIAHX"
@@ -1715,7 +1749,7 @@ exports[`Storyshots Field With a long text 1`] = `
       }
     >
       <div
-        className="sc-cSHVUG CAuLq sc-jzJRlG idGKfE"
+        className="sc-cSHVUG bubdaT sc-jzJRlG iplBh"
       >
         <label
           className="sc-fjdhpX iOYorM"
@@ -1769,7 +1803,7 @@ exports[`Storyshots Field With all additional components 1`] = `
       }
     >
       <div
-        className="sc-cSHVUG CAuLq sc-jzJRlG idGKfE"
+        className="sc-cSHVUG bubdaT sc-jzJRlG iplBh"
         for="thisInput1"
       >
         <label
@@ -1802,12 +1836,12 @@ exports[`Storyshots Field With all additional components 1`] = `
           </p>
         </label>
         <input
-          className="sc-kAzzGY cKRvcT"
+          className="sc-kAzzGY czbVBA"
           disabled={false}
           id="thisInput1"
         />
         <div
-          className="sc-bwzfXH sc-chPdSV fogYWs"
+          className="sc-bwzfXH sc-chPdSV OPDIN"
           color="#cc1439"
         >
           <svg
@@ -1832,7 +1866,7 @@ exports[`Storyshots Field With all additional components 1`] = `
             />
           </svg>
           <div
-            className="sc-bwzfXH crzhMj"
+            className="sc-kgoBCf jnnrjv"
           >
             <p
               className="sc-dnqmqq iUIAHX"
@@ -1843,23 +1877,23 @@ exports[`Storyshots Field With all additional components 1`] = `
               There has been an error
             </p>
             <ul
-              className="sc-kGXeez hoBFIe"
+              className="sc-kpOJdX hZppCQ"
               color="currentColor"
             >
               <li
-                className="sc-kgoBCf geSmhF"
+                className="sc-kGXeez fyDmEz"
                 color="currentColor"
               >
                 Something has gone wrong.
               </li>
               <li
-                className="sc-kgoBCf geSmhF"
+                className="sc-kGXeez fyDmEz"
                 color="currentColor"
               >
                 Entry must be atleast 3 characters long
               </li>
               <li
-                className="sc-kgoBCf geSmhF"
+                className="sc-kGXeez fyDmEz"
                 color="currentColor"
               >
                 <a
@@ -1894,7 +1928,7 @@ exports[`Storyshots Field With format text 1`] = `
       }
     >
       <div
-        className="sc-cSHVUG CAuLq sc-jzJRlG idGKfE"
+        className="sc-cSHVUG bubdaT sc-jzJRlG iplBh"
       >
         <label
           className="sc-fjdhpX iOYorM"
@@ -1932,7 +1966,7 @@ exports[`Storyshots Field With help text 1`] = `
       }
     >
       <div
-        className="sc-cSHVUG CAuLq sc-jzJRlG idGKfE"
+        className="sc-cSHVUG bubdaT sc-jzJRlG iplBh"
       >
         <label
           className="sc-fjdhpX iOYorM"
@@ -1970,7 +2004,7 @@ exports[`Storyshots Field With requirement text 1`] = `
       }
     >
       <div
-        className="sc-cSHVUG CAuLq sc-jzJRlG idGKfE"
+        className="sc-cSHVUG bubdaT sc-jzJRlG iplBh"
       >
         <label
           className="sc-fjdhpX iOYorM"
@@ -2051,17 +2085,17 @@ exports[`Storyshots Form Form 1`] = `
       }
     >
       <form
-        className="sc-kEYyzF lmDVgZ"
+        className="sc-kkGfuU iVKxlT"
       >
         <h2
-          className="sc-dxgOiQ eiXrvm"
+          className="sc-ckVGcZ lildcs"
           fontSize={3}
           fontWeight={2}
         >
           New Profile
         </h2>
         <div
-          className="sc-cSHVUG CAuLq sc-jzJRlG idGKfE"
+          className="sc-cSHVUG bubdaT sc-jzJRlG iplBh"
         >
           <label
             className="sc-fjdhpX iOYorM"
@@ -2069,12 +2103,12 @@ exports[`Storyshots Form Form 1`] = `
             Name
           </label>
           <input
-            className="sc-kAzzGY cKRvcT"
+            className="sc-kAzzGY czbVBA"
             disabled={false}
           />
         </div>
         <div
-          className="sc-cSHVUG CAuLq sc-jzJRlG idGKfE"
+          className="sc-cSHVUG bubdaT sc-jzJRlG iplBh"
         >
           <label
             className="sc-fjdhpX iOYorM"
@@ -2106,12 +2140,12 @@ exports[`Storyshots Form Form 1`] = `
             </p>
           </label>
           <input
-            className="sc-kAzzGY cKRvcT"
+            className="sc-kAzzGY czbVBA"
             disabled={false}
           />
         </div>
         <div
-          className="sc-cSHVUG CAuLq sc-jzJRlG idGKfE"
+          className="sc-cSHVUG bubdaT sc-jzJRlG iplBh"
         >
           <label
             className="sc-fjdhpX iOYorM"
@@ -2127,7 +2161,7 @@ exports[`Storyshots Form Form 1`] = `
             </p>
           </label>
           <input
-            className="sc-kAzzGY cKRvcT"
+            className="sc-kAzzGY czbVBA"
             disabled={false}
           />
         </div>
@@ -2154,25 +2188,25 @@ exports[`Storyshots Form With form sections 1`] = `
       }
     >
       <form
-        className="sc-kEYyzF lmDVgZ"
+        className="sc-kkGfuU iVKxlT"
       >
         <h2
-          className="sc-dxgOiQ eiXrvm"
+          className="sc-ckVGcZ lildcs"
           fontSize={3}
           fontWeight={2}
         >
           New Profile
         </h2>
         <fieldset
-          className="sc-hMqMXs jfJffV"
+          className="sc-kEYyzF jpRcfR"
         >
           <legend
-            className="sc-eNQAEJ jYhpNq"
+            className="sc-hMqMXs bYqtyw"
           >
             Personal Information
           </legend>
           <div
-            className="sc-cSHVUG CAuLq sc-jzJRlG idGKfE"
+            className="sc-cSHVUG bubdaT sc-jzJRlG iplBh"
           >
             <label
               className="sc-fjdhpX iOYorM"
@@ -2180,12 +2214,12 @@ exports[`Storyshots Form With form sections 1`] = `
               Name
             </label>
             <input
-              className="sc-kAzzGY cKRvcT"
+              className="sc-kAzzGY czbVBA"
               disabled={false}
             />
           </div>
           <div
-            className="sc-cSHVUG CAuLq sc-jzJRlG idGKfE"
+            className="sc-cSHVUG bubdaT sc-jzJRlG iplBh"
           >
             <label
               className="sc-fjdhpX iOYorM"
@@ -2217,12 +2251,12 @@ exports[`Storyshots Form With form sections 1`] = `
               </p>
             </label>
             <input
-              className="sc-kAzzGY cKRvcT"
+              className="sc-kAzzGY czbVBA"
               disabled={false}
             />
           </div>
           <div
-            className="sc-cSHVUG CAuLq sc-jzJRlG idGKfE"
+            className="sc-cSHVUG bubdaT sc-jzJRlG iplBh"
           >
             <label
               className="sc-fjdhpX iOYorM"
@@ -2238,21 +2272,21 @@ exports[`Storyshots Form With form sections 1`] = `
               </p>
             </label>
             <input
-              className="sc-kAzzGY cKRvcT"
+              className="sc-kAzzGY czbVBA"
               disabled={false}
             />
           </div>
         </fieldset>
         <fieldset
-          className="sc-hMqMXs jfJffV"
+          className="sc-kEYyzF jpRcfR"
         >
           <legend
-            className="sc-eNQAEJ jYhpNq"
+            className="sc-hMqMXs bYqtyw"
           >
             General Information
           </legend>
           <div
-            className="sc-cSHVUG CAuLq sc-jzJRlG idGKfE"
+            className="sc-cSHVUG bubdaT sc-jzJRlG iplBh"
           >
             <label
               className="sc-fjdhpX iOYorM"
@@ -2260,12 +2294,12 @@ exports[`Storyshots Form With form sections 1`] = `
               Gender
             </label>
             <input
-              className="sc-kAzzGY cKRvcT"
+              className="sc-kAzzGY czbVBA"
               disabled={false}
             />
           </div>
           <div
-            className="sc-cSHVUG CAuLq sc-jzJRlG idGKfE"
+            className="sc-cSHVUG bubdaT sc-jzJRlG iplBh"
           >
             <label
               className="sc-fjdhpX iOYorM"
@@ -2273,7 +2307,7 @@ exports[`Storyshots Form With form sections 1`] = `
               Ocupation
             </label>
             <input
-              className="sc-kAzzGY cKRvcT"
+              className="sc-kAzzGY czbVBA"
               disabled={false}
             />
           </div>
@@ -2301,20 +2335,20 @@ exports[`Storyshots Form With form sections without titles 1`] = `
       }
     >
       <form
-        className="sc-kEYyzF lmDVgZ"
+        className="sc-kkGfuU iVKxlT"
       >
         <h2
-          className="sc-dxgOiQ eiXrvm"
+          className="sc-ckVGcZ lildcs"
           fontSize={3}
           fontWeight={2}
         >
           New Profile
         </h2>
         <fieldset
-          className="sc-hMqMXs ZNPda"
+          className="sc-kEYyzF kTgrvy"
         >
           <div
-            className="sc-cSHVUG CAuLq sc-jzJRlG idGKfE"
+            className="sc-cSHVUG bubdaT sc-jzJRlG iplBh"
           >
             <label
               className="sc-fjdhpX iOYorM"
@@ -2322,12 +2356,12 @@ exports[`Storyshots Form With form sections without titles 1`] = `
               Name
             </label>
             <input
-              className="sc-kAzzGY cKRvcT"
+              className="sc-kAzzGY czbVBA"
               disabled={false}
             />
           </div>
           <div
-            className="sc-cSHVUG CAuLq sc-jzJRlG idGKfE"
+            className="sc-cSHVUG bubdaT sc-jzJRlG iplBh"
           >
             <label
               className="sc-fjdhpX iOYorM"
@@ -2359,12 +2393,12 @@ exports[`Storyshots Form With form sections without titles 1`] = `
               </p>
             </label>
             <input
-              className="sc-kAzzGY cKRvcT"
+              className="sc-kAzzGY czbVBA"
               disabled={false}
             />
           </div>
           <div
-            className="sc-cSHVUG CAuLq sc-jzJRlG idGKfE"
+            className="sc-cSHVUG bubdaT sc-jzJRlG iplBh"
           >
             <label
               className="sc-fjdhpX iOYorM"
@@ -2380,16 +2414,16 @@ exports[`Storyshots Form With form sections without titles 1`] = `
               </p>
             </label>
             <input
-              className="sc-kAzzGY cKRvcT"
+              className="sc-kAzzGY czbVBA"
               disabled={false}
             />
           </div>
         </fieldset>
         <fieldset
-          className="sc-hMqMXs ZNPda"
+          className="sc-kEYyzF kTgrvy"
         >
           <div
-            className="sc-cSHVUG CAuLq sc-jzJRlG idGKfE"
+            className="sc-cSHVUG bubdaT sc-jzJRlG iplBh"
           >
             <label
               className="sc-fjdhpX iOYorM"
@@ -2397,12 +2431,12 @@ exports[`Storyshots Form With form sections without titles 1`] = `
               Gender
             </label>
             <input
-              className="sc-kAzzGY cKRvcT"
+              className="sc-kAzzGY czbVBA"
               disabled={false}
             />
           </div>
           <div
-            className="sc-cSHVUG CAuLq sc-jzJRlG idGKfE"
+            className="sc-cSHVUG bubdaT sc-jzJRlG iplBh"
           >
             <label
               className="sc-fjdhpX iOYorM"
@@ -2410,7 +2444,7 @@ exports[`Storyshots Form With form sections without titles 1`] = `
               Ocupation
             </label>
             <input
-              className="sc-kAzzGY cKRvcT"
+              className="sc-kAzzGY czbVBA"
               disabled={false}
             />
           </div>
@@ -2438,15 +2472,15 @@ exports[`Storyshots Form Without title 1`] = `
       }
     >
       <form
-        className="sc-kEYyzF fAlhcv"
+        className="sc-kkGfuU SofoD"
       >
         <h2
-          className="sc-dxgOiQ eiXrvm"
+          className="sc-ckVGcZ lildcs"
           fontSize={3}
           fontWeight={2}
         />
         <div
-          className="sc-cSHVUG CAuLq sc-jzJRlG idGKfE"
+          className="sc-cSHVUG bubdaT sc-jzJRlG iplBh"
         >
           <label
             className="sc-fjdhpX iOYorM"
@@ -2454,12 +2488,12 @@ exports[`Storyshots Form Without title 1`] = `
             Name
           </label>
           <input
-            className="sc-kAzzGY cKRvcT"
+            className="sc-kAzzGY czbVBA"
             disabled={false}
           />
         </div>
         <div
-          className="sc-cSHVUG CAuLq sc-jzJRlG idGKfE"
+          className="sc-cSHVUG bubdaT sc-jzJRlG iplBh"
         >
           <label
             className="sc-fjdhpX iOYorM"
@@ -2491,12 +2525,12 @@ exports[`Storyshots Form Without title 1`] = `
             </p>
           </label>
           <input
-            className="sc-kAzzGY cKRvcT"
+            className="sc-kAzzGY czbVBA"
             disabled={false}
           />
         </div>
         <div
-          className="sc-cSHVUG CAuLq sc-jzJRlG idGKfE"
+          className="sc-cSHVUG bubdaT sc-jzJRlG iplBh"
         >
           <label
             className="sc-fjdhpX iOYorM"
@@ -2512,7 +2546,7 @@ exports[`Storyshots Form Without title 1`] = `
             </p>
           </label>
           <input
-            className="sc-kAzzGY cKRvcT"
+            className="sc-kAzzGY czbVBA"
             disabled={false}
           />
         </div>
@@ -2564,10 +2598,12 @@ exports[`Storyshots Header Validation Header Validation 1`] = `
           />
         </svg>
         <div
-          className="sc-jDwBTQ cJcuTw"
+          className="sc-gPEVay fDmLkl"
         >
           <h3
-            className="sc-ckVGcZ sc-jKJlTe cCtrgV"
+            className="sc-jKJlTe sc-eNQAEJ ftVvoK"
+            fontSize={2}
+            fontWeight={2}
           >
             Error has occured ...
           </h3>
@@ -2580,23 +2616,23 @@ exports[`Storyshots Header Validation Header Validation 1`] = `
             Instructions and description of an error
           </p>
           <ul
-            className="sc-kGXeez hoBFIe"
+            className="sc-kpOJdX hZppCQ"
             color="currentColor"
           >
             <li
-              className="sc-kgoBCf geSmhF"
+              className="sc-kGXeez fyDmEz"
               color="currentColor"
             >
               Affected field
             </li>
             <li
-              className="sc-kgoBCf geSmhF"
+              className="sc-kGXeez fyDmEz"
               color="currentColor"
             >
               Unmet criteria
             </li>
             <li
-              className="sc-kgoBCf geSmhF"
+              className="sc-kGXeez fyDmEz"
               color="currentColor"
             >
               <a
@@ -2655,10 +2691,12 @@ exports[`Storyshots Header Validation With message only 1`] = `
           />
         </svg>
         <div
-          className="sc-jDwBTQ cJcuTw"
+          className="sc-gPEVay fDmLkl"
         >
           <h3
-            className="sc-ckVGcZ sc-jKJlTe cCtrgV"
+            className="sc-jKJlTe sc-eNQAEJ ftVvoK"
+            fontSize={2}
+            fontWeight={2}
           >
             Error has occured ...
           </h3>
@@ -2694,7 +2732,7 @@ exports[`Storyshots Headings Section Title 1`] = `
       }
     >
       <h2
-        className="sc-dxgOiQ eiXrvm"
+        className="sc-ckVGcZ lildcs"
         fontSize={3}
         fontWeight={2}
       >
@@ -2722,7 +2760,9 @@ exports[`Storyshots Headings Subsection Title 1`] = `
       }
     >
       <h3
-        className="sc-ckVGcZ sc-jKJlTe faGspe"
+        className="sc-jKJlTe sc-eNQAEJ vwQnx"
+        fontSize={2}
+        fontWeight={2}
       >
         SubsectionTitle
       </h3>
@@ -2748,7 +2788,7 @@ exports[`Storyshots Headings Title 1`] = `
       }
     >
       <h1
-        className="sc-kpOJdX fAhtwp"
+        className="sc-dxgOiQ bFhixT"
         fontSize={4}
         fontWeight={0}
       >
@@ -2776,7 +2816,7 @@ exports[`Storyshots Headings With a custom margin 1`] = `
       }
     >
       <h1
-        className="sc-kpOJdX fAhtwp"
+        className="sc-dxgOiQ bFhixT"
         fontSize={4}
         fontWeight={0}
       >
@@ -8133,7 +8173,7 @@ exports[`Storyshots Inline Validation Inline Validation 1`] = `
       }
     >
       <div
-        className="sc-bwzfXH sc-chPdSV fogYWs"
+        className="sc-bwzfXH sc-chPdSV OPDIN"
         color="#cc1439"
       >
         <svg
@@ -8158,7 +8198,7 @@ exports[`Storyshots Inline Validation Inline Validation 1`] = `
           />
         </svg>
         <div
-          className="sc-bwzfXH crzhMj"
+          className="sc-kgoBCf jnnrjv"
         >
           <p
             className="sc-dnqmqq iUIAHX"
@@ -8192,7 +8232,7 @@ exports[`Storyshots Inline Validation With list items 1`] = `
       }
     >
       <div
-        className="sc-bwzfXH sc-chPdSV fogYWs"
+        className="sc-bwzfXH sc-chPdSV OPDIN"
         color="#cc1439"
       >
         <svg
@@ -8217,7 +8257,7 @@ exports[`Storyshots Inline Validation With list items 1`] = `
           />
         </svg>
         <div
-          className="sc-bwzfXH crzhMj"
+          className="sc-kgoBCf jnnrjv"
         >
           <p
             className="sc-dnqmqq iUIAHX"
@@ -8228,27 +8268,27 @@ exports[`Storyshots Inline Validation With list items 1`] = `
             Something has gone wrong
           </p>
           <ul
-            className="sc-kGXeez hoBFIe"
+            className="sc-kpOJdX hZppCQ"
             color="currentColor"
           >
             <li
-              className="sc-kgoBCf geSmhF"
+              className="sc-kGXeez fyDmEz"
               color="currentColor"
             >
               Something has gone wrong.
             </li>
             <li
-              className="sc-kgoBCf geSmhF"
+              className="sc-kGXeez fyDmEz"
               color="currentColor"
             >
               Entry must be atleast 3 characters long
             </li>
             <li
-              className="sc-kgoBCf geSmhF"
+              className="sc-kGXeez fyDmEz"
               color="currentColor"
             >
               <a
-                className="sc-kkGfuU iBuRRP"
+                className="sc-iAyFgw guCxJm"
                 color="blue"
                 href="https://nulogy.design/"
               >
@@ -8280,7 +8320,7 @@ exports[`Storyshots Input Input 1`] = `
       }
     >
       <input
-        className="sc-kAzzGY cKRvcT"
+        className="sc-kAzzGY czbVBA"
         disabled={false}
       />
     </div>
@@ -8305,7 +8345,7 @@ exports[`Storyshots Input Set to disabled 1`] = `
       }
     >
       <input
-        className="sc-kAzzGY icvraf"
+        className="sc-kAzzGY hNnQgG"
         disabled={true}
       />
     </div>
@@ -8330,7 +8370,7 @@ exports[`Storyshots Input Set to error 1`] = `
       }
     >
       <input
-        className="sc-kAzzGY iPtnDp"
+        className="sc-kAzzGY cyxhvs"
         disabled={false}
       />
     </div>
@@ -8355,7 +8395,7 @@ exports[`Storyshots Link Link 1`] = `
       }
     >
       <a
-        className="sc-kkGfuU iBuRRP"
+        className="sc-iAyFgw guCxJm"
         color="blue"
         href="http://nulogy.design"
       >
@@ -8383,7 +8423,7 @@ exports[`Storyshots Link With a different color 1`] = `
       }
     >
       <a
-        className="sc-kkGfuU gterGe"
+        className="sc-iAyFgw hesweU"
         color="black"
         href="http://nulogy.design"
       >
@@ -8411,7 +8451,7 @@ exports[`Storyshots Link Without underline 1`] = `
       }
     >
       <a
-        className="sc-kkGfuU breiWK"
+        className="sc-iAyFgw bwdJrY"
         color="blue"
         href="http://nulogy.design"
       >
@@ -8439,23 +8479,23 @@ exports[`Storyshots List List 1`] = `
       }
     >
       <ul
-        className="sc-kGXeez LsRfR"
+        className="sc-kpOJdX byPrxs"
         color="currentColor"
       >
         <li
-          className="sc-kgoBCf geSmhF"
+          className="sc-kGXeez fyDmEz"
           color="currentColor"
         >
           List Item 1
         </li>
         <li
-          className="sc-kgoBCf geSmhF"
+          className="sc-kGXeez fyDmEz"
           color="currentColor"
         >
           List Item 2 that is really really really really really really really really really long
         </li>
         <li
-          className="sc-kgoBCf geSmhF"
+          className="sc-kGXeez fyDmEz"
           color="currentColor"
         >
           List Item 3
@@ -8483,23 +8523,23 @@ exports[`Storyshots List With compact spacing 1`] = `
       }
     >
       <ul
-        className="sc-kGXeez hoBFIe"
+        className="sc-kpOJdX hZppCQ"
         color="currentColor"
       >
         <li
-          className="sc-kgoBCf geSmhF"
+          className="sc-kGXeez fyDmEz"
           color="currentColor"
         >
           List Item 1
         </li>
         <li
-          className="sc-kgoBCf geSmhF"
+          className="sc-kGXeez fyDmEz"
           color="currentColor"
         >
           List Item 2 that is really really really really really really really really really long
         </li>
         <li
-          className="sc-kgoBCf geSmhF"
+          className="sc-kGXeez fyDmEz"
           color="currentColor"
         >
           List Item 3
@@ -8527,23 +8567,23 @@ exports[`Storyshots List With custom colour 1`] = `
       }
     >
       <ul
-        className="sc-kGXeez jvOuxq"
+        className="sc-kpOJdX chsAtK"
         color="red"
       >
         <li
-          className="sc-kgoBCf geSmhF"
+          className="sc-kGXeez fyDmEz"
           color="currentColor"
         >
           List Item 1
         </li>
         <li
-          className="sc-kgoBCf geSmhF"
+          className="sc-kGXeez fyDmEz"
           color="currentColor"
         >
           List Item 2 that is really really really really really really really really really long
         </li>
         <li
-          className="sc-kgoBCf geSmhF"
+          className="sc-kGXeez fyDmEz"
           color="currentColor"
         >
           List Item 3
@@ -8571,24 +8611,24 @@ exports[`Storyshots List With custom font size and line height 1`] = `
       }
     >
       <ul
-        className="sc-kGXeez eSXRjC"
+        className="sc-kpOJdX eqfhwr"
         color="currentColor"
         fontSize={0}
       >
         <li
-          className="sc-kgoBCf geSmhF"
+          className="sc-kGXeez fyDmEz"
           color="currentColor"
         >
           List Item 1
         </li>
         <li
-          className="sc-kgoBCf geSmhF"
+          className="sc-kGXeez fyDmEz"
           color="currentColor"
         >
           List Item 2 that is really really really really really really really really really long
         </li>
         <li
-          className="sc-kgoBCf geSmhF"
+          className="sc-kGXeez fyDmEz"
           color="currentColor"
         >
           List Item 3
@@ -8616,44 +8656,44 @@ exports[`Storyshots Radio Controlled 1`] = `
       }
     >
       <div
-        className="sc-cvbbAY hckPSv sc-bwzfXH crzhMj"
+        className="sc-jWBwVP jtkSCv sc-bwzfXH crzhMj"
       >
         <label
-          className="sc-hSdWYo kjktNz"
+          className="sc-eHgmQL MYfsu"
           disabled={false}
         >
           <input
             checked={true}
-            className="sc-cvbbAY hckPSv sc-eHgmQL kjVntA"
+            className="sc-jWBwVP jtkSCv sc-cvbbAY fWgmSr"
             disabled={false}
             onChange={[Function]}
             type="radio"
           />
           <div
             checked={true}
-            className="sc-iAyFgw dKmPoj"
+            className="sc-hSdWYo cVfzpU"
             disabled={false}
           />
           I am controlled and checked
         </label>
       </div>
       <div
-        className="sc-cvbbAY hckPSv sc-bwzfXH crzhMj"
+        className="sc-jWBwVP jtkSCv sc-bwzfXH crzhMj"
       >
         <label
-          className="sc-hSdWYo kjktNz"
+          className="sc-eHgmQL MYfsu"
           disabled={false}
         >
           <input
             checked={false}
-            className="sc-cvbbAY hckPSv sc-eHgmQL kjVntA"
+            className="sc-jWBwVP jtkSCv sc-cvbbAY fWgmSr"
             disabled={false}
             onChange={[Function]}
             type="radio"
           />
           <div
             checked={false}
-            className="sc-iAyFgw dKmPoj"
+            className="sc-hSdWYo cVfzpU"
             disabled={false}
           />
           I am controlled and unchecked
@@ -8681,19 +8721,19 @@ exports[`Storyshots Radio Radio 1`] = `
       }
     >
       <div
-        className="sc-cvbbAY hckPSv sc-bwzfXH crzhMj"
+        className="sc-jWBwVP jtkSCv sc-bwzfXH crzhMj"
       >
         <label
-          className="sc-hSdWYo kjktNz"
+          className="sc-eHgmQL MYfsu"
           disabled={false}
         >
           <input
-            className="sc-cvbbAY hckPSv sc-eHgmQL kjVntA"
+            className="sc-jWBwVP jtkSCv sc-cvbbAY fWgmSr"
             disabled={false}
             type="radio"
           />
           <div
-            className="sc-iAyFgw dKmPoj"
+            className="sc-hSdWYo cVfzpU"
             disabled={false}
           />
           I am a radio button
@@ -8721,20 +8761,20 @@ exports[`Storyshots Radio Set to defaultChecked 1`] = `
       }
     >
       <div
-        className="sc-cvbbAY hckPSv sc-bwzfXH crzhMj"
+        className="sc-jWBwVP jtkSCv sc-bwzfXH crzhMj"
       >
         <label
-          className="sc-hSdWYo kjktNz"
+          className="sc-eHgmQL MYfsu"
           disabled={false}
         >
           <input
-            className="sc-cvbbAY hckPSv sc-eHgmQL kjVntA"
+            className="sc-jWBwVP jtkSCv sc-cvbbAY fWgmSr"
             defaultChecked={true}
             disabled={false}
             type="radio"
           />
           <div
-            className="sc-iAyFgw dKmPoj"
+            className="sc-hSdWYo cVfzpU"
             disabled={false}
           />
           I am checked by default
@@ -8762,40 +8802,40 @@ exports[`Storyshots Radio Set to disabled 1`] = `
       }
     >
       <div
-        className="sc-cvbbAY hckPSv sc-bwzfXH crzhMj"
+        className="sc-jWBwVP jtkSCv sc-bwzfXH crzhMj"
       >
         <label
-          className="sc-hSdWYo kOVuBP"
+          className="sc-eHgmQL iQMhnz"
           disabled={true}
         >
           <input
-            className="sc-cvbbAY hckPSv sc-eHgmQL kimcRa"
+            className="sc-jWBwVP jtkSCv sc-cvbbAY koHdYk"
             disabled={true}
             type="radio"
           />
           <div
-            className="sc-iAyFgw bWjNB"
+            className="sc-hSdWYo ezonno"
             disabled={true}
           />
           I am disabled
         </label>
       </div>
       <div
-        className="sc-cvbbAY hckPSv sc-bwzfXH crzhMj"
+        className="sc-jWBwVP jtkSCv sc-bwzfXH crzhMj"
       >
         <label
-          className="sc-hSdWYo kOVuBP"
+          className="sc-eHgmQL iQMhnz"
           disabled={true}
         >
           <input
             checked={true}
-            className="sc-cvbbAY hckPSv sc-eHgmQL kimcRa"
+            className="sc-jWBwVP jtkSCv sc-cvbbAY koHdYk"
             disabled={true}
             type="radio"
           />
           <div
             checked={true}
-            className="sc-iAyFgw bWjNB"
+            className="sc-hSdWYo ezonno"
             disabled={true}
           />
           I am disabled
@@ -8823,18 +8863,18 @@ exports[`Storyshots RadioGroup Controlled 1`] = `
       }
     >
       <div
-        className="sc-jWBwVP ebJHFF"
+        className="sc-brqgnP ygVYg"
       >
         <div
-          className="sc-cvbbAY hckPSv sc-bwzfXH crzhMj"
+          className="sc-jWBwVP jtkSCv sc-bwzfXH crzhMj"
         >
           <label
-            className="sc-hSdWYo kjktNz"
+            className="sc-eHgmQL MYfsu"
             disabled={false}
           >
             <input
               checked={true}
-              className="sc-cvbbAY hckPSv sc-eHgmQL kjVntA"
+              className="sc-jWBwVP jtkSCv sc-cvbbAY fWgmSr"
               disabled={false}
               name="settingSelection"
               onChange={[Function]}
@@ -8843,22 +8883,22 @@ exports[`Storyshots RadioGroup Controlled 1`] = `
             />
             <div
               checked={true}
-              className="sc-iAyFgw dKmPoj"
+              className="sc-hSdWYo cVfzpU"
               disabled={false}
             />
             Option A
           </label>
         </div>
         <div
-          className="sc-cvbbAY hckPSv sc-bwzfXH crzhMj"
+          className="sc-jWBwVP jtkSCv sc-bwzfXH crzhMj"
         >
           <label
-            className="sc-hSdWYo kjktNz"
+            className="sc-eHgmQL MYfsu"
             disabled={false}
           >
             <input
               checked={false}
-              className="sc-cvbbAY hckPSv sc-eHgmQL kjVntA"
+              className="sc-jWBwVP jtkSCv sc-cvbbAY fWgmSr"
               disabled={false}
               name="settingSelection"
               onChange={[Function]}
@@ -8867,22 +8907,22 @@ exports[`Storyshots RadioGroup Controlled 1`] = `
             />
             <div
               checked={false}
-              className="sc-iAyFgw dKmPoj"
+              className="sc-hSdWYo cVfzpU"
               disabled={false}
             />
             Option B
           </label>
         </div>
         <div
-          className="sc-cvbbAY hckPSv sc-bwzfXH crzhMj"
+          className="sc-jWBwVP jtkSCv sc-bwzfXH crzhMj"
         >
           <label
-            className="sc-hSdWYo kjktNz"
+            className="sc-eHgmQL MYfsu"
             disabled={false}
           >
             <input
               checked={false}
-              className="sc-cvbbAY hckPSv sc-eHgmQL kjVntA"
+              className="sc-jWBwVP jtkSCv sc-cvbbAY fWgmSr"
               disabled={false}
               name="settingSelection"
               onChange={[Function]}
@@ -8891,7 +8931,7 @@ exports[`Storyshots RadioGroup Controlled 1`] = `
             />
             <div
               checked={false}
-              className="sc-iAyFgw dKmPoj"
+              className="sc-hSdWYo cVfzpU"
               disabled={false}
             />
             Option C
@@ -8920,17 +8960,17 @@ exports[`Storyshots RadioGroup Radio Group 1`] = `
       }
     >
       <div
-        className="sc-jWBwVP ebJHFF"
+        className="sc-brqgnP ygVYg"
       >
         <div
-          className="sc-cvbbAY hckPSv sc-bwzfXH crzhMj"
+          className="sc-jWBwVP jtkSCv sc-bwzfXH crzhMj"
         >
           <label
-            className="sc-hSdWYo kjktNz"
+            className="sc-eHgmQL MYfsu"
             disabled={false}
           >
             <input
-              className="sc-cvbbAY hckPSv sc-eHgmQL kjVntA"
+              className="sc-jWBwVP jtkSCv sc-cvbbAY fWgmSr"
               defaultChecked={true}
               disabled={false}
               name="settingSelection"
@@ -8938,49 +8978,49 @@ exports[`Storyshots RadioGroup Radio Group 1`] = `
               value="a"
             />
             <div
-              className="sc-iAyFgw dKmPoj"
+              className="sc-hSdWYo cVfzpU"
               disabled={false}
             />
             Option A
           </label>
         </div>
         <div
-          className="sc-cvbbAY hckPSv sc-bwzfXH crzhMj"
+          className="sc-jWBwVP jtkSCv sc-bwzfXH crzhMj"
         >
           <label
-            className="sc-hSdWYo kjktNz"
+            className="sc-eHgmQL MYfsu"
             disabled={false}
           >
             <input
-              className="sc-cvbbAY hckPSv sc-eHgmQL kjVntA"
+              className="sc-jWBwVP jtkSCv sc-cvbbAY fWgmSr"
               disabled={false}
               name="settingSelection"
               type="radio"
               value="b"
             />
             <div
-              className="sc-iAyFgw dKmPoj"
+              className="sc-hSdWYo cVfzpU"
               disabled={false}
             />
             Option B
           </label>
         </div>
         <div
-          className="sc-cvbbAY hckPSv sc-bwzfXH crzhMj"
+          className="sc-jWBwVP jtkSCv sc-bwzfXH crzhMj"
         >
           <label
-            className="sc-hSdWYo kjktNz"
+            className="sc-eHgmQL MYfsu"
             disabled={false}
           >
             <input
-              className="sc-cvbbAY hckPSv sc-eHgmQL kjVntA"
+              className="sc-jWBwVP jtkSCv sc-cvbbAY fWgmSr"
               disabled={false}
               name="settingSelection"
               type="radio"
               value="c"
             />
             <div
-              className="sc-iAyFgw dKmPoj"
+              className="sc-hSdWYo cVfzpU"
               disabled={false}
             />
             Option C
@@ -9009,7 +9049,7 @@ exports[`Storyshots RadioGroup Radio Group Field 1`] = `
       }
     >
       <div
-        className="sc-cSHVUG CAuLq sc-jzJRlG idGKfE"
+        className="sc-cSHVUG bubdaT sc-jzJRlG iplBh"
       >
         <label
           className="sc-fjdhpX iOYorM"
@@ -9025,17 +9065,17 @@ exports[`Storyshots RadioGroup Radio Group Field 1`] = `
           </p>
         </label>
         <div
-          className="sc-jWBwVP ebJHFF"
+          className="sc-brqgnP ygVYg"
         >
           <div
-            className="sc-cvbbAY hckPSv sc-bwzfXH crzhMj"
+            className="sc-jWBwVP jtkSCv sc-bwzfXH crzhMj"
           >
             <label
-              className="sc-hSdWYo kjktNz"
+              className="sc-eHgmQL MYfsu"
               disabled={false}
             >
               <input
-                className="sc-cvbbAY hckPSv sc-eHgmQL kjVntA"
+                className="sc-jWBwVP jtkSCv sc-cvbbAY fWgmSr"
                 defaultChecked={true}
                 disabled={false}
                 name="settingSelection"
@@ -9043,49 +9083,49 @@ exports[`Storyshots RadioGroup Radio Group Field 1`] = `
                 value="a"
               />
               <div
-                className="sc-iAyFgw dKmPoj"
+                className="sc-hSdWYo cVfzpU"
                 disabled={false}
               />
               Option A
             </label>
           </div>
           <div
-            className="sc-cvbbAY hckPSv sc-bwzfXH crzhMj"
+            className="sc-jWBwVP jtkSCv sc-bwzfXH crzhMj"
           >
             <label
-              className="sc-hSdWYo kjktNz"
+              className="sc-eHgmQL MYfsu"
               disabled={false}
             >
               <input
-                className="sc-cvbbAY hckPSv sc-eHgmQL kjVntA"
+                className="sc-jWBwVP jtkSCv sc-cvbbAY fWgmSr"
                 disabled={false}
                 name="settingSelection"
                 type="radio"
                 value="b"
               />
               <div
-                className="sc-iAyFgw dKmPoj"
+                className="sc-hSdWYo cVfzpU"
                 disabled={false}
               />
               Option B
             </label>
           </div>
           <div
-            className="sc-cvbbAY hckPSv sc-bwzfXH crzhMj"
+            className="sc-jWBwVP jtkSCv sc-bwzfXH crzhMj"
           >
             <label
-              className="sc-hSdWYo kjktNz"
+              className="sc-eHgmQL MYfsu"
               disabled={false}
             >
               <input
-                className="sc-cvbbAY hckPSv sc-eHgmQL kjVntA"
+                className="sc-jWBwVP jtkSCv sc-cvbbAY fWgmSr"
                 disabled={false}
                 name="settingSelection"
                 type="radio"
                 value="c"
               />
               <div
-                className="sc-iAyFgw dKmPoj"
+                className="sc-hSdWYo cVfzpU"
                 disabled={false}
               />
               Option C
@@ -9115,17 +9155,17 @@ exports[`Storyshots RadioGroup Set to disabled 1`] = `
       }
     >
       <div
-        className="sc-jWBwVP ebJHFF"
+        className="sc-brqgnP ygVYg"
       >
         <div
-          className="sc-cvbbAY hckPSv sc-bwzfXH crzhMj"
+          className="sc-jWBwVP jtkSCv sc-bwzfXH crzhMj"
         >
           <label
-            className="sc-hSdWYo kOVuBP"
+            className="sc-eHgmQL iQMhnz"
             disabled={true}
           >
             <input
-              className="sc-cvbbAY hckPSv sc-eHgmQL kimcRa"
+              className="sc-jWBwVP jtkSCv sc-cvbbAY koHdYk"
               defaultChecked={true}
               disabled={true}
               name="settingSelection"
@@ -9133,49 +9173,49 @@ exports[`Storyshots RadioGroup Set to disabled 1`] = `
               value="a"
             />
             <div
-              className="sc-iAyFgw bWjNB"
+              className="sc-hSdWYo ezonno"
               disabled={true}
             />
             Option A
           </label>
         </div>
         <div
-          className="sc-cvbbAY hckPSv sc-bwzfXH crzhMj"
+          className="sc-jWBwVP jtkSCv sc-bwzfXH crzhMj"
         >
           <label
-            className="sc-hSdWYo kOVuBP"
+            className="sc-eHgmQL iQMhnz"
             disabled={true}
           >
             <input
-              className="sc-cvbbAY hckPSv sc-eHgmQL kimcRa"
+              className="sc-jWBwVP jtkSCv sc-cvbbAY koHdYk"
               disabled={true}
               name="settingSelection"
               type="radio"
               value="b"
             />
             <div
-              className="sc-iAyFgw bWjNB"
+              className="sc-hSdWYo ezonno"
               disabled={true}
             />
             Option B
           </label>
         </div>
         <div
-          className="sc-cvbbAY hckPSv sc-bwzfXH crzhMj"
+          className="sc-jWBwVP jtkSCv sc-bwzfXH crzhMj"
         >
           <label
-            className="sc-hSdWYo kOVuBP"
+            className="sc-eHgmQL iQMhnz"
             disabled={true}
           >
             <input
-              className="sc-cvbbAY hckPSv sc-eHgmQL kimcRa"
+              className="sc-jWBwVP jtkSCv sc-cvbbAY koHdYk"
               disabled={true}
               name="settingSelection"
               type="radio"
               value="c"
             />
             <div
-              className="sc-iAyFgw bWjNB"
+              className="sc-hSdWYo ezonno"
               disabled={true}
             />
             Option C
@@ -9368,11 +9408,11 @@ exports[`Storyshots Toggle Controlled Toggle 1`] = `
         className="sc-bwzfXH sc-chPdSV gylzpL"
       >
         <label
-          className="sc-cMljjf farnmW"
+          className="sc-jAaTju iXytCD"
         >
           <input
             checked={true}
-            className="sc-jAaTju gkslhI"
+            className="sc-jDwBTQ lpdiWL"
             disabled={false}
             id={null}
             onChange={[Function]}
@@ -9381,7 +9421,7 @@ exports[`Storyshots Toggle Controlled Toggle 1`] = `
             value="on"
           />
           <span
-            className="sc-brqgnP NLaGk"
+            className="sc-cMljjf iSJmXJ"
             disabled={false}
           />
         </label>
@@ -9398,11 +9438,11 @@ exports[`Storyshots Toggle Controlled Toggle 1`] = `
         className="sc-bwzfXH sc-chPdSV gylzpL"
       >
         <label
-          className="sc-cMljjf farnmW"
+          className="sc-jAaTju iXytCD"
         >
           <input
             checked={false}
-            className="sc-jAaTju gkslhI"
+            className="sc-jDwBTQ lpdiWL"
             disabled={false}
             id={null}
             onChange={[Function]}
@@ -9411,7 +9451,7 @@ exports[`Storyshots Toggle Controlled Toggle 1`] = `
             value="on"
           />
           <span
-            className="sc-brqgnP NLaGk"
+            className="sc-cMljjf iSJmXJ"
             disabled={false}
           />
         </label>
@@ -9446,15 +9486,15 @@ exports[`Storyshots Toggle Toggle 1`] = `
       }
     >
       <label
-        className="sc-cMljjf farnmW"
+        className="sc-jAaTju iXytCD"
       >
         <input
-          className="sc-jAaTju gkslhI"
+          className="sc-jDwBTQ lpdiWL"
           disabled={false}
           type="checkbox"
         />
         <span
-          className="sc-brqgnP NLaGk"
+          className="sc-cMljjf iSJmXJ"
           disabled={false}
         />
       </label>
@@ -9480,7 +9520,7 @@ exports[`Storyshots Toggle Toggle Field 1`] = `
       }
     >
       <div
-        className="sc-cSHVUG CAuLq sc-jzJRlG idGKfE"
+        className="sc-cSHVUG bubdaT sc-jzJRlG iplBh"
       >
         <label
           className="sc-fjdhpX iOYorM"
@@ -9499,11 +9539,11 @@ exports[`Storyshots Toggle Toggle Field 1`] = `
           className="sc-bwzfXH sc-chPdSV gylzpL"
         >
           <label
-            className="sc-cMljjf farnmW"
+            className="sc-jAaTju iXytCD"
           >
             <input
               checked={false}
-              className="sc-jAaTju gkslhI"
+              className="sc-jDwBTQ lpdiWL"
               disabled={false}
               id={null}
               onChange={[Function]}
@@ -9512,7 +9552,7 @@ exports[`Storyshots Toggle Toggle Field 1`] = `
               value="on"
             />
             <span
-              className="sc-brqgnP NLaGk"
+              className="sc-cMljjf iSJmXJ"
               disabled={false}
             />
           </label>
@@ -9548,16 +9588,16 @@ exports[`Storyshots Toggle Toggle set to defaultToggled 1`] = `
       }
     >
       <label
-        className="sc-cMljjf farnmW"
+        className="sc-jAaTju iXytCD"
       >
         <input
-          className="sc-jAaTju gkslhI"
+          className="sc-jDwBTQ lpdiWL"
           defaultChecked={true}
           disabled={false}
           type="checkbox"
         />
         <span
-          className="sc-brqgnP NLaGk"
+          className="sc-cMljjf iSJmXJ"
           disabled={false}
         />
       </label>
@@ -9583,29 +9623,29 @@ exports[`Storyshots Toggle Toggle set to disabled 1`] = `
       }
     >
       <label
-        className="sc-cMljjf farnmW"
+        className="sc-jAaTju iXytCD"
       >
         <input
-          className="sc-jAaTju jqLXaY"
+          className="sc-jDwBTQ coQDkl"
           disabled={true}
           type="checkbox"
         />
         <span
-          className="sc-brqgnP fYTmUY"
+          className="sc-cMljjf jQFZvP"
           disabled={true}
         />
       </label>
       <label
-        className="sc-cMljjf farnmW"
+        className="sc-jAaTju iXytCD"
       >
         <input
-          className="sc-jAaTju jqLXaY"
+          className="sc-jDwBTQ coQDkl"
           defaultChecked={true}
           disabled={true}
           type="checkbox"
         />
         <span
-          className="sc-brqgnP fYTmUY"
+          className="sc-cMljjf jQFZvP"
           disabled={true}
         />
       </label>
@@ -9634,11 +9674,11 @@ exports[`Storyshots Toggle With text 1`] = `
         className="sc-bwzfXH sc-chPdSV gylzpL"
       >
         <label
-          className="sc-cMljjf farnmW"
+          className="sc-jAaTju iXytCD"
         >
           <input
             checked={false}
-            className="sc-jAaTju gkslhI"
+            className="sc-jDwBTQ lpdiWL"
             disabled={false}
             id={null}
             onChange={[Function]}
@@ -9647,7 +9687,7 @@ exports[`Storyshots Toggle With text 1`] = `
             value="on"
           />
           <span
-            className="sc-brqgnP NLaGk"
+            className="sc-cMljjf iSJmXJ"
             disabled={false}
           />
         </label>
@@ -9682,14 +9722,14 @@ exports[`Storyshots Typography Article 1`] = `
       }
     >
       <h1
-        className="sc-kpOJdX fAhtwp"
+        className="sc-dxgOiQ bFhixT"
         fontSize={4}
         fontWeight={0}
       >
         Nunc vitae nisl vestibulum vitae nisl vestibulum vitae nisl vestibulum
       </h1>
       <h2
-        className="sc-dxgOiQ eiXrvm"
+        className="sc-ckVGcZ lildcs"
         fontSize={3}
         fontWeight={2}
       >
@@ -9704,7 +9744,9 @@ exports[`Storyshots Typography Article 1`] = `
         Nunc tempor eget mauris id facilisis. Morbi convallis mauris at fermentum gravida. Nunc lacinia a odio eu rutrum. Etiam in libero vestibulum, lobortis mi fermentum, pharetra lacus. Aliquam commodo molestie dolor, vel tristique orci efficitur eu. Nullam eleifend malesuada. Nam luctus blandit dignissim. Mauris eu odio tristique, lorem quis, lobortis nulla. Interdum et malesuada fames ac ante ipsum primis in faucibus. Nunc quis lacus felis. Ut convallis rhoncus orci. Maecenas sit amet leo dui. Integer semper porta dignissim.
       </p>
       <h3
-        className="sc-ckVGcZ sc-jKJlTe faGspe"
+        className="sc-jKJlTe sc-eNQAEJ vwQnx"
+        fontSize={2}
+        fontWeight={2}
       >
         Long Titile that Hopefully wraps. Maybe now? How About Now? Now? Now? Now? Now? Now? Now?
       </h3>
@@ -9717,14 +9759,16 @@ exports[`Storyshots Typography Article 1`] = `
         Porttitor urna sit amet, congue nulla. Etiam in posuere nibh. Nam pellentesque, lacus id elementum posuere, neque purus ullamcorper nunc, consequat mi velit eget mi. Duis ipsum augue, pulvinar ullamcorper fringilla in, dignissim congue velit.
       </p>
       <h2
-        className="sc-dxgOiQ eiXrvm"
+        className="sc-ckVGcZ lildcs"
         fontSize={3}
         fontWeight={2}
       >
         Donec leo felis
       </h2>
       <h3
-        className="sc-ckVGcZ sc-jKJlTe faGspe"
+        className="sc-jKJlTe sc-eNQAEJ vwQnx"
+        fontSize={2}
+        fontWeight={2}
       >
         Two pargraphs and moderatly long title
       </h3>
@@ -9737,7 +9781,9 @@ exports[`Storyshots Typography Article 1`] = `
         Nunc tempor eget mauris id facilisis. Morbi convallis mauris at fermentum gravida. Nunc lacinia a odio eu rutrum. Etiam in libero vestibulum, lobortis mi fermentum, pharetra lacus. Aliquam commodo molestie dolor, vel tristique orci efficitur eu. Nullam eleifend malesuada. Nam luctus blandit dignissim. Mauris eu odio tristique, lorem quis, lobortis nulla. Interdum et malesuada fames ac ante ipsum primis in faucibus. Nunc quis lacus felis. Ut convallis rhoncus orci. Maecenas sit amet leo dui. Integer semper porta dignissim.
       </p>
       <h3
-        className="sc-ckVGcZ sc-jKJlTe faGspe"
+        className="sc-jKJlTe sc-eNQAEJ vwQnx"
+        fontSize={2}
+        fontWeight={2}
       >
         Two pargraphs with List
       </h3>
@@ -9750,23 +9796,23 @@ exports[`Storyshots Typography Article 1`] = `
         Nunc tempor eget mauris id facilisis. Morbi convallis mauris at fermentum gravida. Nunc lacinia a odio eu rutrum. Etiam in libero vestibulum, lobortis mi fermentum, pharetra lacus. Aliquam commodo molestie dolor, vel tristique orci efficitur eu. Nullam eleifend malesuada. Nam luctus blandit dignissim. Mauris eu odio tristique, lorem quis, lobortis nulla. Interdum et malesuada fames ac ante ipsum primis in faucibus. Nunc quis lacus felis. Ut convallis rhoncus orci. Maecenas sit amet leo dui. Integer semper porta dignissim.
       </p>
       <ul
-        className="sc-kGXeez LsRfR"
+        className="sc-kpOJdX byPrxs"
         color="currentColor"
       >
         <li
-          className="sc-kgoBCf geSmhF"
+          className="sc-kGXeez fyDmEz"
           color="currentColor"
         >
           List Item 1
         </li>
         <li
-          className="sc-kgoBCf geSmhF"
+          className="sc-kGXeez fyDmEz"
           color="currentColor"
         >
           List Item 2 that is really really really really really really really really really long
         </li>
         <li
-          className="sc-kgoBCf geSmhF"
+          className="sc-kGXeez fyDmEz"
           color="currentColor"
         >
           List Item 3
@@ -9789,7 +9835,9 @@ exports[`Storyshots Typography Article 1`] = `
         Nunc id arcu sagittis, volutpat sit amet, accumsan diam. Pellentesque luctus, nulla a ornare semper, dui mollis nisi, vel lacinia neque velit eget sapien. Etiam sodales dolor, vel dictum libero cursus ac. Nam vulputate tempor mauris vel. Nam tristique metus et dignissim pretium. Aliquam erat volutpat.
       </p>
       <h3
-        className="sc-ckVGcZ sc-jKJlTe faGspe"
+        className="sc-jKJlTe sc-eNQAEJ vwQnx"
+        fontSize={2}
+        fontWeight={2}
       >
         This is small text (14px) with medium(default) line height (24px).
       </h3>
@@ -9802,7 +9850,9 @@ exports[`Storyshots Typography Article 1`] = `
         Porttitor urna sit amet, congue nulla. Etiam in posuere nibh. Nam pellentesque, lacus id elementum posuere, neque purus ullamcorper nunc, consequat mi velit eget mi. Duis ipsum augue, pulvinar ullamcorper fringilla in, dignissim congue velit. Nunc id arcu sagittis, volutpat sit amet, accumsan diam. Pellentesque luctus, nulla a ornare semper, dui mollis nisi, vel lacinia neque velit eget sapien. Etiam sodales dolor, vel dictum libero cursus ac. Nam vulputate tempor mauris vel. Nam tristique metus et dignissim pretium. Aliquam erat volutpat.
       </p>
       <h3
-        className="sc-ckVGcZ sc-jKJlTe faGspe"
+        className="sc-jKJlTe sc-eNQAEJ vwQnx"
+        fontSize={2}
+        fontWeight={2}
       >
         This is small text (14px) with small line height (16px). Reserved for buttons, inputs ...
       </h3>

--- a/components/src/Field/Field.js
+++ b/components/src/Field/Field.js
@@ -6,6 +6,7 @@ import theme from "../theme";
 import RequirementText from "./RequirementText";
 import HelpText from "./HelpText";
 import FormatText from "./FormatText";
+import Input from "../Input/Input"
 
 const Label = styled.label`
   font-size: ${theme.fontSizes[1]};
@@ -15,6 +16,12 @@ const Label = styled.label`
 
 const FieldWrapper = styled.div`
   ${space}
+  > * {
+    margin-bottom: ${theme.space[2]};
+  }
+  > *:last-child {
+  margin-bottom: 0;
+  }
 `;
 
 FieldWrapper.propTypes = {
@@ -62,6 +69,7 @@ BaseField.defaultProps = {
   formatText: null,
 };
 
-const Field = styled(BaseField)``;
+const Field = styled(BaseField)`
+`;
 
 export default Field;

--- a/components/src/Field/Field.js
+++ b/components/src/Field/Field.js
@@ -6,7 +6,6 @@ import theme from "../theme";
 import RequirementText from "./RequirementText";
 import HelpText from "./HelpText";
 import FormatText from "./FormatText";
-import Input from "../Input/Input"
 
 const Label = styled.label`
   font-size: ${theme.fontSizes[1]};

--- a/components/src/Field/Field.story.js
+++ b/components/src/Field/Field.story.js
@@ -10,6 +10,11 @@ storiesOf("Field", module)
   .add("Field", () => (
     <Field labelText="Default label" />
   ))
+  .add("With Input", () => (
+    <Field labelText="Default label">
+      <Input />
+    </Field>
+  ))
   .add("With Input and InlineValidation", () => (
     <Field labelText="Default label">
       <Input />

--- a/components/src/Input/Input.js
+++ b/components/src/Input/Input.js
@@ -58,7 +58,6 @@ Input.propTypes = {
 Input.defaultProps = {
   disabled: false,
   error: false,
-  mb: 2,
 };
 
 export default Input;

--- a/components/src/Type/Headings.js
+++ b/components/src/Type/Headings.js
@@ -27,13 +27,13 @@ SectionTitle.defaultProps = {
 const SubsectionTitleBase = Text.withComponent("h3");
 
 const SubsectionTitle = styled(SubsectionTitleBase)`
-  margin: 0;
-  font-size: ${theme.fontSizes[2]};
-  font-weight: ${theme.fontWeights[2]};
-  line-height: ${theme.lineHeights.subsectionTitle};
 `;
 
 SubsectionTitle.defaultProps = {
+  m: 0,
+  fontSize: 2,
+  fontWeight: 2,
+  lineHeight: theme.lineHeights.sectionTitle,
   mb: 2,
   theme,
 };

--- a/components/src/Validation/InlineValidation.js
+++ b/components/src/Validation/InlineValidation.js
@@ -1,22 +1,31 @@
 import React from "react";
 import PropTypes from "prop-types";
+import styled from "styled-components";
 import theme from "../theme";
 import Text from "../Type/Text";
 import Icon from "../Icon/Icon";
 import Flex from "../Flex/Flex";
-import Box from "../Box/Box";
+
+const Wrapper = styled.div`
+  ${Text} {
+    margin-bottom: ${theme.space[2]};
+  }
+  > *:last-child {
+   margin-bottom: 0;
+ }
+`;
 
 const InlineValidation = ({
   message,
   children,
   ...boxProps
 }) => (
-  <Flex color={ theme.colors.red } mb={ 2 } { ...boxProps }>
+  <Flex color={ theme.colors.red } { ...boxProps }>
     <Icon icon="error" mr={ 2 } />
-    <Box>
+    <Wrapper>
       <Text mb={ 0 }>{message}</Text>
       {children}
-    </Box>
+    </Wrapper>
   </Flex>
 );
 


### PR DESCRIPTION
Intent: review to merge

This changes the styling on Field and input to make it so that Input type components and inline validation passed into Field will have margins handled by Field. Atomic components should not apply their own margins.