### PR TITLE
Nds 676 create a checkboxgroup component

### DIFF
--- a/components/spec/__snapshots__/Storyshots.spec.js.snap
+++ b/components/spec/__snapshots__/Storyshots.spec.js.snap
@@ -46,6 +46,20 @@ exports[`Storyshots Checkbox Set to error 1`] = `ReactWrapper {}`;
 
 exports[`Storyshots Checkbox Set to required 1`] = `ReactWrapper {}`;
 
+exports[`Storyshots CheckboxGroup Checkbox Group 1`] = `ReactWrapper {}`;
+
+exports[`Storyshots CheckboxGroup Controlled 1`] = `ReactWrapper {}`;
+
+exports[`Storyshots CheckboxGroup Set to disabled 1`] = `ReactWrapper {}`;
+
+exports[`Storyshots CheckboxGroup with additional text 1`] = `ReactWrapper {}`;
+
+exports[`Storyshots CheckboxGroup with defaultValue 1`] = `ReactWrapper {}`;
+
+exports[`Storyshots CheckboxGroup with helpText 1`] = `ReactWrapper {}`;
+
+exports[`Storyshots CheckboxGroup with requirementText 1`] = `ReactWrapper {}`;
+
 exports[`Storyshots DemoPage Demo Page 1`] = `ReactWrapper {}`;
 
 exports[`Storyshots Field Field 1`] = `ReactWrapper {}`;
@@ -192,9 +206,13 @@ exports[`Storyshots RadioGroup Controlled 1`] = `ReactWrapper {}`;
 
 exports[`Storyshots RadioGroup Radio Group 1`] = `ReactWrapper {}`;
 
-exports[`Storyshots RadioGroup Radio Group Field 1`] = `ReactWrapper {}`;
-
 exports[`Storyshots RadioGroup Set to disabled 1`] = `ReactWrapper {}`;
+
+exports[`Storyshots RadioGroup with additional text 1`] = `ReactWrapper {}`;
+
+exports[`Storyshots RadioGroup with helpText 1`] = `ReactWrapper {}`;
+
+exports[`Storyshots RadioGroup with requirementText 1`] = `ReactWrapper {}`;
 
 exports[`Storyshots Select Select 1`] = `ReactWrapper {}`;
 

--- a/components/src/Checkbox/CheckboxGroup.js
+++ b/components/src/Checkbox/CheckboxGroup.js
@@ -12,6 +12,7 @@ const getCheckboxButtons = props => {
     const {
       value,
       disabled,
+      required,
       ...checkboxProps
     } = checkbox.props;
     return (
@@ -23,6 +24,7 @@ const getCheckboxButtons = props => {
         defaultChecked={ props.defaultValue ? props.defaultValue.includes(value) : undefined }
         checked={ props.checkedValue ? props.checkedValue.includes(value) : undefined }
         onChange={ props.onChange }
+        required={ props.required}
       />
     );
   });

--- a/components/src/Checkbox/CheckboxGroup.js
+++ b/components/src/Checkbox/CheckboxGroup.js
@@ -29,21 +29,21 @@ const getCheckboxButtons = props => {
   return (checkboxButtons);
 };
 
