### PR TITLE
Nds 823 menu items dont close in safari

### DIFF
--- a/components/src/NavBar/MenuTrigger.js
+++ b/components/src/NavBar/MenuTrigger.js
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import PropTypes from "prop-types";
 import { Manager, Reference, Popper } from "react-popper";
 import theme from "../theme";
-import { OutsideAlerter } from "../Utils";
+import { DetectOutsideClick } from "../Utils";
 import { Icon } from "../Icon";
 import SubMenu from "./SubMenu";
 import SubMenuTrigger from "./SubMenuTrigger";
@@ -181,27 +181,27 @@ class MenuTrigger extends React.Component {
 
   render() {
     return (
-        <Manager>
-          <Reference>
-            {({ ref }) => (
-              <MenuTriggerButton aria-haspopup="true" aria-expanded={ this.state.subMenuOpen } { ...this.props } { ...this.menuTriggerEventHandlers() } ref={ ref }>
-                { this.props.name }
-                <Icon style={ { position: "absolute", top: "11px" } } icon="downArrow" color="lightGrey" size="20px" p="2px" />
-              </MenuTriggerButton>
-            )}
-          </Reference>
-          {this.state.subMenuOpen && (
+      <Manager>
+        <Reference>
+          {({ ref }) => (
+            <MenuTriggerButton aria-haspopup="true" aria-expanded={ this.state.subMenuOpen } { ...this.props } { ...this.menuTriggerEventHandlers() } ref={ ref }>
+              { this.props.name }
+              <Icon style={ { position: "absolute", top: "11px" } } icon="downArrow" color="lightGrey" size="20px" p="2px" />
+            </MenuTriggerButton>
+          )}
+        </Reference>
+        {this.state.subMenuOpen && (
           <Popper placement="bottom-start" modifiers={ { flip: { behavior: ["bottom"] } } }>
             {popperProps => (
-              <OutsideAlerter handleOutsideClick={ this.handleOutsideClick }>
+              <DetectOutsideClick onClick={ this.handleOutsideClick }>
                 <SubMenu popperProps={ popperProps } { ...this.subMenuEventHandlers() }>
                   {renderSubMenuItems(this.props.menuData, () => { this.hideSubMenu(true); })}
                 </SubMenu>
-              </OutsideAlerter>
+              </DetectOutsideClick>
             )}
           </Popper>
-          )}
-        </Manager>
+        )}
+      </Manager>
     );
   }
 }

