### PR TITLE
Fix global styling

### DIFF
--- a/components-e2e/cypress/integration/components/NavBar.spec.js
+++ b/components-e2e/cypress/integration/components/NavBar.spec.js
@@ -1,0 +1,24 @@
+import React from "react";
+
+import { NDSProvider, NavBar } from "@nulogy/components";
+
+describe("NavBar", () => {
+  it("renders", () => {
+    const data = {
+      primaryMenu: [
+        {
+          name: "Menu 1",
+          items: [
+            { name: "Item 1", description: "description", href: "/" },
+          ],
+        },
+      ],
+    };
+
+    cy.mount(
+      <NDSProvider>
+        <NavBar menuData={ data } />
+      </NDSProvider>
+    );
+  });
+});

--- a/components-e2e/package.json
+++ b/components-e2e/package.json
@@ -6,11 +6,11 @@
   "license": "MIT",
   "private": true,
   "scripts": {
+    "start": "cypress open",
+    "test": "yarn lint && yarn cypress run --spec '**/components/**/*spec.js'",
     "lint": "yarn run eslint",
     "eslint": "eslint --config .eslintrc './**/*.js'",
-    "eslint:fix": "yarn run eslint --fix",
-    "test": "yarn lint && yarn cypress run --spec '**/components/**/*spec.js'",
-    "cypress:open": "cypress open"
+    "eslint:fix": "yarn run eslint --fix"
   },
   "devDependencies": {
     "@babel/preset-react": "7.0.0",

--- a/components/.storybook/config.js
+++ b/components/.storybook/config.js
@@ -3,7 +3,6 @@ import { configure, addDecorator } from '@storybook/react';
 import { withBackgrounds } from '@storybook/addon-backgrounds';
 import withStyles from "@sambego/storybook-styles";
 import NDSProvider from '../src/NDSProvider/NDSProvider';
-import theme from '../src/theme';
 
 const grid = {
   base: { colour: 'hsla(120, 100%, 100%, 0.4)', size: `${theme.space.x1}` },
@@ -39,7 +38,7 @@ function loadStories() {
 }
 
 addDecorator((story) => (
-  <NDSProvider theme={theme}>
+  <NDSProvider>
     {story()}
   </NDSProvider>
 ))

--- a/components/.storybook/config.js
+++ b/components/.storybook/config.js
@@ -3,6 +3,7 @@ import { configure, addDecorator } from '@storybook/react';
 import { withBackgrounds } from '@storybook/addon-backgrounds';
 import withStyles from "@sambego/storybook-styles";
 import NDSProvider from '../src/NDSProvider/NDSProvider';
+import theme from "../src/theme";
 
 const grid = {
   base: { colour: 'hsla(120, 100%, 100%, 0.4)', size: `${theme.space.x1}` },

--- a/components/CHANGELOG.md
+++ b/components/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+- Fixed global styles. NavBar logo will now display at the correct size.
+
+### Security
+
+## [0.5.2] - 2019-04-09
+
+### Fixed
+
+- Form elements no longer generate random IDs, allowing snapshot tests to work.

--- a/components/src/NDSProvider/NDSProvider.js
+++ b/components/src/NDSProvider/NDSProvider.js
@@ -28,11 +28,12 @@ export const GlobalStyles = styled.div({
   },
 });
 
-const NDSProvider = ({ ...props }) => (
+const NDSProvider = ({ children }) => (
   <React.Fragment>
     <Reset />
+    <GlobalStyles />
     <ThemeProvider theme={ theme }>
-      <GlobalStyles { ...props } />
+      { children }
     </ThemeProvider>
   </React.Fragment>
 );

--- a/components/src/NDSProvider/NDSProvider.js
+++ b/components/src/NDSProvider/NDSProvider.js
@@ -1,17 +1,20 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { createGlobalStyle, ThemeProvider } from "styled-components";
+import styled, { createGlobalStyle, ThemeProvider } from "styled-components";
 import defaultTheme from "../theme";
 
-const GlobalStyles = createGlobalStyle(({ theme }) => ({
+const Reset = createGlobalStyle({
   "body": {
     margin: 0,
-    color: theme.colors.black,
-    fontFamily: theme.fonts.base,
-    lineHeight: theme.lineHeights.base,
-    "-webkit-font-smoothing": "antialiased",
-    "-moz-osx-font-smoothing": "grayscale",
   },
+});
+
+const GlobalStyles = styled.div(({ theme }) => ({
+  color: theme.colors.black,
+  fontFamily: theme.fonts.base,
+  lineHeight: theme.lineHeights.base,
+  "-webkit-font-smoothing": "antialiased",
+  "-moz-osx-font-smoothing": "grayscale",
   "button": {
     fontFamily: theme.fonts.base,
   },
@@ -26,10 +29,12 @@ const GlobalStyles = createGlobalStyle(({ theme }) => ({
 
 const NDSProvider = ({ theme, children }) => (
   <React.Fragment>
-    <GlobalStyles theme={ theme } />
-    <ThemeProvider theme={ theme }>
-      { children }
-    </ThemeProvider>
+    <Reset />
+    <GlobalStyles theme={ theme }>
+      <ThemeProvider theme={ theme }>
+        { children }
+      </ThemeProvider>
+    </GlobalStyles>
   </React.Fragment>
 );
 

--- a/components/src/NDSProvider/NDSProvider.js
+++ b/components/src/NDSProvider/NDSProvider.js
@@ -1,24 +1,20 @@
 import React from "react";
-import styled, { createGlobalStyle, ThemeProvider } from "styled-components";
+import PropTypes from "prop-types";
+import { createGlobalStyle, ThemeProvider } from "styled-components";
 import theme from "../theme";
 
-const Reset = createGlobalStyle(
-  {
-    "body": {
-      margin: 0,
-      color: theme.colors.black,
-    },
-    "button": {
-      fontFamily: theme.fonts.base,
-    },
-  }
-);
-
-export const GlobalStyles = styled.div({
-  fontFamily: theme.fonts.base,
-  lineHeight: theme.lineHeights.base,
-  "-webkit-font-smoothing": "antialiased",
-  "-moz-osx-font-smoothing": "grayscale",
+const GlobalStyles = createGlobalStyle({
+  "body": {
+    margin: 0,
+    color: theme.colors.black,
+    fontFamily: theme.fonts.base,
+    lineHeight: theme.lineHeights.base,
+    "-webkit-font-smoothing": "antialiased",
+    "-moz-osx-font-smoothing": "grayscale",
+  },
+  "button": {
+    fontFamily: theme.fonts.base,
+  },
   "*": {
     boxSizing: "border-box",
   },
@@ -30,12 +26,15 @@ export const GlobalStyles = styled.div({
 
 const NDSProvider = ({ children }) => (
   <React.Fragment>
-    <Reset />
     <GlobalStyles />
     <ThemeProvider theme={ theme }>
       { children }
     </ThemeProvider>
   </React.Fragment>
 );
+
+NDSProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};
 
 export default NDSProvider;

--- a/components/src/NDSProvider/NDSProvider.js
+++ b/components/src/NDSProvider/NDSProvider.js
@@ -1,9 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { createGlobalStyle, ThemeProvider } from "styled-components";
-import theme from "../theme";
+import defaultTheme from "../theme";
 
-const GlobalStyles = createGlobalStyle({
+const GlobalStyles = createGlobalStyle(({ theme }) => ({
   "body": {
     margin: 0,
     color: theme.colors.black,
@@ -22,11 +22,11 @@ const GlobalStyles = createGlobalStyle({
     maxWidth: "100%",
     height: "auto",
   },
-});
+}));
 
-const NDSProvider = ({ children }) => (
+const NDSProvider = ({ theme, children }) => (
   <React.Fragment>
-    <GlobalStyles />
+    <GlobalStyles theme={ theme } />
     <ThemeProvider theme={ theme }>
       { children }
     </ThemeProvider>
@@ -35,6 +35,11 @@ const NDSProvider = ({ children }) => (
 
 NDSProvider.propTypes = {
   children: PropTypes.node.isRequired,
+  theme: PropTypes.shape({}),
+};
+
+NDSProvider.defaultProps = {
+  theme: defaultTheme,
 };
 
 export default NDSProvider;

--- a/components/src/index.js
+++ b/components/src/index.js
@@ -1,3 +1,4 @@
+export { default as NDSProvider } from "./NDSProvider/NDSProvider";
 export { default as theme } from "./theme";
 export { default as Box } from "./Box/Box";
 export { default as Button } from "./Button/Button";
@@ -24,7 +25,6 @@ export { default as RadioGroup } from "./Radio/RadioGroup";
 export { default as Toggle } from "./Toggle/Toggle";
 export { default as Select } from "./Select/Select";
 export * from "./Type/Headings";
-export { default as NDSProvider } from "./NDSProvider/NDSProvider";
 export { default as DemoPage } from "./DemoPage/DemoPage";
 export { default as Form } from "./Form/Form";
 export { default as FormSection } from "./Form/FormSection";

--- a/docs/src/components/Layout.js
+++ b/docs/src/components/Layout.js
@@ -5,12 +5,11 @@ import {
 } from "@nulogy/components";
 import { Helmet } from "react-helmet";
 import { Navigation } from "./Nav";
-import theme from "../../../components/src/theme";
 
 import HighlightStyles from "./HighlightStyles";
 
 const Layout = ({ children }) => (
-  <NDSProvider theme={ theme }>
+  <NDSProvider>
     <Box>
       <Helmet titleTemplate="%s | Nulogy Design System">
         <html lang="en" />


### PR DESCRIPTION
`styled-components` injects styles in the order of component creation.
Updated the NDS index file to export NDSProvider first, so that the Global Styles get injected first.

This fixes the navbar logo.

As a bonus, `NDSProvider` was updated to accept custom themes.
Also removed unnecessary theme being passed into NDSProvider for the docs site.