### PR TITLE
[NDS-955] Build tokens when running storyshots

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -16,7 +16,7 @@
     "build-storybook": "build-storybook",
     "deploy-storybook": "storybook-to-ghpages",
     "icons": "node scripts/collect-icon-svgs",
-    "storyshots": "jest --testPathPattern='Storyshots.spec.js'",
+    "storyshots": "yarn workspace @nulogy/tokens build && jest --testPathPattern='Storyshots.spec.js'",
     "storyshots:update": "yarn storyshots -u",
     "storyshots:visual:initial": "rm -rf scripts/visual-storyshots/__image_snapshots__ && yarn run storyshots:visual",
     "storyshots:visual": "yarn build-storybook && jest --testRegex='scripts/.+spec.js' scripts/visual-storyshots/Storyshots.visual.js",


### PR DESCRIPTION
This should prevent storyshots failing due to out of date or non-existent tokens. 