### PR TITLE
Nds 643 setup alias for root

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -50,7 +50,7 @@
   "settings": {
     "import/resolver": {
       "webpack": {
-        "config": "webpack/webpack.base.config.js"
+        "config": "../webpack.config.js"
       }
     }
   },

--- a/components/.storybook/webpack.config.js
+++ b/components/.storybook/webpack.config.js
@@ -5,21 +5,21 @@ module.exports = {
       ComponentsRoot: path.resolve(__dirname, "../../components/src"),
     },
   },
-    module: {
-      rules: [
-        {
-          test: /\.story\.js?$/,
-          loaders: [require.resolve('@storybook/addon-storysource/loader')],
-          enforce: 'pre',
-        },
-        {
-          test: /\.svg$/,
-          loader: 'svg-sprite-loader'
-        },
-        {
-          test: /\.css$/,
-          loaders: ["style-loader", "css-loader"]
-        }
-      ],
-    },
-  };
+  module: {
+    rules: [
+      {
+        test: /\.story\.js?$/,
+        loaders: [require.resolve('@storybook/addon-storysource/loader')],
+        enforce: 'pre',
+      },
+      {
+        test: /\.svg$/,
+        loader: 'svg-sprite-loader'
+      },
+      {
+        test: /\.css$/,
+        loaders: ["style-loader", "css-loader"]
+      }
+    ],
+  },
+};

