### PR TITLE
Stop loading fonts through NDSProvider

### DIFF
--- a/components/.storybook/preview-head.html
+++ b/components/.storybook/preview-head.html
@@ -1,0 +1,2 @@
+<link href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono" rel="stylesheet">

--- a/components/README.md
+++ b/components/README.md
@@ -6,10 +6,18 @@ Built with React, compononents make it easy to create interfaces that conform to
 
 ## Usage
 
-### 1. Wrap your appliction in our theme provider 
+### 1. Add fonts
+Add [IBM Plex Sans](https://fonts.google.com/specimen/IBM+Plex+Sans) and [IBM Plex Mono](https://fonts.google.com/specimen/IBM+Plex+Sans) to your application
+
+```html
+<link href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono" rel="stylesheet">
+```
+
+### 2. Wrap your appliction in our theme provider 
 Wrap your application in the NDSProvider component to access Nulogy's theme values and add typographic defaults. 
 
-```
+```js
 import React from 'react'
 import { NDSProvider } from '@nulogy/components'
 
@@ -24,8 +32,8 @@ class App extends React.Component {
 }
 ```
 
-### 2. Import desired components
-```
+### 3. Import desired components
+```js
 import { Button } from '@nulogy/components'
 
 const SomeView = () => (

--- a/components/src/NDSProvider/NDSProvider.js
+++ b/components/src/NDSProvider/NDSProvider.js
@@ -3,8 +3,6 @@ import styled, { createGlobalStyle, ThemeProvider } from "styled-components";
 import theme from "../theme";
 
 const Reset = createGlobalStyle(
-  ["@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:300,400,500,600');"],
-  ["@import url('https://fonts.googleapis.com/css?family=IBM+Plex+Mono');"],
   {
     "body": {
       margin: 0,


### PR DESCRIPTION
This PR removes the font imports from NDSProvider, manually adds them to storybook and updates the documentation.