### PR TITLE
Add disabled prop to DropdownMenu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Added `disabled` prop to [DropdownMenu](https://nulogy.design/components/dropdown-menu/)
+
 ### Changed
 
 ### Deprecated

--- a/components/src/Button/Button.js
+++ b/components/src/Button/Button.js
@@ -71,6 +71,7 @@ const Button = styled(BaseButton)(
     verticalAlign: "middle",
     lineHeight: theme.lineHeights.base,
     transition: ".2s",
+    cursor: disabled ? "default" : "pointer",
     color: theme.colors.blue,
     backgroundColor: theme.colors.white,
     border: `1px solid ${theme.colors.darkBlue}`,

--- a/components/src/Button/Button.js
+++ b/components/src/Button/Button.js
@@ -71,7 +71,6 @@ const Button = styled(BaseButton)(
     verticalAlign: "middle",
     lineHeight: theme.lineHeights.base,
     transition: ".2s",
-    cursor: disabled ? "arrow" : "pointer",
     color: theme.colors.blue,
     backgroundColor: theme.colors.white,
     border: `1px solid ${theme.colors.darkBlue}`,

--- a/components/src/Button/IconicButton.js
+++ b/components/src/Button/IconicButton.js
@@ -21,7 +21,7 @@ const HoverText = styled.div({
   pointerEvents: "none"
 });
 
-const WrapperButton = styled.button(space, ({ disabled }) => ({
+const WrapperButton = styled.button(space, () => ({
   background: "transparent",
   border: "none",
   position: "relative",

--- a/components/src/Button/IconicButton.js
+++ b/components/src/Button/IconicButton.js
@@ -29,7 +29,6 @@ const WrapperButton = styled.button(space, ({ disabled }) => ({
   alignItems: "center",
   padding: `${theme.space.half} ${theme.space.none}`,
   color: theme.colors.darkBlue,
-  cursor: disabled ? "arrow" : "pointer",
 
   [`${Icon}`]: {
     borderRadius: theme.radii.circle,

--- a/components/src/Button/IconicButton.js
+++ b/components/src/Button/IconicButton.js
@@ -29,7 +29,7 @@ const WrapperButton = styled.button(space, ({ disabled }) => ({
   alignItems: "center",
   padding: `${theme.space.half} ${theme.space.none}`,
   color: theme.colors.darkBlue,
-  cursor: disabled ? "arrow" : "pointer",
+  cursor: disabled ? "default" : "pointer",
 
   [`${Icon}`]: {
     borderRadius: theme.radii.circle,

--- a/components/src/Button/IconicButton.js
+++ b/components/src/Button/IconicButton.js
@@ -21,7 +21,7 @@ const HoverText = styled.div({
   pointerEvents: "none"
 });
 
-const WrapperButton = styled.button(space, () => ({
+const WrapperButton = styled.button(space, ({ disabled }) => ({
   background: "transparent",
   border: "none",
   position: "relative",
@@ -29,6 +29,7 @@ const WrapperButton = styled.button(space, () => ({
   alignItems: "center",
   padding: `${theme.space.half} ${theme.space.none}`,
   color: theme.colors.darkBlue,
+  cursor: disabled ? "arrow" : "pointer",
 
   [`${Icon}`]: {
     borderRadius: theme.radii.circle,

--- a/components/src/DropdownMenu/DropdownMenu.js
+++ b/components/src/DropdownMenu/DropdownMenu.js
@@ -137,6 +137,7 @@ class DropdownMenu extends React.Component {
 
 DropdownMenu.propTypes = {
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
+  disabled: PropTypes.bool,
   showDelay: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   hideDelay: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   trigger: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
@@ -161,6 +162,7 @@ DropdownMenu.propTypes = {
 };
 
 DropdownMenu.defaultProps = {
+  disabled: false,
   showDelay: "100",
   hideDelay: "200",
   trigger: () => <IconicButton icon="more" />,

--- a/components/src/DropdownMenu/DropdownMenu.js
+++ b/components/src/DropdownMenu/DropdownMenu.js
@@ -84,7 +84,7 @@ class DropdownMenu extends React.Component {
   }
 
   render() {
-    const { trigger, children, backgroundColor, placement, modifiers, showArrow } = this.props;
+    const { trigger, children, disabled, backgroundColor, placement, modifiers, showArrow } = this.props;
     const childrenFnc = typeof children === "function" ? children : () => children;
     return (
       <Manager>
@@ -94,6 +94,7 @@ class DropdownMenu extends React.Component {
               "aria-haspopup": true,
               "aria-expanded": this.state.open,
               type: "button",
+              disabled: disabled ? true : null,
               ...this.menuTriggerEventHandlers(),
               ref
             })

--- a/components/src/DropdownMenu/DropdownMenu.story.js
+++ b/components/src/DropdownMenu/DropdownMenu.story.js
@@ -53,4 +53,10 @@ storiesOf("DropdownMenu", module)
         </a>
       </DropdownItem>
     </DropdownMenu>
+  ))
+  .add("Set to disabled", () => (
+    <DropdownMenu disabled>
+      <DropdownLink href="/">Dropdown Link</DropdownLink>
+      <DropdownButton onClick={() => {}}>Dropdown Button</DropdownButton>
+    </DropdownMenu>
   ));

--- a/docs/src/pages/components/dropdown-menu.js
+++ b/docs/src/pages/components/dropdown-menu.js
@@ -35,6 +35,12 @@ const propsRows = [
       "Function that returns a button component that will be used as the trigger"
   },
   {
+    name: "disabled",
+    type: "Boolean",
+    defaultValue: "false",
+    description: "Marks the button as disabled and unable to be activated"
+  },
+  {
     name: "backgroundColor",
     type: "String",
     defaultValue: "whiteGrey",
@@ -143,6 +149,20 @@ export default () => (
 <DropdownMenu backgroundColor="blackBlue">
   <DropdownLink href="/" {...customColors}>Dropdown Link</DropdownLink>
   <DropdownButton {...customColors}>Dropdown Button</DropdownButton>
+</DropdownMenu>
+`}
+        </Highlight>
+      </Box>
+      <Box mb="x6">
+        <SubsectionTitle>Disabled</SubsectionTitle>
+        <DropdownMenu disabled>
+          <DropdownLink href="/">Dropdown Link</DropdownLink>
+          <DropdownButton>Dropdown Button</DropdownButton>
+        </DropdownMenu>
+        <Highlight className="js">
+          {`<DropdownMenu disabled>
+  <DropdownLink href="/">Dropdown Link</DropdownLink>
+  <DropdownButton>Dropdown Button</DropdownButton>
 </DropdownMenu>
 `}
         </Highlight>


### PR DESCRIPTION
Fix for this closed PR: https://github.com/nulogy/design-system/pull/342

We never added a disabled prop to DropDownMenu so if you tried to use it like other iconicbuttons and say it's disabled, it wouldn't actually pass that down to the button tag. 

[Note: a lot of these commits are because i removed some css and then slowly realized it was still necessary) 
