### PR TITLE
Add serve command to docs

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -34,6 +34,7 @@
     "eslint:fix": "yarn run eslint --fix",
     "build": "yarn workspace @nulogy/components build && gatsby build",
     "develop": "yarn workspace @nulogy/components build && gatsby develop",
+    "serve": "yarn build && gatsby serve",
     "start": "yarn develop",
     "format": "prettier --write \"src/**/*.js\"",
     "test": "echo \"Write tests! -> https://gatsby.app/unit-testing\""


### PR DESCRIPTION
We were missing a way to run `gatsby serve`, which allows you to view the production build at `localhost:9000`. This is useful for testing how your build will look before deploying it to Netlify, as using the .html files can cause CORS and file reference issues. This PR adds a custom `yarn serve` that builds our components, builds the docs site and then serves. 

