### PR TITLE
Fix nulogy.design phone behaviours 

### DIFF
--- a/docs/src/components/Layout.js
+++ b/docs/src/components/Layout.js
@@ -1,8 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
-import styled from "styled-components";
 import {
-  Box, Flex, NDSProvider,
+  Box, NDSProvider,
 } from "@nulogy/components";
 import { Helmet } from "react-helmet";
 import { Navigation } from "./Nav";

--- a/docs/src/components/Layout.js
+++ b/docs/src/components/Layout.js
@@ -21,7 +21,7 @@ const Layout = ({ children }) => (
       </Helmet>
       <HighlightStyles />
       <Navigation />
-      <Box ml={ { small: 0, large: "260px" } }>
+      <Box ml={ { small: 0, large: "220px" } }>
         <Box pt={ { small: 0, large: "x8" } } px="x3" maxWidth="740px" m="0 auto">
           {children}
         </Box>

--- a/docs/src/components/Layout.js
+++ b/docs/src/components/Layout.js
@@ -22,7 +22,7 @@ const Layout = ({ children }) => (
       </Helmet>
       <HighlightStyles />
       <Navigation />
-      <Box ml={{small: 0, large: "260px"}}>
+      <Box ml={ { small: 0, large: "260px" } }>
         <Box pt={ { small: 0, large: "x8" } } px="x3" maxWidth="740px" m="0 auto">
           {children}
         </Box>

--- a/docs/src/components/Layout.js
+++ b/docs/src/components/Layout.js
@@ -10,17 +10,9 @@ import theme from "../../../components/src/theme";
 
 import HighlightStyles from "./HighlightStyles";
 
-const ScrollContainer = styled.div({
-  height: "100vh",
-  width: "100%",
-  "@media screen and (min-width: 1024px)": {
-    overflow: "auto",
-  },
-});
-
 const Layout = ({ children }) => (
   <NDSProvider theme={ theme }>
-    <Flex flexDirection={ { small: "column", large: "row" } }>
+    <Box>
       <Helmet titleTemplate="%s | Nulogy Design System">
         <html lang="en" />
         <meta charSet="utf-8" />
@@ -30,12 +22,12 @@ const Layout = ({ children }) => (
       </Helmet>
       <HighlightStyles />
       <Navigation />
-      <ScrollContainer>
-        <Box pt={ { small: 0, large: "x8" } } px="x3" maxWidth="620px" m="0 auto">
+      <Box ml={{small: 0, large: "260px"}}>
+        <Box pt={ { small: 0, large: "x8" } } px="x3" maxWidth="740px" m="0 auto">
           {children}
         </Box>
-      </ScrollContainer>
-    </Flex>
+      </Box>
+    </Box>
   </NDSProvider>
 );
 

--- a/docs/src/components/Nav.js
+++ b/docs/src/components/Nav.js
@@ -11,11 +11,13 @@ import { menuData } from "../shared/menuData";
 const NavContainer = styled(Box)(
   ({ isOpen }) => ({
     background: theme.colors.whiteGrey,
-    overflow: "auto",
-    position: isOpen ? "absolute" : null,
+    position: isOpen ? "absolute" : "fixed",
+    top: 0,
+    left: 0,
+    overflow: "scroll",
     zIndex: 1,
     height: "100vh",
-    width: isOpen ? "100%" : "auto",
+    width: isOpen ? "100%" : "260px",
     paddingTop: theme.space.x3,
     "@media screen and (max-width: 1024px)": {
       display: isOpen ? "block" : "none",

--- a/docs/src/components/Nav.js
+++ b/docs/src/components/Nav.js
@@ -98,10 +98,10 @@ class Navigation extends React.Component {
           </Box>
           <Box p="x4">
             {menuData.map(menuItem => (
-              <List mb="x4" p="0">
+              <List key={menuItem.name} mb="x4" p="0">
                 <SubsectionTitle>{menuItem.name}</SubsectionTitle>
                 {menuItem.links.map(menuLink => (
-                  <NavItem><Link href={ menuLink.href } underline={ false }>{menuLink.name}</Link></NavItem>
+                  <NavItem key={menuLink.href}><Link href={ menuLink.href } underline={ false }>{menuLink.name}</Link></NavItem>
                 ))}
               </List>
             ))}

--- a/docs/src/components/Nav.js
+++ b/docs/src/components/Nav.js
@@ -21,6 +21,7 @@ const NavContainer = styled(Box)(
     height: "100%",
     width: isOpen ? "100%" : "260px",
     paddingTop: theme.space.x3,
+    "-webkit-overflow-scrolling": "touch",
     "@media screen and (max-width: 1024px)": {
       display: isOpen ? "block" : "none",
     },

--- a/docs/src/components/Nav.js
+++ b/docs/src/components/Nav.js
@@ -102,10 +102,10 @@ class Navigation extends React.Component {
           </Box>
           <Box p="x4">
             {menuData.map(menuItem => (
-              <List key={ menuItem.name } mb="x4" p="0">
+              <List key={menuItem.name} mb="x4" p="0">
                 <SubsectionTitle>{menuItem.name}</SubsectionTitle>
                 {menuItem.links.map(menuLink => (
-                  <NavItem key={ menuLink.href }><Link href={ menuLink.href } underline={ false }>{menuLink.name}</Link></NavItem>
+                  <NavItem key={menuLink.href}><Link href={ menuLink.href } underline={ false }>{menuLink.name}</Link></NavItem>
                 ))}
               </List>
             ))}

--- a/docs/src/components/Nav.js
+++ b/docs/src/components/Nav.js
@@ -1,12 +1,21 @@
 import React from "react";
 import PropTypes from "prop-types";
-import styled from "styled-components";
+import styled, { createGlobalStyle } from "styled-components";
 import {
   Box, Link, SubsectionTitle, IconicButton, List,
 } from "@nulogy/components";
 import logo from "../images/nulogy.svg";
 import theme from "../../../components/src/theme";
 import { menuData } from "../shared/menuData";
+
+const LockBody = createGlobalStyle(
+  ({ isOpen }) => ({
+    body: {
+      height: isOpen ? "100%" : null,
+      overflow: isOpen ? "hidden" : null,
+    }
+  })
+);
 
 const NavContainer = styled(Box)(
   ({ isOpen }) => ({
@@ -96,6 +105,7 @@ class Navigation extends React.Component {
     return (
       <>
         <OpenButton onClick={ this.openMenu } />
+        <LockBody isOpen={ this.state.menuOpen } />
         <NavContainer isOpen={ this.state.menuOpen }>
           <CloseButton isOpen={ this.state.menuOpen } onClick={ this.closeMenu } />
           <Box pt="x4" pb="0" px="x4">

--- a/docs/src/components/Nav.js
+++ b/docs/src/components/Nav.js
@@ -11,7 +11,7 @@ import { menuData } from "../shared/menuData";
 const NavContainer = styled(Box)(
   ({ isOpen }) => ({
     background: theme.colors.whiteGrey,
-    position: "fixed",
+    position: isOpen ? "absolute" : "fixed",
     top: 0,
     right: 0,
     bottom: 0,

--- a/docs/src/components/Nav.js
+++ b/docs/src/components/Nav.js
@@ -13,7 +13,7 @@ const LockBody = createGlobalStyle(
     body: {
       height: isOpen ? "100%" : null,
       overflow: isOpen ? "hidden" : null,
-    }
+    },
   })
 );
 
@@ -113,10 +113,10 @@ class Navigation extends React.Component {
           </Box>
           <Box p="x4">
             {menuData.map(menuItem => (
-              <List key={menuItem.name} mb="x4" p="0">
+              <List key={ menuItem.name } mb="x4" p="0">
                 <SubsectionTitle>{menuItem.name}</SubsectionTitle>
                 {menuItem.links.map(menuLink => (
-                  <NavItem key={menuLink.href}><Link href={ menuLink.href } underline={ false }>{menuLink.name}</Link></NavItem>
+                  <NavItem key={ menuLink.href }><Link href={ menuLink.href } underline={ false }>{menuLink.name}</Link></NavItem>
                 ))}
               </List>
             ))}

--- a/docs/src/components/Nav.js
+++ b/docs/src/components/Nav.js
@@ -19,7 +19,7 @@ const NavContainer = styled(Box)(
     overflow: "scroll",
     zIndex: 1,
     height: "100%",
-    width: isOpen ? "100%" : "260px",
+    width: isOpen ? "100%" : "220px",
     paddingTop: theme.space.x3,
     "-webkit-overflow-scrolling": "touch",
     "@media screen and (max-width: 1024px)": {

--- a/docs/src/components/Nav.js
+++ b/docs/src/components/Nav.js
@@ -11,12 +11,14 @@ import { menuData } from "../shared/menuData";
 const NavContainer = styled(Box)(
   ({ isOpen }) => ({
     background: theme.colors.whiteGrey,
-    position: isOpen ? "absolute" : "fixed",
+    position: "fixed",
     top: 0,
+    right: 0,
+    bottom: 0,
     left: 0,
     overflow: "scroll",
     zIndex: 1,
-    height: "100vh",
+    height: "100%",
     width: isOpen ? "100%" : "260px",
     paddingTop: theme.space.x3,
     "@media screen and (max-width: 1024px)": {
@@ -100,10 +102,10 @@ class Navigation extends React.Component {
           </Box>
           <Box p="x4">
             {menuData.map(menuItem => (
-              <List key={menuItem.name} mb="x4" p="0">
+              <List key={ menuItem.name } mb="x4" p="0">
                 <SubsectionTitle>{menuItem.name}</SubsectionTitle>
                 {menuItem.links.map(menuLink => (
-                  <NavItem key={menuLink.href}><Link href={ menuLink.href } underline={ false }>{menuLink.name}</Link></NavItem>
+                  <NavItem key={ menuLink.href }><Link href={ menuLink.href } underline={ false }>{menuLink.name}</Link></NavItem>
                 ))}
               </List>
             ))}

--- a/docs/src/pages/components/icon.js
+++ b/docs/src/pages/components/icon.js
@@ -29,7 +29,7 @@ const iconNames = Object.keys(icons);
 const IconDisplay = props => (
   <Flex flexWrap="wrap" { ...props }>
     {iconNames.map(icon => (
-      <Flex key={ icon } width={ {small: 1/2, large: 1/5 } }>
+      <Flex key={ icon } width={ { small: 1 / 2, large: 1 / 5 } }>
         <Icon icon={ icon } />
         <Text align="center" ml="x1">{icon}</Text>
       </Flex>

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -11,7 +11,7 @@ const IndexPage = () => (
       <IntroText>The Nulogy Design System is a collection of Visual Guidelines and UI Components that will allow designers and developers to quickly create consistent experiences for our customers using established best practices.</IntroText>
     </Intro>
 
-    <Flex flexDirection={ { small: "column", medium: "row" } }>
+    <Flex flexDirection={ { small: "column", medium: "row" } } mb={{small: "x6", large: 0}}>
       <Box width={ { small: 1, medium: 1 / 2 } } mb="x6">
         <SectionTitle mb="x3">Visual Style</SectionTitle>
         <Text mb="x3">Learn about the style that makes up Nulogy applications; including logo usage, typography, our colour system, iconography and spacing.</Text>

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -11,7 +11,7 @@ const IndexPage = () => (
       <IntroText>The Nulogy Design System is a collection of Visual Guidelines and UI Components that will allow designers and developers to quickly create consistent experiences for our customers using established best practices.</IntroText>
     </Intro>
 
-    <Flex flexDirection={ { small: "column", medium: "row" } } mb={{small: "x6", large: 0}}>
+    <Flex flexDirection={ { small: "column", medium: "row" } } mb={ { small: "x6", large: 0 } }>
       <Box width={ { small: 1, medium: 1 / 2 } } mb="x6">
         <SectionTitle mb="x3">Visual Style</SectionTitle>
         <Text mb="x3">Learn about the style that makes up Nulogy applications; including logo usage, typography, our colour system, iconography and spacing.</Text>

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { Helmet } from "react-helmet";
 import {
   Box, PrimaryButton, Flex, Text, Title, SectionTitle,
 } from "@nulogy/components";
@@ -6,6 +7,9 @@ import { Intro, IntroText, Layout } from "../components";
 
 const IndexPage = () => (
   <Layout>
+    <Helmet>
+      <meta name="description" content="The Nulogy Design System is a collection of Visual Guidelines and UI Components that will allow designers and developers to quickly create consistent experiences for our customers using established best practices." />
+    </Helmet>
     <Intro>
       <Title>Nulogy Design System</Title>
       <IntroText>The Nulogy Design System is a collection of Visual Guidelines and UI Components that will allow designers and developers to quickly create consistent experiences for our customers using established best practices.</IntroText>


### PR DESCRIPTION
The Flex stuff we added yesterday was causing a number of behaviour issues so we removed it. This PR also fixes the bug where you could scroll past the mobile menu, adds some vertical spacing to some elements on small screens and adds momentum scrolling for the navigation.

I also snuck an unrelated fix in here: added a meta description for the homepage because Google was repeating "Nulogy Design System" in our description when it made its own due.