### PR TITLE
Fix font stack fallback

### DIFF
--- a/components/src/NDSProvider/NDSProvider.js
+++ b/components/src/NDSProvider/NDSProvider.js
@@ -13,8 +13,8 @@ const Reset = createGlobalStyle`
   `;
 
 export const GlobalStyles = styled.div`
-    font-family: 'IBM Plex Sans';
-    line-height: 1.5;
+    font-family: ${theme.fonts.base};
+    line-height: ${theme.lineHeights.base};
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 

--- a/tokens/build/_variables.scss
+++ b/tokens/build/_variables.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 19 Feb 2019 16:07:46 GMT
+ * Generated on Wed, 20 Feb 2019 20:10:58 GMT
  */
 
 $color-base-black: #011e38;
@@ -18,7 +18,7 @@ $color-base-light-green: #e6faf0;
 $color-base-red: #cc1439;
 $color-base-light-red: #faebec;
 $color-base-yellow: #ffbb00;
-$font-family-base: 'IBM Plex Sans', sans;
+$font-family-base: 'IBM Plex Sans', sans-serif;
 $font-family-mono: 'IBM Plex Mono', monospace;
 $line-height-base: 1.5;
 $line-height-title: 1.04347826;

--- a/tokens/build/exports.js
+++ b/tokens/build/exports.js
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 19 Feb 2019 16:07:46 GMT
+ * Generated on Wed, 20 Feb 2019 20:10:58 GMT
  */
 
 export const color_base_black = "#011e38";
@@ -18,7 +18,7 @@ export const color_base_light_green = "#e6faf0";
 export const color_base_red = "#cc1439";
 export const color_base_light_red = "#faebec";
 export const color_base_yellow = "#ffbb00";
-export const font_family_base = "'IBM Plex Sans', sans";
+export const font_family_base = "'IBM Plex Sans', sans-serif";
 export const font_family_mono = "'IBM Plex Mono', monospace";
 export const line_height_base = "1.5";
 export const line_height_title = "1.04347826";

--- a/tokens/build/variables.css
+++ b/tokens/build/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 19 Feb 2019 16:07:46 GMT
+ * Generated on Wed, 20 Feb 2019 20:10:58 GMT
  */
 
 :root {
@@ -19,7 +19,7 @@
  --color-base-red: #cc1439;
  --color-base-light-red: #faebec;
  --color-base-yellow: #ffbb00;
- --font-family-base: 'IBM Plex Sans', sans;
+ --font-family-base: 'IBM Plex Sans', sans-serif;
  --font-family-mono: 'IBM Plex Mono', monospace;
  --line-height-base: 1.5;
  --line-height-title: 1.04347826;

--- a/tokens/src/font/family.json
+++ b/tokens/src/font/family.json
@@ -1,7 +1,7 @@
 {
     "font": {
       "family": {
-        "base" : { "value": "'IBM Plex Sans', sans" },        
+        "base" : { "value": "'IBM Plex Sans', sans-serif" },
         "mono" : { "value": "'IBM Plex Mono', monospace" }
       }
     }


### PR DESCRIPTION
The doc site's flash of unstyled content brought to my attention that our sans-serif fallback wasn't working, i.e if Plex isn't loaded it shows a serif font until it is. We still want a sans-serif font if Plex fails for whatever reason, so this PR will fix that. I also noticed we weren't using our tokens in our NDSProvider so I updated that as well. 