-const internalSpacingStyles = (hasHelpText) => {
-  if (hasHelpText){
+const internalSpacingStyles = hasHelpText => {
+  if (hasHelpText) {
     return ({
-      "p":{
+      "p": {
         marginBottom: theme.space.x1,
       },
-    })
+    });
   } else {
     return ({
       "legend": {
         marginBottom: theme.space.x1,
       },
-    })
-  } 
-}
+    });
+  }
+};
 
 const Fieldset = styled.fieldset({
   padding: 0,
@@ -53,11 +53,9 @@ const Fieldset = styled.fieldset({
     padding: 0,
   },
 },
-({hasHelpText}) => (
+({ hasHelpText }) => (
   internalSpacingStyles(hasHelpText)
-),
-
-);
+),);
 
 const BaseCheckboxGroup = ({
   className,
@@ -66,9 +64,9 @@ const BaseCheckboxGroup = ({
   requirementText,
   ...props
 }) => (
-  <Fieldset className={ className } hasHelpText={!!helpText}>
+  <Fieldset className={ className } hasHelpText={ !!helpText }>
     <legend>
-      { labelText } 
+      { labelText }
       { requirementText && (<RequirementText>{requirementText}</RequirementText>) }
     </legend>
     { helpText && (<HelpText>{helpText}</HelpText>) }

--- a/components/src/Checkbox/CheckboxGroup.js
+++ b/components/src/Checkbox/CheckboxGroup.js
@@ -1,11 +1,12 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import { Checkbox } from "ComponentsRoot";
+import {
+  Checkbox,
+  HelpText,
+  RequirementText,
+} from "ComponentsRoot";
 import theme from "../theme";
-import HelpText from "../Field/HelpText";
-import RequirementText from "../Field/RequirementText";
-
 
 const getCheckboxButtons = props => {
   const checkboxButtons = React.Children.map(props.children, checkbox => {
@@ -18,13 +19,13 @@ const getCheckboxButtons = props => {
     return (
       <Checkbox
         { ...checkboxProps }
-        disabled={ props.disabled || disabled }
-        name={ props.name }
         value={ value }
+        disabled={ props.disabled || disabled }
+        required={ props.required || required }
+        name={ props.name }
         defaultChecked={ props.defaultValue ? props.defaultValue.includes(value) : undefined }
         checked={ props.checkedValue ? props.checkedValue.includes(value) : undefined }
         onChange={ props.onChange }
-        required={ props.required}
       />
     );
   });

--- a/components/src/Checkbox/CheckboxGroup.js
+++ b/components/src/Checkbox/CheckboxGroup.js
@@ -1,32 +1,32 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import { Radio } from "ComponentsRoot";
+import { Checkbox } from "ComponentsRoot";
 import theme from "../theme";
 import HelpText from "../Field/HelpText";
 import RequirementText from "../Field/RequirementText";
 
 
-const getRadioButtons = props => {
-  const radioButtons = React.Children.map(props.children, radio => {
+const getCheckboxButtons = props => {
+  const checkboxButtons = React.Children.map(props.children, checkbox => {
     const {
       value,
       disabled,
-      ...radioProps
-    } = radio.props;
+      ...checkboxProps
+    } = checkbox.props;
     return (
-      <Radio
-        { ...radioProps }
+      <Checkbox
+        { ...checkboxProps }
         disabled={ props.disabled || disabled }
         name={ props.name }
         value={ value }
-        defaultChecked={ value === props.defaultValue ? true : undefined }
-        checked={ props.checkedValue && (value === props.checkedValue) }
+        defaultChecked={ props.defaultValue ? props.defaultValue.includes(value) : undefined }
+        checked={ props.checkedValue ? props.checkedValue.includes(value) : undefined }
         onChange={ props.onChange }
       />
     );
   });
-  return (radioButtons);
+  return (checkboxButtons);
 };
 
 const internalSpacingStyles = (hasHelpText) => {
@@ -59,45 +59,45 @@ const Fieldset = styled.fieldset({
 
 );
 
-const BaseRadioGroup = ({
+const BaseCheckboxGroup = ({
   className,
   labelText,
   helpText,
   requirementText,
   ...props
 }) => (
-  <Fieldset role="radiogroup" className={ className } hasHelpText={!!helpText}>
+  <Fieldset className={ className } hasHelpText={!!helpText}>
     <legend>
-      { labelText }
+      { labelText } 
       { requirementText && (<RequirementText>{requirementText}</RequirementText>) }
     </legend>
     { helpText && (<HelpText>{helpText}</HelpText>) }
-    { getRadioButtons(props) }
+    { getCheckboxButtons(props) }
   </Fieldset>
 );
 
-BaseRadioGroup.propTypes = {
+BaseCheckboxGroup.propTypes = {
   labelText: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   children: PropTypes.oneOfType([
     PropTypes.shape({
-      type: PropTypes.oneOf([Radio]),
+      type: PropTypes.oneOf([Checkbox]),
     }),
     PropTypes.arrayOf(
       PropTypes.shape({
-        type: PropTypes.oneOf([Radio]),
+        type: PropTypes.oneOf([Checkbox]),
       })
     ),
   ]).isRequired,
-  defaultValue: PropTypes.string,
-  checkedValue: PropTypes.string,
+  defaultValue: PropTypes.arrayOf(PropTypes.string),
+  checkedValue: PropTypes.arrayOf(PropTypes.string),
   onChange: PropTypes.func,
   className: PropTypes.string,
   helpText: PropTypes.string,
   requirementText: PropTypes.string,
 };
 
-BaseRadioGroup.defaultProps = {
+BaseCheckboxGroup.defaultProps = {
   defaultValue: undefined,
   checkedValue: undefined,
   onChange: undefined,
@@ -106,6 +106,6 @@ BaseRadioGroup.defaultProps = {
   requirementText: null,
 };
 
-const RadioGroup = styled(BaseRadioGroup)({});
+const CheckboxGroup = styled(BaseCheckboxGroup)({});
 
-export default RadioGroup;
+export default CheckboxGroup;

--- a/components/src/Checkbox/CheckboxGroup.story.js
+++ b/components/src/Checkbox/CheckboxGroup.story.js
@@ -28,14 +28,14 @@ storiesOf("CheckboxGroup", module)
     </CheckboxGroup>
   ))
   .add("with requirementText", () => (
-    <CheckboxGroup labelText="Setting Selection" requirementText="(Required)" name="settingSelection" defaultValue={ ["a"] }>
+    <CheckboxGroup labelText="Setting Selection" required requirementText="(Required)" name="settingSelection" defaultValue={ ["a"] }>
       <Checkbox value="a" labelText="Option A" />
       <Checkbox value="b" labelText="Option B" />
       <Checkbox value="c" labelText="Option C" />
     </CheckboxGroup>
   ))
   .add("with additional text", () => (
-    <CheckboxGroup labelText="Setting Selection" helpText="Select a setting from the menu below:" requirementText="(Required)" name="settingSelection" defaultValue={ ["a"] }>
+    <CheckboxGroup labelText="Setting Selection" helpText="Select a setting from the menu below:" required requirementText="(Required)" name="settingSelection" defaultValue={ ["a"] }>
       <Checkbox value="a" labelText="Option A" />
       <Checkbox value="b" labelText="Option B" />
       <Checkbox value="c" labelText="Option C" />

--- a/components/src/Checkbox/CheckboxGroup.story.js
+++ b/components/src/Checkbox/CheckboxGroup.story.js
@@ -1,0 +1,57 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import {
+  Checkbox,
+  CheckboxGroup,
+} from "ComponentsRoot";
+
+storiesOf("CheckboxGroup", module)
+  .add("Checkbox Group", () => (
+    <CheckboxGroup labelText="Setting Selection" name="settingSelection" defaultValue={["a"]}>
+      <Checkbox value="a" labelText="Option A" />
+      <Checkbox value="b" labelText="Option B" />
+      <Checkbox value="c" labelText="Option C" />
+    </CheckboxGroup>
+  ))
+  .add("with defaultValue", () => (
+    <CheckboxGroup labelText="Setting Selection" name="settingSelection" defaultValue={["a"]}>
+      <Checkbox value="a" labelText="Option A" />
+      <Checkbox value="b" labelText="Option B" />
+      <Checkbox value="c" labelText="Option C" />
+    </CheckboxGroup>
+  ))
+  .add("with helpText", () => (
+      <CheckboxGroup labelText="Setting Selection" helpText="Select a setting from the menu below:" name="settingSelection" defaultValue={["a"]}>
+        <Checkbox value="a" labelText="Option A" />
+        <Checkbox value="b" labelText="Option B" />
+        <Checkbox value="c" labelText="Option C" />
+      </CheckboxGroup>
+  ))
+  .add("with requirementText", () => (
+    <CheckboxGroup labelText="Setting Selection" requirementText="(Required)" name="settingSelection" defaultValue={["a"]}>
+      <Checkbox value="a" labelText="Option A" />
+      <Checkbox value="b" labelText="Option B" />
+      <Checkbox value="c" labelText="Option C" />
+    </CheckboxGroup>
+  ))
+  .add("with additional text", () => (
+    <CheckboxGroup labelText="Setting Selection" helpText="Select a setting from the menu below:" requirementText="(Required)" name="settingSelection" defaultValue={["a"]}>
+      <Checkbox value="a" labelText="Option A" />
+      <Checkbox value="b" labelText="Option B" />
+      <Checkbox value="c" labelText="Option C" />
+    </CheckboxGroup>
+  ))
+  .add("Set to disabled", () => (
+    <CheckboxGroup disabled labelText="Setting Selection" name="settingSelection" defaultValue={["a"]}>
+      <Checkbox value="a" labelText="Option A" />
+      <Checkbox value="b" labelText="Option B" />
+      <Checkbox value="c" labelText="Option C" />
+    </CheckboxGroup>
+  ))
+  .add("Controlled", () => (
+    <CheckboxGroup labelText="Setting Selection" name="settingSelection" checkedValue={["a"]} onChange={ () => {} }>
+      <Checkbox value="a" labelText="Option A" />
+      <Checkbox value="b" labelText="Option B" />
+      <Checkbox value="c" labelText="Option C" />
+    </CheckboxGroup>
+  ));

--- a/components/src/Checkbox/CheckboxGroup.story.js
+++ b/components/src/Checkbox/CheckboxGroup.story.js
@@ -7,49 +7,49 @@ import {
 
 storiesOf("CheckboxGroup", module)
   .add("Checkbox Group", () => (
-    <CheckboxGroup labelText="Setting Selection" name="settingSelection" defaultValue={["a"]}>
+    <CheckboxGroup labelText="Setting Selection" name="settingSelection" defaultValue={ ["a"] }>
       <Checkbox value="a" labelText="Option A" />
       <Checkbox value="b" labelText="Option B" />
       <Checkbox value="c" labelText="Option C" />
     </CheckboxGroup>
   ))
   .add("with defaultValue", () => (
-    <CheckboxGroup labelText="Setting Selection" name="settingSelection" defaultValue={["a"]}>
+    <CheckboxGroup labelText="Setting Selection" name="settingSelection" defaultValue={ ["a"] }>
       <Checkbox value="a" labelText="Option A" />
       <Checkbox value="b" labelText="Option B" />
       <Checkbox value="c" labelText="Option C" />
     </CheckboxGroup>
   ))
   .add("with helpText", () => (
-      <CheckboxGroup labelText="Setting Selection" helpText="Select a setting from the menu below:" name="settingSelection" defaultValue={["a"]}>
-        <Checkbox value="a" labelText="Option A" />
-        <Checkbox value="b" labelText="Option B" />
-        <Checkbox value="c" labelText="Option C" />
-      </CheckboxGroup>
+    <CheckboxGroup labelText="Setting Selection" helpText="Select a setting from the menu below:" name="settingSelection" defaultValue={ ["a"] }>
+      <Checkbox value="a" labelText="Option A" />
+      <Checkbox value="b" labelText="Option B" />
+      <Checkbox value="c" labelText="Option C" />
+    </CheckboxGroup>
   ))
   .add("with requirementText", () => (
-    <CheckboxGroup labelText="Setting Selection" requirementText="(Required)" name="settingSelection" defaultValue={["a"]}>
+    <CheckboxGroup labelText="Setting Selection" requirementText="(Required)" name="settingSelection" defaultValue={ ["a"] }>
       <Checkbox value="a" labelText="Option A" />
       <Checkbox value="b" labelText="Option B" />
       <Checkbox value="c" labelText="Option C" />
     </CheckboxGroup>
   ))
   .add("with additional text", () => (
-    <CheckboxGroup labelText="Setting Selection" helpText="Select a setting from the menu below:" requirementText="(Required)" name="settingSelection" defaultValue={["a"]}>
+    <CheckboxGroup labelText="Setting Selection" helpText="Select a setting from the menu below:" requirementText="(Required)" name="settingSelection" defaultValue={ ["a"] }>
       <Checkbox value="a" labelText="Option A" />
       <Checkbox value="b" labelText="Option B" />
       <Checkbox value="c" labelText="Option C" />
     </CheckboxGroup>
   ))
   .add("Set to disabled", () => (
-    <CheckboxGroup disabled labelText="Setting Selection" name="settingSelection" defaultValue={["a"]}>
+    <CheckboxGroup disabled labelText="Setting Selection" name="settingSelection" defaultValue={ ["a"] }>
       <Checkbox value="a" labelText="Option A" />
       <Checkbox value="b" labelText="Option B" />
       <Checkbox value="c" labelText="Option C" />
     </CheckboxGroup>
   ))
   .add("Controlled", () => (
-    <CheckboxGroup labelText="Setting Selection" name="settingSelection" checkedValue={["a"]} onChange={ () => {} }>
+    <CheckboxGroup labelText="Setting Selection" name="settingSelection" checkedValue={ ["a"] } onChange={ () => {} }>
       <Checkbox value="a" labelText="Option A" />
       <Checkbox value="b" labelText="Option B" />
       <Checkbox value="c" labelText="Option C" />

--- a/components/src/DemoPage/DemoPage.js
+++ b/components/src/DemoPage/DemoPage.js
@@ -359,7 +359,7 @@ const DemoPage = () => {
                 </Field>
 
                 <Field labelText="Reconcile" htmlFor="reconcile">
-                  <RadioGroup name="settingSelection" defaultValue="yes" id="reconcile">
+                  <RadioGroup labelText="Reconcile" name="settingSelection" defaultValue="yes" id="reconcile">
                     <Radio value="yes" labelText="Yes" />
                     <Radio value="no" labelText="No" />
                     <Radio value="maybe" labelText="Maybe" disabled />

--- a/components/src/Form/Form.story.js
+++ b/components/src/Form/Form.story.js
@@ -156,7 +156,7 @@ storiesOf("Form", module)
           </Field>
 
           <Field labelText="Reconcile" htmlFor="reconcile">
-            <RadioGroup name="settingSelection" defaultValue="yes" id="reconcile">
+            <RadioGroup labelText="Reconcile" name="settingSelection" defaultValue="yes" id="reconcile">
               <Radio value="yes" labelText="Yes" />
               <Radio value="no" labelText="No" />
               <Radio value="maybe" labelText="Maybe" disabled />

--- a/components/src/Radio/RadioGroup.js
+++ b/components/src/Radio/RadioGroup.js
@@ -29,21 +29,21 @@ const getRadioButtons = props => {
   return (radioButtons);
 };
 
-const internalSpacingStyles = (hasHelpText) => {
-  if (hasHelpText){
+const internalSpacingStyles = hasHelpText => {
+  if (hasHelpText) {
     return ({
-      "p":{
+      "p": {
         marginBottom: theme.space.x1,
       },
-    })
+    });
   } else {
     return ({
       "legend": {
         marginBottom: theme.space.x1,
       },
-    })
-  } 
-}
+    });
+  }
+};
 
 const Fieldset = styled.fieldset({
   padding: 0,
@@ -53,11 +53,9 @@ const Fieldset = styled.fieldset({
     padding: 0,
   },
 },
-({hasHelpText}) => (
+({ hasHelpText }) => (
   internalSpacingStyles(hasHelpText)
-),
-
-);
+),);
 
 const BaseRadioGroup = ({
   className,
@@ -66,7 +64,7 @@ const BaseRadioGroup = ({
   requirementText,
   ...props
 }) => (
-  <Fieldset role="radiogroup" className={ className } hasHelpText={!!helpText}>
+  <Fieldset role="radiogroup" className={ className } hasHelpText={ !!helpText }>
     <legend>
       { labelText }
       { requirementText && (<RequirementText>{requirementText}</RequirementText>) }

--- a/components/src/Radio/RadioGroup.js
+++ b/components/src/Radio/RadioGroup.js
@@ -12,6 +12,7 @@ const getRadioButtons = props => {
     const {
       value,
       disabled,
+      required,
       ...radioProps
     } = radio.props;
     return (
@@ -23,6 +24,7 @@ const getRadioButtons = props => {
         defaultChecked={ value === props.defaultValue ? true : undefined }
         checked={ props.checkedValue && (value === props.checkedValue) }
         onChange={ props.onChange }
+        required={ props.required}
       />
     );
   });

--- a/components/src/Radio/RadioGroup.js
+++ b/components/src/Radio/RadioGroup.js
@@ -1,11 +1,12 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import { Radio } from "ComponentsRoot";
+import {
+  Radio,
+  HelpText,
+  RequirementText,
+} from "ComponentsRoot";
 import theme from "../theme";
-import HelpText from "../Field/HelpText";
-import RequirementText from "../Field/RequirementText";
-
 
 const getRadioButtons = props => {
   const radioButtons = React.Children.map(props.children, radio => {
@@ -18,13 +19,13 @@ const getRadioButtons = props => {
     return (
       <Radio
         { ...radioProps }
-        disabled={ props.disabled || disabled }
-        name={ props.name }
         value={ value }
+        disabled={ props.disabled || disabled }
+        required={ props.required || required }
+        name={ props.name }
         defaultChecked={ value === props.defaultValue ? true : undefined }
         checked={ props.checkedValue && (value === props.checkedValue) }
         onChange={ props.onChange }
-        required={ props.required}
       />
     );
   });

--- a/components/src/Radio/RadioGroup.js
+++ b/components/src/Radio/RadioGroup.js
@@ -2,11 +2,14 @@ import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { Radio } from "ComponentsRoot";
+import theme from "../theme";
+import HelpText from "../Field/HelpText";
+import RequirementText from "../Field/RequirementText";
+
 
 const getRadioButtons = props => {
   const radioButtons = React.Children.map(props.children, radio => {
     const {
-
       value,
       disabled,
       ...radioProps
@@ -26,23 +29,53 @@ const getRadioButtons = props => {
   return (radioButtons);
 };
 
+const internalSpacingStyles = (hasHelpText) => {
+  if (hasHelpText){
+    return ({
+      "p":{
+        marginBottom: theme.space.x1,
+      },
+    })
+  } else {
+    return ({
+      "legend": {
+        marginBottom: theme.space.x1,
+      },
+    })
+  } 
+}
+
 const Fieldset = styled.fieldset({
   padding: 0,
   border: 0,
   margin: 0,
-});
+  "legend": {
+    padding: 0,
+  },
+},
+({hasHelpText}) => (
+  internalSpacingStyles(hasHelpText)
+),
+
+);
 
 const BaseRadioGroup = ({
   className,
+  labelText,
+  helpText,
+  requirementText,
   ...props
 }) => (
-  <Fieldset role="radiogroup" className={ className }>
-    <legend>Title</legend>
+  <Fieldset role="radiogroup" className={ className } hasHelpText={!!helpText}>
+    <legend>{ labelText }    { requirementText && (<RequirementText>{requirementText}</RequirementText>) }</legend>
+ 
+    { helpText && (<HelpText>{helpText}</HelpText>) }
     { getRadioButtons(props) }
   </Fieldset>
 );
 
 BaseRadioGroup.propTypes = {
+  labelText: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   children: PropTypes.oneOfType([
     PropTypes.shape({
@@ -58,6 +91,8 @@ BaseRadioGroup.propTypes = {
   checkedValue: PropTypes.string,
   onChange: PropTypes.func,
   className: PropTypes.string,
+  helpText: PropTypes.string,
+  requirementText: PropTypes.string,
 };
 
 BaseRadioGroup.defaultProps = {
@@ -65,6 +100,8 @@ BaseRadioGroup.defaultProps = {
   checkedValue: undefined,
   onChange: undefined,
   className: null,
+  helpText: null,
+  requirementText: null,
 };
 
 const RadioGroup = styled(BaseRadioGroup)({});

--- a/components/src/Radio/RadioGroup.story.js
+++ b/components/src/Radio/RadioGroup.story.js
@@ -35,14 +35,14 @@ storiesOf("RadioGroup", module)
     </RadioGroup>
   ))
   .add("Set to disabled", () => (
-    <RadioGroup disabled name="settingSelection" defaultValue="a">
+    <RadioGroup disabled labelText="Setting Selection" name="settingSelection" defaultValue="a">
       <Radio value="a" labelText="Option A" />
       <Radio value="b" labelText="Option B" />
       <Radio value="c" labelText="Option C" />
     </RadioGroup>
   ))
   .add("Controlled", () => (
-    <RadioGroup name="settingSelection" checkedValue="a" onChange={ () => {} }>
+    <RadioGroup labelText="Setting Selection" name="settingSelection" checkedValue="a" onChange={ () => {} }>
       <Radio value="a" labelText="Option A" />
       <Radio value="b" labelText="Option B" />
       <Radio value="c" labelText="Option C" />

--- a/components/src/Radio/RadioGroup.story.js
+++ b/components/src/Radio/RadioGroup.story.js
@@ -3,25 +3,36 @@ import { storiesOf } from "@storybook/react";
 import {
   Radio,
   RadioGroup,
-  Field,
 } from "ComponentsRoot";
 
 storiesOf("RadioGroup", module)
   .add("Radio Group", () => (
-    <RadioGroup name="settingSelection" defaultValue="a">
+    <RadioGroup labelText="Setting Selection" name="settingSelection" defaultValue="a">
       <Radio value="a" labelText="Option A" />
       <Radio value="b" labelText="Option B" />
       <Radio value="c" labelText="Option C" />
     </RadioGroup>
   ))
-  .add("Radio Group Field", () => (
-    <Field labelText="Setting Selection" helpText="Select a setting from the menu below:"> {/* eslint-disable-line */}
-      <RadioGroup name="settingSelection" defaultValue="a">
+  .add("with helpText", () => (
+      <RadioGroup labelText="Setting Selection" helpText="Select a setting from the menu below:" name="settingSelection" defaultValue="a">
         <Radio value="a" labelText="Option A" />
         <Radio value="b" labelText="Option B" />
         <Radio value="c" labelText="Option C" />
       </RadioGroup>
-    </Field>
+  ))
+  .add("with requirementText", () => (
+    <RadioGroup labelText="Setting Selection" requirementText="(Required)" name="settingSelection" defaultValue="a">
+      <Radio value="a" labelText="Option A" />
+      <Radio value="b" labelText="Option B" />
+      <Radio value="c" labelText="Option C" />
+    </RadioGroup>
+  ))
+  .add("with additional text", () => (
+    <RadioGroup labelText="Setting Selection" helpText="Select a setting from the menu below:" requirementText="(Required)" name="settingSelection" defaultValue="a">
+      <Radio value="a" labelText="Option A" />
+      <Radio value="b" labelText="Option B" />
+      <Radio value="c" labelText="Option C" />
+    </RadioGroup>
   ))
   .add("Set to disabled", () => (
     <RadioGroup disabled name="settingSelection" defaultValue="a">

--- a/components/src/Radio/RadioGroup.story.js
+++ b/components/src/Radio/RadioGroup.story.js
@@ -21,14 +21,14 @@ storiesOf("RadioGroup", module)
     </RadioGroup>
   ))
   .add("with requirementText", () => (
-    <RadioGroup labelText="Setting Selection" requirementText="(Required)" name="settingSelection" defaultValue="a">
+    <RadioGroup labelText="Setting Selection" required requirementText="(Required)" name="settingSelection" defaultValue="a">
       <Radio value="a" labelText="Option A" />
       <Radio value="b" labelText="Option B" />
       <Radio value="c" labelText="Option C" />
     </RadioGroup>
   ))
   .add("with additional text", () => (
-    <RadioGroup labelText="Setting Selection" helpText="Select a setting from the menu below:" requirementText="(Required)" name="settingSelection" defaultValue="a">
+    <RadioGroup labelText="Setting Selection" helpText="Select a setting from the menu below:" required requirementText="(Required)" name="settingSelection" defaultValue="a">
       <Radio value="a" labelText="Option A" />
       <Radio value="b" labelText="Option B" />
       <Radio value="c" labelText="Option C" />

--- a/components/src/Radio/RadioGroup.story.js
+++ b/components/src/Radio/RadioGroup.story.js
@@ -14,11 +14,11 @@ storiesOf("RadioGroup", module)
     </RadioGroup>
   ))
   .add("with helpText", () => (
-      <RadioGroup labelText="Setting Selection" helpText="Select a setting from the menu below:" name="settingSelection" defaultValue="a">
-        <Radio value="a" labelText="Option A" />
-        <Radio value="b" labelText="Option B" />
-        <Radio value="c" labelText="Option C" />
-      </RadioGroup>
+    <RadioGroup labelText="Setting Selection" helpText="Select a setting from the menu below:" name="settingSelection" defaultValue="a">
+      <Radio value="a" labelText="Option A" />
+      <Radio value="b" labelText="Option B" />
+      <Radio value="c" labelText="Option C" />
+    </RadioGroup>
   ))
   .add("with requirementText", () => (
     <RadioGroup labelText="Setting Selection" requirementText="(Required)" name="settingSelection" defaultValue="a">

--- a/components/src/index.js
+++ b/components/src/index.js
@@ -18,6 +18,7 @@ export { default as HelpText } from "./Field/HelpText";
 export { default as RequirementText } from "./Field/RequirementText";
 export { default as Input } from "./Input/Input";
 export { default as Checkbox } from "./Checkbox/Checkbox";
+export { default as CheckboxGroup } from "./Checkbox/CheckboxGroup";
 export { default as Radio } from "./Radio/Radio";
 export { default as RadioGroup } from "./Radio/RadioGroup";
 export { default as Toggle } from "./Toggle/Toggle";


### PR DESCRIPTION
Intent: Review to merge

This PR:
 - modifies RadioGroup to use the Legend as its "label"
 - adds HelpText and RequirementText to RadioGroup
 - creates CheckboxGroup that is identical to RadioGroup except there can be multiple defaultValues or checkedValues (uncontrolled vs controlled respectively).

Looking for feedback on:
 - Spacing styling build into the Legend (<legend> cannot be set to "inline" which resulted in me adding RequirementText into the Legend - the drawback of this is the text will be read by a screenreader whenever the legend is read.
 - Should a general "InputGroup" component be pulled out here and then used for the cases of Checkbox and Radio? These are the only two instances for where it is used right now so it may not make sense to pull anything out yet