### PR TITLE
[NDS-624] New docs structure

### DIFF
--- a/docs/src/components/HighlightStyles.js
+++ b/docs/src/components/HighlightStyles.js
@@ -1,0 +1,78 @@
+import theme from "../../../components/src/theme";
+import { createGlobalStyle } from "styled-components";
+
+const HighlightStyles = createGlobalStyle`
+
+.hljs {
+  display: block;
+  overflow-x: auto;
+  font-family: ${theme.fonts.mono};
+  font-size: 14px;
+  padding: ${theme.space.x2};
+  background: ${theme.colors.whiteGrey};
+  color: ${theme.colors.darkBlue};
+  border-radius: 4px;
+}
+
+.hljs-tag,
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-literal,
+.hljs-strong,
+.hljs-name {
+  color: ${theme.colors.blackBlue};
+}
+
+.hljs-code {
+  color: ${theme.colors.darkBlue};
+}
+
+.hljs-class .hljs-title {
+  color: ${theme.colors.darkBlue};
+}
+
+.hljs-attribute,
+.hljs-symbol,
+.hljs-regexp,
+.hljs-link {
+  color: ${theme.colors.darkBlue};
+}
+
+.hljs-string,
+.hljs-bullet,
+.hljs-subst,
+.hljs-title,
+.hljs-section,
+.hljs-emphasis,
+.hljs-type,
+.hljs-built_in,
+.hljs-builtin-name,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-addition,
+.hljs-variable,
+.hljs-template-tag,
+.hljs-template-variable {
+  color: ${theme.colors.green};
+}
+
+.hljs-comment,
+.hljs-quote,
+.hljs-deletion,
+.hljs-meta {
+  color: #75715e;
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-literal,
+.hljs-doctag,
+.hljs-title,
+.hljs-section,
+.hljs-type,
+.hljs-selector-id {
+  font-weight: 500;
+}
+`
+
+export default HighlightStyles;

--- a/docs/src/components/HighlightStyles.js
+++ b/docs/src/components/HighlightStyles.js
@@ -1,5 +1,5 @@
-import theme from "../../../components/src/theme";
 import { createGlobalStyle } from "styled-components";
+import theme from "../../../components/src/theme";
 
 const HighlightStyles = createGlobalStyle`
 
@@ -73,6 +73,6 @@ const HighlightStyles = createGlobalStyle`
 .hljs-selector-id {
   font-weight: 500;
 }
-`
+`;
 
 export default HighlightStyles;

--- a/docs/src/components/Layout.js
+++ b/docs/src/components/Layout.js
@@ -9,6 +9,17 @@ import NDSProvider from "../../../components/src/NDSProvider/NDSProvider";
 import theme from "../../../components/src/theme";
 
 import logo from "../images/nulogy.svg";