--- a/components/.storybook/webpack.config.js
+++ b/components/.storybook/webpack.config.js
@@ -1,4 +1,10 @@
+const path = require("path");
 module.exports = {
+  resolve: {
+    alias: {
+      ComponentsRoot: path.resolve(__dirname, "../../components/src"),
+    },
+  },
     module: {
       rules: [
         {

--- a/components/package.json
+++ b/components/package.json
@@ -88,7 +88,7 @@
       "^.+\\.jsx?$": "babel-jest"
     },
     "moduleNameMapper": {
-      "^ComponentsRoot(.*)$": "<rootDir>$1",
+      "^ComponentsRoot(.*)$": "<rootDir>/src$1",
       "\\.(css|sass)$": "identity-obj-proxy"
     },
     "transformIgnorePatterns": [

--- a/components/package.json
+++ b/components/package.json
@@ -58,6 +58,7 @@
     "enzyme": "3.8.0",
     "enzyme-adapter-react-16": "1.9.1",
     "eslint-config-airbnb": "17.1.0",
+    "eslint-import-resolver-webpack": "^0.11.0",
     "identity-obj-proxy": "3.0.0",
     "jest": "24.0.0",
     "prop-types": "15.6.2",

--- a/components/package.json
+++ b/components/package.json
@@ -88,6 +88,7 @@
       "^.+\\.jsx?$": "babel-jest"
     },
     "moduleNameMapper": {
+      "^ComponentsRoot(.*)$": "<rootDir>$1",
       "\\.(css|sass)$": "identity-obj-proxy"
     },
     "transformIgnorePatterns": [

--- a/components/src/Box/Box.story.js
+++ b/components/src/Box/Box.story.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { Box } from "../index";
+import { Box } from "ComponentsRoot";
 
 storiesOf("Box", module)
   .add("Box", () => (

--- a/components/src/Button/Button.js
+++ b/components/src/Button/Button.js
@@ -2,10 +2,10 @@ import styled from "styled-components";
 import { space } from "styled-system";
 import React from "react";
 import PropTypes from "prop-types";
+import { Icon } from "ComponentsRoot";
 import theme from "../theme";
 import icons from "../../icons/icons.json";
 import { subPx, omit } from "../Utils";
-import { Icon } from "../index";
 
 const iconNames = Object.keys(icons);
 

--- a/components/src/Button/Button.story.js
+++ b/components/src/Button/Button.story.js
@@ -5,7 +5,7 @@ import {
   PrimaryButton,
   DangerButton,
   QuietButton,
-} from "../index";
+} from "ComponentsRoot";
 
 storiesOf("Buttons", module)
   .add("Button", () => (

--- a/components/src/Button/DangerButton.js
+++ b/components/src/Button/DangerButton.js
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { darken } from "polished";
 import theme from "../theme";
-import { Button } from "../index";
+import { Button } from "ComponentsRoot";
 
 const DangerButton = styled(Button)(({ disabled }) => ({
   color: theme.colors.white,

--- a/components/src/Button/DangerButton.js
+++ b/components/src/Button/DangerButton.js
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { darken } from "polished";
-import theme from "../theme";
 import { Button } from "ComponentsRoot";
+import theme from "../theme";
 
 const DangerButton = styled(Button)(({ disabled }) => ({
   color: theme.colors.white,

--- a/components/src/Button/IconicButton.js
+++ b/components/src/Button/IconicButton.js
@@ -2,8 +2,8 @@ import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { space } from "styled-system";
-import theme from "../theme";
 import { Icon, Text } from "ComponentsRoot";
+import theme from "../theme";
 import icons from "../../icons/icons.json";
 
 const Wrapper = styled.button(

--- a/components/src/Button/IconicButton.js
+++ b/components/src/Button/IconicButton.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import styled from "styled-components";
 import { space } from "styled-system";
 import theme from "../theme";
-import { Icon, Text } from "../index";
+import { Icon, Text } from "ComponentsRoot";
 import icons from "../../icons/icons.json";
 
 const Wrapper = styled.button(

--- a/components/src/Button/IconicButton.story.js
+++ b/components/src/Button/IconicButton.story.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { IconicButton } from "../index";
+import { IconicButton } from "ComponentsRoot";
 
 storiesOf("IconicButton", module)
   .add("With label", () => (

--- a/components/src/Button/PrimaryButton.js
+++ b/components/src/Button/PrimaryButton.js
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { darken } from "polished";
 import theme from "../theme";
-import { Button } from "../index";
+import { Button } from "ComponentsRoot";
 
 const PrimaryButton = styled(Button)(({ disabled }) => ({
   color: theme.colors.white,

--- a/components/src/Button/PrimaryButton.js
+++ b/components/src/Button/PrimaryButton.js
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { darken } from "polished";
-import theme from "../theme";
 import { Button } from "ComponentsRoot";
+import theme from "../theme";
 
 const PrimaryButton = styled(Button)(({ disabled }) => ({
   color: theme.colors.white,

--- a/components/src/Button/QuietButton.js
+++ b/components/src/Button/QuietButton.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
-import theme from "../theme";
 import { Button } from "ComponentsRoot";
+import theme from "../theme";
 
 const QuietButton = styled(Button)({
   color: theme.colors.blue,

--- a/components/src/Button/QuietButton.js
+++ b/components/src/Button/QuietButton.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import theme from "../theme";
-import { Button } from "../index";
+import { Button } from "ComponentsRoot";
 
 const QuietButton = styled(Button)({
   color: theme.colors.blue,

--- a/components/src/Checkbox/Checkbox.js
+++ b/components/src/Checkbox/Checkbox.js
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import theme from "../theme";
 import { Box, Text } from "ComponentsRoot";
+import theme from "../theme";
 import { InputClickableArea } from "../Utils";
 
 const checkboxStyle = {

--- a/components/src/Checkbox/Checkbox.js
+++ b/components/src/Checkbox/Checkbox.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import theme from "../theme";
-import { Box, Text } from "../index";
+import { Box, Text } from "ComponentsRoot";
 import { InputClickableArea } from "../Utils";
 
 const checkboxStyle = {

--- a/components/src/Checkbox/Checkbox.story.js
+++ b/components/src/Checkbox/Checkbox.story.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { Checkbox } from "../index";
+import { Checkbox } from "ComponentsRoot";
 
 storiesOf("Checkbox", module)
   .add("Checkbox", () => (

--- a/components/src/DemoPage/DemoPage.js
+++ b/components/src/DemoPage/DemoPage.js
@@ -24,7 +24,7 @@ import {
   Select,
   Text,
   Link,
-} from "../index";
+} from "ComponentsRoot";
 
 const Menu = styled(Flex)({
   flexGrow: "2",

--- a/components/src/DemoPage/DemoPage.js
+++ b/components/src/DemoPage/DemoPage.js
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import theme from "../theme";
 import {
   Title,
   PrimaryButton,
@@ -25,6 +24,7 @@ import {
   Text,
   Link,
 } from "ComponentsRoot";
+import theme from "../theme";
 
 const Menu = styled(Flex)({
   flexGrow: "2",

--- a/components/src/DemoPage/DemoPage.story.js
+++ b/components/src/DemoPage/DemoPage.story.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { DemoPage } from "../index";
+import { DemoPage } from "ComponentsRoot";
 
 storiesOf("DemoPage", module)
   .add("Demo Page", () => (

--- a/components/src/Field/Field.js
+++ b/components/src/Field/Field.js
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import { space } from "styled-system";
 import PropTypes from "prop-types";
 import theme from "../theme";
-import { RequirementText, HelpText } from "../index";
+import { RequirementText, HelpText } from "ComponentsRoot";
 
 const Label = styled.label(
   space,

--- a/components/src/Field/Field.js
+++ b/components/src/Field/Field.js
@@ -2,8 +2,8 @@ import React from "react";
 import styled from "styled-components";
 import { space } from "styled-system";
 import PropTypes from "prop-types";
-import theme from "../theme";
 import { RequirementText, HelpText } from "ComponentsRoot";
+import theme from "../theme";
 
 const Label = styled.label(
   space,

--- a/components/src/Field/Field.story.js
+++ b/components/src/Field/Field.story.js
@@ -6,7 +6,7 @@ import {
   InlineValidation,
   List,
   ListItem,
-} from "../index";
+} from "ComponentsRoot";
 
 storiesOf("Field", module)
   .add("Field", () => (

--- a/components/src/Field/HelpText.js
+++ b/components/src/Field/HelpText.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
-import theme from "../theme";
 import { Text } from "ComponentsRoot";
+import theme from "../theme";
 
 const HelpText = props => (
   <Text

--- a/components/src/Field/HelpText.js
+++ b/components/src/Field/HelpText.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import theme from "../theme";
-import { Text } from "../index";
+import { Text } from "ComponentsRoot";
 
 const HelpText = props => (
   <Text

--- a/components/src/Field/RequirementText.js
+++ b/components/src/Field/RequirementText.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Text } from "../index";
+import { Text } from "ComponentsRoot";
 
 const RequirementText = props => (
   <Text

--- a/components/src/Flex/Flex.js
+++ b/components/src/Flex/Flex.js
@@ -5,7 +5,7 @@ import {
   flexWrap,
   flexDirection,
 } from "styled-system";
-import { Box } from "../index";
+import { Box } from "ComponentsRoot";
 
 const Flex = styled(Box)(
   {

--- a/components/src/Flex/Flex.story.js
+++ b/components/src/Flex/Flex.story.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { Box, Flex } from "../index";
+import { Box, Flex } from "ComponentsRoot";
 import theme from "../theme";
 
 const flexWrapperStyles = {

--- a/components/src/Form/Form.js
+++ b/components/src/Form/Form.js
@@ -2,13 +2,13 @@ import React from "react";
 import styled from "styled-components";
 import { space } from "styled-system";
 import PropTypes from "prop-types";
-import theme from "../theme";
 import {
   SectionTitle,
   FormSection,
   Field,
   HeaderValidation,
 } from "ComponentsRoot";
+import theme from "../theme";
 
 const BaseForm = ({
   title,

--- a/components/src/Form/Form.js
+++ b/components/src/Form/Form.js
@@ -8,7 +8,7 @@ import {
   FormSection,
   Field,
   HeaderValidation,
-} from "../index";
+} from "ComponentsRoot";
 
 const BaseForm = ({
   title,

--- a/components/src/Form/Form.story.js
+++ b/components/src/Form/Form.story.js
@@ -14,7 +14,7 @@ import {
   List,
   ListItem,
   Select,
-} from "../index";
+} from "ComponentsRoot";
 
 const options = [
   { value: "planned", label: "Planned" },

--- a/components/src/Form/FormSection.js
+++ b/components/src/Form/FormSection.js
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
 import theme from "../theme";
-import { SubsectionTitle, Field } from "../index";
+import { SubsectionTitle, Field } from "ComponentsRoot";
 
 const FormSectionTitle = styled(SubsectionTitle).attrs({
   as: "legend",

--- a/components/src/Form/FormSection.js
+++ b/components/src/Form/FormSection.js
@@ -1,8 +1,8 @@
 import React from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
-import theme from "../theme";
 import { SubsectionTitle, Field } from "ComponentsRoot";
+import theme from "../theme";
 
 const FormSectionTitle = styled(SubsectionTitle).attrs({
   as: "legend",

--- a/components/src/Icon/Icon.story.js
+++ b/components/src/Icon/Icon.story.js
@@ -1,13 +1,13 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { storiesOf } from "@storybook/react";
-import theme from "../theme";
 import {
   Icon,
   InlineIcon,
   Box,
   Flex,
 } from "ComponentsRoot";
+import theme from "../theme";
 import icons from "../../icons/icons.json";
 
 const iconNames = Object.keys(icons);

--- a/components/src/Icon/Icon.story.js
+++ b/components/src/Icon/Icon.story.js
@@ -7,7 +7,7 @@ import {
   InlineIcon,
   Box,
   Flex,
-} from "../index";
+} from "ComponentsRoot";
 import icons from "../../icons/icons.json";
 
 const iconNames = Object.keys(icons);

--- a/components/src/Input/Input.story.js
+++ b/components/src/Input/Input.story.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { Input } from "../index";
+import { Input } from "ComponentsRoot";
 
 storiesOf("Input", module)
   .add("Input", () => (

--- a/components/src/Link/Link.story.js
+++ b/components/src/Link/Link.story.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { Link } from "../index";
+import { Link } from "ComponentsRoot";
 
 storiesOf("Link", module)
   .add("Link", () => (

--- a/components/src/List/List.js
+++ b/components/src/List/List.js
@@ -3,8 +3,8 @@ import styled from "styled-components";
 import {
   space, color, fontSize, fontWeight, lineHeight,
 } from "styled-system";
-import theme from "../theme";
 import { ListItem } from "ComponentsRoot";
+import theme from "../theme";
 
 const List = styled.ul(
   ({ compact }) => ({

--- a/components/src/List/List.js
+++ b/components/src/List/List.js
@@ -4,7 +4,7 @@ import {
   space, color, fontSize, fontWeight, lineHeight,
 } from "styled-system";
 import theme from "../theme";
-import { ListItem } from "../index";
+import { ListItem } from "ComponentsRoot";
 
 const List = styled.ul(
   ({ compact }) => ({

--- a/components/src/List/List.story.js
+++ b/components/src/List/List.story.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { List, ListItem } from "../index";
+import { List, ListItem } from "ComponentsRoot";
 
 storiesOf("List", module)
   .add("List", () => (

--- a/components/src/Radio/Radio.js
+++ b/components/src/Radio/Radio.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import theme from "../theme";
-import { Box, Text } from "../index";
+import { Box, Text } from "ComponentsRoot";
 import { InputClickableArea } from "../Utils";
 
 const radioStyle = {

--- a/components/src/Radio/Radio.js
+++ b/components/src/Radio/Radio.js
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import theme from "../theme";
 import { Box, Text } from "ComponentsRoot";
+import theme from "../theme";
 import { InputClickableArea } from "../Utils";
 
 const radioStyle = {

--- a/components/src/Radio/Radio.story.js
+++ b/components/src/Radio/Radio.story.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { Radio } from "../index";
+import { Radio } from "ComponentsRoot";
 
 storiesOf("Radio", module)
   .add("Radio", () => (

--- a/components/src/Radio/RadioGroup.js
+++ b/components/src/Radio/RadioGroup.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import { Radio } from "../index";
+import { Radio } from "ComponentsRoot";
 
 const getRadioButtons = props => {
   const radioButtons = React.Children.map(props.children, radio => {

--- a/components/src/Radio/RadioGroup.story.js
+++ b/components/src/Radio/RadioGroup.story.js
@@ -4,7 +4,7 @@ import {
   Radio,
   RadioGroup,
   Field,
-} from "../index";
+} from "ComponentsRoot";
 
 storiesOf("RadioGroup", module)
   .add("Radio Group", () => (

--- a/components/src/Select/Select.js
+++ b/components/src/Select/Select.js
@@ -3,8 +3,8 @@ import PropTypes from "prop-types";
 import Downshift from "downshift";
 import styled from "styled-components";
 import { transparentize } from "polished";
-import theme from "../theme";
 import { Icon } from "ComponentsRoot";
+import theme from "../theme";
 import { subPx } from "../Utils";
 
 const getBorderColor = ({

--- a/components/src/Select/Select.js
+++ b/components/src/Select/Select.js
@@ -4,7 +4,7 @@ import Downshift from "downshift";
 import styled from "styled-components";
 import { transparentize } from "polished";
 import theme from "../theme";
-import { Icon } from "../index";
+import { Icon } from "ComponentsRoot";
 import { subPx } from "../Utils";
 
 const getBorderColor = ({

--- a/components/src/Select/Select.story.js
+++ b/components/src/Select/Select.story.js
@@ -4,7 +4,7 @@ import {
   Select,
   Input,
   PrimaryButton,
-} from "../index";
+} from "ComponentsRoot";
 
 const options = [
   { value: "accepted", label: "Accepted" },

--- a/components/src/Textarea/Textarea.story.js
+++ b/components/src/Textarea/Textarea.story.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { Textarea } from "../index";
+import { Textarea } from "ComponentsRoot";
 
 storiesOf("Textarea", module)
   .add("Textarea", () => (

--- a/components/src/Toggle/Toggle.js
+++ b/components/src/Toggle/Toggle.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import theme from "../theme";
-import { Text, Box } from "../index";
+import { Text, Box } from "ComponentsRoot";
 import { InputClickableArea, omit } from "../Utils";
 
 const Slider = styled.span(({ disabled }) => ({

--- a/components/src/Toggle/Toggle.js
+++ b/components/src/Toggle/Toggle.js
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import theme from "../theme";
 import { Text, Box } from "ComponentsRoot";
+import theme from "../theme";
 import { InputClickableArea, omit } from "../Utils";
 
 const Slider = styled.span(({ disabled }) => ({

--- a/components/src/Toggle/Toggle.story.js
+++ b/components/src/Toggle/Toggle.story.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { Toggle, Field } from "../index";
+import { Toggle, Field } from "ComponentsRoot";
 
 storiesOf("Toggle", module)
   .add("Toggle", () => (

--- a/components/src/Type/Headings.js
+++ b/components/src/Type/Headings.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
-import theme from "../theme";
 import { Text } from "ComponentsRoot";
+import theme from "../theme";
 
 const Title = Text.withComponent("h1");
 

--- a/components/src/Type/Headings.js
+++ b/components/src/Type/Headings.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import theme from "../theme";
-import { Text } from "../index";
+import { Text } from "ComponentsRoot";
 
 const Title = Text.withComponent("h1");
 

--- a/components/src/Type/Headings.story.js
+++ b/components/src/Type/Headings.story.js
@@ -5,7 +5,7 @@ import {
   Title,
   SectionTitle,
   SubsectionTitle,
-} from "../index";
+} from "ComponentsRoot";
 
 storiesOf("Headings", module)
   .add("Title", () => (

--- a/components/src/Type/Text.story.js
+++ b/components/src/Type/Text.story.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { Text, Box } from "../index";
+import { Text, Box } from "ComponentsRoot";
 
 storiesOf("Text", module)
   .add("Text", () => (

--- a/components/src/Type/Typography.story.js
+++ b/components/src/Type/Typography.story.js
@@ -8,7 +8,7 @@ import {
   SubsectionTitle,
   List,
   ListItem,
-} from "../index";
+} from "ComponentsRoot";
 
 storiesOf("Typography", module)
   .add("Article", () => (

--- a/components/src/Type/Typography.story.js
+++ b/components/src/Type/Typography.story.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import theme from "../theme";
 import {
   Text,
   Title,
@@ -9,6 +8,7 @@ import {
   List,
   ListItem,
 } from "ComponentsRoot";
+import theme from "../theme";
 
 storiesOf("Typography", module)
   .add("Article", () => (

--- a/components/src/Validation/HeaderValidation.js
+++ b/components/src/Validation/HeaderValidation.js
@@ -1,13 +1,13 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import theme from "../theme";
 import {
   Flex,
   Text,
   SubsectionTitle,
   Icon,
 } from "ComponentsRoot";
+import theme from "../theme";
 
 const Wrapper = styled.div({
   [`${Text}`]: {

--- a/components/src/Validation/HeaderValidation.js
+++ b/components/src/Validation/HeaderValidation.js
@@ -7,7 +7,7 @@ import {
   Text,
   SubsectionTitle,
   Icon,
-} from "../index";
+} from "ComponentsRoot";
 
 const Wrapper = styled.div({
   [`${Text}`]: {

--- a/components/src/Validation/HeaderValidation.story.js
+++ b/components/src/Validation/HeaderValidation.story.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { HeaderValidation, List, ListItem } from "../index";
+import { HeaderValidation, List, ListItem } from "ComponentsRoot";
 
 storiesOf("Header Validation", module)
   .add("Header Validation", () => (

--- a/components/src/Validation/InlineValidation.js
+++ b/components/src/Validation/InlineValidation.js
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import theme from "../theme";
 import { Text, Icon, Flex } from "ComponentsRoot";
+import theme from "../theme";
 
 const Wrapper = styled.div({
   [`${Text}`]: {

--- a/components/src/Validation/InlineValidation.js
+++ b/components/src/Validation/InlineValidation.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import theme from "../theme";
-import { Text, Icon, Flex } from "../index";
+import { Text, Icon, Flex } from "ComponentsRoot";
 
 const Wrapper = styled.div({
   [`${Text}`]: {

--- a/components/src/Validation/InlineValidation.story.js
+++ b/components/src/Validation/InlineValidation.story.js
@@ -5,7 +5,7 @@ import {
   List,
   ListItem,
   Link,
-} from "../index";
+} from "ComponentsRoot";
 
 storiesOf("Inline Validation", module)
   .add("Inline Validation", () => (

--- a/docs/.eslintrc
+++ b/docs/.eslintrc
@@ -15,7 +15,7 @@
   "settings": {
     "import/resolver": {
       "webpack": {
-        "config": "webpack/webpack.base.config.js"
+        "config": "../webpack.config.js"
       }
     }
   },

--- a/docs/package.json
+++ b/docs/package.json
@@ -40,6 +40,7 @@
     "test": "echo \"Write tests! -> https://gatsby.app/unit-testing\""
   },
   "devDependencies": {
+    "eslint-import-resolver-webpack": "^0.11.0",
     "prettier": "^1.15.2"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,11 @@
+const path = require("path");
+
 module.exports = {
+  resolve: {
+    alias: {
+      ComponentsRoot: path.resolve(__dirname, "./components/src/"),
+    },
+  },
   output: {
     libraryTarget: "umd",
     globalObject: `(typeof self !== 'undefined' ? self : this)` // https://github.com/markdalgleish/static-site-generator-webpack-plugin/issues/130

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,12 +8,13 @@ module.exports = {
   },
   output: {
     libraryTarget: "umd",
-    globalObject: `(typeof self !== 'undefined' ? self : this)` // https://github.com/markdalgleish/static-site-generator-webpack-plugin/issues/130
+    globalObject: "(typeof self !== 'undefined' ? self : this)",
+    // https://github.com/markdalgleish/static-site-generator-webpack-plugin/issues/130
   },
   externals: [
     "react",
     "react-dom",
-    "styled-components"
+    "styled-components",
   ],
   module: {
     rules: [
@@ -23,19 +24,19 @@ module.exports = {
         use: {
           loader: "babel-loader",
           options: {
-            presets: ['@babel/react']
-          }
-        }
+            presets: ["@babel/react"],
+          },
+        },
       },
       {
         test: /\.stories\.jsx?$/,
-        loaders: [require.resolve('@storybook/addon-storysource/loader')],
-        enforce: 'pre',
+        loaders: [require.resolve("@storybook/addon-storysource/loader")],
+        enforce: "pre",
       },
       {
         test: /\.svg$/,
-        loader: 'svg-sprite-loader'
-      }
-    ]
-  }
-}
+        loader: "svg-sprite-loader",
+      },
+    ],
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2755,6 +2755,11 @@ array-find-index@^1.0.1:
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
   integrity sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=
 
+array-find@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-find/-/array-find-1.0.0.tgz#6c8e286d11ed768327f8e62ecee87353ca3e78b8"
+  integrity sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg=
+
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
@@ -6135,6 +6140,15 @@ enhanced-resolve@^4.1.0:
     memory-fs "^0.4.0"
     tapable "^1.0.0"
 
+enhanced-resolve@~0.9.0:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz#4d6e689b3725f86090927ccc86cd9f1635b89e2e"
+  integrity sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=
+  dependencies:
+    graceful-fs "^4.1.2"
+    memory-fs "^0.2.0"
+    tapable "^0.1.8"
+
 entities@^1.1.1, entities@~1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
@@ -6340,6 +6354,22 @@ eslint-import-resolver-node@^0.3.2:
   dependencies:
     debug "^2.6.9"
     resolve "^1.5.0"
+
+eslint-import-resolver-webpack@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.11.0.tgz#75d08ee06fc55eb24bd75147b7b4b6756886b12f"
+  integrity sha512-vX8rYSPdKtTLkK2FoU1ZRyEsl6wP1FB40ytjrEgMhzUkEkBLuZAkv1KNR+2Ml7lzMOObXI3yaEDiaQ/Yvoczhw==
+  dependencies:
+    array-find "^1.0.0"
+    debug "^2.6.8"
+    enhanced-resolve "~0.9.0"
+    find-root "^1.1.0"
+    has "^1.0.1"
+    interpret "^1.0.0"
+    lodash "^4.17.4"
+    node-libs-browser "^1.0.0 || ^2.0.0"
+    resolve "^1.4.0"
+    semver "^5.3.0"
 
 eslint-loader@^2.1.0:
   version "2.1.2"
@@ -7164,6 +7194,11 @@ find-npm-prefix@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz#8d8ce2c78b3b4b9e66c8acc6a37c231eb841cfdf"
   integrity sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==
+
+find-root@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
+  integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
 
 find-up@3.0.0, find-up@^3.0.0:
   version "3.0.0"
@@ -11155,6 +11190,11 @@ memoize-one@^4.0.0:
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.1.0.tgz#a2387c58c03fff27ca390c31b764a79addf3f906"
   integrity sha512-2GApq0yI/b22J2j9rhbrAlsHb0Qcz+7yWxeLG8h+95sl1XPUgeLimQSOdur4Vw7cUhrBHwaUZxWFZueojqNRzA==
 
+memory-fs@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.2.0.tgz#f2bb25368bc121e391c2520de92969caee0a0290"
+  integrity sha1-8rslNovBIeORwlIN6Slpyu4KApA=
+
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
@@ -11743,7 +11783,7 @@ node-int64@^0.4.0:
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
 
-node-libs-browser@^2.0.0:
+"node-libs-browser@^1.0.0 || ^2.0.0", node-libs-browser@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.2.0.tgz#c72f60d9d46de08a940dedbb25f3ffa2f9bbaa77"
   integrity sha512-5MQunG/oyOaBdttrL40dA7bUfPORLRWMUJLQtMg7nluxUvk5XwnLdL9twQHFAjRx/y7mIMkLKT9++qPbbk6BZA==
@@ -14646,7 +14686,7 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.8.1, resolve@^1.9.0:
+resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.8.1, resolve@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.0.tgz#3bdaaeaf45cc07f375656dfd2e54ed0810b101ba"
   integrity sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==
@@ -16144,6 +16184,11 @@ table@^5.0.2:
     lodash "^4.17.11"
     slice-ansi "^2.0.0"
     string-width "^2.1.1"
+
+tapable@^0.1.8:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.1.10.tgz#29c35707c2b70e50d07482b5d202e8ed446dafd4"
+  integrity sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q=
 
 tapable@^1.0.0, tapable@^1.1.0:
   version "1.1.1"


### PR DESCRIPTION
Intent: Review to merge

Changes:
creates webpack alias for components/src/ called ComponentsRoot 
 - in webpack.config.js
 - in /components/.storybook/webpack.config.js
adds a moduleNameMapper setting to jest in components/package.json
updates all /components/src components to use alias on imports