### PR TITLE
Nds 709 width controlled tooltip

### DIFF
--- a/components/spec/__snapshots__/Storyshots.spec.js.snap
+++ b/components/spec/__snapshots__/Storyshots.spec.js.snap
@@ -292,4 +292,6 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `ReactWrapper {}
 
 exports[`Storyshots Tooltip with placement 1`] = `ReactWrapper {}`;
 
+exports[`Storyshots Tooltip with wrapped text 1`] = `ReactWrapper {}`;
+
 exports[`Storyshots Typography Article 1`] = `ReactWrapper {}`;

--- a/components/src/Tooltip/Tooltip.js
+++ b/components/src/Tooltip/Tooltip.js
@@ -306,7 +306,7 @@ Tooltip.defaultProps = {
   showDelay: "100",
   hideDelay: "350",
   fullWidth: false,
-  maxWidth: "18em",
+  maxWidth: "24em",
 };
 
 export default Tooltip;

--- a/components/src/Tooltip/Tooltip.js
+++ b/components/src/Tooltip/Tooltip.js
@@ -306,7 +306,7 @@ Tooltip.defaultProps = {
   showDelay: "100",
   hideDelay: "350",
   fullWidth: false,
-  maxWidth: "256px",
+  maxWidth: "18em",
 };
 
 export default Tooltip;

--- a/components/src/Tooltip/Tooltip.story.js
+++ b/components/src/Tooltip/Tooltip.story.js
@@ -37,7 +37,7 @@ storiesOf("Tooltip", module)
     <Flex p="x8">
       <Tooltip
         placement="bottom"
-        tooltip="I am a Tooltip! I have very long text, and my default max-width is 18em, which is equal to 288px, or approximately 40 characters."
+        tooltip="I am a Tooltip! I have very long text, and my default max-width is 24em (based on 14px font-size), which is equal to 336px, or approximately 45 characters."
         id="tooltip1"
       >
         <Button> Button </Button>

--- a/components/src/Tooltip/Tooltip.story.js
+++ b/components/src/Tooltip/Tooltip.story.js
@@ -33,6 +33,17 @@ storiesOf("Tooltip", module)
       </Tooltip>
     </Flex>
   ))
+  .add("with wrapped text", () => (
+    <Flex p="x8">
+      <Tooltip
+        placement="bottom"
+        tooltip="I am a Tooltip! I have very long text, and my default max-width is 18em, which is equal to 288px, or approximately 40 characters."
+        id="tooltip1"
+      >
+        <Button> Button </Button>
+      </Tooltip>
+    </Flex>
+  ))
   .add("with custom maxWidth", () => (
     <Flex p="x8">
       <Tooltip


### PR DESCRIPTION
Intent: review to merge

The tooltip already had a default width. What I did is:
- adjusted the value to 24em(336px, ~ 45 characters), and
- created "Tooltip / with wrapped text story"