### PR TITLE
 NDS-815-fix-select-api 

### DIFF
--- a/components/CHANGELOG.md
+++ b/components/CHANGELOG.md
@@ -12,24 +12,24 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Select API changed, given the following options:
 
-```js
-options = [
-  {label: "label1", value: "value1},
-  {label: "label2", value: "value2},
-]
-```
+    ```js
+    options = [
+      {label: "label1", value: "value1},
+      {label: "label2", value: "value2},
+    ]
+    ```
 
-Old API:
+    Old API:
 
-```js
-<Select options={options} value={options[1]}>
-```
+    ```js
+    <Select options={options} value={options[1]}>
+    ```
 
-New API:
+    New API:
 
-```js
-<Select options={options} value="value2">
-```
+    ```js
+    <Select options={options} value="value2">
+    ```
 
 ### Deprecated
 

--- a/components/CHANGELOG.md
+++ b/components/CHANGELOG.md
@@ -10,6 +10,26 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 ### Changed
+- Select API changed, given the following options:
+
+```js
+options = [
+  {label: "label1", value: "value1},
+  {label: "label2", value: "value2},
+]
+```
+
+Old API:
+
+```js
+<Select options={options} value={options[1]}>
+```
+
+New API:
+
+```js
+<Select options={options} value="value2">
+```
 
 ### Deprecated
 

--- a/components/src/Select/Select.js
+++ b/components/src/Select/Select.js
@@ -215,7 +215,7 @@ Select.propTypes = {
 const extractLabelFromOption = option => option && option.label;
 
 Select.defaultProps = {
-  value: undefined,
+  value: null,
   required: false,
   onChange: undefined,
   error: null,

--- a/components/src/Select/Select.js
+++ b/components/src/Select/Select.js
@@ -121,11 +121,7 @@ const MenuItem = styled.div(({ isSelected, isActive }) => ({
   },
 }));
 
-const parseValueProp = (value, options) => (
-  (typeof value === "string")
-    ? options.filter(option => option.value === value)[0]
-    : value
-);
+const parseValueProp = (value, options) => options.find(o => o.value === value);
 
 const Select = ({
   error, onChange, disabled,
@@ -198,7 +194,7 @@ const Select = ({
 
 Select.propTypes = {
   placeholder: PropTypes.string,
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.shape({})]),
+  value: PropTypes.string,
   options: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   optionToString: PropTypes.func,
   required: PropTypes.bool,

--- a/components/src/Select/Select.js
+++ b/components/src/Select/Select.js
@@ -121,6 +121,12 @@ const MenuItem = styled.div(({ isSelected, isActive }) => ({
   },
 }));
 
+const parseValueProp = (value, options) => (
+  (typeof value === "string")
+    ? options.filter(option => option.value === value)[0]
+    : value
+);
+
 const Select = ({
   error, onChange, disabled,
   options, optionToString, value,
@@ -130,7 +136,7 @@ const Select = ({
   <Field>
     <Downshift
       itemToString={ optionToString }
-      selectedItem={ value }
+      selectedItem={ parseValueProp(value, options) }
       onChange={ onChange }
       defaultHighlightedIndex={ 0 }
       initialIsOpen={ initialIsOpen }
@@ -192,7 +198,7 @@ const Select = ({
 
 Select.propTypes = {
   placeholder: PropTypes.string,
-  value: PropTypes.shape({}),
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.shape({})]),
   options: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   optionToString: PropTypes.func,
   required: PropTypes.bool,

--- a/components/src/Select/Select.js
+++ b/components/src/Select/Select.js
@@ -211,7 +211,7 @@ Select.propTypes = {
 const extractLabelFromOption = option => option && option.label;
 
 Select.defaultProps = {
-  value: null,
+  value: undefined,
   required: false,
   onChange: undefined,
   error: null,

--- a/components/src/Select/Select.story.js
+++ b/components/src/Select/Select.story.js
@@ -48,12 +48,12 @@ storiesOf("Select", module)
   .add("Select with an option selected", () => (
     <>
       <Select
-        value={ options[0] } placeholder="Please select inventory status" options={ options } labelText="Inventory status"
+        value={ options[0].value } placeholder="Please select inventory status" options={ options } labelText="Inventory status"
         optionToString={ optionToString }
       />
       <br />
       <Select
-        value={ options[0] } placeholder="Please select inventory status" options={ options } labelText="Inventory status"
+        value={ options[0].value } placeholder="Please select inventory status" options={ options } labelText="Inventory status"
         optionToString={ optionToString } initialIsOpen
       />
     </>

--- a/docs/src/pages/components/select.js
+++ b/docs/src/pages/components/select.js
@@ -17,7 +17,7 @@ const options = [
 const propsRows = [
   {
     name: "options", type: "Array", defaultValue: "Required", description: "The options available to be selected, containing a value and a label",
-    name: "value", type: "String", defaultValue: "null", description: "Value of the current selected option, used when controlling the Select component"
+    name: "value", type: "String", defaultValue: "undefined", description: "Value of the current selected option, used when controlling the Select component"
   },
   ...inputProps,
 ];

--- a/docs/src/pages/components/select.js
+++ b/docs/src/pages/components/select.js
@@ -17,6 +17,7 @@ const options = [
 const propsRows = [
   {
     name: "options", type: "Array", defaultValue: "Required", description: "The options available to be selected, containing a value and a label",
+    name: "value", type: "String", defaultValue: "null", description: "Value of the current selected option, used when controlling the Select component"
   },
   ...inputProps,
 ];


### PR DESCRIPTION
Intent: review to merge

This PR:
 - enabled the API to accept value={"string"} as well as value={{label="String", value="string"}}
 - this is done by parsing the prop to determine what it is and convert it to the object form if it is passed in as a string (DownShift expects the object form)
 - Open Discussion: do we need to or should we support both cases? Is supporting just the string better?