### PR TITLE
Nds 583 rename toggle components 

### DIFF
--- a/components/spec/__snapshots__/Storyshots.spec.js.snap
+++ b/components/spec/__snapshots__/Storyshots.spec.js.snap
@@ -9485,19 +9485,34 @@ exports[`Storyshots Toggle Toggle 1`] = `
         }
       }
     >
-      <label
-        className="sc-jAaTju iXytCD"
+      <div
+        className="sc-bwzfXH sc-chPdSV gylzpL"
       >
-        <input
-          className="sc-jDwBTQ lpdiWL"
-          disabled={false}
-          type="checkbox"
+        <label
+          className="sc-jAaTju iXytCD"
+        >
+          <input
+            checked={false}
+            className="sc-jDwBTQ lpdiWL"
+            disabled={false}
+            id={null}
+            onChange={[Function]}
+            onClick={[Function]}
+            type="checkbox"
+            value="on"
+          />
+          <span
+            className="sc-cMljjf iSJmXJ"
+            disabled={false}
+          />
+        </label>
+        <p
+          className="sc-dnqmqq bPGUUg"
+          color="currentColor"
+          display="block"
+          fontSize={1}
         />
-        <span
-          className="sc-cMljjf iSJmXJ"
-          disabled={false}
-        />
-      </label>
+      </div>
     </div>
   </div>
 </div>
@@ -9587,20 +9602,34 @@ exports[`Storyshots Toggle Toggle set to defaultToggled 1`] = `
         }
       }
     >
-      <label
-        className="sc-jAaTju iXytCD"
+      <div
+        className="sc-bwzfXH sc-chPdSV gylzpL"
       >
-        <input
-          className="sc-jDwBTQ lpdiWL"
-          defaultChecked={true}
-          disabled={false}
-          type="checkbox"
+        <label
+          className="sc-jAaTju iXytCD"
+        >
+          <input
+            checked={true}
+            className="sc-jDwBTQ lpdiWL"
+            disabled={false}
+            id={null}
+            onChange={[Function]}
+            onClick={[Function]}
+            type="checkbox"
+            value="on"
+          />
+          <span
+            className="sc-cMljjf iSJmXJ"
+            disabled={false}
+          />
+        </label>
+        <p
+          className="sc-dnqmqq bPGUUg"
+          color="currentColor"
+          display="block"
+          fontSize={1}
         />
-        <span
-          className="sc-cMljjf iSJmXJ"
-          disabled={false}
-        />
-      </label>
+      </div>
     </div>
   </div>
 </div>
