### PR TITLE
[NDS-781] Display theme on tokens page

### DIFF
--- a/components/src/index.js
+++ b/components/src/index.js
@@ -1,3 +1,4 @@
+export { default as theme } from "./theme";
 export { default as Box } from "./Box/Box";
 export { default as Button } from "./Button/Button";
 export { default as PrimaryButton } from "./Button/PrimaryButton";

--- a/docs/src/pages/components/box.js
+++ b/docs/src/pages/components/box.js
@@ -62,7 +62,7 @@ export default () => (
       </Box>
       <Box mb="x4">
         <SubsectionTitle>Text Color</SubsectionTitle>
-        <Text>Color can be set using a reference to the <Link href="https://github.com/nulogy/design-system/blob/master/components/src/theme.js">theme.colors</Link> object.</Text>
+        <Text>Color can be set using a reference to the <Link href="https://nulogy.design/tokens">theme.colors</Link> object.</Text>
         <Box color="blue">blue</Box>
         <Highlight className="js">
           {"<Box color=\"blue\">blue</Box>"}
@@ -70,7 +70,7 @@ export default () => (
       </Box>
       <Box mb="x4">
         <SubsectionTitle>Background Color</SubsectionTitle>
-        <Text>Color can be set using a reference to the <Link href="https://github.com/nulogy/design-system/blob/master/components/src/theme.js">theme.colors</Link> object.</Text>
+        <Text>Color can be set using a reference to the <Link href="https://nulogy.design/tokens">theme.colors</Link> object.</Text>
         <Box bg="lightBlue">lightBlue</Box>
         <Highlight className="js">
           {"<Box bg=\"lightBlue\">lightBlue</Box>"}
@@ -78,7 +78,7 @@ export default () => (
       </Box>
       <Box mb="x4">
         <SubsectionTitle>Margins</SubsectionTitle>
-        <Text>Margins can be set using a reference to the <Link href="https://github.com/nulogy/design-system/blob/master/components/src/theme.js">theme.space</Link> object.</Text>
+        <Text>Margins can be set using a reference to the <Link href="https://nulogy.design/tokens">theme.space</Link> object.</Text>
         <Box bg="lightBlue" m="x3">x3 (24px)</Box>
         <Highlight className="js">
           {"<Box m=\"x3\">x3</Box"}
@@ -86,7 +86,7 @@ export default () => (
       </Box>
       <Box mb="x4">
         <SubsectionTitle>Padding</SubsectionTitle>
-        <Text>Padding can be set using a reference to the <Link href="https://github.com/nulogy/design-system/blob/master/components/src/theme.js">theme.space</Link> object.</Text>
+        <Text>Padding can be set using a reference to the <Link href="https://nulogy.design/tokens">theme.space</Link> object.</Text>
         <Box bg="lightBlue" p="x3">x3 (24px)</Box>
         <Highlight className="js">
           {"<Box p=\"x3\">x3</Box"}
@@ -94,7 +94,7 @@ export default () => (
       </Box>
       <Box mb="x4">
         <SubsectionTitle>Responsive</SubsectionTitle>
-        <Text>All Box props can be used responsively by using an object that defines small, medium and/or large, based on the <Link href="https://github.com/nulogy/design-system/blob/master/components/src/theme.js">theme.breakpoints</Link> object</Text>
+        <Text>All Box props can be used responsively by using an object that defines small, medium and/or large, based on the <Link href="https://nulogy.design/tokens">theme.breakpoints</Link> object</Text>
         <Box color={ { small: "red", medium: "blue", large: "green" } }>Green text on large screens, blue on medium and red on small.</Box>
         <Highlight className="js">
           {`<Box color={{ small: "red", medium: "blue", large: "green"}}>
@@ -116,6 +116,7 @@ export default () => (
 
     <DocSection>
       <SectionTitle>Resources</SectionTitle>
+      <ListItem><Link href="https://nulogy.design/tokens/">NDS theme</Link></ListItem>
       <ListItem><Link href="https://storybook.nulogy.design/?selectedKind=Box">View in Storybook</Link></ListItem>
     </DocSection>
 

--- a/docs/src/pages/components/flex.js
+++ b/docs/src/pages/components/flex.js
@@ -52,7 +52,7 @@ export default () => (
 
     <DocSection>
       <SectionTitle>Responsive</SectionTitle>
-      <Text>Like Box, all props can be used responsively by using an object that defines small, medium and/or large, based on the <Link href="https://github.com/nulogy/design-system/blob/master/components/src/theme.js">theme.breakpoints</Link> object</Text>
+      <Text>Like Box, all props can be used responsively by using an object that defines small, medium and/or large, based on the <Link href="https://nulogy.design/tokens">theme.breakpoints</Link> object</Text>
       <Text>This example displays columns on small screens and rows on large ones.</Text>
       <Flex bg="lightBlue" flexDirection={ { small: "column", large: "row" } }>
         <Box width={ 1 / 2 } p="x3" m="x3" bg="blackBlue" />
@@ -81,6 +81,7 @@ export default () => (
 
     <DocSection>
       <SectionTitle>Resources</SectionTitle>
+      <ListItem><Link href="https://nulogy.design/tokens/">NDS theme</Link></ListItem>
       <ListItem><Link href="https://storybook.nulogy.design/?selectedKind=Flex">View in Storybook</Link></ListItem>
     </DocSection>
 

--- a/docs/src/pages/components/headings.js
+++ b/docs/src/pages/components/headings.js
@@ -55,6 +55,7 @@ export default () => (
 
     <DocSection>
       <SectionTitle>Resources</SectionTitle>
+      <ListItem><Link href="https://nulogy.design/tokens/">NDS theme</Link></ListItem>
       <ListItem><Link href="https://storybook.nulogy.design/?selectedKind=Headings">View in Storybook</Link></ListItem>
     </DocSection>
   </Layout>

--- a/docs/src/pages/components/text.js
+++ b/docs/src/pages/components/text.js
@@ -120,7 +120,7 @@ export default () => (
 
     <DocSection>
       <SectionTitle>Responsive</SectionTitle>
-      <Text>All Text props can be used responsively by using an object that defines small, medium and/or large, based on the <Link href="https://github.com/nulogy/design-system/blob/master/components/src/theme.js">theme.breakpoints</Link> object</Text>
+      <Text>All Text props can be used responsively by using an object that defines small, medium and/or large, based on the <Link href="https://nulogy.design/tokens">theme.breakpoints</Link> object</Text>
       <Text>This example displays columns on small screens and rows on large ones.</Text>
       <Text color={ { small: "red", medium: "blue", large: "green" } }>Green text on large screens, blue on medium and red on small.</Text>
       <Highlight className="js">
@@ -142,6 +142,7 @@ export default () => (
 
     <DocSection>
       <SectionTitle>Resources</SectionTitle>
+      <ListItem><Link href="https://nulogy.design/tokens/">NDS theme</Link></ListItem>
       <ListItem><Link href="https://storybook.nulogy.design/?selectedKind=Text">View in Storybook</Link></ListItem>
     </DocSection>
   </Layout>

--- a/docs/src/pages/guides/layout.js
+++ b/docs/src/pages/guides/layout.js
@@ -222,7 +222,7 @@ export default () => (
     </DocSection>
     <DocSection>
       <SectionTitle>Responsiveness</SectionTitle>
-      <Text>Providing different prop values for different breaking points that are based on the <Link href="https://github.com/nulogy/design-system/blob/master/components/src/theme.js">theme.breakpoints</Link> is possible by passing an object to a prop.</Text>
+      <Text>Providing different prop values for different breaking points that are based on the <Link href="https://nulogy.design/tokens">theme.breakpoints</Link> is possible by passing an object to a prop.</Text>
       <Text mb="x2" color="darkGrey">Size and background colour change based on the screen size</Text>
       <Flex color="white">
         <Box width={ { small: 1 / 9, medium: 1 / 9, large: 7 / 9 } } bg={ { small: "blue", medium: "darkBlue", large: "blackBlue" } } m="x1" py="x3" px="x4">1</Box>

--- a/docs/src/pages/tokens.js
+++ b/docs/src/pages/tokens.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { Helmet } from "react-helmet";
+import styled from "styled-components";
 import Highlight from "react-highlight";
 import {
   Box, Title, SectionTitle, SubsectionTitle, Link, ListItem, theme,
@@ -7,6 +8,12 @@ import {
 import {
   DocText as Text, Layout, Intro, IntroText, DocSection,
 } from "../components";
+
+const CustomComponent = styled.div({
+  background: theme.colors.darkBlue,
+  color: theme.colors.white,
+  padding: theme.space.x3,
+});
 
 export default () => (
   <Layout>
@@ -21,26 +28,38 @@ export default () => (
 
     <DocSection>
       <SubsectionTitle>Full theme</SubsectionTitle>
-      <pre>{JSON.stringify(theme, null, "  ")}</pre>
+      <Highlight>{JSON.stringify(theme, null, "  ")}</Highlight>
     </DocSection>
 
     <DocSection>
       <SectionTitle>Usage</SectionTitle>
 
-      <SubsectionTitle>For custom components</SubsectionTitle>
-      <Text>Tokens can be by used by importing the theme file and referencing the appropriate object. Always reference a token by its key, not its value.</Text>
-      <Highlight className="js">
-        {"import { theme } from @nulogy/components;\n\nBlue is ${theme.colors.blue}"}
-      </Highlight>
+      <Box mb="x4">
+        <SubsectionTitle>Theme as props</SubsectionTitle>
+        <Text>Some of our components have props that reference our theme, e.g for color or spacing values. These are connected via <Link href="https://styled-system.com/getting-started">Styled-System</Link>, which does the work of finding the appropriate object for you, e.g:</Text>
+        <Box bg="darkBlue" color="white" p="x3">Styled Box</Box>
+        <Highlight className="js">
+          {`import { Box } from @nulogy/components;
 
-      <SubsectionTitle>Theme as props</SubsectionTitle>
-      <Text>Some of our components have props that reference our theme, e.g for color or spacing values. These are connected via <Link href="https://styled-system.com/getting-started">Styled-System</Link>, which does the work of finding the appropriate object for you.</Text>
-      <Box bg="darkBlue" color="white" p="x3">Box</Box>
-      <Highlight className="js">
-        {`import { Box } from @nulogy/components;
-
-<Box bg="darkBlue" color="white" p="x3">Box</Box>
+<Box bg="darkBlue" color="white" p="x3">Styled Box</Box>
 `}
+        </Highlight>
+      </Box>
+
+      <SubsectionTitle>For custom components</SubsectionTitle>
+      <Text>Tokens can be by used by importing the theme file and referencing the appropriate object directly. For example, if we didn't have the Box component above we could manually create it like so:</Text>
+      <CustomComponent>Custom component</CustomComponent>
+
+      <Highlight className="js">
+        {`import { theme } from @nulogy/components
+
+const CustomComponent = styled.div({
+  background: theme.colors.darkBlue,
+  color: theme.colors.white,
+  padding: theme.space.x3,
+});
+
+<CustomComponent>Custom component</CustomComponent>`}
       </Highlight>
 
     </DocSection>

--- a/docs/src/pages/tokens.js
+++ b/docs/src/pages/tokens.js
@@ -1,8 +1,11 @@
 import React from "react";
 import { Helmet } from "react-helmet";
-import { Title, Link } from "@nulogy/components";
+import Highlight from "react-highlight";
 import {
-  Layout, Intro, IntroText, DocSection,
+  Box, Title, SectionTitle, SubsectionTitle, Link, ListItem, theme,
+} from "@nulogy/components";
+import {
+  DocText as Text, Layout, Intro, IntroText, DocSection,
 } from "../components";
 
 export default () => (
@@ -11,12 +14,41 @@ export default () => (
       <title>Tokens</title>
     </Helmet>
     <Intro>
+
       <Title>Tokens</Title>
-      <IntroText>Here you'll find all of the design options for creating interfaces in Nulogy's style.</IntroText>
+      <IntroText>Tokens are the design options for creating interfaces in Nulogy's style. They can be accessed in Javascript via the theme.</IntroText>
     </Intro>
 
     <DocSection>
-            Tokens can currently be found in the `/src/` folder of the <Link href="https://github.com/nulogy/design-system/tree/master/tokens/">@nulogy/tokens</Link> package.
+      <SubsectionTitle>Full theme</SubsectionTitle>
+      <pre>{JSON.stringify(theme, null, "  ")}</pre>
     </DocSection>
+
+    <DocSection>
+      <SectionTitle>Usage</SectionTitle>
+
+      <SubsectionTitle>For custom components</SubsectionTitle>
+      <Text>Tokens can be by used by importing the theme file and referencing the appropriate object. Always reference a token by its key, not its value.</Text>
+      <Highlight className="js">
+        {"import { theme } from @nulogy/components;\n\nBlue is ${theme.colors.blue}"}
+      </Highlight>
+
+      <SubsectionTitle>Theme as props</SubsectionTitle>
+      <Text>Some of our components have props that reference our theme, e.g for color or spacing values. These are connected via <Link href="https://styled-system.com/getting-started">Styled-System</Link>, which does the work of finding the appropriate object for you.</Text>
+      <Box bg="darkBlue" color="white" p="x3">Box</Box>
+      <Highlight className="js">
+        {`import { Box } from @nulogy/components;
+
+<Box bg="darkBlue" color="white" p="x3">Box</Box>
+`}
+      </Highlight>
+
+    </DocSection>
+
+    <DocSection>
+      <SectionTitle>Resources</SectionTitle>
+      <ListItem><Link href="https://github.com/nulogy/design-system/tree/master/tokens">@nulogy/tokens</Link></ListItem>
+    </DocSection>
+
   </Layout>
 );


### PR DESCRIPTION
This PR adds some basic information about using our theme to the tokens page, including rendering the entire theme object. It also updates any pages that reference the theme to include a link under Resources. 