### PR TITLE
Clear select component current selection when value set to empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- option to hide the label on an [IconicButton](https://nulogy.design/components/iconic-button/) component so it will only appear on hover and on focus
+- Option to hide the label on an [IconicButton](https://nulogy.design/components/iconic-button/) component so it will only appear on hover and on focus
 
 ### Changed
 
-- ref forwarding applied to the [Icon](https://nulogy.design/components/icon/) component (ref points to the inner `svg` tag)
+- Ref forwarding applied to the [Icon](https://nulogy.design/components/icon/) component (ref points to the inner `svg` tag)
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- Bug fixes for the [Select](https://storybook.nulogy.design/?path=/story/select--select-as-a-controlled-component) component
+  - Passing in blank string for `value` prop now clears the value of the select
+  - [**Breaking Change**] onChange now returns the value string instead of the value and label object
 
 ### Security
 

--- a/components-e2e/cypress/integration/components/Select.spec.js
+++ b/components-e2e/cypress/integration/components/Select.spec.js
@@ -106,4 +106,49 @@ describe("Select", () => {
     cy.focused().type("{esc}");
     assertDropDownIsClosed();
   });
+
+  it("works as a controlled component", () => {
+    const options = [
+      { value: "v1", label: "V One" },
+      { value: "v2", label: "V Two" }
+    ];
+
+    class ControlledSelect extends React.Component {
+      constructor() {
+        super();
+
+        this.state = { selectedValue: "" };
+        this.handleChange = this.handleChange.bind(this);
+      }
+
+      handleChange(selectedValue) {
+        this.setState({ selectedValue });
+      }
+
+      render() {
+        const { selectedValue } = this.state;
+        return (
+          <Select
+            onChange={this.handleChange}
+            value={selectedValue}
+            options={options}
+          />
+        );
+      }
+    }
+
+    cy.mount(
+      <NDSProvider>
+        <ControlledSelect />
+      </NDSProvider>
+    );
+
+    assertDropDownIsClosed();
+
+    getSelectComponent().click();
+    cy.contains("V Two").click();
+
+    cy.get("input").should("have.value", "V Two");
+    assertDropDownIsClosed();
+  });
 });

--- a/components/package.json
+++ b/components/package.json
@@ -12,7 +12,7 @@
     "eslint:fix": "yarn run eslint --fix",
     "start": "start-storybook -p 8080",
     "build": "webpack --mode production --config ../webpack.config.js",
-    "watch": "yarn build --watch",
+    "build:watch": "yarn build --watch",
     "build-storybook": "build-storybook",
     "deploy-storybook": "storybook-to-ghpages",
     "icons": "node scripts/collect-icon-svgs",

--- a/components/src/Select/Select.js
+++ b/components/src/Select/Select.js
@@ -116,7 +116,7 @@ const MenuItem = styled.div(({ isSelected, isActive }) => ({
   }
 }));
 
-const parseValueProp = (value, options) => options.find(o => o.value === value);
+const parseValueProp = (value, options) => options.find(o => o.value === value) || "";
 
 const Select = ({
   errorMessage,

--- a/components/src/Select/Select.js
+++ b/components/src/Select/Select.js
@@ -116,7 +116,7 @@ const MenuItem = styled.div(({ isSelected, isActive }) => ({
   }
 }));
 
-const parseValueProp = (value, options) => options.find(o => o.value === value) || "";
+const findOptionFromValue = (value, options) => options.find(o => o.value === value);
 
 const Select = ({
   errorMessage,
@@ -140,8 +140,8 @@ const Select = ({
   <Field>
     <Downshift
       itemToString={optionToString}
-      selectedItem={parseValueProp(value, options)}
-      onChange={onChange}
+      selectedItem={value && findOptionFromValue(value, options)}
+      onChange={onChange && (option => onChange(option && option.value))}
       defaultHighlightedIndex={0}
       initialIsOpen={initialIsOpen}
       inputId={id}

--- a/components/src/Select/Select.spec.js
+++ b/components/src/Select/Select.spec.js
@@ -12,3 +12,15 @@ it("opens the dropdown when clicked", () => {
 
   expect(wrapper.text()).toEqual(expect.stringMatching(/V One/));
 });
+
+it("clears the selection when the value is set to empty string", () => {
+  const options = [{ value: "v1", label: "V One" }, { value: "v2", label: "V Two" }, { value: "v3", label: "V Three" }];
+  const selectedValue = "v1";
+
+  const wrapper = mount(<Select value={selectedValue} options={options} />);
+
+  expect(wrapper.find("input").props().value).toEqual(expect.stringMatching(/V One/));
+  wrapper.setProps({ value: "" });
+
+  expect(wrapper.find("input").props().value).not.toEqual(expect.stringMatching(/V One/));
+});

--- a/components/src/Select/Select.story.js
+++ b/components/src/Select/Select.story.js
@@ -56,7 +56,6 @@ storiesOf("Select", module)
         placeholder="Please select inventory status"
         options={options}
         labelText="Inventory status"
-        optionToString={optionToString}
       />
       <br />
       <Select
@@ -64,7 +63,6 @@ storiesOf("Select", module)
         placeholder="Please select inventory status"
         options={options}
         labelText="Inventory status"
-        optionToString={optionToString}
         initialIsOpen
       />
     </>

--- a/components/src/Select/Select.story.js
+++ b/components/src/Select/Select.story.js
@@ -27,31 +27,21 @@ const wrappingOptions = [
   }
 ];
 
-const optionToString = option => option && option.label;
-
 class SelectWithState extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = { selectedOption: null };
+    this.state = { selectedValue: "" };
     this.handleChange = this.handleChange.bind(this);
   }
 
-  handleChange(selectedOption) {
-    this.setState({ selectedOption });
+  handleChange(selectedValue) {
+    this.setState({ selectedValue });
   }
 
   render() {
-    const { selectedOption } = this.state;
-    return (
-      <Select
-        onChange={this.handleChange}
-        value={selectedOption}
-        options={options}
-        optionToString={optionToString}
-        {...this.props}
-      />
-    );
+    const { selectedValue } = this.state;
+    return <Select onChange={this.handleChange} value={selectedValue} options={options} {...this.props} />;
   }
 }
 


### PR DESCRIPTION
### Context
Coman team is wrapping the NDS Select component in a Formik Field. However, when trying to reset the form fields using Formik, the current selection of the Select component was not being cleared. 

This seems to be due to the fact that when there is no matching value in the options array, the `selectedItem` prop of Downshift is set to `undefined` which will keep the last selectedItem.

Therefore, the change is to default to empty string when `parseValueProp()` can't find a matching option for the value.