@@ -9622,33 +9651,62 @@ exports[`Storyshots Toggle Toggle set to disabled 1`] = `
         }
       }
     >
-      <label
-        className="sc-jAaTju iXytCD"
+      <div
+        className="sc-bwzfXH sc-chPdSV gylzpL"
       >
-        <input
-          className="sc-jDwBTQ coQDkl"
-          disabled={true}
-          type="checkbox"
+        <label
+          className="sc-jAaTju iXytCD"
+        >
+          <input
+            checked={false}
+            className="sc-jDwBTQ coQDkl"
+            disabled={true}
+            id={null}
+            onChange={[Function]}
+            onClick={[Function]}
+            type="checkbox"
+            value="on"
+          />
+          <span
+            className="sc-cMljjf jQFZvP"
+            disabled={true}
+          />
+        </label>
+        <p
+          className="sc-dnqmqq bPGUUg"
+          color="currentColor"
+          display="block"
+          fontSize={1}
         />
-        <span
-          className="sc-cMljjf jQFZvP"
-          disabled={true}
-        />
-      </label>
-      <label
-        className="sc-jAaTju iXytCD"
+      </div>
+      <div
+        className="sc-bwzfXH sc-chPdSV gylzpL"
       >
-        <input
-          className="sc-jDwBTQ coQDkl"
-          defaultChecked={true}
-          disabled={true}
-          type="checkbox"
+        <label
+          className="sc-jAaTju iXytCD"
+        >
+          <input
+            checked={true}
+            className="sc-jDwBTQ coQDkl"
+            disabled={true}
+            id={null}
+            onChange={[Function]}
+            onClick={[Function]}
+            type="checkbox"
+            value="on"
+          />
+          <span
+            className="sc-cMljjf jQFZvP"
+            disabled={true}
+          />
+        </label>
+        <p
+          className="sc-dnqmqq bPGUUg"
+          color="currentColor"
+          display="block"
+          fontSize={1}
         />
-        <span
-          className="sc-cMljjf jQFZvP"
-          disabled={true}
-        />
-      </label>
+      </div>
     </div>
   </div>
 </div>

--- a/components/src/Toggle/Toggle.js
+++ b/components/src/Toggle/Toggle.js
@@ -58,7 +58,7 @@ const ToggleInput = styled.input`
   }
 `;
 
-export const Toggle = props => {
+export const ToggleButton = props => {
   const {
     disabled,
     defaultToggled,
@@ -75,17 +75,17 @@ export const Toggle = props => {
   );
 };
 
-Toggle.propTypes = {
+ToggleButton.propTypes = {
   defaultToggled: PropTypes.bool,
   disabled: PropTypes.bool,
 };
 
-Toggle.defaultProps = {
+ToggleButton.defaultProps = {
   defaultToggled: undefined,
   disabled: false,
 };
 
-class ToggleWithText extends React.Component {
+class Toggle extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -116,7 +116,7 @@ class ToggleWithText extends React.Component {
     } = this.state;
     return (
       <Flex flexDirection="row" alignItems="center">
-        <Toggle
+        <ToggleButton
           checked={ toggled } onChange={ onChange } disabled={ disabled }
           onClick={ e => { this.handleClick(e); } }
           { ...props }
@@ -129,7 +129,7 @@ class ToggleWithText extends React.Component {
   }
 }
 
-ToggleWithText.propTypes = {
+Toggle.propTypes = {
   onChange: PropTypes.func,
   toggled: PropTypes.bool,
   defaultToggled: PropTypes.bool,
@@ -140,7 +140,7 @@ ToggleWithText.propTypes = {
   value: PropTypes.string,
 };
 
-ToggleWithText.defaultProps = {
+Toggle.defaultProps = {
   onChange: () => {},
   toggled: undefined,
   defaultToggled: undefined,
@@ -151,4 +151,4 @@ ToggleWithText.defaultProps = {
   id: null,
 };
 
-export default ToggleWithText;
+export default Toggle;

--- a/components/src/Toggle/Toggle.js
+++ b/components/src/Toggle/Toggle.js
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import Text from "../Type/Text";
 import theme from "../theme";
 import Flex from "../Flex/Flex";
+import { omit } from "../utils";
 
 const getFill = disabled => (disabled ? theme.colors.grey : theme.colors.darkBlue);
 
@@ -110,7 +111,7 @@ class Toggle extends React.Component {
       onText,
       offText,
       ...props
-    } = this.props;
+    } = omit(this.props, "defaultToggled");
     const {
       toggled,
     } = this.state;

--- a/components/src/Toggle/Toggle.story.js
+++ b/components/src/Toggle/Toggle.story.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import Toggle, { ToggleButton } from "./Toggle";
+import Toggle from "./Toggle";
 import Field from "../Field/Field";
 
 storiesOf("Toggle", module)

--- a/components/src/Toggle/Toggle.story.js
+++ b/components/src/Toggle/Toggle.story.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import ToggleWithText, { Toggle } from "./Toggle";
+import Toggle, { ToggleButton } from "./Toggle";
 import Field from "../Field/Field";
 
 storiesOf("Toggle", module)
@@ -11,13 +11,13 @@ storiesOf("Toggle", module)
     <Toggle defaultToggled />
   ))
   .add("Toggle set to disabled", () => (
-    <React.Fragment>
+    <>
       <Toggle disabled />
       <Toggle defaultToggled disabled />
-    </React.Fragment>
+    </>
   ))
   .add("With text", () => (
-    <ToggleWithText
+    <Toggle
       onText="on"
       offText="off"
     />
@@ -27,23 +27,23 @@ storiesOf("Toggle", module)
       labelText="Setting"
       helpText="Turns setting on/off"
     >
-      <ToggleWithText
+      <Toggle
         onText="on"
         offText="off"
       />
     </Field>
   ))
   .add("Controlled Toggle", () => (
-    <React.Fragment>
-      <ToggleWithText
+    <>
+      <Toggle
         toggled
         onText="on"
         offText="off"
       />
-      <ToggleWithText
+      <Toggle
         toggled={ false }
         onText="on"
         offText="off"
       />
-    </React.Fragment>
+    </>
   ));

--- a/components/src/utils.js
+++ b/components/src/utils.js
@@ -1,23 +1,10 @@
-
-export function getTextWidth(text, font) {
-  const canvas = getTextWidth.canvas || (getTextWidth.canvas = document.createElement("canvas"));
-  const context = canvas.getContext("2d");
-  context.font = font;
-  const metrics = context.measureText(text);
-  return metrics.width;
-}
-
-export const addPx = (val1, val2) => {
-  const val2Str = !val2 ? "1px" : `${val2}`;
-  return (`${parseInt(val1.replace("px", ""), 10) + parseInt(val2Str.replace("px", ""), 10)}px`);
+export const omit = (obj, prop) => {
+  const res = Object.assign({}, obj);
+  delete res[prop];
+  return res;
 };
 
 export const subPx = (val1, val2) => {
   const val2Str = !val2 ? "1px" : `${val2}`;
   return (`${parseInt(val1.replace("px", ""), 10) - parseInt(val2Str.replace("px", ""), 10)}px`);
-};
-
-export const multPx = (val1, val2) => {
-  const val2Str = !val2 ? "1px" : `${val2}`;
-  return (`${Math.round(parseFloat(val1.replace("px", "")) * parseFloat(val2Str.replace("px", "")))}px`);
 };


### PR DESCRIPTION
Intent: review to merge

Branch renames the Toggle components:
Toggle -> ToggleButton
ToggleWithText -> Toggle
This was done as the old "ToggleWithText" is actually the main toggle we want people to use, so it should hold the base name "Toggle".

In this branch I also cleaned out the utils.js file, and added a function "omit" that mirrors the behaviour of the lodash omit function