### PR TITLE
Nds 829 navbarsearch input unstyled in safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Description prop in the [`NavBar`](https://nulogy.design/components/navbar/) component has been removed
 
 ### Fixed
+- NavBar search is now be styled properly in Safari.
 ### Security
 
 ## [0.6.0] - 2019-04-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Description prop in the [`NavBar`](https://nulogy.design/components/navbar/) component has been removed
 
 ### Fixed
-- NavBar search is now be styled properly in Safari.
+- NavBar search is now styled properly in Safari.
 ### Security
 
 ## [0.6.0] - 2019-04-26

--- a/components/src/Input/Input.js
+++ b/components/src/Input/Input.js
@@ -42,6 +42,7 @@ const StyledInput = styled.input(
     fontSize: theme.fontSizes.medium,
     fontFamily: theme.fonts.base,
     lineHeight: theme.lineHeights.base,
+    margin: theme.space.none,
     "&:focus": {
       outline: "none",
       color: theme.colors.black,

--- a/components/src/Input/Input.js
+++ b/components/src/Input/Input.js
@@ -52,12 +52,6 @@ const StyledInput = styled.input(
     "::placeholder": {
       color: transparentize(0.4, theme.colors.black),
     },
-    "&[type='search']": {
-      "-webkit-appearance": "textfield",
-      "::-webkit-search-decoration": {
-        "-webkit-appearance": "none",
-      },
-    },
   },
   props => (getInputStyle(props))
 );

--- a/components/src/Input/Input.js
+++ b/components/src/Input/Input.js
@@ -38,7 +38,7 @@ const StyledInput = styled.input(
     width: "100%",
     border: "1px solid",
     borderRadius: theme.radii.medium,
-    padding: `${subPx(theme.space.x1)} ${theme.space.x1}`,
+    padding: subPx(theme.space.x1),
     fontSize: theme.fontSizes.medium,
     fontFamily: theme.fonts.base,
     lineHeight: theme.lineHeights.base,

--- a/components/src/Input/Input.js
+++ b/components/src/Input/Input.js
@@ -32,7 +32,6 @@ const getInputStyle = props => {
 };
 
 const StyledInput = styled.input(
-  space,
   {
     display: "block",
     width: "100%",
@@ -53,6 +52,7 @@ const StyledInput = styled.input(
       color: transparentize(0.4, theme.colors.black),
     },
   },
+  space,
   props => (getInputStyle(props))
 );
 

--- a/components/src/Input/Input.js
+++ b/components/src/Input/Input.js
@@ -38,7 +38,7 @@ const StyledInput = styled.input(
     width: "100%",
     border: "1px solid",
     borderRadius: theme.radii.medium,
-    padding: subPx(theme.space.x1),
+    padding: `${subPx(theme.space.x1)} ${theme.space.x1}`,
     fontSize: theme.fontSizes.medium,
     fontFamily: theme.fonts.base,
     lineHeight: theme.lineHeights.base,
@@ -50,6 +50,12 @@ const StyledInput = styled.input(
     },
     "::placeholder": {
       color: transparentize(0.4, theme.colors.black),
+    },
+    "&[type='search']": {
+      "-webkit-appearance": "textfield",
+      "::-webkit-search-decoration": {
+        "-webkit-appearance": "none",
+      },
     },
   },
   props => (getInputStyle(props))

--- a/components/src/NavBarSearch/NavBarSearch.js
+++ b/components/src/NavBarSearch/NavBarSearch.js
@@ -61,6 +61,7 @@ const NavBarSearch = styled(BaseNavBarSearch)(
       background: "transparent",
       border: "solid 1px transparent",
       borderRadius: theme.radii.medium,
+      margin: theme.space.none,
       ":focus": {
         background: theme.colors.white,
         border: "solid 1px transparent",

--- a/components/src/NavBarSearch/NavBarSearch.js
+++ b/components/src/NavBarSearch/NavBarSearch.js
@@ -61,7 +61,6 @@ const NavBarSearch = styled(BaseNavBarSearch)(
       background: "transparent",
       border: "solid 1px transparent",
       borderRadius: theme.radii.medium,
-      margin: theme.space.none,
       ":focus": {
         background: theme.colors.white,
         border: "solid 1px transparent",

--- a/components/src/NavBarSearch/NavBarSearch.js
+++ b/components/src/NavBarSearch/NavBarSearch.js
@@ -69,6 +69,12 @@ const NavBarSearch = styled(BaseNavBarSearch)(
       "::placeholder": {
         color: transparentize(0.4, theme.colors.black),
       },
+      "&[type='search']": {
+        "-webkit-appearance": "textfield",
+        "::-webkit-search-decoration": {
+          "-webkit-appearance": "none",
+        },
+      },
     },
   }
 );


### PR DESCRIPTION
Intent: Review to merge

What I did:
- forced webkit browsers to treat input type search as textfield input
- Added 0 margin to input to fix the spacing bug in safari - Select filed was followed by some margin from some reason.