### PR TITLE
Nds 726 make it obvious when a menu item is a dropdown trigger

### DIFF
--- a/components/src/Button/Button.js
+++ b/components/src/Button/Button.js
@@ -85,7 +85,7 @@ const Button = styled(BaseButton)(
     verticalAlign: "middle",
     lineHeight: theme.lineHeights.base,
     transition: ".2s",
-    cursor: disabled ? "arrow" : "pointer",
+
     color: theme.colors.blue,
     border: `1px solid ${theme.colors.darkBlue}`,
     borderRadius: theme.radii.medium,

--- a/components/src/Button/Button.js
+++ b/components/src/Button/Button.js
@@ -85,7 +85,7 @@ const Button = styled(BaseButton)(
     verticalAlign: "middle",
     lineHeight: theme.lineHeights.base,
     transition: ".2s",
-
+    cursor: disabled ? "arrow" : "pointer",
     color: theme.colors.blue,
     border: `1px solid ${theme.colors.darkBlue}`,
     borderRadius: theme.radii.medium,

--- a/components/src/NavBar/MenuDropdown/MenuDropdown.js
+++ b/components/src/NavBar/MenuDropdown/MenuDropdown.js
@@ -5,6 +5,7 @@ import { Manager, Reference, Popper } from "react-popper";
 import theme from "ComponentsRoot/theme";
 import SubMenuItemList from "./SubMenuItemList";
 import SubMenu from "./SubMenu";
+import Icon from "../../Icon/Icon";
 
 const MenuDropdownButton = styled.button({
   display: "inline-flex",
@@ -18,8 +19,11 @@ const MenuDropdownButton = styled.button({
   lineHeight: theme.lineHeights.base,
   transition: ".2s",
   fontSize: `${theme.fontSizes.medium}`,
-  padding: `${theme.space.x1} ${theme.space.x2}`,
+  padding: `${theme.space.x1} ${theme.space.half} ${theme.space.x1} ${theme.space.x2}`,
   borderRadius: theme.radii.medium,
+  [`${Icon}`]: {
+    color: theme.colors.lightGrey,
+  },
   "&:hover, &:focus": {
     outline: "none",
     color: theme.colors.lightBlue,
@@ -172,7 +176,7 @@ class MenuDropdown extends React.Component {
       <Manager>
         <Reference>
           {({ ref }) => (
-            <MenuDropdownButton aria-haspopup="true" aria-expanded={ this.state.subMenuOpen } { ...this.props } { ...this.menuDropdownEventHandlers() } ref={ ref }>{ this.props.labelText }</MenuDropdownButton>
+            <MenuDropdownButton aria-haspopup="true" aria-expanded={ this.state.subMenuOpen } { ...this.props } { ...this.menuDropdownEventHandlers() } ref={ ref }>{ this.props.labelText }<Icon icon="downArrow" size="20px" p={2}/></MenuDropdownButton>
           )}
         </Reference>
         {this.state.subMenuOpen && (

--- a/components/src/NavBar/MenuDropdown/MenuDropdown.js
+++ b/components/src/NavBar/MenuDropdown/MenuDropdown.js
@@ -176,7 +176,7 @@ class MenuDropdown extends React.Component {
       <Manager>
         <Reference>
           {({ ref }) => (
-            <MenuDropdownButton aria-haspopup="true" aria-expanded={ this.state.subMenuOpen } { ...this.props } { ...this.menuDropdownEventHandlers() } ref={ ref }>{ this.props.labelText }<Icon icon="downArrow" size="20px" p={2}/></MenuDropdownButton>
+            <MenuDropdownButton aria-haspopup="true" aria-expanded={ this.state.subMenuOpen } { ...this.props } { ...this.menuDropdownEventHandlers() } ref={ ref }>{ this.props.labelText }<Icon icon="downArrow" size="20px" p={ 2 } /></MenuDropdownButton>
           )}
         </Reference>
         {this.state.subMenuOpen && (

--- a/components/src/NavBar/MenuDropdown/MenuDropdown.js
+++ b/components/src/NavBar/MenuDropdown/MenuDropdown.js
@@ -28,6 +28,7 @@ const MenuDropdownButton = styled.button({
     outline: "none",
     color: theme.colors.lightBlue,
     backgroundColor: theme.colors.black,
+    cursor: "pointer",
   },
   "&:disabled": {
     opacity: ".5",

--- a/components/src/NavBar/MenuDropdown/MenuDropdown.js
+++ b/components/src/NavBar/MenuDropdown/MenuDropdown.js
@@ -24,7 +24,6 @@ const MenuDropdownButton = styled.button({
     outline: "none",
     color: theme.colors.lightBlue,
     backgroundColor: theme.colors.black,
-    cursor: "pointer",
   },
   "&:disabled": {
     opacity: ".5",

--- a/components/src/NavBar/MenuItem.js
+++ b/components/src/NavBar/MenuItem.js
@@ -22,7 +22,6 @@ const SubMenuItem = styled(Link).attrs({
     outline: "none",
     color: theme.colors.lightBlue,
     backgroundColor: theme.colors.black,
-    cursor: "pointer",
   },
   "&:disabled": {
     opacity: ".5",

--- a/components/src/NavBar/MenuItem.js
+++ b/components/src/NavBar/MenuItem.js
@@ -22,6 +22,7 @@ const SubMenuItem = styled(Link).attrs({
     outline: "none",
     color: theme.colors.lightBlue,
     backgroundColor: theme.colors.black,
+    textDecoration: "underline",
   },
   "&:disabled": {
     opacity: ".5",

--- a/components/src/NavBar/MenuItem.js
+++ b/components/src/NavBar/MenuItem.js
@@ -23,6 +23,7 @@ const SubMenuItem = styled(Link).attrs({
     color: theme.colors.lightBlue,
     backgroundColor: theme.colors.black,
     textDecoration: "underline",
+    cursor: "pointer",
   },
   "&:disabled": {
     opacity: ".5",

--- a/components/src/NavBar/MobileMenu.js
+++ b/components/src/NavBar/MobileMenu.js
@@ -25,6 +25,9 @@ export const MobileMenu = styled(MobileMenuBase)(
       border: "none",
       padding: `${subPx(theme.space.x1)} ${theme.space.x1}`,
       marginLeft: theme.space.x1,
+      "&:hover": {
+        cursor: "pointer",
+      },
     },
   },
 );

--- a/components/src/NavBar/SubMenuItem.js
+++ b/components/src/NavBar/SubMenuItem.js
@@ -12,6 +12,11 @@ const SubMenuItemLink = styled(Link)({
     outline: "none",
     backgroundColor: theme.colors.lightGrey,
   },
+  "&:hover": {
+    "p:first-child": {
+      textDecoration: "underline",
+    },
+  },
   "&:disabled": {
     opacity: ".5",
   },

--- a/components/src/NavBar/SubMenuItem.js
+++ b/components/src/NavBar/SubMenuItem.js
@@ -11,8 +11,6 @@ const SubMenuItemLink = styled(Link)({
   "&:hover, &:focus": {
     outline: "none",
     backgroundColor: theme.colors.lightGrey,
-  },
-  "&:hover": {
     "p:first-child": {
       textDecoration: "underline",
     },


### PR DESCRIPTION
Intent: Review to merge

The goal of this PR was to make it more obvious which menu items expose the drop down and which link to the new page.

### What I did
- Added down arrow to the dropdown triggers
- Added underline to link hover state
- Remove pointer cursor from all buttons

