### PR TITLE
Specifies react as a peerDependency in components

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -43,8 +43,8 @@
   },
   "main": "dist/main.js",
   "peerDependencies": {
-    "react": "^16.3.2",
-    "react-dom": "^16.3.2"
+    "react": ">=16.3.2",
+    "react-dom": ">=16.3.2"
   },
   "devDependencies": {
     "@babel/core": "7.3.4",
@@ -68,8 +68,8 @@
     "jest": "24.1.0",
     "jest-styled-components": "6.3.1",
     "prop-types": "15.6.2",
-    "react": "*",
-    "react-dom": "*",
+    "react": "^16.3.2",
+    "react-dom": "^16.3.2",
     "react-test-renderer": "~16.3",
     "webpack": "^4.8.3",
     "webpack-cli": "^3.1.0"
@@ -79,8 +79,6 @@
     "@storybook/theming": "^5.0.11",
     "downshift": "3.2.2",
     "polished": "3.0.0",
-    "react": "^16.3.2",
-    "react-dom": "^16.3.2",
     "react-popper": "^1.3.3",
     "styled-components": "^4.1.3",
     "styled-system": "^3.2.1",


### PR DESCRIPTION
I noticed a warning during `yarn install` when adding NDS to another project using a later version of React (16.8.11) than the specified pessimistic version of the peerDependency. I think that the peerDependency should be more permissive, to allow for versions later than the minimum supported version without warning.

I also think that specifying react as both a dependency and peerDependency goes against the whole point of why Yarn supports peerDependencies. By removing the dependency on react, we are now accurately saying that the user of NDS needs to provide their own react version.

I hope this help :)