+import { createGlobalStyle } from "styled-components";
+import HighlightStyles from "../components/HighlightStyles";
+
+const TableStyles = createGlobalStyle`
+  table {border: 1px solid #ccc;}
+  td {
+    border: 1px solid #ccc;
+    padding: 8px;
+  }
+  thead {font-weight: bold;}
+`
 
 const Layout = ({ children }) => (
   <NDSProvider theme={ theme }>
@@ -18,6 +29,8 @@ const Layout = ({ children }) => (
         <meta charSet="utf-8" />
         <title>Welcome</title>
       </Helmet>
+      <HighlightStyles />
+      <TableStyles />
       <Box
         bg="blackBlue" align="center" mb="x6"
         p="x2"

--- a/docs/src/components/Layout.js
+++ b/docs/src/components/Layout.js
@@ -4,13 +4,13 @@ import {
   Box, Flex, Link, Text,
 } from "@nulogy/components";
 import { Helmet } from "react-helmet";
+import { createGlobalStyle } from "styled-components";
 import { NavItem, Nav } from "./Nav";
 import NDSProvider from "../../../components/src/NDSProvider/NDSProvider";
 import theme from "../../../components/src/theme";
 
 import logo from "../images/nulogy.svg";
-import { createGlobalStyle } from "styled-components";
-import HighlightStyles from "../components/HighlightStyles";
+import HighlightStyles from "./HighlightStyles";
 
 const TableStyles = createGlobalStyle`
   table {border: 1px solid #ccc;}
@@ -19,7 +19,7 @@ const TableStyles = createGlobalStyle`
     padding: 8px;
   }
   thead {font-weight: bold;}
-`
+`;
 
 const Layout = ({ children }) => (
   <NDSProvider theme={ theme }>

--- a/docs/src/pages/components/buttons.js
+++ b/docs/src/pages/components/buttons.js
@@ -1,11 +1,13 @@
 import React from "react";
 import { Helmet } from "react-helmet";
 import {
-  Button, DangerButton, PrimaryButton, QuietButton, IconicButton, Box, Flex, SectionTitle, Title,
+  Button, DangerButton, PrimaryButton, QuietButton, IconicButton, Box, Flex, SectionTitle, SubsectionTitle, Title, Link,
 } from "@nulogy/components";
+import Highlight from "react-highlight";
 import {
   DocText as Text, Layout, Intro, DocSection, CheckList,
 } from "../../components";
+
 
 export default () => (
   <Layout>
@@ -13,97 +15,102 @@ export default () => (
       <title>Buttons</title>
     </Helmet>
     <Box
-      bg="whiteGrey" p="x4" borderRadius={ 1 }
+      pt="x4"
       mb="x6"
     >
       <Title m="none">Buttons</Title>
       <Intro>Buttons make common actions immediately detectable and easy to perform.</Intro>
     </Box>
-
     <DocSection>
-      <Flex mb="x3">
-        <Flex width={ 2 / 6 } justifyContent="center" alignItems="center">
-          <Button>Create project</Button>
-        </Flex>
-        <Box width={ 4 / 6 }>
-          <Text mb="none"><Text inline fontWeight="medium">Buttons</Text> are used for actions that do not require any special emphasis and cover most cases.</Text>
-        </Box>
-      </Flex>
-      <Flex mb="x3">
-        <Flex width={ 2 / 6 } justifyContent="center" alignItems="center">
-          <PrimaryButton>Edit project</PrimaryButton>
-        </Flex>
-        <Box width={ 4 / 6 }>
-          <Text mb="none"><Text inline fontWeight="medium">Primary Buttons</Text> are used for the main action in a particular context. There is usually not more than one primary button per screen and not all of the screens require a Primary button.</Text>
-        </Box>
-      </Flex>
-      <Flex mb="x3">
-        <Flex width={ 2 / 6 } justifyContent="center" alignItems="center">
-          <DangerButton>Delete project</DangerButton>
-        </Flex>
-        <Box width={ 4 / 6 }>
-          <Text mb="none"><Text inline fontWeight="medium">Danger Buttons</Text> are used for destructive actions such as deleting. They are most likely to appear in confirmation dialogs.</Text>
-        </Box>
-      </Flex>
-      <Flex mb="x3">
-        <Flex width={ 2 / 6 } justifyContent="center" alignItems="center">
-          <QuietButton>Learn more</QuietButton>
-        </Flex>
-        <Box width={ 4 / 6 }>
-          <Text mb="none"><Text inline fontWeight="medium">Quiet Buttons</Text> are used for less important actions such as “Cancel” or actions that are not directly related to the context of the page (e.g Learn more …). Quiet buttons are often paired with a Primary button.</Text>
-        </Box>
-      </Flex>
-      <Flex mb="x3">
-        <Flex
-          width={ 2 / 6 } justifyContent="center" alignItems="center"
-          flexDirection="column"
-        >
-          <IconicButton mb="x4" icon="add" labelVisibility="hover">Add project</IconicButton>
-        </Flex>
-        <Box width={ 4 / 6 }>
-          <Text mb="none"><Text inline fontWeight="medium">Iconic Buttons</Text> are used for universally understood actions that can effectively be represented using icon.</Text>
-        </Box>
-      </Flex>
+      <Button>Create project</Button>
+      <Highlight className="jsx">
+        {`import {Button} from @nulogy-components;
+
+<Button>Create project</Button>
+`}
+      </Highlight>
     </DocSection>
-
     <DocSection>
-      <SectionTitle>Sizes</SectionTitle>
-      <Text mb="4">Button, Primary Button, Danger Button and Quiet Button are available in three sizes and a full-width option.</Text>
-      <Button size="small" mb="x1">Read more</Button>
-      <Text fontSize="small">Small</Text>
-      <Button size="medium" mb="x1">Add project</Button>
-      <Text fontSize="small">Medium</Text>
-      <Button size="large" mb="x1">Create project</Button>
-      <Text fontSize="small">Large</Text>
-      <Button fullWidth mb="x1">I agree</Button>
-      <Text fontSize="small">Full-width</Text>
+      <SectionTitle>Types of buttons</SectionTitle>
+      <Text>There are multiple types of buttons that all accept the same options.</Text>
+
+      <Box mb="x6">
+        <SubsectionTitle>PrimaryButton</SubsectionTitle>
+        <Text>Primary Buttons are used for the main action in a particular context. There is usually not more than one primary button per screen and not all of the screens require a Primary button.</Text>
+        <PrimaryButton>Create project</PrimaryButton>
+        <Highlight className="js">
+          {"<PrimaryButton>Create project</PrimaryButton>"}
+        </Highlight>
+      </Box>
+
+      <Box mb="x6">
+        <SubsectionTitle>DangerButton</SubsectionTitle>
+        <Text>Danger Buttons are used for destructive actions such as deleting. They are most likely to appear in confirmation dialogs.</Text>
+        <DangerButton>Create project</DangerButton>
+        <Highlight className="js">
+          {"<DangerButton>Create project</DangerButton>"}
+        </Highlight>
+      </Box>
+
+      <Box mb="x6">
+        <SubsectionTitle>QuietButton</SubsectionTitle>
+        <Text>Quiet Buttons are used for less important actions such as “Cancel” or actions that are not directly related to the context of the page (e.g Learn more …). Quiet buttons are often paired with a Primary button.</Text>
+        <QuietButton>Learn more</QuietButton>
+        <Highlight className="js">
+          {"<QuietButton>Create project</QuietButton>"}
+        </Highlight>
+      </Box>
     </DocSection>
 
     <DocSection>
       <SectionTitle>Variations</SectionTitle>
-      <Text>Iconic Buttons come in two variations.</Text>
-      <Flex justifyContent="space-around" alignItems="center">
-        <Flex justifyContent="center" alignItems="center" flexDirection="column">
-          <IconicButton icon="delete" labelVisibility="hover">Delete</IconicButton>
-          <Text fontSize="small" mt="x1">Label exposed on hover</Text>
-        </Flex>
-        <Flex justifyContent="center" alignItems="center" flexDirection="column">
-          <IconicButton icon="delete" labelVisibility="always">Delete</IconicButton>
-          <Text fontSize="small" mt="x1">Permanently exposed label</Text>
-        </Flex>
-      </Flex>
-    </DocSection>
+      <Text>The following variations are available to all button components.</Text>
 
-    <DocSection>
-      <SectionTitle>States</SectionTitle>
-      <Text>All buttons can be disabled. When a button is disabled, it's greyed out and unable to be clicked.</Text>
-      <Flex justifyContent="space-between" alignItems="center">
-        <Button disabled>Create project</Button>
-        <PrimaryButton disabled>Create project</PrimaryButton>
-        <DangerButton disabled>Delete project</DangerButton>
-        <QuietButton disabled>Edit project</QuietButton>
-        <IconicButton icon="delete" labelVisibility="hover" disabled>Delete</IconicButton>
-      </Flex>
+      <Box mb="x6">
+        <SubsectionTitle>Small</SubsectionTitle>
+        <Button size="small">Read more</Button>
+        <Highlight className="js">
+          {"<Button size=\"small\">Read more</Button>"}
+        </Highlight>
+      </Box>
+
+      <Box mb="x6">
+        <SubsectionTitle>Medium</SubsectionTitle>
+        <Button size="medium">Read more</Button>
+        <Highlight className="js">
+          {"<Button size=\"medium\">Read more</Button>"}
+        </Highlight>
+      </Box>
+
+      <Box mb="x6">
+        <SubsectionTitle>Large</SubsectionTitle>
+        <Button size="large">Read more</Button>
+        <Highlight className="js">
+          {"<Button size=\"large\">Read more</Button>"}
+        </Highlight>
+      </Box>
+
+      <Box mb="x6">
+        <SubsectionTitle>Full Width</SubsectionTitle>
+        <Button fullWidth>Read more</Button>
+        <Highlight className="js">
+          {"<Button fullWidth>Full Width</Button>"}
+        </Highlight>
+      </Box>
+
+      <Box mb="x6">
+        <SubsectionTitle>Disabled</SubsectionTitle>
+        <Flex justifyContent="space-between" alignItems="center">
+          <Button disabled>Create project</Button>
+          <PrimaryButton disabled>Create project</PrimaryButton>
+          <DangerButton disabled>Delete project</DangerButton>
+          <QuietButton disabled>Edit project</QuietButton>
+        </Flex>
+        <Highlight className="js">
+          {"<Button disabled>Create project</Button>"}
+        </Highlight>
+      </Box>
+
     </DocSection>
 
     <DocSection>
@@ -112,5 +119,42 @@ export default () => (
       <CheckList>Whenever possible follow with a clear noun <em>(e.g: Create shipment, Approve delivery.)</em></CheckList>
       <CheckList>Always use sentence case</CheckList>
     </DocSection>
+
+    <DocSection>
+      <SectionTitle>Props</SectionTitle>
+      <table>
+        <thead>
+          <tr>
+            <td>Prop</td>
+            <td>Type</td>
+            <td>Default value</td>
+            <td>Description</td>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>size</td>
+            <td>String</td>
+            <td>medium</td>
+            <td>Accepts small, medium, large or fullWidth</td>
+          </tr>
+          <tr>
+            <td>disabled</td>
+            <td>Boolean</td>
+            <td>false</td>
+            <td>Marks the button as disabled and unable to be activated</td>
+          </tr>
+        </tbody>
+      </table>
+    </DocSection>
+    <DocSection>
+      <SectionTitle>Resources</SectionTitle>
+      <Link href="https://storybook.nulogy.design/">Storybook</Link>
+    </DocSection>
+    <DocSection>
+      <SectionTitle>Related components</SectionTitle>
+      <Link>Iconic button</Link>
+    </DocSection>
+
   </Layout>
 );

--- a/docs/src/pages/components/checkbox.js
+++ b/docs/src/pages/components/checkbox.js
@@ -1,16 +1,12 @@
 import React from "react";
 import { Helmet } from "react-helmet";
 import {
-  Box, SectionTitle, SubsectionTitle, Title,
+  Box, SectionTitle, SubsectionTitle, Title, Checkbox, Link,
 } from "@nulogy/components";
+import Highlight from "react-highlight";
 import {
-  Layout, Intro, DocSection, CheckList, Image,
+  Layout, Intro, DocSection, CheckList,
 } from "../../components";
-import anatomy from "../../images/checkbox/checkbox-anatomy.png";
-import basic from "../../images/checkbox/checkbox-basic.png";
-import defaultState from "../../images/checkbox/checkbox-default.png";
-import checked from "../../images/checkbox/checkbox-checked.png";
-import disabled from "../../images/checkbox/checkbox-disabled.png";
 
 export default () => (
   <Layout>
@@ -18,32 +14,109 @@ export default () => (
       <title>Checkbox</title>
     </Helmet>
     <Box
-      bg="whiteGrey" p="x4" borderRadius={ 1 }
+      mt="x2"
       mb="x6"
     >
       <Title mb="none">Checkbox</Title>
       <Intro>Checkboxes allow users to select any number of options from a list.</Intro>
     </Box>
     <DocSection>
-      <Image src={ basic } width="75%" alt="Text input screenshot" />
+      <Checkbox labelText="I am a checkbox" />
+      <Highlight className="jsx">
+        {`import {Checkbox} from @nulogy-components;
+
+<Checkbox labelText="I am a checkbox" />
+`}
+      </Highlight>
     </DocSection>
     <DocSection>
-      <SectionTitle>Anatomy</SectionTitle>
-      <Image src={ anatomy } width="50%" alt="Text input screenshot" />
+      <SectionTitle>Variations</SectionTitle>
+
+      <Box mb="x6">
+        <SubsectionTitle>Disabled</SubsectionTitle>
+        <Checkbox labelText="I am a checkbox" disabled />
+        <Highlight className="jsx">
+          {"<Checkbox labelText=\"I am a checkbox\" disabled />"}
+        </Highlight>
+      </Box>
+
+      <Box mb="x6">
+        <SubsectionTitle>Error</SubsectionTitle>
+        <Checkbox labelText="I am a checkbox" error />
+        <Highlight className="jsx">
+          {"<Checkbox labelText=\"I am a checkbox\" error />"}
+        </Highlight>
+      </Box>
+
+      <Box>
+        <SubsectionTitle>Disabled</SubsectionTitle>
+        <Checkbox labelText="I am a checkbox" defaultChecked="true" />
+        <Highlight className="jsx">
+          {"<Checkbox labelText=\"I am a checkbox\" defaultChecked=\"true\"/>"}
+        </Highlight>
+      </Box>
     </DocSection>
+
     <DocSection>
       <SectionTitle>Guidelines</SectionTitle>
-      <CheckList>Users should be able to select the checkbox by clicking on the box directly or by clicking on its label.</CheckList>
       <CheckList>If there are many items in a list, consider using a "Show all" button</CheckList>
     </DocSection>
+
     <DocSection>
-      <SectionTitle>States</SectionTitle>
-      <SubsectionTitle>Default</SubsectionTitle>
-      <Image src={ defaultState } width="50%" alt="Text input screenshot" />
-      <SubsectionTitle>Checked</SubsectionTitle>
-      <Image src={ checked } width="50%" alt="Text input screenshot" />
-      <SubsectionTitle>Disabled</SubsectionTitle>
-      <Image src={ disabled } width="50%" alt="Text input screenshot" />
+      <SectionTitle>Props</SectionTitle>
+      <table>
+        <thead>
+          <tr>
+            <td>Prop</td>
+            <td>Type</td>
+            <td>Default value</td>
+            <td>Description</td>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>labelText</td>
+            <td>String</td>
+            <td><em>Required</em></td>
+            <td>A label for your option</td>
+          </tr>
+          <tr>
+            <td>disabled</td>
+            <td>Boolean</td>
+            <td>false</td>
+            <td>Marks the field as disabled and disallows user input</td>
+          </tr>
+          <tr>
+            <td>error</td>
+            <td>Boolean</td>
+            <td>false</td>
+            <td>Marks the field as invalid and adds a red border</td>
+          </tr>
+          <tr>
+            <td>required</td>
+            <td>Boolean</td>
+            <td>false</td>
+            <td>Makes the field require input before the form will submit</td>
+          </tr>
+          <tr>
+            <td>defaultChecked</td>
+            <td>Boolean</td>
+            <td>false</td>
+            <td>Makes the field checked by default</td>
+          </tr>
+          <tr>
+            <td>onChange</td>
+            <td>Function</td>
+            <td />
+            <td />
+          </tr>
+        </tbody>
+      </table>
     </DocSection>
+    <DocSection>
+      <SectionTitle>Resources</SectionTitle>
+      <Link href="https://storybook.nulogy.design/">Storybook</Link>
+    </DocSection>
+
   </Layout>
 );

--- a/docs/src/pages/components/select.js
+++ b/docs/src/pages/components/select.js
@@ -1,16 +1,17 @@
 import React from "react";
 import { Helmet } from "react-helmet";
 import {
-  Box, SectionTitle, SubsectionTitle, Title,
+  Box, SectionTitle, SubsectionTitle, Title, Select, Link,
 } from "@nulogy/components";
+import Highlight from "react-highlight";
 import {
-  Layout, Intro, DocSection, CheckList, Image,
+  Layout, Intro, DocSection, CheckList,
 } from "../../components";
-import anatomy from "../../images/select/select-anatomy.png";
-import basic from "../../images/select/select-basic.png";
-import defaultState from "../../images/select/select-state-default.png";
-import selected from "../../images/select/select-state-selected.png";
-import disabled from "../../images/select/select-disabled.png";
+
+const options = [
+  { value: "accepted", label: "Accepted" },
+  { value: "assigned", label: "Assigned to a line" },
+];
 
 export default () => (
   <Layout>
@@ -18,30 +19,94 @@ export default () => (
       <title>Select</title>
     </Helmet>
     <Box
-      bg="whiteGrey" p="x4" borderRadius={ 1 }
+      bg="" mt="x2"
       mb="x6"
     >
       <Title mb="none">Select</Title>
       <Intro>For making one selection from a large list of options.</Intro>
     </Box>
     <DocSection>
-      <Image src={ basic } width="75%" alt="Text input screenshot" />
-      <SubsectionTitle>Use when</SubsectionTitle>
+
+      <Select placeholder="Please select inventory status" options={ options } />
+      <Highlight className="js">
+        {`import {Select} from @nulogy-components;
+
+const options = [
+  { value: "accepted", label: "Accepted" },
+  { value: "assigned", label: "Assigned to a line" },
+];
+
+<Select placeholder="Please select inventory status" options={ options } />`
+}
+      </Highlight>
+    </DocSection>
+    <DocSection>
+      <SectionTitle>Use when</SectionTitle>
       <CheckList>Users need to choose a single option from a list of mutually exclusive options.</CheckList>
       <CheckList>There is a large data set that would be impractical for radio buttons or a toggle.</CheckList>
     </DocSection>
     <DocSection>
-      <SectionTitle>Anatomy</SectionTitle>
-      <Image src={ anatomy } width="50%" alt="Text input screenshot" />
+      <SectionTitle>Variations</SectionTitle>
+      <SubsectionTitle>Disabled</SubsectionTitle>
+
+      <Box mb="x3">
+        <Select placeholder="Please select inventory status" options={ options } disabled />
+        <Highlight className="jsx">
+          {"<Select placeholder=\"Please select inventory status\" options={ options } disabled />"}
+        </Highlight>
+      </Box>
+
+      <SubsectionTitle>Error</SubsectionTitle>
+
+      <Select placeholder="Please select inventory status" options={ options } error />
+      <Highlight className="jsx">
+        {"<Select placeholder=\"Please select inventory status\" options={ options } error />"}
+      </Highlight>
+
+    </DocSection>
+
+    <DocSection>
+      <SectionTitle>Props</SectionTitle>
+      <table>
+        <thead>
+          <tr>
+            <td>Prop</td>
+            <td>Type</td>
+            <td>Default value</td>
+            <td>Description</td>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Placeholder</td>
+            <td>String</td>
+            <td>""</td>
+            <td>A description of what the Select box contains</td>
+          </tr>
+          <tr>
+            <td>Disabled</td>
+            <td>Boolean</td>
+            <td>false</td>
+            <td>Marks the field as disabled and disallows user input</td>
+          </tr>
+          <tr>
+            <td>Error</td>
+            <td>Boolean</td>
+            <td>false</td>
+            <td>Marks the field as invalid and adds a red border</td>
+          </tr>
+          <tr>
+            <td>Required</td>
+            <td>Boolean</td>
+            <td>false</td>
+            <td>Makes the field require input before the form will submit</td>
+          </tr>
+        </tbody>
+      </table>
     </DocSection>
     <DocSection>
-      <SectionTitle>States</SectionTitle>
-      <SubsectionTitle>Default</SubsectionTitle>
-      <Image src={ defaultState } width="50%" alt="Text input screenshot" />
-      <SubsectionTitle>With input</SubsectionTitle>
-      <Image src={ selected } width="50%" alt="Text input screenshot" />
-      <SubsectionTitle>Disabled</SubsectionTitle>
-      <Image src={ disabled } width="50%" alt="Text input screenshot" />
+      <SectionTitle>Resources</SectionTitle>
+      <Link href="https://storybook.nulogy.design/">Storybook</Link> <br />
     </DocSection>
   </Layout>
 );

--- a/docs/src/pages/components/template.js
+++ b/docs/src/pages/components/template.js
@@ -1,0 +1,90 @@
+import React from "react";
+import { Helmet } from "react-helmet";
+import Highlight from "react-highlight";
+import {
+  Button, Box, Flex, SectionTitle, SubsectionTitle, Title, Link,
+} from "@nulogy/components";
+import {
+  DocText as Text, Layout, Intro, DocSection, CheckList,
+} from "../../components";
+
+
+export default () => (
+  <Layout>
+    <Helmet>
+      <title>Component name</title>
+    </Helmet>
+    <Box pt="x4" mb="x6">
+      <Title m="none">Component name</Title>
+      <Intro>A short description of the component.</Intro>
+      </Box>
+
+      <DocSection>
+      <Button>Create project</Button>
+      <Highlight className="jsx">
+        {`import {Button} from @nulogy-components;
+
+<Button>Create project</Button>
+`}
+      </Highlight>
+      </DocSection>
+
+
+    <DocSection>
+      <SectionTitle>When to use</SectionTitle>
+    </DocSection>
+
+    <DocSection>
+      <SectionTitle>Variations</SectionTitle>
+      <Box mb="x4">
+        <SubsectionTitle>Variation 1</SubsectionTitle>
+        <Highlight className="jsx">
+        {``}
+      </Highlight>
+      </Box>
+    </DocSection>
+
+    <DocSection>
+      <SectionTitle>Dos and Donts</SectionTitle>
+    </DocSection>
+
+    <DocSection>
+      <SectionTitle>Accessibility guidelines</SectionTitle>
+    </DocSection>
+
+    <DocSection>
+      <SectionTitle>Responsive information</SectionTitle>
+    </DocSection>
+
+    <DocSection>
+      <SectionTitle>Props</SectionTitle>
+      <table>
+        <thead>
+          <tr>
+            <td>Prop</td>
+            <td>Type</td>
+            <td>Default value</td>
+            <td>Description</td>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+          </tr>
+        </tbody>
+      </table>
+    </DocSection>
+
+    <DocSection>
+      <SectionTitle>Related components</SectionTitle>
+    </DocSection>
+
+    <DocSection>
+      <SectionTitle>Resources</SectionTitle>
+    </DocSection>
+
+  </Layout>
+);

--- a/docs/src/pages/components/template.js
+++ b/docs/src/pages/components/template.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-unused-vars, quotes, react/self-closing-comp */
+
 import React from "react";
 import { Helmet } from "react-helmet";
 import Highlight from "react-highlight";
@@ -7,7 +9,6 @@ import {
 import {
   DocText as Text, Layout, Intro, DocSection, CheckList,
 } from "../../components";
-
 
 export default () => (
   <Layout>
@@ -39,8 +40,8 @@ export default () => (
       <Box mb="x4">
         <SubsectionTitle>Variation 1</SubsectionTitle>
         <Highlight className="jsx">
-        {``}
-      </Highlight>
+          {``}
+        </Highlight>
       </Box>
     </DocSection>
 

--- a/docs/src/pages/components/template.js
+++ b/docs/src/pages/components/template.js
@@ -17,9 +17,9 @@ export default () => (
     <Box pt="x4" mb="x6">
       <Title m="none">Component name</Title>
       <Intro>A short description of the component.</Intro>
-      </Box>
+    </Box>
 
-      <DocSection>
+    <DocSection>
       <Button>Create project</Button>
       <Highlight className="jsx">
         {`import {Button} from @nulogy-components;
@@ -27,7 +27,7 @@ export default () => (
 <Button>Create project</Button>
 `}
       </Highlight>
-      </DocSection>
+    </DocSection>
 
 
     <DocSection>


### PR DESCRIPTION
This PR gets the docs site ready for the new combined design/code structure as follows: 

- 	Component name
- 	Description
- 	Example (with code sample including import statement and initial set-up (e.g object for Select options)
- 	When to use
- 	Variations (with code sample focusing on variation, without import or set-up)
- 	Guidelines
- - Dos and Donts 
- - Accessibility
- - Responsive 
- 	Props (type, default, description)
- 	Related components
- 	Resources

The work included here to support this was:

- Add syntax highlighting plugin using Nulogy colours 
- Create temporary table styling so we can at least add props while waiting for table to be coded this month
- Update three example component pages to new structure (Select, Checkbox, Buttons)
- Create a copy and pasteable starter template with all the possible sections

Work that will still need to be done in further tickets as we focus on component documentation this month:
- Add knobs to storybook for interactive playground
- Explore whether info addon would be helpful for displaying our props inside storybook
- Update intro component to not have grey background or padding
- Update existing component pages:
- - Icons
- - Radio button
- - Text input
- - Toggle
- Add missing component pages: 
- - Box
- - IconicButton (moved from Button)
- - Link
- - List
- - RadioGroup
- - Textarea
- - HeaderValidation
