### PR TITLE
Some fixes, some improvements

### DIFF
--- a/components/babel.config.js
+++ b/components/babel.config.js
@@ -9,9 +9,11 @@ module.exports = {
     ],
     "@babel/preset-react",
   ],
+  "plugins": ["babel-plugin-styled-components"],
   "env": {
     "test": {
       "plugins": [
+        "babel-plugin-styled-components",
         "require-context-hook",
       ],
     },

--- a/components/package.json
+++ b/components/package.json
@@ -54,6 +54,7 @@
     "@storybook/addon-storyshots-puppeteer": "4.1.11",
     "babel-jest": "24.1.0",
     "babel-plugin-require-context-hook": "1.0.0",
+    "babel-plugin-styled-components": "1.10.0",
     "babel-preset-react": "6.24.1",
     "enzyme": "3.9.0",
     "enzyme-adapter-react-16": "1.10.0",

--- a/components/package.json
+++ b/components/package.json
@@ -62,6 +62,7 @@
     "eslint-import-resolver-webpack": "^0.11.0",
     "identity-obj-proxy": "3.0.0",
     "jest": "24.1.0",
+    "jest-styled-components": "6.3.1",
     "prop-types": "15.6.2",
     "react-test-renderer": "~16.3"
   },

--- a/components/package.json
+++ b/components/package.json
@@ -57,6 +57,7 @@
     "babel-preset-react": "6.24.1",
     "enzyme": "3.9.0",
     "enzyme-adapter-react-16": "1.10.0",
+    "enzyme-to-json": "3.3.5",
     "eslint-config-airbnb": "17.1.0",
     "eslint-import-resolver-webpack": "^0.11.0",
     "identity-obj-proxy": "3.0.0",
@@ -102,6 +103,9 @@
     ],
     "setupFilesAfterEnv": [
       "<rootDir>/spec/support/specHelper.js"
+    ],
+    "snapshotSerializers": [
+      "enzyme-to-json/serializer"
     ]
   }
 }

--- a/components/spec/Storyshots.spec.js
+++ b/components/spec/Storyshots.spec.js
@@ -1,5 +1,6 @@
 import initStoryshots from "@storybook/addon-storyshots";
 import { mount } from "enzyme";
+import "jest-styled-components";
 
 initStoryshots({
   renderer: mount,

--- a/components/src/Select/Select.spec.js
+++ b/components/src/Select/Select.spec.js
@@ -1,0 +1,20 @@
+import React from "react";
+import { mount } from "enzyme";
+import Select from "./Select";
+
+it("opens the dropdown when clicked", () => {
+  const options = [
+    { value: "v1", label: "V One" },
+    { value: "v2", label: "V Two" },
+    { value: "v3", label: "V Three" },
+  ];
+
+  const wrapper = mount(
+    <Select options={ options } />
+  );
+
+  expect(wrapper.text()).not.toEqual(expect.stringMatching(/V One/));
+  wrapper.find("input").simulate("click");
+
+  expect(wrapper.text()).toEqual(expect.stringMatching(/V One/));
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5509,7 +5509,7 @@ css-what@2.1, css-what@^2.1.2:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
   integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
 
-css@2.2.4:
+css@2.2.4, css@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
   integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
@@ -10446,6 +10446,13 @@ jest-specific-snapshot@^1.0.0:
   integrity sha512-RXfqUh64epirdCkLvrM6hOEu7emxQWHUJ2+gh9IplJJ88hGCjWQh8ODwEfbQPSJ4lXVccX7Nw7HZ2QKBvOspUg==
   dependencies:
     jest-snapshot "^23.6.0"
+
+jest-styled-components@6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/jest-styled-components/-/jest-styled-components-6.3.1.tgz#fa21a89bfe8c20081c7c083cbaed2200854b60e3"
+  integrity sha512-zie3ajvJbwlbHCAq8/Bv5jdbcYCz0ZMRNNX6adL7wSRpkCVPQtiJigv1140JN1ZOJIODPn8VKrjeFCN+jlPa7w==
+  dependencies:
+    css "^2.2.4"
 
 jest-util@^24.0.0:
   version "24.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3552,7 +3552,7 @@ babel-plugin-require-context-hook@1.0.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-require-context-hook/-/babel-plugin-require-context-hook-1.0.0.tgz#3f0e7cce87c338f53639b948632fd4e73834632d"
   integrity sha512-EMZD1563QUqLhzrqcThk759RhuNVX/ZJdrtGK6drwzgvnR+ARjWyXIHPbu+tUNaMGtPz/gQeAM2M6VUw2UiUeA==
 
-"babel-plugin-styled-components@>= 1", babel-plugin-styled-components@^1.10.0:
+babel-plugin-styled-components@1.10.0, "babel-plugin-styled-components@>= 1", babel-plugin-styled-components@^1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.0.tgz#ff1f42ad2cc78c21f26b62266b8f564dbc862939"
   integrity sha512-sQVKG8irFXx14ZfaK1bBePirfkacl3j8nZwSZK+ZjsbnadRHKQTbhXbe/RB1vT6Vgkz45E+V95LBq4KqdhZUNw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6450,6 +6450,13 @@ enzyme-adapter-utils@^1.10.0:
     prop-types "^15.6.2"
     semver "^5.6.0"
 
+enzyme-to-json@3.3.5:
+  version "3.3.5"
+  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.3.5.tgz#f8eb82bd3d5941c9d8bc6fd9140030777d17d0af"
+  integrity sha512-DmH1wJ68HyPqKSYXdQqB33ZotwfUhwQZW3IGXaNXgR69Iodaoj8TF/D9RjLdz4pEhGq2Tx2zwNUIjBuqoZeTgA==
+  dependencies:
+    lodash "^4.17.4"
+
 enzyme@3.9.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.9.0.tgz#2b491f06ca966eb56b6510068c7894a7e0be3909"


### PR DESCRIPTION
A few things done in this:
- Fixed snapshot tests. We were not taking snapshots. =/
- Improve snapshot diffs
  - Installed jest-styled-components
  - Gets rid of generated class names from diffs.

Also:

Added prefixes to styled-component class names, so that you can identify which styled-component it’s for.
- Old: c23jf3822
- New: Box-c23jf3822