### PR TITLE
Nds 813 close select bug

### DIFF
--- a/components/CHANGELOG.md
+++ b/components/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Fixed global styles. NavBar logo will now display at the correct size.
+- Fixed bug where Select would not close when an option was selected.
 
 ### Security
 

--- a/components/src/FieldLabel/FieldLabel.js
+++ b/components/src/FieldLabel/FieldLabel.js
@@ -7,11 +7,20 @@ import theme from "../theme";
 
 const Label = styled.label(
   space,
-  {
+  ({ color }) => ({
+    color: theme.colors[color] || color,
     display: "inline-block",
     fontSize: theme.fontSizes.medium,
-  }
+  })
 );
+
+Label.propTypes = {
+  color: PropTypes.string,
+};
+
+Label.defaultProps = {
+  color: theme.colors.black,
+};
 
 const BaseFieldLabel = ({
   labelText,

--- a/components/src/Select/Select.js
+++ b/components/src/Select/Select.js
@@ -148,7 +148,7 @@ const Select = ({
         }) => (
           <div style={ { position: "relative" } }>
             <SelectBox { ...getToggleButtonProps({ disabled, error, isOpen }) }>
-              <MaybeFieldLabel style={{width: "100%"}} labelText={ labelText } requirementText={ requirementText } helpText={ helpText }>
+              <MaybeFieldLabel style={ { width: "100%" } } labelText={ labelText } requirementText={ requirementText } helpText={ helpText }>
                 <Input
                   { ...getInputProps({
                     disabled, error, isOpen, autoComplete: "off",

--- a/components/src/Select/Select.js
+++ b/components/src/Select/Select.js
@@ -156,8 +156,8 @@ const Select = ({
                   aria-required={ required } aria-invalid={ error } placeholder={ placeholder }
                   readOnly value={ optionToString(selectedItem) || "" }
                 />
-                <ToggleButton isOpen={ isOpen } />
               </MaybeFieldLabel>
+              <ToggleButton isOpen={ isOpen } />
             </SelectBox>
             {
               isOpen

--- a/components/src/Select/Select.js
+++ b/components/src/Select/Select.js
@@ -67,10 +67,10 @@ const Input = styled.input(({ error, isOpen, disabled }) => ({
 }));
 
 const IndicatorButton = styled.div(() => ({
+  height: theme.space.x3,
   position: "absolute",
-  top: theme.space.x1,
   right: theme.space.half,
-  bottom: "0",
+  bottom: theme.space.x1,
   pointerEvents: "none",
 }));
 
@@ -128,27 +128,27 @@ const Select = ({
   id, labelText, helpText, requirementText,
 }) => (
   <Field>
-    <MaybeFieldLabel labelText={ labelText } requirementText={ requirementText } helpText={ helpText }>
-      <Downshift
-        itemToString={ optionToString }
-        selectedItem={ value }
-        onChange={ onChange }
-        defaultHighlightedIndex={ 0 }
-        initialIsOpen={ initialIsOpen }
-        inputId={ id }
-      >
-        {
-          ({
-            getMenuProps,
-            getItemProps,
-            getInputProps,
-            getToggleButtonProps,
-            isOpen,
-            selectedItem,
-            highlightedIndex,
-          }) => (
-            <div style={ { position: "relative" } }>
-              <SelectBox { ...getToggleButtonProps({ disabled, error, isOpen }) }>
+    <Downshift
+      itemToString={ optionToString }
+      selectedItem={ value }
+      onChange={ onChange }
+      defaultHighlightedIndex={ 0 }
+      initialIsOpen={ initialIsOpen }
+      inputId={ id }
+    >
+      {
+        ({
+          getMenuProps,
+          getItemProps,
+          getInputProps,
+          getToggleButtonProps,
+          isOpen,
+          selectedItem,
+          highlightedIndex,
+        }) => (
+          <div style={ { position: "relative" } }>
+            <SelectBox { ...getToggleButtonProps({ disabled, error, isOpen }) }>
+              <MaybeFieldLabel style={{width: "100%"}} labelText={ labelText } requirementText={ requirementText } helpText={ helpText }>
                 <Input
                   { ...getInputProps({
                     disabled, error, isOpen, autoComplete: "off",
@@ -157,35 +157,35 @@ const Select = ({
                   readOnly value={ optionToString(selectedItem) || "" }
                 />
                 <ToggleButton isOpen={ isOpen } />
-              </SelectBox>
-              {
-                isOpen
-                  && (
-                    <Menu { ...getMenuProps({ error, isOpen }) }>
-                      {
-                        options.map((option, index) => (
-                          <MenuItem
-                            { ...getItemProps({
-                              key: option.value,
-                              item: option,
-                              isSelected: selectedItem === option,
-                              isActive: highlightedIndex === index,
-                              index,
-                              disabled,
-                            }) }
-                          >
-                            {option.label}
-                          </MenuItem>
-                        ))
-                      }
-                    </Menu>
-                  )
-              }
-            </div>
-          )
-        }
-      </Downshift>
-    </MaybeFieldLabel>
+              </MaybeFieldLabel>
+            </SelectBox>
+            {
+              isOpen
+                && (
+                  <Menu { ...getMenuProps({ error, isOpen }) }>
+                    {
+                      options.map((option, index) => (
+                        <MenuItem
+                          { ...getItemProps({
+                            key: option.value,
+                            item: option,
+                            isSelected: selectedItem === option,
+                            isActive: highlightedIndex === index,
+                            index,
+                            disabled,
+                          }) }
+                        >
+                          {option.label}
+                        </MenuItem>
+                      ))
+                    }
+                  </Menu>
+                )
+            }
+          </div>
+        )
+      }
+    </Downshift>
     {error && <InlineValidation mt="x1" message={ error } />}
   </Field>
 );


### PR DESCRIPTION
Intent: Review to merge (bug fix)

This PR:
 - Fixes bug where Select did not close when selecting an option from the dropdown
 - The problem was that MaybeFieldLabel was wrapping the full Downshift component causing multiple clicks when they were not intended (one click from selecting an option and another from the label) causing a net no change.
 - Solution was moving the MaybeFieldLabel to wrap the input within the DownShift component. Some restructuring was required to style correctly and was verified to be unchanged via visual storyshots