--- a/components/src/NavBar/MenuTrigger.js
+++ b/components/src/NavBar/MenuTrigger.js
@@ -146,16 +146,16 @@ class MenuTrigger extends React.Component {
 
   subMenuEventHandlers() {
     return ({
-      onBlur: ()=>(this.hideSubMenu()),
-      onFocus: ()=>(this.showSubMenu()),
+      onBlur: () => (this.hideSubMenu()),
+      onFocus: () => (this.showSubMenu()),
       onKeyDown: e => (this.handleKeyDown(e)),
     });
   }
 
   menuTriggerEventHandlers() {
     return ({
-      onBlur: ()=>(this.hideSubMenu()),
-      onClick: e => (this.showSubMenu()),
+      onBlur: () => (this.hideSubMenu()),
+      onClick: () => (this.showSubMenu()),
       onKeyDown: e => (this.handleKeyDown(e)),
     });
   }
@@ -181,11 +181,11 @@ class MenuTrigger extends React.Component {
 
   render() {
     return (
-      <OutsideAlerter handleClickOutside={this.handleClickOutside}>
+      <OutsideAlerter handleClickOutside={ this.handleClickOutside }>
         <Manager>
           <Reference>
             {({ ref }) => (
-              <MenuTriggerButton aria-haspopup="true" aria-expanded={ this.state.subMenuOpen } { ...this.props } { ...this.menuTriggerEventHandlers() } ref={ref}>
+              <MenuTriggerButton aria-haspopup="true" aria-expanded={ this.state.subMenuOpen } { ...this.props } { ...this.menuTriggerEventHandlers() } ref={ ref }>
                 { this.props.name }
                 <Icon style={ { position: "absolute", top: "11px" } } icon="downArrow" color="lightGrey" size="20px" p="2px" />
               </MenuTriggerButton>

--- a/components/src/NavBar/MenuTrigger.js
+++ b/components/src/NavBar/MenuTrigger.js
@@ -120,7 +120,7 @@ class MenuTrigger extends React.Component {
     this.handleKeyDown = this.handleKeyDown.bind(this);
     this.hideSubMenu = this.hideSubMenu.bind(this);
     this.showSubMenu = this.showSubMenu.bind(this);
-    this.handleClickOutside = this.handleClickOutside.bind(this);
+    this.handleOutsideClick = this.handleOutsideClick.bind(this);
   }
 
   componentWillUnmount() {
@@ -165,12 +165,12 @@ class MenuTrigger extends React.Component {
     clearTimeout(this.showTimeoutID);
   }
 
-  handleClickOutside() {
+  handleOutsideClick() {
     this.hideSubMenu(true);
   }
 
-  handleKeyDown(event) {
-    switch (event.keyCode) {
+  handleKeyDown(e) {
+    switch (e.keyCode) {
       case keyCode.ESC:
         this.hideSubMenu(true);
         break;
@@ -181,7 +181,6 @@ class MenuTrigger extends React.Component {
 
   render() {
     return (
-      <OutsideAlerter handleClickOutside={ this.handleClickOutside }>
         <Manager>
           <Reference>
             {({ ref }) => (
@@ -194,14 +193,15 @@ class MenuTrigger extends React.Component {
           {this.state.subMenuOpen && (
           <Popper placement="bottom-start" modifiers={ { flip: { behavior: ["bottom"] } } }>
             {popperProps => (
-              <SubMenu popperProps={ popperProps } { ...this.subMenuEventHandlers() }>
-                {renderSubMenuItems(this.props.menuData, () => { this.hideSubMenu(true); })}
-              </SubMenu>
+              <OutsideAlerter handleOutsideClick={ this.handleOutsideClick }>
+                <SubMenu popperProps={ popperProps } { ...this.subMenuEventHandlers() }>
+                  {renderSubMenuItems(this.props.menuData, () => { this.hideSubMenu(true); })}
+                </SubMenu>
+              </OutsideAlerter>
             )}
           </Popper>
           )}
         </Manager>
-      </OutsideAlerter>
     );
   }
 }

--- a/components/src/NavBar/MenuTrigger.js
+++ b/components/src/NavBar/MenuTrigger.js
@@ -146,13 +146,16 @@ class MenuTrigger extends React.Component {
 
   subMenuEventHandlers() {
     return ({
+      onBlur: ()=>(this.hideSubMenu()),
+      onFocus: ()=>(this.showSubMenu()),
       onKeyDown: e => (this.handleKeyDown(e)),
     });
   }
 
   menuTriggerEventHandlers() {
     return ({
-      onClick: e => { this.showSubMenu(); e.target.focus(); },
+      onBlur: ()=>(this.hideSubMenu()),
+      onClick: e => (this.showSubMenu()),
       onKeyDown: e => (this.handleKeyDown(e)),
     });
   }

--- a/components/src/NavBar/MenuTrigger.js
+++ b/components/src/NavBar/MenuTrigger.js
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import PropTypes from "prop-types";
 import { Manager, Reference, Popper } from "react-popper";
 import theme from "../theme";
+import { OutsideAlerter } from "../Utils";
 import { Icon } from "../Icon";
 import SubMenu from "./SubMenu";
 import SubMenuTrigger from "./SubMenuTrigger";
@@ -115,9 +116,11 @@ class MenuTrigger extends React.Component {
     this.state = {
       subMenuOpen: false,
     };
+    this.buttonRef = React.createRef();
     this.handleKeyDown = this.handleKeyDown.bind(this);
     this.hideSubMenu = this.hideSubMenu.bind(this);
     this.showSubMenu = this.showSubMenu.bind(this);
+    this.handleClickOutside = this.handleClickOutside.bind(this);
   }
 
   componentWillUnmount() {
@@ -143,16 +146,13 @@ class MenuTrigger extends React.Component {
 
   subMenuEventHandlers() {
     return ({
-      onFocus: () => (this.showSubMenu()),
-      onBlur: () => (this.hideSubMenu()),
       onKeyDown: e => (this.handleKeyDown(e)),
     });
   }
 
   menuTriggerEventHandlers() {
     return ({
-      onClick: () => (this.showSubMenu()),
-      onBlur: () => (this.hideSubMenu()),
+      onClick: e => { this.showSubMenu(); e.target.focus(); },
       onKeyDown: e => (this.handleKeyDown(e)),
     });
   }
@@ -160,6 +160,10 @@ class MenuTrigger extends React.Component {
   clearScheduled() {
     clearTimeout(this.hideTimeoutID);
     clearTimeout(this.showTimeoutID);
+  }
+
+  handleClickOutside() {
+    this.hideSubMenu(true);
   }
 
   handleKeyDown(event) {
@@ -174,25 +178,27 @@ class MenuTrigger extends React.Component {
 
   render() {
     return (
-      <Manager>
-        <Reference>
-          {({ ref }) => (
-            <MenuTriggerButton aria-haspopup="true" aria-expanded={ this.state.subMenuOpen } { ...this.props } { ...this.menuTriggerEventHandlers() } ref={ ref }>
-              { this.props.name }
-              <Icon style={ { position: "absolute", top: "11px" } } icon="downArrow" color="lightGrey" size="20px" p="2px" />
-            </MenuTriggerButton>
+      <OutsideAlerter handleClickOutside={this.handleClickOutside}>
+        <Manager>
+          <Reference>
+            {({ ref }) => (
+              <MenuTriggerButton aria-haspopup="true" aria-expanded={ this.state.subMenuOpen } { ...this.props } { ...this.menuTriggerEventHandlers() } ref={ref}>
+                { this.props.name }
+                <Icon style={ { position: "absolute", top: "11px" } } icon="downArrow" color="lightGrey" size="20px" p="2px" />
+              </MenuTriggerButton>
+            )}
+          </Reference>
+          {this.state.subMenuOpen && (
+          <Popper placement="bottom-start" modifiers={ { flip: { behavior: ["bottom"] } } }>
+            {popperProps => (
+              <SubMenu popperProps={ popperProps } { ...this.subMenuEventHandlers() }>
+                {renderSubMenuItems(this.props.menuData, () => { this.hideSubMenu(true); })}
+              </SubMenu>
+            )}
+          </Popper>
           )}
-        </Reference>
-        {this.state.subMenuOpen && (
-        <Popper placement="bottom-start" modifiers={ { flip: { behavior: ["bottom"] } } }>
-          {popperProps => (
-            <SubMenu popperProps={ popperProps } { ...this.subMenuEventHandlers() }>
-              {renderSubMenuItems(this.props.menuData, () => { this.hideSubMenu(true); })}
-            </SubMenu>
-          )}
-        </Popper>
-        )}
-      </Manager>
+        </Manager>
+      </OutsideAlerter>
     );
   }
 }

--- a/components/src/NavBar/SubMenuTrigger.js
+++ b/components/src/NavBar/SubMenuTrigger.js
@@ -143,13 +143,16 @@ class SubMenuTrigger extends React.Component {
 
   subMenuEventHandlers() {
     return ({
+      onBlur: ()=>(this.hideSubMenu()),
+      onFocus: ()=>(this.showSubMenu()),
       onKeyDown: e => (this.handleKeyDown(e)),
     });
   }
 
   SubMenuTriggerEventHandlers() {
     return ({
-      onClick: e => { this.showSubMenu(); e.target.focus(); },
+      onBlur: ()=>(this.hideSubMenu()),
+      onClick: e => (this.showSubMenu()),
       onKeyDown: e => (this.handleKeyDown(e)),
     });
   }

--- a/components/src/NavBar/SubMenuTrigger.js
+++ b/components/src/NavBar/SubMenuTrigger.js
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import PropTypes from "prop-types";
 import { Manager, Reference, Popper } from "react-popper";
 import theme from "../theme";
+import { OutsideAlerter } from "../Utils";
 import { Icon } from "../Icon";
 import SubMenu from "./SubMenu";
 import SubMenuLink from "./SubMenuLink";
@@ -116,6 +117,7 @@ class SubMenuTrigger extends React.Component {
     this.handleKeyDown = this.handleKeyDown.bind(this);
     this.hideSubMenu = this.hideSubMenu.bind(this);
     this.showSubMenu = this.showSubMenu.bind(this);
+    this.handleClickOutside = this.handleClickOutside.bind(this);
   }
 
   componentWillUnmount() {
@@ -141,16 +143,13 @@ class SubMenuTrigger extends React.Component {
 
   subMenuEventHandlers() {
     return ({
-      onFocus: () => (this.showSubMenu()),
-      onBlur: () => (this.hideSubMenu()),
       onKeyDown: e => (this.handleKeyDown(e)),
     });
   }
 
   SubMenuTriggerEventHandlers() {
     return ({
-      onClick: () => (this.showSubMenu()),
-      onBlur: () => (this.hideSubMenu()),
+      onClick: e => { this.showSubMenu(); e.target.focus(); },
       onKeyDown: e => (this.handleKeyDown(e)),
     });
   }
@@ -158,6 +157,10 @@ class SubMenuTrigger extends React.Component {
   clearScheduled() {
     clearTimeout(this.hideTimeoutID);
     clearTimeout(this.showTimeoutID);
+  }
+
+  handleClickOutside() {
+    this.hideSubMenu(true);
   }
 
   handleKeyDown(event) {
@@ -172,25 +175,27 @@ class SubMenuTrigger extends React.Component {
 
   render() {
     return (
-      <Manager>
-        <Reference>
-          {({ ref }) => (
-            <SubMenuTriggerButton aria-haspopup="true" aria-expanded={ this.state.subMenuOpen } { ...this.props } { ...this.SubMenuTriggerEventHandlers() } ref={ ref }>
-              { this.props.name }
-              <Icon style={ { position: "absolute", top: "11px" } } icon="rightArrow" color="darkBlue" size="20px" p="2px" />
-            </SubMenuTriggerButton>
+      <OutsideAlerter handleClickOutside={this.handleClickOutside}>
+        <Manager>
+          <Reference>
+            {({ ref }) => (
+              <SubMenuTriggerButton aria-haspopup="true" aria-expanded={ this.state.subMenuOpen } { ...this.props } { ...this.SubMenuTriggerEventHandlers() } ref={ ref }>
+                { this.props.name }
+                <Icon style={ { position: "absolute", top: "11px" } } icon="rightArrow" color="darkBlue" size="20px" p="2px" />
+              </SubMenuTriggerButton>
+            )}
+          </Reference>
+          {this.state.subMenuOpen && (
+          <Popper placement="right-start">
+            {popperProps => (
+              <SubMenu renderArrow={ false } popperProps={ popperProps } { ...this.subMenuEventHandlers() }>
+                {renderSubMenuItems(this.props.menuData, this.props.linkOnClick)}
+              </SubMenu>
+            )}
+          </Popper>
           )}
-        </Reference>
-        {this.state.subMenuOpen && (
-        <Popper placement="right-start">
-          {popperProps => (
-            <SubMenu renderArrow={ false } popperProps={ popperProps } { ...this.subMenuEventHandlers() }>
-              {renderSubMenuItems(this.props.menuData, this.props.linkOnClick)}
-            </SubMenu>
-          )}
-        </Popper>
-        )}
-      </Manager>
+        </Manager>
+      </OutsideAlerter>
     );
   }
 }

--- a/components/src/NavBar/SubMenuTrigger.js
+++ b/components/src/NavBar/SubMenuTrigger.js
@@ -143,16 +143,16 @@ class SubMenuTrigger extends React.Component {
 
   subMenuEventHandlers() {
     return ({
-      onBlur: ()=>(this.hideSubMenu()),
-      onFocus: ()=>(this.showSubMenu()),
+      onBlur: () => (this.hideSubMenu()),
+      onFocus: () => (this.showSubMenu()),
       onKeyDown: e => (this.handleKeyDown(e)),
     });
   }
 
   SubMenuTriggerEventHandlers() {
     return ({
-      onBlur: ()=>(this.hideSubMenu()),
-      onClick: e => (this.showSubMenu()),
+      onBlur: () => (this.hideSubMenu()),
+      onClick: () => (this.showSubMenu()),
       onKeyDown: e => (this.handleKeyDown(e)),
     });
   }
@@ -178,7 +178,7 @@ class SubMenuTrigger extends React.Component {
 
   render() {
     return (
-      <OutsideAlerter handleClickOutside={this.handleClickOutside}>
+      <OutsideAlerter handleClickOutside={ this.handleClickOutside }>
         <Manager>
           <Reference>
             {({ ref }) => (

--- a/components/src/NavBar/SubMenuTrigger.js
+++ b/components/src/NavBar/SubMenuTrigger.js
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import PropTypes from "prop-types";
 import { Manager, Reference, Popper } from "react-popper";
 import theme from "../theme";
-import { OutsideAlerter } from "../Utils";
+import { DetectOutsideClick } from "../Utils";
 import { Icon } from "../Icon";
 import SubMenu from "./SubMenu";
 import SubMenuLink from "./SubMenuLink";
@@ -190,11 +190,11 @@ class SubMenuTrigger extends React.Component {
         {this.state.subMenuOpen && (
         <Popper placement="right-start">
           {popperProps => (
-            <OutsideAlerter handleOutsideClick={ this.handleOutsideClick }>
+            <DetectOutsideClick onClick={ this.handleOutsideClick }>
               <SubMenu renderArrow={ false } popperProps={ popperProps } { ...this.subMenuEventHandlers() }>
                 {renderSubMenuItems(this.props.menuData, this.props.linkOnClick)}
               </SubMenu>
-            </OutsideAlerter>
+            </DetectOutsideClick>
           )}
         </Popper>
         )}

--- a/components/src/NavBar/SubMenuTrigger.js
+++ b/components/src/NavBar/SubMenuTrigger.js
@@ -117,7 +117,7 @@ class SubMenuTrigger extends React.Component {
     this.handleKeyDown = this.handleKeyDown.bind(this);
     this.hideSubMenu = this.hideSubMenu.bind(this);
     this.showSubMenu = this.showSubMenu.bind(this);
-    this.handleClickOutside = this.handleClickOutside.bind(this);
+    this.handleOutsideClick = this.handleOutsideClick.bind(this);
   }
 
   componentWillUnmount() {
@@ -162,12 +162,12 @@ class SubMenuTrigger extends React.Component {
     clearTimeout(this.showTimeoutID);
   }
 
-  handleClickOutside() {
+  handleOutsideClick() {
     this.hideSubMenu(true);
   }
 
-  handleKeyDown(event) {
-    switch (event.keyCode) {
+  handleKeyDown(e) {
+    switch (e.keyCode) {
       case keyCode.ESC:
         this.hideSubMenu(true);
         break;
@@ -178,27 +178,27 @@ class SubMenuTrigger extends React.Component {
 
   render() {
     return (
-      <OutsideAlerter handleClickOutside={ this.handleClickOutside }>
-        <Manager>
-          <Reference>
-            {({ ref }) => (
-              <SubMenuTriggerButton aria-haspopup="true" aria-expanded={ this.state.subMenuOpen } { ...this.props } { ...this.SubMenuTriggerEventHandlers() } ref={ ref }>
-                { this.props.name }
-                <Icon style={ { position: "absolute", top: "11px" } } icon="rightArrow" color="darkBlue" size="20px" p="2px" />
-              </SubMenuTriggerButton>
-            )}
-          </Reference>
-          {this.state.subMenuOpen && (
-          <Popper placement="right-start">
-            {popperProps => (
+      <Manager>
+        <Reference>
+          {({ ref }) => (
+            <SubMenuTriggerButton aria-haspopup="true" aria-expanded={ this.state.subMenuOpen } { ...this.props } { ...this.SubMenuTriggerEventHandlers() } ref={ ref }>
+              { this.props.name }
+              <Icon style={ { position: "absolute", top: "11px" } } icon="rightArrow" color="darkBlue" size="20px" p="2px" />
+            </SubMenuTriggerButton>
+          )}
+        </Reference>
+        {this.state.subMenuOpen && (
+        <Popper placement="right-start">
+          {popperProps => (
+            <OutsideAlerter handleOutsideClick={ this.handleOutsideClick }>
               <SubMenu renderArrow={ false } popperProps={ popperProps } { ...this.subMenuEventHandlers() }>
                 {renderSubMenuItems(this.props.menuData, this.props.linkOnClick)}
               </SubMenu>
-            )}
-          </Popper>
+            </OutsideAlerter>
           )}
-        </Manager>
-      </OutsideAlerter>
+        </Popper>
+        )}
+      </Manager>
     );
   }
 }

--- a/components/src/Utils/DetectOutsideClicks.js
+++ b/components/src/Utils/DetectOutsideClicks.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-class OutsideAlerter extends React.Component {
+class DetectOutsideClick extends React.Component {
   constructor(props) {
     super(props);
 
@@ -17,23 +17,23 @@ class OutsideAlerter extends React.Component {
   }
 
   handleOutsideClick(e) {
-    const { handleOutsideClick } = this.props;
+    const { onClick } = this.props;
 
     if (this.wrapperRef && !this.wrapperRef.contains(e.target)) {
-      handleOutsideClick(e);
+      onClick(e);
     }
   }
 
   render() {
     const { children } = this.props;
 
-    return <div ref={ node => this.wrapperRef = node }>{ children }</div>;
+    return <div ref={ node => { this.wrapperRef = node; } }>{ children }</div>;
   }
 }
 
-OutsideAlerter.propTypes = {
-  handleOutsideClick: PropTypes.func.isRequired,
+DetectOutsideClick.propTypes = {
+  onClick: PropTypes.func.isRequired,
   children: PropTypes.element.isRequired,
 };
 
-export default OutsideAlerter;
+export default DetectOutsideClick;

--- a/components/src/Utils/OutsideAlerter.js
+++ b/components/src/Utils/OutsideAlerter.js
@@ -1,0 +1,40 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+class OutsideAlerter extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.setWrapperRef = this.setWrapperRef.bind(this);
+    this.handleClickOutside = this.handleClickOutside.bind(this);
+  }
+
+  componentDidMount() {
+    document.addEventListener('mousedown', this.handleClickOutside);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('mousedown', this.handleClickOutside);
+  }
+
+  setWrapperRef(node) {
+    this.wrapperRef = node;
+  }
+
+  handleClickOutside(event) {
+    if (this.wrapperRef && !this.wrapperRef.contains(event.target)) {
+      this.props.handleClickOutside();
+    }
+  }
+
+  render() {
+    return <div ref={this.setWrapperRef}>{this.props.children}</div>;
+  }
+}
+
+OutsideAlerter.propTypes = {
+  handleClickOutside: PropTypes.func.isRequired,
+  children: PropTypes.element.isRequired,
+};
+
+export default OutsideAlerter;

--- a/components/src/Utils/OutsideAlerter.js
+++ b/components/src/Utils/OutsideAlerter.js
@@ -5,39 +5,34 @@ class OutsideAlerter extends React.Component {
   constructor(props) {
     super(props);
 
-    this.setWrapperRef = this.setWrapperRef.bind(this);
-    this.handleClickOutside = this.handleClickOutside.bind(this);
+    this.handleOutsideClick = this.handleOutsideClick.bind(this);
   }
 
   componentDidMount() {
-    document.addEventListener("mousedown", this.handleClickOutside);
+    document.addEventListener("click", this.handleOutsideClick);
   }
 
   componentWillUnmount() {
-    document.removeEventListener("mousedown", this.handleClickOutside);
+    document.removeEventListener("click", this.handleOutsideClick);
   }
 
-  setWrapperRef(node) {
-    this.wrapperRef = node;
-  }
+  handleOutsideClick(e) {
+    const { handleOutsideClick } = this.props;
 
-  handleClickOutside(event) {
-    const { handleClickOutside } = this.props;
-
-    if (this.wrapperRef && !this.wrapperRef.contains(event.target)) {
-      handleClickOutside();
+    if (this.wrapperRef && !this.wrapperRef.contains(e.target)) {
+      handleOutsideClick(e);
     }
   }
 
   render() {
     const { children } = this.props;
 
-    return <div ref={ this.setWrapperRef }>{ children }</div>;
+    return <div ref={ node => this.wrapperRef = node }>{ children }</div>;
   }
 }
 
 OutsideAlerter.propTypes = {
-  handleClickOutside: PropTypes.func.isRequired,
+  handleOutsideClick: PropTypes.func.isRequired,
   children: PropTypes.element.isRequired,
 };
 

--- a/components/src/Utils/OutsideAlerter.js
+++ b/components/src/Utils/OutsideAlerter.js
@@ -10,11 +10,11 @@ class OutsideAlerter extends React.Component {
   }
 
   componentDidMount() {
-    document.addEventListener('mousedown', this.handleClickOutside);
+    document.addEventListener("mousedown", this.handleClickOutside);
   }
 
   componentWillUnmount() {
-    document.removeEventListener('mousedown', this.handleClickOutside);
+    document.removeEventListener("mousedown", this.handleClickOutside);
   }
 
   setWrapperRef(node) {
@@ -22,13 +22,17 @@ class OutsideAlerter extends React.Component {
   }
 
   handleClickOutside(event) {
+    const { handleClickOutside } = this.props;
+
     if (this.wrapperRef && !this.wrapperRef.contains(event.target)) {
-      this.props.handleClickOutside();
+      handleClickOutside();
     }
   }
 
   render() {
-    return <div ref={this.setWrapperRef}>{this.props.children}</div>;
+    const { children } = this.props;
+
+    return <div ref={ this.setWrapperRef }>{ children }</div>;
   }
 }
 

--- a/components/src/Utils/index.js
+++ b/components/src/Utils/index.js
@@ -3,3 +3,4 @@ export { default as omit } from "./omit";
 export { default as subPx } from "./subPx";
 export { default as withGeneratedId } from "./withGeneratedId";
 export { default as withWindowDimensions } from "./withWindowDimensions";
+export { default as OutsideAlerter } from "./OutsideAlerter";

--- a/components/src/Utils/index.js
+++ b/components/src/Utils/index.js
@@ -3,4 +3,4 @@ export { default as omit } from "./omit";
 export { default as subPx } from "./subPx";
 export { default as withGeneratedId } from "./withGeneratedId";
 export { default as withWindowDimensions } from "./withWindowDimensions";
-export { default as OutsideAlerter } from "./OutsideAlerter";
+export { default as DetectOutsideClick } from "./DetectOutsideClicks";


### PR DESCRIPTION
Intent: Review to merge

Cause:
 - Bug was caused because safari does not have the same logic for focusing a button onClick as all other browsers

This PR:
 - Adds OutsideAlerter Util component
    - This component is able to detect a click outside of a given component
 - Updates the MenuTrigger + SubMenuTrigger so that clicks outside will close the menu properly