### PR TITLE
Fix box mobile page

### DIFF
--- a/docs/src/pages/components/box.js
+++ b/docs/src/pages/components/box.js
@@ -54,10 +54,10 @@ export default () => (
         <SubsectionTitle>Width</SubsectionTitle>
         <Text>Width can be set using a fraction or string.</Text>
         <Box bg="lightBlue" p="x3" width={ 1 / 2 }>Half</Box>
-        <Box bg="lightBlue" p="x3" width="400px">400px</Box>
+        <Box bg="lightBlue" p="x3" width="200px">200px</Box>
         <Highlight className="js">
           {`<Box width={1/2}>Half</Box>
-<Box width="400px">400px</Box>`}
+<Box width="200px">200px</Box>`}
         </Highlight>
       </Box>
       <Box mb="x4">

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -25,7 +25,7 @@ const IndexPage = () => (
       <Box width={ { small: 1, medium: 1 / 2 } }>
         <SectionTitle mb="x3">Components</SectionTitle>
         <Text mb="x3">Built using React, components are tested interface design patterns designed to ensure a consistent experience for our users.</Text>
-        <PrimaryButton as="a" href="components/Box">Use our components</PrimaryButton>
+        <PrimaryButton as="a" href="components/box">Use our components</PrimaryButton>
       </Box>
     </Flex>
   </Layout>


### PR DESCRIPTION
An example was causing unnecessary scrollability on the box documentation page. This reduces the width of the example to not go past the container. 