### PR TITLE
NDS-579 Border-box for buttons

### DIFF
--- a/components/spec/__snapshots__/Storyshots.spec.js.snap
+++ b/components/spec/__snapshots__/Storyshots.spec.js.snap
@@ -303,7 +303,7 @@ exports[`Storyshots Buttons As a link 1`] = `
       }
     >
       <a
-        className="sc-EHOje sc-bZQynM kAIjfD"
+        className="sc-EHOje sc-bZQynM chlmYJ"
         href="/"
       >
         Create project

--- a/components/spec/__snapshots__/Storyshots.spec.js.snap
+++ b/components/spec/__snapshots__/Storyshots.spec.js.snap
@@ -303,7 +303,7 @@ exports[`Storyshots Buttons Button 1`] = `
       }
     >
       <button
-        className="sc-EHOje gjVgLK"
+        className="sc-EHOje eoyXkx"
         theme={
           Object {
             "borders": Array [],
@@ -398,7 +398,7 @@ exports[`Storyshots Buttons DangerButton 1`] = `
       }
     >
       <button
-        className="sc-EHOje sc-gzVnrw bcbnxu"
+        className="sc-EHOje sc-gzVnrw htXgkC"
         theme={
           Object {
             "borders": Array [],
@@ -493,7 +493,7 @@ exports[`Storyshots Buttons PrimaryButton 1`] = `
       }
     >
       <button
-        className="sc-EHOje sc-bZQynM kAIjfD"
+        className="sc-EHOje sc-bZQynM chlmYJ"
         theme={
           Object {
             "borders": Array [],
@@ -588,7 +588,7 @@ exports[`Storyshots Buttons QuietButton 1`] = `
       }
     >
       <button
-        className="sc-EHOje sc-htoDjs frsftw"
+        className="sc-EHOje sc-htoDjs dhIkJJ"
         theme={
           Object {
             "borders": Array [],
@@ -683,7 +683,7 @@ exports[`Storyshots Buttons Set to disabled 1`] = `
       }
     >
       <button
-        className="sc-EHOje sc-bZQynM gSApCy"
+        className="sc-EHOje sc-bZQynM cGIeBD"
         disabled={true}
         theme={
           Object {
@@ -779,7 +779,7 @@ exports[`Storyshots Buttons Set to full width 1`] = `
       }
     >
       <button
-        className="sc-EHOje sc-bZQynM gviJDf"
+        className="sc-EHOje sc-bZQynM epDHnL"
         fullWidth={true}
         theme={
           Object {
@@ -875,7 +875,7 @@ exports[`Storyshots Buttons With a selected Icon 1`] = `
       }
     >
       <button
-        className="sc-EHOje gjVgLK"
+        className="sc-EHOje eoyXkx"
         theme={
           Object {
             "borders": Array [],
@@ -970,7 +970,7 @@ exports[`Storyshots Buttons With a selected Icon 1`] = `
         Create project
       </button>
       <button
-        className="sc-EHOje gjVgLK"
+        className="sc-EHOje eoyXkx"
         theme={
           Object {
             "borders": Array [],
@@ -1086,7 +1086,7 @@ exports[`Storyshots Buttons With a selected size 1`] = `
       }
     >
       <button
-        className="sc-EHOje bFkiiR"
+        className="sc-EHOje ekJmCy"
         size="small"
         theme={
           Object {
@@ -1161,7 +1161,7 @@ exports[`Storyshots Buttons With a selected size 1`] = `
         Create project
       </button>
       <button
-        className="sc-EHOje gjVgLK"
+        className="sc-EHOje eoyXkx"
         size="medium"
         theme={
           Object {
@@ -1236,7 +1236,7 @@ exports[`Storyshots Buttons With a selected size 1`] = `
         Create project
       </button>
       <button
-        className="sc-EHOje iFcZkf"
+        className="sc-EHOje aqYDZ"
         size="large"
         theme={
           Object {
@@ -8629,7 +8629,7 @@ exports[`Storyshots IconicButton Disabled 1`] = `
       }
     >
       <button
-        className="sc-iwsKbI gmeZXv"
+        className="sc-iwsKbI dpRAek"
         disabled={true}
         label="Cancel"
       >
@@ -8664,7 +8664,7 @@ exports[`Storyshots IconicButton Disabled 1`] = `
         </p>
       </button>
       <button
-        className="sc-iwsKbI gmeZXv"
+        className="sc-iwsKbI dpRAek"
         disabled={true}
         label="Lock"
       >
@@ -8720,7 +8720,7 @@ exports[`Storyshots IconicButton With a long label 1`] = `
       }
     >
       <button
-        className="sc-iwsKbI fBcxSJ"
+        className="sc-iwsKbI defWWS"
         disabled={false}
         label="I am an Iconic Button with a really really really long label"
       >
@@ -8776,7 +8776,7 @@ exports[`Storyshots IconicButton With label 1`] = `
       }
     >
       <button
-        className="sc-iwsKbI fBcxSJ"
+        className="sc-iwsKbI defWWS"
         disabled={false}
         label="Delete"
       >

--- a/components/src/Button/Button.js
+++ b/components/src/Button/Button.js
@@ -76,9 +76,7 @@ const Button = styled(BaseButton)`
     display: inline-flex;
     justify-content: center;
     align-items: center;
-    -webkit-font-smoothing: antialiased;
     font-weight: ${props => props.theme.fontWeights[2]};
-    border: 0;
     text-decoration: none;
     vertical-align: middle;
     line-height: ${props => props.theme.lineHeights.base};
@@ -95,9 +93,17 @@ const Button = styled(BaseButton)`
     &:hover {
       background-color: ${props => (props.disabled ? null : props.theme.colors.lightBlue)};
     }
-    &:focus {outline: none;}
-    &:active {transform: scale(0.98); transition: .2s ease-in;}
-    &:disabled {opacity: .5;}
+    &:focus {
+      outline: none;
+      background-color: ${props => (props.disabled ? null : props.theme.colors.lightBlue)};
+    }
+    &:active {
+      transform: scale(0.98); 
+      transition: .2s ease-in;
+    }
+    &:disabled {
+      opacity: .5;
+    }
 `;
 Button.propTypes = {
   size: PropTypes.oneOf(["small", "medium", "large"]),

--- a/components/src/Button/Button.js
+++ b/components/src/Button/Button.js
@@ -90,10 +90,7 @@ const Button = styled(BaseButton)`
     ${size}
     ${space}
 
-    &:hover {
-      background-color: ${props => (props.disabled ? null : props.theme.colors.lightBlue)};
-    }
-    &:focus {
+    &:hover, &:focus {
       outline: none;
       background-color: ${props => (props.disabled ? null : props.theme.colors.lightBlue)};
     }

--- a/components/src/Button/DangerButton.js
+++ b/components/src/Button/DangerButton.js
@@ -8,12 +8,7 @@ const DangerButton = styled(Button)`
   border-color: ${theme.colors.red};
   background-color: ${theme.colors.red};
 
-  &:hover {
-    background-color: ${props => (props.disabled ? null : darken(0.1, theme.colors.red))};
-    border-color: ${props => (props.disabled ? null : darken(0.1, theme.colors.red))};
-  }
-
-  &:focus {
+  &:hover, &:focus {
     outline: none;
     background-color: ${props => (props.disabled ? null : darken(0.1, theme.colors.red))};
     border-color: ${props => (props.disabled ? null : darken(0.1, theme.colors.red))};

--- a/components/src/Button/DangerButton.js
+++ b/components/src/Button/DangerButton.js
@@ -4,11 +4,17 @@ import Button from "./Button";
 import theme from "../theme";
 
 const DangerButton = styled(Button)`
-    color: ${theme.colors.white};
-    border-color: ${theme.colors.red};
-    background-color: ${theme.colors.red};
+  color: ${theme.colors.white};
+  border-color: ${theme.colors.red};
+  background-color: ${theme.colors.red};
 
   &:hover {
+    background-color: ${props => (props.disabled ? null : darken(0.1, theme.colors.red))};
+    border-color: ${props => (props.disabled ? null : darken(0.1, theme.colors.red))};
+  }
+
+  &:focus {
+    outline: none;
     background-color: ${props => (props.disabled ? null : darken(0.1, theme.colors.red))};
     border-color: ${props => (props.disabled ? null : darken(0.1, theme.colors.red))};
   }

--- a/components/src/Button/IconicButton.js
+++ b/components/src/Button/IconicButton.js
@@ -32,7 +32,12 @@ const Wrapper = styled.button`
         background ${theme.colors.lightBlue};
     }
   }
-  &:focus {outline: none;}
+  &:focus {
+    outline: none;
+    ${Icon} {
+      background ${theme.colors.lightBlue};
+    }
+  }
   &:active {
     ${Icon} {
       transform: scale(0.875); transition: .2s ease-in;}

--- a/components/src/Button/IconicButton.js
+++ b/components/src/Button/IconicButton.js
@@ -27,12 +27,7 @@ const Wrapper = styled.button`
     fontWeight: props.theme.fontWeights[2],
     textAlign: "left",
   }
-  &:hover{
-    ${Icon} {
-        background ${theme.colors.lightBlue};
-    }
-  }
-  &:focus {
+  &:hover, &:focus {
     outline: none;
     ${Icon} {
       background ${theme.colors.lightBlue};

--- a/components/src/Button/PrimaryButton.js
+++ b/components/src/Button/PrimaryButton.js
@@ -4,11 +4,17 @@ import Button from "./Button";
 import theme from "../theme";
 
 const PrimaryButton = styled(Button)`
-    color: ${theme.colors.white};
-    border-color: ${theme.colors.blue};
-    background-color: ${theme.colors.blue};
+  color: ${theme.colors.white};
+  border-color: ${theme.colors.blue};
+  background-color: ${theme.colors.blue};
 
   &:hover {
+    background-color: ${props => (props.disabled ? null : darken(0.1, theme.colors.blue))};
+    border-color: ${props => (props.disabled ? null : darken(0.1, theme.colors.blue))};
+  }
+
+  &:focus {
+    outline: none;
     background-color: ${props => (props.disabled ? null : darken(0.1, theme.colors.blue))};
     border-color: ${props => (props.disabled ? null : darken(0.1, theme.colors.blue))};
   }

--- a/components/src/Button/PrimaryButton.js
+++ b/components/src/Button/PrimaryButton.js
@@ -8,12 +8,7 @@ const PrimaryButton = styled(Button)`
   border-color: ${theme.colors.blue};
   background-color: ${theme.colors.blue};
 
-  &:hover {
-    background-color: ${props => (props.disabled ? null : darken(0.1, theme.colors.blue))};
-    border-color: ${props => (props.disabled ? null : darken(0.1, theme.colors.blue))};
-  }
-
-  &:focus {
+  &:hover, &:focus {
     outline: none;
     background-color: ${props => (props.disabled ? null : darken(0.1, theme.colors.blue))};
     border-color: ${props => (props.disabled ? null : darken(0.1, theme.colors.blue))};


### PR DESCRIPTION
Intent: review for merge

The original purpose of this ticket was to explore if I could remove the subPx function and use border-box for inputs and buttons. My findings are that since buttons need to wrap and change height, height cannot be set meaning that border-box is not useful for this application. 

Things that are done in this ticket:
 - cleaned up some styling on Button 
 - adds focus to all buttons (the styling is the same as the button's hover)