### PR TITLE
[NDS-705] Fix Textarea font size

### DIFF
--- a/components/src/Textarea/Textarea.js
+++ b/components/src/Textarea/Textarea.js
@@ -39,7 +39,7 @@ const Textarea = styled.textarea.attrs(({ error, required, placeholder }) => ({
     border: "1px solid",
     borderRadius: theme.radii.medium,
     padding: subPx(theme.space.x1),
-    fontSize: theme.fontSizes[1],
+    fontSize: theme.fontSizes.medium,
     fontFamily: theme.fonts.base,
     lineHeight: theme.lineHeights.base,
     minHeight: "40px",


### PR DESCRIPTION
Textarea was built during the time when we were switching our space array to an object and fontSize got missed in the merge so this updates it. 