### PR TITLE
Make font-weight match the weight we're loading

### DIFF
--- a/tokens/src/weight/font.json
+++ b/tokens/src/weight/font.json
@@ -1,8 +1,8 @@
 {
     "weight": {
       "font": {
-        "light": {"value": "100"},
-        "normal" : { "value": "400" },        
+        "light": {"value": "300"},
+        "normal" : { "value": "400" },
         "medium" : { "value": "500" },
         "bold": { "value": "600" }
       }


### PR DESCRIPTION
We were loading the 300 (light) style of Plex from Google but calling it 100 (extralight). This caused a flash if you had Plex installed locally because it would switch from 100 to 300 when the font loaded from Google. This does not solve the overall flash of content issue but is a first step. 