### PR TITLE
[WIP] Switch header from maxWidth to width

### DIFF
--- a/docs/src/components/Layout.js
+++ b/docs/src/components/Layout.js
@@ -38,7 +38,7 @@ const Layout = ({ children }) => (
         p="x2"
       >
         <Box
-          pl="x3" pr="x3" maxWidth={ 960 }
+          pl="x3" pr="x3" width={ 960 }
           m="auto"
         >
           <Flex>

--- a/docs/src/components/Nav.js
+++ b/docs/src/components/Nav.js
@@ -1,6 +1,8 @@
 import styled from "styled-components";
+import theme from "../../../components/src/theme";
 
 const Nav = styled.ul`
+  padding-left: ${theme.space.x3}
 `;
 
 const NavItem = styled.li`


### PR DESCRIPTION
This stops our header from being responsive while the rest of the site isn't. We should make the site responsive soon, but in the mean time while it's not, nothing should look responsive so it doesn't feel like a bug. It also fixes the padding discrepancy between the main content and the headers container due to browser default ul padding.