### PR TITLE
Styled iconic button and alias for box shadow

### DIFF
--- a/components/src/Button/IconicButton.js
+++ b/components/src/Button/IconicButton.js
@@ -51,7 +51,7 @@ const Wrapper = styled.button(
   })
 );
 
-const IconicButton = props => {
+const BaseIconicButton = props => {
   const {
     children,
     icon,
@@ -65,15 +65,17 @@ const IconicButton = props => {
   );
 };
 
+const IconicButton = styled(BaseIconicButton)({});
+
 export const iconNames = Object.keys(icons);
 
-IconicButton.propTypes = {
+BaseIconicButton.propTypes = {
   children: PropTypes.node.isRequired,
   disabled: PropTypes.bool,
   icon: PropTypes.oneOf(iconNames).isRequired,
 };
 
-IconicButton.defaultProps = {
+BaseIconicButton.defaultProps = {
   disabled: false,
 };
 

--- a/components/src/Select/Select.js
+++ b/components/src/Select/Select.js
@@ -49,7 +49,7 @@ const Input = styled.input(({ error, isOpen, disabled }) => ({
   borderTopRightRadius: theme.radii.medium,
   borderBottomLeftRadius: isOpen ? 0 : theme.radii.medium,
   borderBottomRightRadius: isOpen ? 0 : theme.radii.medium,
-  boxShadow: isOpen ? theme.boxShadows[0] : "none",
+  boxShadow: isOpen ? theme.boxShadows.small : "none",
   outline: "none",
   background: disabled ? theme.colors.whiteGrey : theme.colors.white,
   "&:hover, &:focus": {
@@ -103,7 +103,7 @@ const Menu = styled.div(({ error, disabled, isOpen }) => ({
   borderRightStyle: "solid",
   borderRadius: `0 0 ${theme.radii.medium} ${theme.radii.medium}`,
   marginTop: 0,
-  boxShadow: theme.boxShadows[0],
+  boxShadow: theme.boxShadows.small,
   background: disabled ? theme.colors.whiteGrey : theme.colors.white,
   zIndex: 100,
 }));

--- a/components/src/theme.js
+++ b/components/src/theme.js
@@ -55,7 +55,9 @@ export default {
     mono: tokens.font_family_mono,
   },
   borders: [],
-  boxShadows: [tokens.shadow_box_small],
+  boxShadows: {
+    small: tokens.shadow_box_small,
+  },
   radii: {
     small: tokens.radius_border_small,
     medium: tokens.radius_border_medium,


### PR DESCRIPTION
To make the creation of Capacity Planning Custom Card component easier following was done:

- IconicButton was turned into a styled component
- Small alias name was added to box-shadow
- Select was updated to use updated box-shadow