### PR TITLE
[NDS-946] Differentiate focus and hover more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Added text wrapping
   - Added prop `maxHeight`
 - Changed small shadow token
+- Changed appearance of focused components
 - Updated login page stories to include additional responsive behaviors
 
 ### Deprecated

--- a/components/src/Button/Button.js
+++ b/components/src/Button/Button.js
@@ -78,13 +78,17 @@ const Button = styled(BaseButton)(
     borderRadius: theme.radii.medium,
     width: fullWidth ? "100%" : "auto",
     margin: theme.space.none,
-    "&:hover, &:focus": {
+    "&:hover": {
       backgroundColor: disabled ? null : theme.colors.lightBlue
     },
     "&:focus": {
       outline: "none",
       borderColor: theme.colors.blue,
-      boxShadow: theme.shadows.focus
+      boxShadow: theme.shadows.focus,
+      backgroundColor: theme.colors.white,
+      "&:hover": {
+        backgroundColor: theme.colors.lightBlue
+      }
     },
     "&:active": {
       transform: "scale(0.98)",

--- a/components/src/Button/DangerButton.js
+++ b/components/src/Button/DangerButton.js
@@ -7,14 +7,18 @@ const DangerButton = styled(Button)(({ disabled }) => ({
   color: theme.colors.white,
   borderColor: theme.colors.red,
   backgroundColor: theme.colors.red,
-  "&:hover, &:focus": {
+  "&:hover": {
     backgroundColor: disabled ? null : darken(0.1, theme.colors.red),
     borderColor: disabled ? null : darken(0.1, theme.colors.red)
   },
   "&:focus": {
     outline: "none",
+    backgroundColor: theme.colors.red,
     borderColor: theme.colors.blue,
-    boxShadow: theme.shadows.focus
+    boxShadow: theme.shadows.focus,
+    "&:hover": {
+      backgroundColor: darken(0.1, theme.colors.red)
+    }
   }
 }));
 

--- a/components/src/Button/IconicButton.js
+++ b/components/src/Button/IconicButton.js
@@ -26,8 +26,7 @@ const WrapperButton = styled.button(space, ({ disabled }) => ({
     fontWeight: theme.fontWeights.medium,
     textAlign: "left"
   },
-  "&:hover, &:focus": {
-    outline: "none",
+  "&:hover": {
     [`${Icon}`]: {
       backgroundColor: theme.colors.lightBlue
     }
@@ -48,6 +47,7 @@ const WrapperButton = styled.button(space, ({ disabled }) => ({
     }
   },
   "&:focus": {
+    outline: "none",
     [`${Icon}`]: {
       boxShadow: theme.shadows.focus
     }

--- a/components/src/Button/PrimaryButton.js
+++ b/components/src/Button/PrimaryButton.js
@@ -7,14 +7,18 @@ const PrimaryButton = styled(Button)(({ disabled }) => ({
   color: theme.colors.white,
   borderColor: theme.colors.blue,
   backgroundColor: theme.colors.blue,
-  "&:hover, &:focus": {
+  "&:hover": {
     backgroundColor: disabled ? null : darken(0.1, theme.colors.blue),
     borderColor: disabled ? null : darken(0.1, theme.colors.blue)
   },
   "&:focus": {
     outline: "none",
     borderColor: theme.colors.blue,
-    boxShadow: theme.shadows.focus
+    boxShadow: theme.shadows.focus,
+    backgroundColor: theme.colors.blue,
+    "&:hover": {
+      backgroundColor: darken(0.1, theme.colors.blue)
+    }
   }
 }));
 

--- a/components/src/Link/Link.js
+++ b/components/src/Link/Link.js
@@ -18,7 +18,7 @@ const getHoverColor = props =>
 const Link = styled.a(color, space, ({ underline, ...props }) => ({
   ...resetButtonStyles,
   textDecoration: underline ? "underline" : "none",
-  "&:hover, &:focus": {
+  "&:hover": {
     cursor: "pointer",
     color: getHoverColor(props)
   },

--- a/tokens/src/shadow/focus.json
+++ b/tokens/src/shadow/focus.json
@@ -1,5 +1,5 @@
 {
   "shadow": {
-    "focus": { "value": "0px 0px 3px 0px rgba(33, 107, 235, .5)" }
+    "focus": { "value": "0px 0px 5px 0px rgba(33, 107, 235, .9)" }
   }
 }


### PR DESCRIPTION
This PR updates the focus shadow token to have greater depth and less translucency, and removes the darkened background on buttons that are focused but not hovered. 