### PR TITLE
Fix Toggle console errors

### DIFF
--- a/components/src/Toggle/Toggle.js
+++ b/components/src/Toggle/Toggle.js
@@ -17,14 +17,14 @@ const MaybeToggleTitle = ({
 }) => (
   labelText
     ? (
-      <Text { ...props }>
+      <div { ...props }>
         <Box mb={ children && "x1" }>
           {labelText}
           {requirementText && (<RequirementText>{requirementText}</RequirementText>)}
           {helpText && (<HelpText>{helpText}</HelpText>)}
         </Box>
         {children}
-      </Text>
+      </div>
     )
     : (
       <>


### PR DESCRIPTION
The toggle consisted of divs wrapped in a p which triggers errors e.g `validateDOMNesting(...): <div> cannot appear as a descendant of <p>.` This PR just replaces the p with a div. 