### PR TITLE
Adds name to Select component

### DIFF
--- a/components/src/Select/Select.js
+++ b/components/src/Select/Select.js
@@ -133,6 +133,7 @@ const Select = ({
   id,
   labelText,
   helpText,
+  name,
   requirementText
 }) => (
   <Field>
@@ -172,6 +173,7 @@ const Select = ({
                 aria-invalid={error}
                 placeholder={placeholder}
                 readOnly
+                name={name}
                 value={optionToString(selectedItem) || ""}
               />
             </MaybeFieldLabel>

--- a/components/src/Select/Select.js
+++ b/components/src/Select/Select.js
@@ -207,6 +207,7 @@ const Select = ({
 Select.propTypes = {
   placeholder: PropTypes.string,
   value: PropTypes.string,
+  name: PropTypes.string,
   options: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   optionToString: PropTypes.func,
   required: PropTypes.bool,
@@ -226,6 +227,7 @@ const extractLabelFromOption = option => option && option.label;
 
 Select.defaultProps = {
   value: undefined,
+  name: undefined,
   required: false,
   onChange: undefined,
   error: undefined,

--- a/docs/src/pages/components/select.js
+++ b/docs/src/pages/components/select.js
@@ -33,13 +33,6 @@ const propsRows = [
     description:
       "The options available to be selected, containing a value and a label"
   },
-  {
-    name: "value",
-    type: "String",
-    defaultValue: "undefined",
-    description:
-      "Value of the current selected option, used when controlling the Select component"
-  },
   ...inputProps
 ];
 

--- a/docs/src/shared/groupProps.js
+++ b/docs/src/shared/groupProps.js
@@ -33,7 +33,7 @@ const groupProps = [
   {
     name: "labelText",
     type: "String",
-    defaultValue: "null",
+    defaultValue: "Required",
     description: "Informs users what the corresponding input field is for."
   },
   {

--- a/docs/src/shared/groupProps.js
+++ b/docs/src/shared/groupProps.js
@@ -1,5 +1,11 @@
 const groupProps = [
   {
+    name: "name",
+    type: "String",
+    defaultValue: "Required",
+    description: "A unique name for this input that groups inputs together"
+  },
+  {
     name: "defaultValue",
     type: "String",
     defaultValue: "null",
@@ -29,12 +35,6 @@ const groupProps = [
     type: "String",
     defaultValue: "null",
     description: "Informs users what the corresponding input field is for."
-  },
-  {
-    name: "name",
-    type: "String",
-    defaultValue: "Required",
-    description: "A unique name for this input"
   },
   {
     name: "required",

--- a/docs/src/shared/inputProps.js
+++ b/docs/src/shared/inputProps.js
@@ -1,5 +1,23 @@
 const inputProps = [
   {
+    name: "name",
+    type: "String",
+    defaultValue: "Required",
+    description: "A unique name for this input"
+  },
+  {
+    name: "value",
+    type: "String",
+    defaultValue: "Required",
+    description: "Value of selection for submission"
+  },
+  {
+    name: "id",
+    type: "String",
+    defaultValue: "Required",
+    description: "A unique ID for this input"
+  },
+  {
     name: "disabled",
     type: "Boolean",
     defaultValue: "false",
@@ -23,12 +41,6 @@ const inputProps = [
     defaultValue: "null",
     description:
       "Placed below the label to provide assistance on how to fill out a field or the expected format. It can also provide an explanation of why the information is needed and how it will be used."
-  },
-  {
-    name: "id",
-    type: "String",
-    defaultValue: "Required",
-    description: "A unique ID for this input"
   },
   {
     name: "labelText",

--- a/docs/src/shared/inputProps.js
+++ b/docs/src/shared/inputProps.js
@@ -15,7 +15,7 @@ const inputProps = [
     name: "value",
     type: "String",
     defaultValue: "undefined",
-    description: "Value of selection for submission"
+    description: "Value of input, used when controlling the component"
   },
   {
     name: "disabled",

--- a/docs/src/shared/inputProps.js
+++ b/docs/src/shared/inputProps.js
@@ -1,21 +1,21 @@
 const inputProps = [
   {
-    name: "name",
+    name: "id",
     type: "String",
     defaultValue: "Required",
+    description: "A unique ID for this input"
+  },
+  {
+    name: "name",
+    type: "String",
+    defaultValue: "undefined",
     description: "A unique name for this input"
   },
   {
     name: "value",
     type: "String",
-    defaultValue: "Required",
+    defaultValue: "undefined",
     description: "Value of selection for submission"
-  },
-  {
-    name: "id",
-    type: "String",
-    defaultValue: "Required",
-    description: "A unique ID for this input"
   },
   {
     name: "disabled",

--- a/docs/src/shared/radioProps.js
+++ b/docs/src/shared/radioProps.js
@@ -7,14 +7,14 @@ const radioProps = [
   },
   {
     name: "name",
-    type: "undefined",
-    defaultValue: "Required",
+    type: "String",
+    defaultValue: "undefined",
     description: "Identified that groups inputs together"
   },
   {
     name: "value",
-    type: "undefined",
-    defaultValue: "Required",
+    type: "String",
+    defaultValue: "undefined",
     description: "Value of selection for submission"
   },
   {

--- a/docs/src/shared/radioProps.js
+++ b/docs/src/shared/radioProps.js
@@ -1,5 +1,23 @@
 const radioProps = [
   {
+    name: "id",
+    type: "String",
+    defaultValue: "Required",
+    description: "A unique ID for this input"
+  },
+  {
+    name: "name",
+    type: "undefined",
+    defaultValue: "Required",
+    description: "Identified that groups inputs together"
+  },
+  {
+    name: "value",
+    type: "undefined",
+    defaultValue: "Required",
+    description: "Value of selection for submission"
+  },
+  {
     name: "defaultChecked",
     type: "Boolean",
     defaultValue: "false",
@@ -16,12 +34,6 @@ const radioProps = [
     type: "Boolean",
     defaultValue: "false",
     description: "Marks the field as invalid and turns red"
-  },
-  {
-    name: "id",
-    type: "String",
-    defaultValue: "Required",
-    description: "A unique ID for this input"
   },
   {
     name: "labelText",


### PR DESCRIPTION
Intent: Review to merge

changes from: https://nulogy-go.atlassian.net/browse/NDS-903

This PR:
 - adds name to the input within the Select component to allow for use in a simple HTML form submission uncontrolled
 - adds documentation for name and value props on input type components