### PR TITLE
Add NPM badges

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,2 @@
-# Enables the project's binstubs
-PATH_add bin
-PATH_add client/node_modules/.bin
-
 # Enables the project's version of node (relies on .nvmrc)
 . ~/.nvm/nvm.sh && nvm use

--- a/components/README.md
+++ b/components/README.md
@@ -1,3 +1,5 @@
+![npm (scoped)](https://img.shields.io/npm/v/@nulogy/components.svg?color=blue)
+
 # @nulogy/components
 Built with React, compononents make it easy to create interfaces that conform to the principles of the Nulogy Design System. Components are [styled-components](https://www.styled-components.com/) written using [styled-system](https://jxnblk.com/styled-system/). This makes it possible to write CSS directly in JS and pass props based on our design constraints. 
 

--- a/css/readme.md
+++ b/css/readme.md
@@ -1,3 +1,5 @@
+![npm (scoped)](https://img.shields.io/npm/v/@nulogy/css.svg?color=blue)
+
 # @nulogy/css
 Sass variables and atomic classes for writing CSS using Nulogy design tokens. These variables can be used to create CSS versions of our React components and the atomic classes can be 
 

--- a/tokens/readme.md
+++ b/tokens/readme.md
@@ -1,3 +1,5 @@
+![npm (scoped)](https://img.shields.io/npm/v/@nulogy/tokens.svg?color=blue)
+
 # @nulogy/tokens
 This is where Nulogy's design tokens are stored and converted using [Style Dictionary](https://amzn.github.io/style-dictionary). Tokens are mostly used in our React components and CSS classes, but tokens can be imported directly into your application if needed. 
 


### PR DESCRIPTION
I added NPM badges to the nested packages of this project. I used shields.io, which creates a dynamic badge that pulls the latest version of the package direct from NPM. I was not sure whether it is desired to have these badges in the root README of the project as well. I'll leave up to the core maintainers to decide.

I also fixed an issue that prevented direnv from working.

I hope this helps.