### PR TITLE
[NDS-922] Align validation styles to Alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Branding API changes
   - [**Breaking Change**] Renamed the prop `alignment` value "middle" to "center"
   - Adds [`withLine`](https://storybook.nulogy.design/?path=/story/branding--branding) prop
+- [HeaderValidation](https://nulogy.design/components/header-validation/) now uses Alert component
 
 ### Changed
 

--- a/components/src/Validation/HeaderValidation.js
+++ b/components/src/Validation/HeaderValidation.js
@@ -5,8 +5,8 @@ import { Box } from "../Box";
 import { Alert } from "../Alert";
 import mapErrorsToList from "./mapErrorsToList";
 
-const BaseHeaderValidation = ({ title, errorMessage, errorList, children }) => (
-  <Box mb="x2">
+const BaseHeaderValidation = ({ className, title, errorMessage, errorList, children }) => (
+  <Box mb="x2" className={className}>
     <Alert title={title} type="danger">
       {errorMessage}
       {mapErrorsToList(errorList)}
@@ -18,6 +18,7 @@ const BaseHeaderValidation = ({ title, errorMessage, errorList, children }) => (
 const HeaderValidation = styled(BaseHeaderValidation)({});
 
 BaseHeaderValidation.propTypes = {
+  className: PropTypes.string,
   title: PropTypes.string.isRequired,
   errorMessage: PropTypes.string.isRequired,
   errorList: PropTypes.arrayOf(PropTypes.string),
@@ -25,6 +26,7 @@ BaseHeaderValidation.propTypes = {
 };
 
 BaseHeaderValidation.defaultProps = {
+  className: null,
   errorList: null,
   children: null
 };

--- a/components/src/Validation/HeaderValidation.js
+++ b/components/src/Validation/HeaderValidation.js
@@ -1,31 +1,18 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import { Flex } from "../Flex";
-import { Text, SubsectionTitle } from "../Type";
-import { Icon } from "../Icon";
+import { Box } from "../Box";
+import { Alert } from "../Alert";
 import mapErrorsToList from "./mapErrorsToList";
-import theme from "../theme";
 
-const Wrapper = styled.div({
-  [`${Text}`]: {
-    marginBottom: theme.space.x1
-  },
-  "> *:last-child": {
-    marginBottom: 0
-  }
-});
-
-const BaseHeaderValidation = ({ title, errorMessage, errorList, children, ...boxProps }) => (
-  <Flex color="red" {...boxProps}>
-    <Icon icon="error" size={theme.space.x6} mr={theme.space.x2} />
-    <Wrapper>
-      <SubsectionTitle mb="none">{title}</SubsectionTitle>
-      <Text>{errorMessage}</Text>
+const BaseHeaderValidation = ({ title, errorMessage, errorList, children }) => (
+  <Box mb="x2">
+    <Alert title={title} type="danger">
+      {errorMessage}
       {mapErrorsToList(errorList)}
       {children}
-    </Wrapper>
-  </Flex>
+    </Alert>
+  </Box>
 );
 
 const HeaderValidation = styled(BaseHeaderValidation)({});


### PR DESCRIPTION
This PR makes HeaderValidation use the new Alert component instead of a custom style. 

We (Nikola and I) decided not to update any inline validation styles as they already shared the icon and red colour with the Alerts and adding the background made everything a little intense.

