### PR TITLE
Nav bar mobile scroll

### DIFF
--- a/components/.storybook/config.js
+++ b/components/.storybook/config.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { configure, addDecorator } from '@storybook/react';
 import { withBackgrounds } from '@storybook/addon-backgrounds';
-import withStyles from "@sambego/storybook-styles";
 import NDSProvider from '../src/NDSProvider/NDSProvider';
 import theme from "../src/theme";
 
@@ -10,7 +9,7 @@ const grid = {
   major: { colour: 'hsla(120, 100%, 100%, 0.5)', size: `${theme.space.x3}`},
 }
 
-addDecorator(withStyles({
+const gridStyles = {
   backgroundImage: `
     linear-gradient(${grid.major.colour} 1px, transparent 1px),
     linear-gradient(90deg, ${grid.major.colour} 1px, transparent 1px),
@@ -25,7 +24,13 @@ addDecorator(withStyles({
   backgroundPosition: '-1px -1px',
   padding: `${grid.major.size}`,
   minHeight: `100vh`,
-}));
+}
+
+addDecorator((story) => (
+  <div style={gridStyles}>
+    {story()}
+  </div>
+))
 
 addDecorator(withBackgrounds([
   { name: 'none', value: '', default: true },

--- a/components/package.json
+++ b/components/package.json
@@ -49,7 +49,6 @@
   "devDependencies": {
     "@babel/core": "7.3.4",
     "@babel/preset-env": "7.3.1",
-    "@sambego/storybook-styles": "^1.0.0",
     "@storybook/addon-backgrounds": "^4.1.12",
     "@storybook/addon-info": "^4.1.4",
     "@storybook/addon-storyshots": "4.1.11",

--- a/components/src/DemoPage/DemoPage.story.js
+++ b/components/src/DemoPage/DemoPage.story.js
@@ -1,6 +1,21 @@
 import React from "react";
+import styled from "styled-components";
 import { storiesOf } from "@storybook/react";
-import { DemoPage } from ".";
+import { DemoPage as NDSDemoPage } from ".";
+
+const ResetStorybookView = styled.div({
+  position: "absolute",
+  top: 0,
+  left: 0,
+  width: "100vw",
+  height: "100vh",
+})
+
+const DemoPage = (props) => (
+  <ResetStorybookView>
+    <NDSDemoPage { ...props }/>
+  </ResetStorybookView>
+)
 
 storiesOf("DemoPage", module)
   .add("Demo Page", () => (

--- a/components/src/DemoPage/DemoPage.story.js
+++ b/components/src/DemoPage/DemoPage.story.js
@@ -9,13 +9,13 @@ const ResetStorybookView = styled.div({
   left: 0,
   width: "100vw",
   height: "100vh",
-})
+});
 
-const DemoPage = (props) => (
+const DemoPage = props => (
   <ResetStorybookView>
-    <NDSDemoPage { ...props }/>
+    <NDSDemoPage { ...props } />
   </ResetStorybookView>
-)
+);
 
 storiesOf("DemoPage", module)
   .add("Demo Page", () => (

--- a/components/src/NavBar/NavBar.js
+++ b/components/src/NavBar/NavBar.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import { Box } from "../Box";
+import { createGlobalStyle } from "styled-components";
 import { Flex } from "../Flex";
 import { Icon } from "../Icon";
 import NavBarSearch from "../NavBarSearch/NavBarSearch";
@@ -13,14 +13,24 @@ import isValidMenuItem from "./isValidMenuItem";
 import theme from "../theme";
 import { subPx } from "../Utils";
 
+const LockBody = createGlobalStyle(
+  ({ isOpen }) => ({
+    body: {
+      height: isOpen ? "100%" : null,
+      overflow: isOpen ? "hidden" : null,
+    },
+  })
+);
+
 const MediumNavBar = ({
   menuData,
   desktopSrc,
   alt,
+  style,
   ...props
 }) => (
   <header { ...props }>
-    <Flex>
+    <Flex style={ style }>
       <Branding desktopSrc={ desktopSrc } alt={ alt } />
       <Flex justifyContent="space-between" alignContent="flex-end" style={ { flexGrow: "1", margin: `0 0 0 ${theme.space.x3}` } }>
         {menuData.primaryMenu
@@ -74,16 +84,35 @@ const MobileMenuTrigger = styled.button(
   }
 );
 
+const SmallHeader = styled.header(({ isOpen }) => (
+  isOpen ? {
+  position: "fixed",
+  width: "100%",
+  height: "100%",
+  zIndex: "100",
+  overflow: "auto",
+  top: "0",
+  left: "0",
+  right: "0",
+  bottom: "0",
+  } :
+  null
+  )
+);
+
 const SmallNavBar = withMenuState(({
   display,
   menuData,
   menuState: { isOpen, handleMenuToggle, closeMenu },
   mobileSrc,
+  style,
   alt,
   ...props
 }) => (
-  <header { ...props }>
-    <Flex>
+  <>
+  <LockBody isOpen={ isOpen } />
+  <SmallHeader isOpen={ isOpen } { ...props }>
+    <Flex style={ style }>
       <Branding mobileSrc={ mobileSrc } alt={ alt } />
       <Flex justifyContent="flex-end" style={ { flexGrow: "1", margin: `0 0 0 ${theme.space.x3}` } }>
         {menuData.search
@@ -110,7 +139,8 @@ const SmallNavBar = withMenuState(({
       <MobileMenu menuData={ menuData } closeMenu={ closeMenu } />
       )
     }
-  </header>
+  </SmallHeader>
+  </>
 ));
 
 const navBarStyles = {

--- a/components/src/NavBar/NavBar.js
+++ b/components/src/NavBar/NavBar.js
@@ -90,7 +90,7 @@ const SmallHeader = styled.header(({ isOpen }) => (
   width: "100%",
   height: "100%",
   zIndex: "100",
-  overflow: "auto",
+  overflow: "scroll",
   top: "0",
   left: "0",
   right: "0",
@@ -100,48 +100,64 @@ const SmallHeader = styled.header(({ isOpen }) => (
   )
 );
 
-const SmallNavBar = withMenuState(({
-  display,
-  menuData,
-  menuState: { isOpen, handleMenuToggle, closeMenu },
-  mobileSrc,
-  style,
-  alt,
-  ...props
-}) => (
-  <>
-  <LockBody isOpen={ isOpen } />
-  <SmallHeader isOpen={ isOpen } { ...props }>
-    <Flex style={ style }>
-      <Branding mobileSrc={ mobileSrc } alt={ alt } />
-      <Flex justifyContent="flex-end" style={ { flexGrow: "1", margin: `0 0 0 ${theme.space.x3}` } }>
-        {menuData.search
-        && (
-        <Flex maxWidth="18em" alignItems="center" px="0">
-          <NavBarSearch { ...menuData.search } />
-        </Flex>
-        )
-      }
-        {(menuData.primaryMenu || menuData.secondaryMenu)
-        && (
-        <MobileMenuTrigger onClick={ handleMenuToggle } aria-expanded={ isOpen ? true : null }>
-          {
-          isOpen
-            ? <Icon icon="close" title="Close Menu" />
-            : <Icon icon="menu" title="Open Menu" />
+class SmallNavBarNoState extends React.Component { 
+  constructor() {
+    super();
+    this.navRef = React.createRef();
+  }
+
+  componentDidUpdate() {
+    if (this.props.menuState.isOpen) this.navRef.current.scrollTop = 0;
+  }
+
+  render() {
+    const {
+      display,
+      menuData,
+      menuState: { isOpen, handleMenuToggle, closeMenu },
+      mobileSrc,
+      style,
+      alt,
+      ...props
+    }= this.props; 
+  return(
+    <>
+      <LockBody isOpen={ isOpen } />
+      <SmallHeader ref={ this.navRef } isOpen={ isOpen } { ...props }>
+        <Flex style={ style }>
+          <Branding mobileSrc={ mobileSrc } alt={ alt } />
+          <Flex justifyContent="flex-end" style={ { flexGrow: "1", margin: `0 0 0 ${theme.space.x3}` } }>
+            {menuData.search
+            && (
+            <Flex maxWidth="18em" alignItems="center" px="0">
+              <NavBarSearch { ...menuData.search } />
+            </Flex>
+            )
           }
-        </MobileMenuTrigger>
-        )
-      }
-      </Flex>
-    </Flex>
-    {(isOpen) && (
-      <MobileMenu menuData={ menuData } closeMenu={ closeMenu } />
-      )
-    }
-  </SmallHeader>
-  </>
-));
+            {(menuData.primaryMenu || menuData.secondaryMenu)
+            && (
+            <MobileMenuTrigger onClick={()=>{handleMenuToggle()}} aria-expanded={ isOpen ? true : null }>
+              {
+              isOpen
+                ? <Icon icon="close" title="Close Menu" />
+                : <Icon icon="menu" title="Open Menu" />
+              }
+            </MobileMenuTrigger>
+            )
+          }
+          </Flex>
+        </Flex>
+        {(isOpen) && (
+          <MobileMenu menuData={ menuData } closeMenu={ closeMenu } />
+          )
+        }
+      </SmallHeader>
+    </>
+    )
+  }
+};
+
+const SmallNavBar = withMenuState(SmallNavBarNoState);
 
 const navBarStyles = {
   background: theme.colors.blackBlue,

--- a/components/src/NavBar/NavBar.js
+++ b/components/src/NavBar/NavBar.js
@@ -11,7 +11,7 @@ import MobileMenu from "./MobileMenu";
 import { withMenuState } from "./withMenuState";
 import isValidMenuItem from "./isValidMenuItem";
 import theme from "../theme";
-import { subPx } from "../Utils";
+import { subPx, withWindowDimensions } from "../Utils";
 
 const LockBody = createGlobalStyle(
   ({ isOpen }) => ({
@@ -164,43 +164,23 @@ const navBarStyles = {
   padding: `${theme.space.x2} ${theme.space.x3}`,
 };
 
-class BaseNavBar extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { width: 0 };
-    this.updateWindowDimensions = this.updateWindowDimensions.bind(this);
+const BaseNavBar = withWindowDimensions(({
+  menuData,
+  breakpoint,
+  windowDimensions: { windowWidth },
+  ...props,
+}) => {
+  if (windowWidth >= breakpoint) {
+    return(
+      <MediumNavBar { ...props } menuData={ menuData } style={ navBarStyles } />
+    );
+  } else {
+    return(
+      <SmallNavBar { ...props } menuData={ menuData } style={ navBarStyles } />
+    );
   }
+})
   
-  componentDidMount() {
-    this.updateWindowDimensions();
-    window.addEventListener('resize', this.updateWindowDimensions);
-  }
-  
-  componentWillUnmount() {
-    window.removeEventListener('resize', this.updateWindowDimensions);
-  }
-  
-  updateWindowDimensions() {
-    this.setState({ width: window.innerWidth });
-  }  
-
-  render () {
-    const {
-      menuData,
-      ...props
-    } = this.props;
-    if (this.state.width >= this.props.breakpoint) {
-      return(
-        <MediumNavBar { ...props } menuData={ menuData } style={ navBarStyles } />
-      );
-    } else {
-      return(
-        <SmallNavBar { ...props } menuData={ menuData } style={ navBarStyles } />
-      );
-    }
-  }
-}
-
 BaseNavBar.propTypes = {
   menuData: PropTypes.shape({
     "primaryMenu": PropTypes.arrayOf(isValidMenuItem),

--- a/components/src/NavBar/NavBar.js
+++ b/components/src/NavBar/NavBar.js
@@ -106,8 +106,8 @@ class SmallNavBarNoState extends React.Component {
     this.navRef = React.createRef();
   }
 
-  componentDidUpdate() {
-    if (this.props.menuState.isOpen) this.navRef.current.scrollTop = 0;
+  componentDidUpdate(prevProps) {
+    if (this.props.menuState.isOpen && !prevProps.menuState.isOpen) this.navRef.current.scrollTop = 0;
   }
 
   render() {

--- a/components/src/NavBar/NavBar.js
+++ b/components/src/NavBar/NavBar.js
@@ -19,26 +19,28 @@ const MediumNavBar = ({
   alt,
   ...props
 }) => (
-  <Box { ...props }>
-    <Branding desktopSrc={ desktopSrc } alt={ alt } />
-    <Flex justifyContent="space-between" alignContent="flex-end" style={ { flexGrow: "1", margin: `0 0 0 ${theme.space.x3}` } }>
-      {menuData.primaryMenu
-        && <DesktopMenu style={ { paddingRight: theme.space.x3 } } aria-labelledby="primary-navigation" menuData={ menuData.primaryMenu } />
-      }
-      <Flex style={ { float: "right" } }>
-        {menuData.search
-        && (
-        <div style={ { maxWidth: "18em" } }>
-          <NavBarSearch { ...menuData.search } />
-        </div>
-        )
+  <header { ...props }>
+    <Flex>
+      <Branding desktopSrc={ desktopSrc } alt={ alt } />
+      <Flex justifyContent="space-between" alignContent="flex-end" style={ { flexGrow: "1", margin: `0 0 0 ${theme.space.x3}` } }>
+        {menuData.primaryMenu
+          && <DesktopMenu style={ { paddingRight: theme.space.x3 } } aria-labelledby="primary-navigation" menuData={ menuData.primaryMenu } />
         }
-        {menuData.secondaryMenu
-        && <DesktopMenu aria-labelledby="secondary-navigation" pl="x2" menuData={ menuData.secondaryMenu } />
-        }
+        <Flex style={ { float: "right" } }>
+          {menuData.search
+          && (
+          <div style={ { maxWidth: "18em" } }>
+            <NavBarSearch { ...menuData.search } />
+          </div>
+          )
+          }
+          {menuData.secondaryMenu
+          && <DesktopMenu aria-labelledby="secondary-navigation" pl="x2" menuData={ menuData.secondaryMenu } />
+          }
+        </Flex>
       </Flex>
     </Flex>
-  </Box>
+  </header>
 );
 
 MediumNavBar.propTypes = {
@@ -80,8 +82,8 @@ const SmallNavBar = withMenuState(({
   alt,
   ...props
 }) => (
-  <>
-    <Box display={ display } { ...props }>
+  <header { ...props }>
+    <Flex>
       <Branding mobileSrc={ mobileSrc } alt={ alt } />
       <Flex justifyContent="flex-end" style={ { flexGrow: "1", margin: `0 0 0 ${theme.space.x3}` } }>
         {menuData.search
@@ -103,13 +105,12 @@ const SmallNavBar = withMenuState(({
         )
       }
       </Flex>
-    </Box>
-    {(isOpen)
-        && (
-          <MobileMenu display={ display } menuData={ menuData } closeMenu={ closeMenu } />
-        )
-      }
-  </>
+    </Flex>
+    {(isOpen) && (
+      <MobileMenu menuData={ menuData } closeMenu={ closeMenu } />
+      )
+    }
+  </header>
 ));
 
 const navBarStyles = {
@@ -117,15 +118,42 @@ const navBarStyles = {
   padding: `${theme.space.x2} ${theme.space.x3}`,
 };
 
-const BaseNavBar = ({
-  menuData,
-  ...props
-}) => (
-  <header { ...props }>
-    <MediumNavBar menuData={ menuData } display={ { small: "none", medium: "none", large: "flex" } } style={ navBarStyles } />
-    <SmallNavBar menuData={ menuData } display={ { small: "flex", medium: "flex", large: "none" } } style={ navBarStyles } />
-  </header>
-);
+class BaseNavBar extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { width: 0 };
+    this.updateWindowDimensions = this.updateWindowDimensions.bind(this);
+  }
+  
+  componentDidMount() {
+    this.updateWindowDimensions();
+    window.addEventListener('resize', this.updateWindowDimensions);
+  }
+  
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.updateWindowDimensions);
+  }
+  
+  updateWindowDimensions() {
+    this.setState({ width: window.innerWidth });
+  }  
+
+  render () {
+    const {
+      menuData,
+      ...props
+    } = this.props;
+    if (this.state.width >= this.props.breakpoint) {
+      return(
+        <MediumNavBar { ...props } menuData={ menuData } style={ navBarStyles } />
+      );
+    } else {
+      return(
+        <SmallNavBar { ...props } menuData={ menuData } style={ navBarStyles } />
+      );
+    }
+  }
+}
 
 BaseNavBar.propTypes = {
   menuData: PropTypes.shape({
@@ -136,11 +164,13 @@ BaseNavBar.propTypes = {
     }),
   }),
   className: PropTypes.string,
+  breakpoint: PropTypes.number,
 };
 
 BaseNavBar.defaultProps = {
   menuData: null,
   className: null,
+  breakpoint: 1024,
 };
 
 const NavBar = styled(BaseNavBar)({});

--- a/components/src/NavBar/NavBar.js
+++ b/components/src/NavBar/NavBar.js
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import styled from "styled-components";
-import { createGlobalStyle } from "styled-components";
+import styled, { createGlobalStyle } from "styled-components";
 import { Flex } from "../Flex";
 import { Icon } from "../Icon";
 import NavBarSearch from "../NavBarSearch/NavBarSearch";
@@ -57,12 +56,14 @@ MediumNavBar.propTypes = {
   alt: PropTypes.string,
   desktopSrc: PropTypes.string,
   menuData: PropTypes.shape({}),
+  style: PropTypes.shape({}),
 };
 
 MediumNavBar.defaultProps = {
   alt: null,
   desktopSrc: undefined,
   menuData: null,
+  style: null,
 };
 
 const MobileMenuTrigger = styled.button(
@@ -86,21 +87,21 @@ const MobileMenuTrigger = styled.button(
 
 const SmallHeader = styled.header(({ isOpen }) => (
   isOpen ? {
-  position: "fixed",
-  width: "100%",
-  height: "100%",
-  zIndex: "100",
-  overflow: "scroll",
-  top: "0",
-  left: "0",
-  right: "0",
-  bottom: "0",
-  } :
-  null
-  )
-);
+    position: "fixed",
+    width: "100%",
+    height: "100%",
+    zIndex: "100",
+    overflow: "scroll",
+    top: "0",
+    left: "0",
+    right: "0",
+    bottom: "0",
+  }
+    : null
+));
 
-class SmallNavBarNoState extends React.Component { 
+/* eslint-disable react/destructuring-assignment */
+class SmallNavBarNoState extends React.Component {
   constructor() {
     super();
     this.navRef = React.createRef();
@@ -112,31 +113,30 @@ class SmallNavBarNoState extends React.Component {
 
   render() {
     const {
-      display,
       menuData,
       menuState: { isOpen, handleMenuToggle, closeMenu },
       mobileSrc,
-      style,
       alt,
+      style,
       ...props
-    }= this.props; 
-  return(
-    <>
-      <LockBody isOpen={ isOpen } />
-      <SmallHeader ref={ this.navRef } isOpen={ isOpen } { ...props }>
-        <Flex style={ style }>
-          <Branding mobileSrc={ mobileSrc } alt={ alt } />
-          <Flex justifyContent="flex-end" style={ { flexGrow: "1", margin: `0 0 0 ${theme.space.x3}` } }>
-            {menuData.search
+    } = this.props;
+    return (
+      <>
+        <LockBody isOpen={ isOpen } />
+        <SmallHeader ref={ this.navRef } isOpen={ isOpen } { ...props }>
+          <Flex style={ style }>
+            <Branding mobileSrc={ mobileSrc } alt={ alt } />
+            <Flex justifyContent="flex-end" style={ { flexGrow: "1", margin: `0 0 0 ${theme.space.x3}` } }>
+              {menuData.search
             && (
             <Flex maxWidth="18em" alignItems="center" px="0">
               <NavBarSearch { ...menuData.search } />
             </Flex>
             )
           }
-            {(menuData.primaryMenu || menuData.secondaryMenu)
+              {(menuData.primaryMenu || menuData.secondaryMenu)
             && (
-            <MobileMenuTrigger onClick={()=>{handleMenuToggle()}} aria-expanded={ isOpen ? true : null }>
+            <MobileMenuTrigger onClick={ () => { handleMenuToggle(); } } aria-expanded={ isOpen ? true : null }>
               {
               isOpen
                 ? <Icon icon="close" title="Close Menu" />
@@ -145,16 +145,36 @@ class SmallNavBarNoState extends React.Component {
             </MobileMenuTrigger>
             )
           }
+            </Flex>
           </Flex>
-        </Flex>
-        {(isOpen) && (
+          {(isOpen) && (
           <MobileMenu menuData={ menuData } closeMenu={ closeMenu } />
           )
         }
-      </SmallHeader>
-    </>
-    )
+        </SmallHeader>
+      </>
+    );
   }
+}
+/* eslint-enable react/destructuring-assignment */
+
+SmallNavBarNoState.propTypes = {
+  menuState: PropTypes.shape({
+    isOpen: PropTypes.bool,
+    handleMenuToggle: PropTypes.func,
+    closeMenu: PropTypes.func,
+  }).isRequired,
+  menuData: PropTypes.shape({}),
+  mobileSrc: PropTypes.string,
+  alt: PropTypes.string,
+  style: PropTypes.shape({}),
+};
+
+SmallNavBarNoState.defaultProps = {
+  menuData: null,
+  mobileSrc: undefined,
+  alt: undefined,
+  style: null,
 };
 
 const SmallNavBar = withMenuState(SmallNavBarNoState);
@@ -168,19 +188,19 @@ const BaseNavBar = withWindowDimensions(({
   menuData,
   breakpoint,
   windowDimensions: { windowWidth },
-  ...props,
+  ...props
 }) => {
   if (windowWidth >= breakpoint) {
-    return(
+    return (
       <MediumNavBar { ...props } menuData={ menuData } style={ navBarStyles } />
     );
   } else {
-    return(
+    return (
       <SmallNavBar { ...props } menuData={ menuData } style={ navBarStyles } />
     );
   }
-})
-  
+});
+
 BaseNavBar.propTypes = {
   menuData: PropTypes.shape({
     "primaryMenu": PropTypes.arrayOf(isValidMenuItem),

--- a/components/src/NavBar/NavBar.story.js
+++ b/components/src/NavBar/NavBar.story.js
@@ -1,7 +1,21 @@
 import React from "react";
+import styled from "styled-components";
 import { storiesOf } from "@storybook/react";
-import { NavBar } from ".";
-import { Text } from "../Type"
+import { NavBar as NDSNavBar } from ".";
+
+const ResetStorybookView = styled.div({
+  position: "absolute",
+  top: 0,
+  left: 0,
+  width: "100vw",
+  height: "100vh",
+})
+
+const NavBar = (props) => (
+  <ResetStorybookView>
+    <NDSNavBar { ...props }/>
+  </ResetStorybookView>
+)
 
 const primaryMenu = [
   {
@@ -117,143 +131,7 @@ const search = {
 
 storiesOf("NavBar", module)
   .add("NavBar", () => (
-    <>
     <NavBar menuData={ { primaryMenu, secondaryMenu, search } } />
-    <Text>ABC</Text>
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-    <Text>ABC</Text>
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-    <Text>ABC</Text>
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-    <Text>ABC</Text>
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-    <Text>ABC</Text>
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-    <Text>ABC</Text>
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-    <Text>ABC</Text>
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-    <Text>ABC</Text>
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-    <Text>ABC</Text>
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-    <Text>ABC</Text>
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-    <Text>ABC</Text>
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-    <Text>ABC</Text>
-
-
-    </>
   ))
   .add("Without search", () => (
     <NavBar menuData={ { primaryMenu, secondaryMenu } } />

--- a/components/src/NavBar/NavBar.story.js
+++ b/components/src/NavBar/NavBar.story.js
@@ -9,13 +9,13 @@ const ResetStorybookView = styled.div({
   left: 0,
   width: "100vw",
   height: "100vh",
-})
+});
 
-const NavBar = (props) => (
+const NavBar = props => (
   <ResetStorybookView>
-    <NDSNavBar { ...props }/>
+    <NDSNavBar { ...props } />
   </ResetStorybookView>
-)
+);
 
 const primaryMenu = [
   {

--- a/components/src/NavBar/NavBar.story.js
+++ b/components/src/NavBar/NavBar.story.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import { NavBar } from ".";
+import { Text } from "../Type"
 
 const primaryMenu = [
   {
@@ -116,7 +117,143 @@ const search = {
 
 storiesOf("NavBar", module)
   .add("NavBar", () => (
+    <>
     <NavBar menuData={ { primaryMenu, secondaryMenu, search } } />
+    <Text>ABC</Text>
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+    <Text>ABC</Text>
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+    <Text>ABC</Text>
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+    <Text>ABC</Text>
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+    <Text>ABC</Text>
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+    <Text>ABC</Text>
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+    <Text>ABC</Text>
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+    <Text>ABC</Text>
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+    <Text>ABC</Text>
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+    <Text>ABC</Text>
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+    <Text>ABC</Text>
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+    <Text>ABC</Text>
+
+
+    </>
   ))
   .add("Without search", () => (
     <NavBar menuData={ { primaryMenu, secondaryMenu } } />

--- a/components/src/Utils/index.js
+++ b/components/src/Utils/index.js
@@ -2,3 +2,4 @@ export { default as ClickInputLabel } from "./ClickInputLabel";
 export { default as omit } from "./omit";
 export { default as subPx } from "./subPx";
 export { default as withGeneratedId } from "./withGeneratedId";
+export { default as withWindowDimensions } from "./withWindowDimensions";

--- a/components/src/Utils/withWindowDimensions.js
+++ b/components/src/Utils/withWindowDimensions.js
@@ -1,0 +1,47 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+class WindowDimensions extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { width: 0, height: 0 };
+    this.updateWindowDimensions = this.updateWindowDimensions.bind(this);
+  }
+  
+  componentDidMount() {
+    this.updateWindowDimensions();
+    window.addEventListener('resize', this.updateWindowDimensions);
+  }
+  
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.updateWindowDimensions);
+  }
+  
+  updateWindowDimensions() {
+    this.setState({ width: window.innerWidth, height: window.innerHeight });
+  }  
+
+  render() {
+    const { width, height } = this.state;
+    const { children: renderMenu } = this.props;
+
+    return renderMenu({
+      windowWidth: width,
+      windowHeight: height,
+      handleMenuToggle: this.handleOnClick,
+      handleMenuKeydown: this.handleKeyDown,
+      openMenu: this.openMenu,
+      closeMenu: this.closeMenu,
+    });
+  }
+}
+
+const withWindowDimensions = Component => props => (
+  <WindowDimensions>
+    {
+      windowDimensions => <Component windowDimensions={ windowDimensions } { ...props } />
+    }
+  </WindowDimensions>
+);
+
+export default withWindowDimensions;

--- a/components/src/Utils/withWindowDimensions.js
+++ b/components/src/Utils/withWindowDimensions.js
@@ -33,7 +33,7 @@ class WindowDimensions extends React.Component {
 }
 
 WindowDimensions.propTypes = {
-  children: PropTypes.node.isRequired,
+  children: PropTypes.func.isRequired,
 };
 
 const withWindowDimensions = Component => props => (

--- a/components/src/Utils/withWindowDimensions.js
+++ b/components/src/Utils/withWindowDimensions.js
@@ -7,19 +7,19 @@ class WindowDimensions extends React.Component {
     this.state = { width: 0, height: 0 };
     this.updateWindowDimensions = this.updateWindowDimensions.bind(this);
   }
-  
+
   componentDidMount() {
     this.updateWindowDimensions();
-    window.addEventListener('resize', this.updateWindowDimensions);
+    window.addEventListener("resize", this.updateWindowDimensions);
   }
-  
+
   componentWillUnmount() {
-    window.removeEventListener('resize', this.updateWindowDimensions);
+    window.removeEventListener("resize", this.updateWindowDimensions);
   }
-  
+
   updateWindowDimensions() {
     this.setState({ width: window.innerWidth, height: window.innerHeight });
-  }  
+  }
 
   render() {
     const { width, height } = this.state;
@@ -31,6 +31,10 @@ class WindowDimensions extends React.Component {
     });
   }
 }
+
+WindowDimensions.propTypes = {
+  children: PropTypes.node.isRequired,
+};
 
 const withWindowDimensions = Component => props => (
   <WindowDimensions>

--- a/components/src/Utils/withWindowDimensions.js
+++ b/components/src/Utils/withWindowDimensions.js
@@ -28,10 +28,6 @@ class WindowDimensions extends React.Component {
     return renderMenu({
       windowWidth: width,
       windowHeight: height,
-      handleMenuToggle: this.handleOnClick,
-      handleMenuKeydown: this.handleKeyDown,
-      openMenu: this.openMenu,
-      closeMenu: this.closeMenu,
     });
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2162,11 +2162,6 @@
     react-lifecycles-compat "^3.0.4"
     warning "^3.0.0"
 
-"@sambego/storybook-styles@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@sambego/storybook-styles/-/storybook-styles-1.0.0.tgz#4f840ee26dd0b25dcb803a75caa42e16071dcaae"
-  integrity sha512-n0SqZwDewUDRaStEcoNMiYy9qovaLVStsh4Gb2dc2LLiG3IIK0UXdeR1N7puVuRihJq/192uOyGPCjZ/NAteuA==
-
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"


### PR DESCRIPTION
Intent: Review to merge

This PR:
 - Creates withWindowDimensions HOC component
 - Updates NavBar to use withWindowDimensions to manage responsive changes
    - This allows us to only have one header + navbar on the dom rather than having both on the dom
 - Adds scrolling to the small screen nav independent of the scrolling on the main content
 - overrides the storybook margin we apply for stories that contain a NavBar
 - removes https://github.com/Sambego/storybook-styles dependency
    - This library has low stars, is not maintained, and is very easy to replace with our own code

