### PR TITLE
Rename Radio Button page to Radio

### DIFF
--- a/docs/src/pages/components/radio.js
+++ b/docs/src/pages/components/radio.js
@@ -12,10 +12,10 @@ import radioProps from "../../shared/radioProps";
 export default () => (
   <Layout>
     <Helmet>
-      <title>Radio button</title>
+      <title>Radio</title>
     </Helmet>
     <Intro>
-      <Title>Radio button</Title>
+      <Title>Radio</Title>
       <IntroText>Radio buttons allow one selection from a group of options</IntroText>
     </Intro>
     <DocSection>


### PR DESCRIPTION
Component page should match the component name. This will fix the 404 from when I redid the nav and didn't realize we had an extra word in Radio's url and title. 