### PR TITLE
Nds 1016 navbar make third level submenus open on hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Enhanced [NavBar](https://nulogy.design/components/navbar/) component behavior so that nested menus will open on hover
+
 ### Deprecated
 
 ### Removed

--- a/components/src/DropdownMenu/DropdownMenu.js
+++ b/components/src/DropdownMenu/DropdownMenu.js
@@ -42,7 +42,7 @@ class StatelessDropdownMenu extends React.Component {
 
   handleTriggerClick() {
     if (this.props.triggerTogglesMenuState) {
-      this.props.menuState.handleMenuToggle();
+      this.props.menuState.toggleMenu();
     } else {
       this.openMenu();
     }
@@ -61,7 +61,7 @@ class StatelessDropdownMenu extends React.Component {
       placement,
       modifiers,
       showArrow,
-      menuState: { isOpen, handleMenuToggle, closeMenu, openMenu }
+      menuState: { isOpen, toggleMenu, closeMenu, openMenu }
     } = this.props;
     const childrenFnc = typeof children === "function" ? children : () => children;
     return (

--- a/components/src/DropdownMenu/DropdownMenu.js
+++ b/components/src/DropdownMenu/DropdownMenu.js
@@ -49,20 +49,41 @@ class DropdownMenu extends React.Component {
   }
 
   subMenuEventHandlers() {
-    return {
-      onClick: () => this.openMenu(),
-      onBlur: () => this.closeMenu(),
-      onFocus: () => this.openMenu(),
-      onKeyDown: e => this.handleKeyDown(e)
-    };
+    if (this.props.opensOnHover) {
+      return {
+        onMouseEnter: () => this.openMenu(),
+        onMouseLeave: () => this.closeMenu(),
+        onClick: () => this.openMenu(),
+        onBlur: () => this.closeMenu(),
+        onFocus: () => this.openMenu(),
+        onKeyDown: e => this.handleKeyDown(e)
+      };
+    } else {
+      return {
+        onClick: () => this.openMenu(),
+        onBlur: () => this.closeMenu(),
+        onFocus: () => this.openMenu(),
+        onKeyDown: e => this.handleKeyDown(e)
+      };
+    }
   }
 
   menuTriggerEventHandlers() {
-    return {
-      onBlur: () => this.closeMenu(),
-      onClick: () => this.openMenu(),
-      onKeyDown: e => this.handleKeyDown(e)
-    };
+    if (this.props.opensOnHover) {
+      return {
+        onMouseEnter: () => this.openMenu(),
+        onMouseLeave: () => this.closeMenu(),
+        onBlur: () => this.closeMenu(),
+        onClick: () => this.openMenu(),
+        onKeyDown: e => this.handleKeyDown(e)
+      };
+    } else {
+      return {
+        onBlur: () => this.closeMenu(),
+        onClick: () => this.openMenu(),
+        onKeyDown: e => this.handleKeyDown(e)
+      };
+    }
   }
 
   clearScheduled() {
@@ -158,7 +179,8 @@ DropdownMenu.propTypes = {
     "right-end"
   ]),
   modifiers: PropTypes.shape({}),
-  defaultOpen: PropTypes.bool
+  defaultOpen: PropTypes.bool,
+  opensOnHover: PropTypes.bool
 };
 
 DropdownMenu.defaultProps = {
@@ -170,7 +192,8 @@ DropdownMenu.defaultProps = {
   showArrow: true,
   placement: "bottom-start",
   modifiers: { flip: { behavior: ["bottom"] } },
-  defaultOpen: false
+  defaultOpen: false,
+  opensOnHover: false
 };
 
 export default DropdownMenu;

--- a/components/src/DropdownMenu/DropdownMenu.js
+++ b/components/src/DropdownMenu/DropdownMenu.js
@@ -41,7 +41,7 @@ class DropdownMenu extends React.Component {
     }
   }
 
-  toggleSubMenuState(skipTimer = false) {
+  toggleMenuState(skipTimer = false) {
     this.clearScheduled();
     this.conditionallyApplyDelay(
       () => this.setState(prevState => ({ open: !prevState.open })),
@@ -50,7 +50,7 @@ class DropdownMenu extends React.Component {
     );
   }
 
-  setSubMenuState(newState, skipTimer = false) {
+  setMenuState(newState, skipTimer = false) {
     this.clearScheduled();
     this.conditionallyApplyDelay(
       () => this.setState({ open: newState }),
@@ -60,14 +60,22 @@ class DropdownMenu extends React.Component {
   }
 
   closeMenu(skipTimer) {
-    this.setSubMenuState(false, skipTimer);
+    this.setMenuState(false, skipTimer);
   }
 
   openMenu(skipTimer) {
-    this.setSubMenuState(true, skipTimer);
+    this.setMenuState(true, skipTimer);
   }
 
-  subMenuEventHandlers() {
+  handleTriggerClick() {
+    if (this.props.triggerTogglesMenuState) {
+      this.toggleMenuState();
+    } else {
+      this.openMenu();
+    }
+  }
+
+  menuEventHandlers() {
     return {
       onBlur: () => this.closeMenu(),
       onFocus: () => this.openMenu(),
@@ -79,7 +87,7 @@ class DropdownMenu extends React.Component {
   menuTriggerEventHandlers() {
     return {
       onBlur: () => this.closeMenu(),
-      onClick: () => this.toggleSubMenuState(),
+      onClick: () => this.handleTriggerClick(),
       onKeyDown: e => this.handleKeyDown(e)
     };
   }
@@ -143,7 +151,7 @@ class DropdownMenu extends React.Component {
                 backgroundColor={backgroundColor}
                 popperProps={popperProps}
                 showArrow={showArrow}
-                {...this.subMenuEventHandlers()}
+                {...this.menuEventHandlers()}
                 ref={node => {
                   popperProps.ref(node);
                   this.setMenuRef(node);
@@ -193,7 +201,8 @@ DropdownMenu.propTypes = {
     "right-end"
   ]),
   modifiers: PropTypes.shape({}),
-  defaultOpen: PropTypes.bool
+  defaultOpen: PropTypes.bool,
+  triggerTogglesMenuState: PropTypes.bool
 };
 
 DropdownMenu.defaultProps = {
@@ -205,7 +214,8 @@ DropdownMenu.defaultProps = {
   showArrow: true,
   placement: "bottom-start",
   modifiers: { flip: { behavior: ["bottom"] } },
-  defaultOpen: false
+  defaultOpen: false,
+  triggerTogglesMenuState: true
 };
 
 export default DropdownMenu;

--- a/components/src/DropdownMenu/DropdownMenu.js
+++ b/components/src/DropdownMenu/DropdownMenu.js
@@ -2,7 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Manager, Reference, Popper } from "react-popper";
 import { DetectOutsideClick, withMenuState } from "../utils";
-import { keyCodes } from "../constants";
 import { IconicButton } from "../Button";
 import DropdownMenuContainer from "./DropdownMenuContainer";
 
@@ -52,7 +51,7 @@ class StatelessDropdownMenu extends React.Component {
       placement,
       modifiers,
       showArrow,
-      menuState: { isOpen, toggleMenu, closeMenu, openMenu }
+      menuState: { isOpen, closeMenu, openMenu }
     } = this.props;
     const childrenFnc = typeof children === "function" ? children : () => children;
     return (
@@ -121,6 +120,12 @@ class StatelessDropdownMenu extends React.Component {
 
 StatelessDropdownMenu.propTypes = {
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
+  menuState: PropTypes.shape({
+    isOpen: PropTypes.bool,
+    openMenu: PropTypes.func,
+    closeMenu: PropTypes.func,
+    toggleMenu: PropTypes.func
+  }).isRequired,
   disabled: PropTypes.bool,
   trigger: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   backgroundColor: PropTypes.string,

--- a/components/src/DropdownMenu/DropdownMenu.js
+++ b/components/src/DropdownMenu/DropdownMenu.js
@@ -81,6 +81,10 @@ class StatelessDropdownMenu extends React.Component {
           <Popper placement={placement} modifiers={modifiers}>
             {popperProps => (
               <DropdownMenuContainer
+                onMouseDown={e => {
+                  e.preventDefault();
+                  e.target.focus();
+                }}
                 placement={placement}
                 backgroundColor={backgroundColor}
                 popperProps={popperProps}

--- a/components/src/DropdownMenu/DropdownMenu.js
+++ b/components/src/DropdownMenu/DropdownMenu.js
@@ -1,10 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Manager, Reference, Popper } from "react-popper";
-import { DetectOutsideClick } from "../utils";
+import { DetectOutsideClick, withMenuState } from "../utils";
 import { keyCodes } from "../constants";
 import { IconicButton } from "../Button";
-import { withMenuState } from "../NavBar/withMenuState.js";
 import DropdownMenuContainer from "./DropdownMenuContainer";
 
 /* eslint-disable react/destructuring-assignment */

--- a/components/src/DropdownMenu/DropdownMenu.js
+++ b/components/src/DropdownMenu/DropdownMenu.js
@@ -144,8 +144,7 @@ StatelessDropdownMenu.propTypes = {
     "right-start",
     "right-end"
   ]),
-  modifiers: PropTypes.shape({}),
-  defaultOpen: PropTypes.bool
+  modifiers: PropTypes.shape({})
 };
 
 StatelessDropdownMenu.defaultProps = {
@@ -154,20 +153,21 @@ StatelessDropdownMenu.defaultProps = {
   backgroundColor: undefined,
   showArrow: true,
   placement: "bottom-start",
-  modifiers: { flip: { behavior: ["bottom"] } },
-  defaultOpen: false
+  modifiers: { flip: { behavior: ["bottom"] } }
 };
 
 const DropdownMenu = withMenuState(StatelessDropdownMenu);
 
 DropdownMenu.propTypes = {
   showDelay: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  hideDelay: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  hideDelay: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  defaultOpen: PropTypes.bool
 };
 
 DropdownMenu.defaultProps = {
   showDelay: "100",
-  hideDelay: "200"
+  hideDelay: "200",
+  defaultOpen: false
 };
 
 export default DropdownMenu;

--- a/components/src/DropdownMenu/DropdownMenu.js
+++ b/components/src/DropdownMenu/DropdownMenu.js
@@ -27,7 +27,7 @@ class StatelessDropdownMenu extends React.Component {
   menuTriggerEventHandlers() {
     return {
       onBlur: () => this.props.menuState.closeMenu(false),
-      onClick: () => this.handleTriggerClick(false)
+      onClick: () => this.props.menuState.toggleMenu()
     };
   }
 
@@ -37,14 +37,6 @@ class StatelessDropdownMenu extends React.Component {
       onFocus: () => this.props.menuState.openMenu(false),
       onClick: () => this.props.menuState.openMenu(false)
     };
-  }
-
-  handleTriggerClick() {
-    if (this.props.triggerTogglesMenuState) {
-      this.props.menuState.toggleMenu();
-    } else {
-      this.openMenu();
-    }
   }
 
   handleOutsideClick() {
@@ -70,11 +62,11 @@ class StatelessDropdownMenu extends React.Component {
             React.cloneElement(
               trigger({
                 closeMenu: e => {
-                  closeMenu;
+                  closeMenu();
                   e.stopPropagation();
                 },
                 openMenu: e => {
-                  openMenu;
+                  openMenu();
                   e.stopPropagation();
                 }
               }),
@@ -109,11 +101,11 @@ class StatelessDropdownMenu extends React.Component {
                 <DetectOutsideClick onClick={this.handleOutsideClick} clickRef={[this.menuRef, this.triggerRef]} />
                 {childrenFnc({
                   closeMenu: e => {
-                    this.closeMenu(true);
+                    closeMenu();
                     e.stopPropagation();
                   },
                   openMenu: e => {
-                    this.openMenu(true);
+                    openMenu();
                     e.stopPropagation();
                   }
                 })}
@@ -150,8 +142,7 @@ StatelessDropdownMenu.propTypes = {
     "right-end"
   ]),
   modifiers: PropTypes.shape({}),
-  defaultOpen: PropTypes.bool,
-  triggerTogglesMenuState: PropTypes.bool
+  defaultOpen: PropTypes.bool
 };
 
 StatelessDropdownMenu.defaultProps = {
@@ -161,8 +152,7 @@ StatelessDropdownMenu.defaultProps = {
   showArrow: true,
   placement: "bottom-start",
   modifiers: { flip: { behavior: ["bottom"] } },
-  defaultOpen: false,
-  triggerTogglesMenuState: true
+  defaultOpen: false
 };
 
 const DropdownMenu = withMenuState(StatelessDropdownMenu);

--- a/components/src/DropdownMenu/DropdownMenu.js
+++ b/components/src/DropdownMenu/DropdownMenu.js
@@ -60,14 +60,8 @@ class StatelessDropdownMenu extends React.Component {
           {({ ref }) =>
             React.cloneElement(
               trigger({
-                closeMenu: e => {
-                  closeMenu();
-                  e.stopPropagation();
-                },
-                openMenu: e => {
-                  openMenu();
-                  e.stopPropagation();
-                }
+                closeMenu,
+                openMenu
               }),
               {
                 "aria-haspopup": true,

--- a/components/src/DropdownMenu/DropdownMenu.js
+++ b/components/src/DropdownMenu/DropdownMenu.js
@@ -33,12 +33,13 @@ class DropdownMenu extends React.Component {
     this.triggerRef = node;
   }
 
-  conditionallyApplyDelay(fnc, skipTimer, delay) {
-    if (!skipTimer) {
-      this.timeoutID = setTimeout(fnc, delay);
-    } else {
-      fnc();
-    }
+  setMenuState(newState, skipTimer = false) {
+    this.clearScheduled();
+    this.conditionallyApplyDelay(
+      () => this.setState({ open: newState }),
+      skipTimer,
+      newState ? this.props.showDelay : this.props.hideDelay
+    );
   }
 
   toggleMenuState(skipTimer = false) {
@@ -50,13 +51,12 @@ class DropdownMenu extends React.Component {
     );
   }
 
-  setMenuState(newState, skipTimer = false) {
-    this.clearScheduled();
-    this.conditionallyApplyDelay(
-      () => this.setState({ open: newState }),
-      skipTimer,
-      newState ? this.props.showDelay : this.props.hideDelay
-    );
+  conditionallyApplyDelay(fnc, skipTimer, delay) {
+    if (!skipTimer) {
+      this.timeoutID = setTimeout(fnc, delay);
+    } else {
+      fnc();
+    }
   }
 
   closeMenu(skipTimer) {
@@ -96,8 +96,7 @@ class DropdownMenu extends React.Component {
     clearTimeout(this.timeoutID);
   }
 
-  handleOutsideClick(e) {
-    console.log(e.target);
+  handleOutsideClick() {
     this.closeMenu();
   }
 

--- a/components/src/DropdownMenu/DropdownMenuContainer.js
+++ b/components/src/DropdownMenu/DropdownMenuContainer.js
@@ -60,7 +60,7 @@ BaseSubMenu.defaultProps = {
   popperProps: null
 };
 
-const DropdownMenu = styled(BaseSubMenu)(
+const DropdownMenuContainer = styled(BaseSubMenu)(
   ({ placement, showArrow, backgroundColor }) => ({
     backgroundColor: getThemeColor(backgroundColor),
     borderRadius: theme.radii.medium,
@@ -76,14 +76,14 @@ const DropdownMenu = styled(BaseSubMenu)(
   })
 );
 
-DropdownMenu.propTypes = {
+DropdownMenuContainer.propTypes = {
   backgroundColor: PropTypes.string,
   showArrow: PropTypes.bool
 };
 
-DropdownMenu.defaultProps = {
+DropdownMenuContainer.defaultProps = {
   backgroundColor: "whiteGrey",
   showArrow: true
 };
 
-export default DropdownMenu;
+export default DropdownMenuContainer;

--- a/components/src/NavBar/MenuTrigger.js
+++ b/components/src/NavBar/MenuTrigger.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import { themeGet } from "styled-system";
 import theme from "../theme";
 import { Icon } from "../Icon";
-import { DropdownMenu } from "../DropdownMenu";
+import NavBarDropdownMenu from "./NavBarDropdownMenu";
 import SubMenuTrigger from "./SubMenuTrigger";
 import renderSubMenuItems from "./renderSubMenuItems";
 
@@ -76,7 +76,7 @@ MenuTriggerButton.defaultProps = {
 const MenuTrigger = props => {
   const { menuData, name, color, hoverColor, hoverBackground, ...otherProps } = props;
   return (
-    <DropdownMenu
+    <NavBarDropdownMenu
       {...otherProps}
       trigger={() => (
         <MenuTriggerButton color={color} hoverColor={hoverColor} hoverBackground={hoverBackground} name={name} />
@@ -87,7 +87,7 @@ const MenuTrigger = props => {
           {renderSubMenuItems(menuData, closeMenu, SubMenuTrigger)}
         </ul>
       )}
-    </DropdownMenu>
+    </NavBarDropdownMenu>
   );
 };
 

--- a/components/src/NavBar/MenuTrigger.js
+++ b/components/src/NavBar/MenuTrigger.js
@@ -84,7 +84,14 @@ const MenuTrigger = props => {
     >
       {({ closeMenu }) => (
         <ul style={{ listStyle: "none", margin: "0", padding: "0" }}>
-          {renderSubMenuItems(menuData, closeMenu, SubMenuTrigger)}
+          {renderSubMenuItems(
+            menuData,
+            e => {
+              closeMenu(e);
+              e.stopPropagation();
+            },
+            SubMenuTrigger
+          )}
         </ul>
       )}
     </NavBarDropdownMenu>

--- a/components/src/NavBar/NavBar.js
+++ b/components/src/NavBar/NavBar.js
@@ -10,10 +10,9 @@ import NavBarSearch from "../NavBarSearch/NavBarSearch";
 import { Branding } from "../Branding";
 import DesktopMenu from "./DesktopMenu";
 import MobileMenu from "./MobileMenu";
-import { withMenuState } from "./withMenuState";
 import isValidMenuItem from "./isValidMenuItem";
 import theme from "../theme";
-import { subPx, withWindowDimensions } from "../utils";
+import { subPx, withWindowDimensions, withMenuState } from "../utils";
 
 const LockBody = createGlobalStyle(({ isOpen }) => ({
   body: {

--- a/components/src/NavBar/NavBar.js
+++ b/components/src/NavBar/NavBar.js
@@ -155,7 +155,7 @@ class SmallNavBarNoState extends React.Component {
   render() {
     const {
       menuData,
-      menuState: { isOpen, handleMenuToggle, closeMenu },
+      menuState: { isOpen, toggleMenu, closeMenu },
       windowWidth,
       breakpointLower,
       smallScreen = windowWidth < parseInt(breakpointLower, 10),
@@ -191,7 +191,7 @@ class SmallNavBarNoState extends React.Component {
                 <MobileMenuTrigger
                   {...getThemeColor(themeColor)}
                   onClick={() => {
-                    handleMenuToggle();
+                    toggleMenu();
                   }}
                   aria-expanded={isOpen ? true : null}
                 >
@@ -219,7 +219,7 @@ class SmallNavBarNoState extends React.Component {
 SmallNavBarNoState.propTypes = {
   menuState: PropTypes.shape({
     isOpen: PropTypes.bool,
-    handleMenuToggle: PropTypes.func,
+    toggleMenu: PropTypes.func,
     closeMenu: PropTypes.func
   }).isRequired,
   menuData: PropTypes.shape({}),

--- a/components/src/NavBar/NavBarDropdownMenu.js
+++ b/components/src/NavBar/NavBarDropdownMenu.js
@@ -2,8 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Manager, Reference, Popper } from "react-popper";
 import { DetectOutsideClick, withMenuState } from "../utils";
-import { keyCodes } from "../constants";
-import { IconicButton } from "../Button";
 import DropdownMenuContainer from "../DropdownMenu/DropdownMenuContainer";
 
 /* eslint-disable react/destructuring-assignment */
@@ -58,7 +56,7 @@ class StatelessNavBarDropdownMenu extends React.Component {
       placement,
       modifiers,
       showArrow,
-      menuState: { isOpen, toggleMenu, closeMenu, openMenu }
+      menuState: { isOpen, closeMenu, openMenu }
     } = this.props;
     const childrenFnc = typeof children === "function" ? children : () => children;
     return (
@@ -126,6 +124,12 @@ class StatelessNavBarDropdownMenu extends React.Component {
 StatelessNavBarDropdownMenu.propTypes = {
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
   trigger: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
+  menuState: PropTypes.shape({
+    isOpen: PropTypes.bool,
+    openMenu: PropTypes.func,
+    closeMenu: PropTypes.func,
+    toggleMenu: PropTypes.func
+  }).isRequired,
   showArrow: PropTypes.bool,
   placement: PropTypes.oneOf(["bottom-start", "right-start"]),
   modifiers: PropTypes.shape({}),

--- a/components/src/NavBar/NavBarDropdownMenu.js
+++ b/components/src/NavBar/NavBarDropdownMenu.js
@@ -67,11 +67,9 @@ class StatelessNavBarDropdownMenu extends React.Component {
               trigger({
                 closeMenu: e => {
                   closeMenu();
-                  e.stopPropagation();
                 },
                 openMenu: e => {
                   openMenu();
-                  e.stopPropagation();
                 }
               }),
               {
@@ -104,11 +102,9 @@ class StatelessNavBarDropdownMenu extends React.Component {
                 {childrenFnc({
                   closeMenu: e => {
                     closeMenu();
-                    e.stopPropagation();
                   },
                   openMenu: e => {
                     openMenu();
-                    e.stopPropagation();
                   }
                 })}
               </DropdownMenuContainer>

--- a/components/src/NavBar/NavBarDropdownMenu.js
+++ b/components/src/NavBar/NavBarDropdownMenu.js
@@ -56,6 +56,7 @@ class StatelessNavBarDropdownMenu extends React.Component {
       placement,
       modifiers,
       showArrow,
+      dropdownMenuContainerEventHandlers,
       menuState: { isOpen, closeMenu, openMenu }
     } = this.props;
     const childrenFnc = typeof children === "function" ? children : () => children;
@@ -93,6 +94,7 @@ class StatelessNavBarDropdownMenu extends React.Component {
                   popperProps.ref(node);
                   this.setMenuRef(node);
                 }}
+                {...dropdownMenuContainerEventHandlers({ openMenu, closeMenu })}
               >
                 <DetectOutsideClick onClick={this.handleOutsideClick} clickRef={[this.menuRef, this.triggerRef]} />
                 {childrenFnc({
@@ -125,14 +127,16 @@ StatelessNavBarDropdownMenu.propTypes = {
   showArrow: PropTypes.bool,
   placement: PropTypes.oneOf(["bottom-start", "right-start"]),
   modifiers: PropTypes.shape({}),
-  triggerTogglesMenuState: PropTypes.bool
+  triggerTogglesMenuState: PropTypes.bool,
+  dropdownMenuContainerEventHandlers: PropTypes.func
 };
 
 StatelessNavBarDropdownMenu.defaultProps = {
   showArrow: true,
   placement: "bottom-start",
   modifiers: { flip: { behavior: ["bottom"] } },
-  triggerTogglesMenuState: true
+  triggerTogglesMenuState: true,
+  dropdownMenuContainerEventHandlers: () => {}
 };
 
 const NavBarDropdownMenu = withMenuState(StatelessNavBarDropdownMenu);

--- a/components/src/NavBar/NavBarDropdownMenu.js
+++ b/components/src/NavBar/NavBarDropdownMenu.js
@@ -65,12 +65,8 @@ class StatelessNavBarDropdownMenu extends React.Component {
           {({ ref }) =>
             React.cloneElement(
               trigger({
-                closeMenu: e => {
-                  closeMenu();
-                },
-                openMenu: e => {
-                  openMenu();
-                }
+                closeMenu,
+                openMenu
               }),
               {
                 "aria-haspopup": true,

--- a/components/src/NavBar/NavBarDropdownMenu.js
+++ b/components/src/NavBar/NavBarDropdownMenu.js
@@ -94,6 +94,10 @@ class StatelessNavBarDropdownMenu extends React.Component {
                   popperProps.ref(node);
                   this.setMenuRef(node);
                 }}
+                onMouseDown={e => {
+                  e.preventDefault();
+                  e.target.focus();
+                }}
                 {...dropdownMenuContainerEventHandlers({ openMenu, closeMenu })}
               >
                 <DetectOutsideClick onClick={this.handleOutsideClick} clickRef={[this.menuRef, this.triggerRef]} />
@@ -144,7 +148,7 @@ NavBarDropdownMenu.propTypes = {
 
 NavBarDropdownMenu.defaultProps = {
   showDelay: "0",
-  hideDelay: "0"
+  hideDelay: "100"
 };
 
 export default NavBarDropdownMenu;

--- a/components/src/NavBar/NavBarDropdownMenu.js
+++ b/components/src/NavBar/NavBarDropdownMenu.js
@@ -148,7 +148,7 @@ NavBarDropdownMenu.propTypes = {
 
 NavBarDropdownMenu.defaultProps = {
   showDelay: "0",
-  hideDelay: "100"
+  hideDelay: "0"
 };
 
 export default NavBarDropdownMenu;

--- a/components/src/NavBar/NavBarDropdownMenu.js
+++ b/components/src/NavBar/NavBarDropdownMenu.js
@@ -98,12 +98,8 @@ class StatelessNavBarDropdownMenu extends React.Component {
               >
                 <DetectOutsideClick onClick={this.handleOutsideClick} clickRef={[this.menuRef, this.triggerRef]} />
                 {childrenFnc({
-                  closeMenu: e => {
-                    closeMenu();
-                  },
-                  openMenu: e => {
-                    openMenu();
-                  }
+                  closeMenu,
+                  openMenu
                 })}
               </DropdownMenuContainer>
             )}

--- a/components/src/NavBar/NavBarDropdownMenu.js
+++ b/components/src/NavBar/NavBarDropdownMenu.js
@@ -4,10 +4,10 @@ import { Manager, Reference, Popper } from "react-popper";
 import { DetectOutsideClick, withMenuState } from "../utils";
 import { keyCodes } from "../constants";
 import { IconicButton } from "../Button";
-import DropdownMenuContainer from "./DropdownMenuContainer";
+import DropdownMenuContainer from "../DropdownMenu/DropdownMenuContainer";
 
 /* eslint-disable react/destructuring-assignment */
-class StatelessDropdownMenu extends React.Component {
+class StatelessNavBarDropdownMenu extends React.Component {
   constructor(props) {
     super(props);
 
@@ -27,7 +27,7 @@ class StatelessDropdownMenu extends React.Component {
   menuTriggerEventHandlers() {
     return {
       onBlur: () => this.props.menuState.closeMenu(false),
-      onClick: () => this.props.menuState.toggleMenu()
+      onClick: () => this.handleTriggerClick(false)
     };
   }
 
@@ -39,6 +39,14 @@ class StatelessDropdownMenu extends React.Component {
     };
   }
 
+  handleTriggerClick() {
+    if (this.props.triggerTogglesMenuState) {
+      this.props.menuState.toggleMenu();
+    } else {
+      this.props.menuState.openMenu();
+    }
+  }
+
   handleOutsideClick() {
     this.props.menuState.closeMenu(false);
   }
@@ -47,8 +55,6 @@ class StatelessDropdownMenu extends React.Component {
     const {
       trigger,
       children,
-      disabled,
-      backgroundColor,
       placement,
       modifiers,
       showArrow,
@@ -74,7 +80,6 @@ class StatelessDropdownMenu extends React.Component {
                 "aria-haspopup": true,
                 "aria-expanded": isOpen,
                 type: "button",
-                disabled: disabled ? true : null,
                 ...this.menuTriggerEventHandlers(),
                 ref: node => {
                   ref(node);
@@ -89,7 +94,6 @@ class StatelessDropdownMenu extends React.Component {
             {popperProps => (
               <DropdownMenuContainer
                 placement={placement}
-                backgroundColor={backgroundColor}
                 popperProps={popperProps}
                 showArrow={showArrow}
                 {...this.menuEventHandlers()}
@@ -119,50 +123,32 @@ class StatelessDropdownMenu extends React.Component {
 }
 /* eslint-enable react/destructuring-assignment */
 
-StatelessDropdownMenu.propTypes = {
+StatelessNavBarDropdownMenu.propTypes = {
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
-  disabled: PropTypes.bool,
-  trigger: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
-  backgroundColor: PropTypes.string,
+  trigger: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
   showArrow: PropTypes.bool,
-  placement: PropTypes.oneOf([
-    "top",
-    "top-start",
-    "top-end",
-    "bottom",
-    "bottom-start",
-    "bottom-end",
-    "left",
-    "left-start",
-    "left-end",
-    "right",
-    "right-start",
-    "right-end"
-  ]),
+  placement: PropTypes.oneOf(["bottom-start", "right-start"]),
   modifiers: PropTypes.shape({}),
-  defaultOpen: PropTypes.bool
+  triggerTogglesMenuState: PropTypes.bool
 };
 
-StatelessDropdownMenu.defaultProps = {
-  disabled: false,
-  trigger: () => <IconicButton icon="more" />,
-  backgroundColor: undefined,
+StatelessNavBarDropdownMenu.defaultProps = {
   showArrow: true,
   placement: "bottom-start",
   modifiers: { flip: { behavior: ["bottom"] } },
-  defaultOpen: false
+  triggerTogglesMenuState: true
 };
 
-const DropdownMenu = withMenuState(StatelessDropdownMenu);
+const NavBarDropdownMenu = withMenuState(StatelessNavBarDropdownMenu);
 
-DropdownMenu.propTypes = {
+NavBarDropdownMenu.propTypes = {
   showDelay: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   hideDelay: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
 };
 
-DropdownMenu.defaultProps = {
-  showDelay: "100",
-  hideDelay: "200"
+NavBarDropdownMenu.defaultProps = {
+  showDelay: "0",
+  hideDelay: "100"
 };
 
-export default DropdownMenu;
+export default NavBarDropdownMenu;

--- a/components/src/NavBar/SubMenuTrigger.js
+++ b/components/src/NavBar/SubMenuTrigger.js
@@ -52,14 +52,7 @@ const SubMenuTrigger = props => {
       triggerTogglesMenuState={false}
       {...otherProps}
       trigger={({ closeMenu, openMenu }) => (
-        <SubMenuTriggerButton
-          name={name}
-          onClick={() => {
-            console.log("click");
-          }}
-          onMouseEnter={openMenu}
-          onMouseLeave={closeMenu}
-        />
+        <SubMenuTriggerButton name={name} onMouseEnter={openMenu} onMouseLeave={closeMenu} />
       )}
     >
       {({ closeMenu, openMenu }) => (

--- a/components/src/NavBar/SubMenuTrigger.js
+++ b/components/src/NavBar/SubMenuTrigger.js
@@ -51,26 +51,16 @@ const SubMenuTrigger = props => {
       showArrow={false}
       triggerTogglesMenuState={false}
       {...otherProps}
+      dropdownMenuContainerEventHandlers={({ openMenu, closeMenu }) => ({
+        onMouseEnter: openMenu,
+        onMouseLeave: closeMenu
+      })}
       trigger={({ closeMenu, openMenu }) => (
-        <SubMenuTriggerButton
-          name={name}
-          onMouseEnter={openMenu}
-          onMouseLeave={e => {
-            e.stopPropagation();
-            closeMenu(e);
-          }}
-        />
+        <SubMenuTriggerButton name={name} onMouseEnter={openMenu} onMouseLeave={closeMenu} />
       )}
     >
       {({ closeMenu, openMenu }) => (
-        <ul
-          onMouseEnter={openMenu}
-          onMouseLeave={e => {
-            e.stopPropagation();
-            closeMenu(e);
-          }}
-          style={{ listStyle: "none", margin: "0", padding: "0" }}
-        >
+        <ul style={{ listStyle: "none", margin: "0", padding: "0" }}>
           {renderSubMenuItems(menuData, onItemClick, SubMenuTrigger)}
         </ul>
       )}

--- a/components/src/NavBar/SubMenuTrigger.js
+++ b/components/src/NavBar/SubMenuTrigger.js
@@ -46,16 +46,27 @@ const SubMenuTrigger = props => {
   const { menuData, name, onItemClick, ...otherProps } = props;
   return (
     <DropdownMenu
-      opensOnHover
       placement="right-start"
       modifiers={null}
       showArrow={false}
+      triggerTogglesMenuState={false}
       {...otherProps}
-      trigger={() => <SubMenuTriggerButton name={name} />}
+      trigger={({ closeMenu, openMenu }) => (
+        <SubMenuTriggerButton
+          name={name}
+          onClick={() => {
+            console.log("click");
+          }}
+          onMouseEnter={openMenu}
+          onMouseLeave={closeMenu}
+        />
+      )}
     >
-      <ul style={{ listStyle: "none", margin: "0", padding: "0" }}>
-        {renderSubMenuItems(menuData, onItemClick, SubMenuTrigger)}
-      </ul>
+      {({ closeMenu, openMenu }) => (
+        <ul onMouseEnter={openMenu} onMouseLeave={closeMenu} style={{ listStyle: "none", margin: "0", padding: "0" }}>
+          {renderSubMenuItems(menuData, onItemClick, SubMenuTrigger)}
+        </ul>
+      )}
     </DropdownMenu>
   );
 };

--- a/components/src/NavBar/SubMenuTrigger.js
+++ b/components/src/NavBar/SubMenuTrigger.js
@@ -52,11 +52,25 @@ const SubMenuTrigger = props => {
       triggerTogglesMenuState={false}
       {...otherProps}
       trigger={({ closeMenu, openMenu }) => (
-        <SubMenuTriggerButton name={name} onMouseEnter={openMenu} onMouseLeave={closeMenu} />
+        <SubMenuTriggerButton
+          name={name}
+          onMouseEnter={openMenu}
+          onMouseLeave={e => {
+            e.stopPropagation();
+            closeMenu(e);
+          }}
+        />
       )}
     >
       {({ closeMenu, openMenu }) => (
-        <ul onMouseEnter={openMenu} onMouseLeave={closeMenu} style={{ listStyle: "none", margin: "0", padding: "0" }}>
+        <ul
+          onMouseEnter={openMenu}
+          onMouseLeave={e => {
+            e.stopPropagation();
+            closeMenu(e);
+          }}
+          style={{ listStyle: "none", margin: "0", padding: "0" }}
+        >
           {renderSubMenuItems(menuData, onItemClick, SubMenuTrigger)}
         </ul>
       )}

--- a/components/src/NavBar/SubMenuTrigger.js
+++ b/components/src/NavBar/SubMenuTrigger.js
@@ -46,6 +46,7 @@ const SubMenuTrigger = props => {
   const { menuData, name, onItemClick, ...otherProps } = props;
   return (
     <DropdownMenu
+      opensOnHover
       placement="right-start"
       modifiers={null}
       showArrow={false}

--- a/components/src/NavBar/SubMenuTrigger.js
+++ b/components/src/NavBar/SubMenuTrigger.js
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import PropTypes from "prop-types";
 import theme from "../theme";
 import { Icon } from "../Icon";
-import { DropdownMenu } from "../DropdownMenu";
+import NavBarDropdownMenu from "./NavBarDropdownMenu";
 import renderSubMenuItems from "./renderSubMenuItems";
 
 const StyledButton = styled.button({
@@ -45,7 +45,7 @@ SubMenuTriggerButton.propTypes = {
 const SubMenuTrigger = props => {
   const { menuData, name, onItemClick, ...otherProps } = props;
   return (
-    <DropdownMenu
+    <NavBarDropdownMenu
       placement="right-start"
       modifiers={null}
       showArrow={false}
@@ -60,7 +60,7 @@ const SubMenuTrigger = props => {
           {renderSubMenuItems(menuData, onItemClick, SubMenuTrigger)}
         </ul>
       )}
-    </DropdownMenu>
+    </NavBarDropdownMenu>
   );
 };
 

--- a/components/src/NavBar/SubMenuTrigger.js
+++ b/components/src/NavBar/SubMenuTrigger.js
@@ -59,11 +59,9 @@ const SubMenuTrigger = props => {
         <SubMenuTriggerButton name={name} onMouseEnter={openMenu} onMouseLeave={closeMenu} />
       )}
     >
-      {({ closeMenu, openMenu }) => (
-        <ul style={{ listStyle: "none", margin: "0", padding: "0" }}>
-          {renderSubMenuItems(menuData, onItemClick, SubMenuTrigger)}
-        </ul>
-      )}
+      <ul style={{ listStyle: "none", margin: "0", padding: "0" }}>
+        {renderSubMenuItems(menuData, onItemClick, SubMenuTrigger)}
+      </ul>
     </NavBarDropdownMenu>
   );
 };

--- a/components/src/NavBar/withMenuState.js
+++ b/components/src/NavBar/withMenuState.js
@@ -23,6 +23,7 @@ class MenuState extends React.Component {
 
   componentWillUnmount() {
     document.removeEventListener("keydown", this.handleKeyDown);
+    this.clearScheduled();
   }
 
   clearScheduled() {
@@ -95,7 +96,7 @@ MenuState.propTypes = {
   children: PropTypes.func.isRequired
 };
 
-const withMenuState = MenuComponentWithoutState => (props, showDelay, hideDelay) => (
+const withMenuState = MenuComponentWithoutState => ({ showDelay, hideDelay, ...props }) => (
   <MenuState showDelay={showDelay} hideDelay={hideDelay}>
     {menuState => <MenuComponentWithoutState menuState={menuState} {...props} />}
   </MenuState>

--- a/components/src/NavBar/withMenuState.js
+++ b/components/src/NavBar/withMenuState.js
@@ -25,28 +25,46 @@ class MenuState extends React.Component {
     document.removeEventListener("keydown", this.handleKeyDown);
   }
 
-  handleOnClick() {
-    this.toggleMenu();
+  clearScheduled() {
+    clearTimeout(this.timeoutID);
   }
 
-  toggleMenu() {
-    const { isOpen } = this.state;
-
-    this.setState({
-      isOpen: !isOpen
-    });
+  setMenuState(newState, skipTimer = true) {
+    this.clearScheduled();
+    this.conditionallyApplyDelay(
+      () => this.setState({ isOpen: newState }),
+      skipTimer,
+      newState ? this.props.showDelay : this.props.hideDelay
+    );
   }
 
-  openMenu() {
-    this.setState({
-      isOpen: true
-    });
+  toggleMenu(skipTimer = true) {
+    this.clearScheduled();
+    this.conditionallyApplyDelay(
+      () => this.setState(prevState => ({ isOpen: !prevState.isOpen })),
+      skipTimer,
+      this.state.isOpen ? this.props.hideDelay : this.props.showDelay
+    );
   }
 
-  closeMenu() {
-    this.setState({
-      isOpen: false
-    });
+  conditionallyApplyDelay(fnc, skipTimer, delay) {
+    if (!skipTimer) {
+      this.timeoutID = setTimeout(fnc, delay);
+    } else {
+      fnc();
+    }
+  }
+
+  closeMenu(skipTimer) {
+    this.setMenuState(false, skipTimer);
+  }
+
+  openMenu(skipTimer) {
+    this.setMenuState(true, skipTimer);
+  }
+
+  handleOnClick(skipTimer) {
+    this.toggleMenu(skipTimer);
   }
 
   handleKeyDown(event) {
@@ -77,8 +95,10 @@ MenuState.propTypes = {
   children: PropTypes.func.isRequired
 };
 
-const withMenuState = MenuComponentWithoutState => props => (
-  <MenuState>{menuState => <MenuComponentWithoutState menuState={menuState} {...props} />}</MenuState>
+const withMenuState = MenuComponentWithoutState => (props, showDelay, hideDelay) => (
+  <MenuState showDelay={showDelay} hideDelay={hideDelay}>
+    {menuState => <MenuComponentWithoutState menuState={menuState} {...props} />}
+  </MenuState>
 );
 
 export { withMenuState };

--- a/components/src/NavBar/withMenuState.js
+++ b/components/src/NavBar/withMenuState.js
@@ -10,7 +10,6 @@ class MenuState extends React.Component {
       isOpen: false
     };
 
-    this.handleOnClick = this.handleOnClick.bind(this);
     this.handleKeyDown = this.handleKeyDown.bind(this);
     this.toggleMenu = this.toggleMenu.bind(this);
     this.openMenu = this.openMenu.bind(this);
@@ -64,10 +63,6 @@ class MenuState extends React.Component {
     this.setMenuState(true, skipTimer);
   }
 
-  handleOnClick(skipTimer) {
-    this.toggleMenu(skipTimer);
-  }
-
   handleKeyDown(event) {
     switch (event.keyCode) {
       case keyCodes.ESC:
@@ -84,7 +79,7 @@ class MenuState extends React.Component {
 
     return renderMenu({
       isOpen,
-      handleMenuToggle: this.handleOnClick,
+      toggleMenu: this.toggleMenu,
       handleMenuKeydown: this.handleKeyDown,
       openMenu: this.openMenu,
       closeMenu: this.closeMenu
@@ -96,7 +91,7 @@ MenuState.propTypes = {
   children: PropTypes.func.isRequired
 };
 
-const withMenuState = MenuComponentWithoutState => ({ showDelay, hideDelay, ...props }) => (
+const withMenuState = MenuComponentWithoutState => ({ showDelay = 0, hideDelay = 0, ...props }) => (
   <MenuState showDelay={showDelay} hideDelay={hideDelay}>
     {menuState => <MenuComponentWithoutState menuState={menuState} {...props} />}
   </MenuState>

--- a/components/src/Tooltip/Tooltip.js
+++ b/components/src/Tooltip/Tooltip.js
@@ -4,8 +4,7 @@ import PropTypes from "prop-types";
 import { Manager, Reference, Popper } from "react-popper";
 import { Box } from "../Box";
 import theme from "../theme";
-import { withGeneratedId, DetectOutsideClick, PopperArrow } from "../utils";
-import { withMenuState } from "../NavBar/withMenuState.js";
+import { withMenuState, withGeneratedId, DetectOutsideClick, PopperArrow } from "../utils";
 
 const tooltipStyles = {
   backgroundColor: theme.colors.white,

--- a/components/src/Tooltip/Tooltip.js
+++ b/components/src/Tooltip/Tooltip.js
@@ -144,6 +144,11 @@ StatelessTooltip.propTypes = {
   children: PropTypes.element.isRequired,
   id: PropTypes.string.isRequired,
   tooltip: PropTypes.node.isRequired,
+  menuState: PropTypes.shape({
+    isOpen: PropTypes.bool,
+    openMenu: PropTypes.func,
+    closeMenu: PropTypes.func
+  }).isRequired,
   placement: PropTypes.oneOf([
     "top",
     "top-start",

--- a/components/src/Tooltip/Tooltip.js
+++ b/components/src/Tooltip/Tooltip.js
@@ -5,7 +5,7 @@ import { Manager, Reference, Popper } from "react-popper";
 import { Box } from "../Box";
 import theme from "../theme";
 import { withGeneratedId, DetectOutsideClick, PopperArrow } from "../utils";
-import { keyCodes } from "../constants";
+import { withMenuState } from "../NavBar/withMenuState.js";
 
 const tooltipStyles = {
   backgroundColor: theme.colors.white,
@@ -59,21 +59,12 @@ const TooltipContainer = styled(Box)(
 );
 
 /* eslint-disable react/destructuring-assignment */
-class Tooltip extends React.Component {
+class StatelessTooltip extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-      open: false
-    };
-    this.handleKeyDown = this.handleKeyDown.bind(this);
-    this.hideTooltip = this.hideTooltip.bind(this);
-    this.showTooltip = this.showTooltip.bind(this);
+
     this.setTriggerRef = this.setTriggerRef.bind(this);
     this.setTooltipRef = this.setTooltipRef.bind(this);
-  }
-
-  componentWillUnmount() {
-    this.clearScheduled();
   }
 
   setTriggerRef(node) {
@@ -86,47 +77,20 @@ class Tooltip extends React.Component {
 
   tooltipEventHandlers() {
     return {
-      onFocus: () => this.showTooltip(),
-      onBlur: () => this.hideTooltip(),
-      onMouseEnter: () => this.showTooltip(),
-      onMouseLeave: () => this.hideTooltip(),
-      onKeyDown: e => this.handleKeyDown(e)
+      onFocus: () => this.props.menuState.openMenu(false),
+      onBlur: () => this.props.menuState.closeMenu(false),
+      onMouseEnter: () => this.props.menuState.openMenu(false),
+      onMouseLeave: () => this.props.menuState.closeMenu(false)
     };
   }
 
   triggerEventHandlers() {
     return {
-      onFocus: () => this.showTooltip(),
-      onBlur: () => this.hideTooltip(),
-      onMouseEnter: () => this.showTooltip(),
-      onMouseLeave: () => this.hideTooltip(),
-      onKeyDown: e => this.handleKeyDown(e)
+      onFocus: () => this.props.menuState.openMenu(false),
+      onBlur: () => this.props.menuState.closeMenu(false),
+      onMouseEnter: () => this.props.menuState.openMenu(false),
+      onMouseLeave: () => this.props.menuState.closeMenu(false)
     };
-  }
-
-  clearScheduled() {
-    clearTimeout(this.hideTimeoutID);
-    clearTimeout(this.showTimeoutID);
-  }
-
-  hideTooltip(skipTimer) {
-    this.clearScheduled();
-    if (!skipTimer) {
-      this.hideTimeoutID = setTimeout(() => this.setState({ open: false }), this.props.hideDelay);
-    } else {
-      this.setState({ open: false });
-    }
-  }
-
-  showTooltip() {
-    this.clearScheduled();
-    this.showTimeoutID = setTimeout(() => this.setState({ open: true }), this.props.showDelay);
-  }
-
-  handleKeyDown(event) {
-    if (event.keyCode === keyCodes.ESC) {
-      this.hideTooltip(true);
-    }
   }
 
   render() {
@@ -136,7 +100,7 @@ class Tooltip extends React.Component {
           {({ ref }) =>
             React.cloneElement(this.props.children, {
               "aria-haspopup": true,
-              "aria-expanded": this.state.open,
+              "aria-expanded": this.props.menuState.isOpen,
               "aria-describedby": this.props.id,
               ...this.triggerEventHandlers(),
               ref
@@ -147,7 +111,7 @@ class Tooltip extends React.Component {
           {({ ref, style, placement, arrowProps }) => (
             <TooltipContainer
               maxWidth={this.props.maxWidth}
-              open={this.state.open}
+              open={this.props.menuState.isOpen}
               role="tooltip"
               id={this.props.id}
               ref={node => {
@@ -163,10 +127,10 @@ class Tooltip extends React.Component {
             </TooltipContainer>
           )}
         </Popper>
-        {this.state.open && (
+        {this.props.menuState.isOpen && (
           <DetectOutsideClick
             onClick={() => {
-              this.hideTooltip(true);
+              this.props.menuState.openMenu();
             }}
             clickRef={[this.triggerRef, this.tooltipRef]}
           />
@@ -177,7 +141,7 @@ class Tooltip extends React.Component {
 }
 /* eslint-enable react/destructuring-assignment */
 
-Tooltip.propTypes = {
+StatelessTooltip.propTypes = {
   children: PropTypes.element.isRequired,
   id: PropTypes.string.isRequired,
   tooltip: PropTypes.node.isRequired,
@@ -195,16 +159,24 @@ Tooltip.propTypes = {
     "right-start",
     "right-end"
   ]),
-  showDelay: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  hideDelay: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   maxWidth: PropTypes.string
 };
 
-Tooltip.defaultProps = {
+StatelessTooltip.defaultProps = {
   placement: "bottom",
-  showDelay: "100",
-  hideDelay: "350",
   maxWidth: "24em"
+};
+
+const Tooltip = withMenuState(StatelessTooltip);
+
+Tooltip.propTypes = {
+  showDelay: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  hideDelay: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+};
+
+Tooltip.defaultProps = {
+  showDelay: "100",
+  hideDelay: "350"
 };
 
 export default withGeneratedId(Tooltip);

--- a/components/src/utils/index.js
+++ b/components/src/utils/index.js
@@ -6,3 +6,4 @@ export { default as withWindowDimensions } from "./withWindowDimensions";
 export { default as DetectOutsideClick } from "./DetectOutsideClick";
 export { default as PopperArrow } from "./PopperArrow";
 export { default as ScrollIndicators } from "./ScrollIndicators";
+export { default as withMenuState } from "./withMenuState";

--- a/components/src/utils/withMenuState.js
+++ b/components/src/utils/withMenuState.js
@@ -27,47 +27,47 @@ class MenuState extends React.Component {
     this.clearScheduled();
   }
 
-  setMenuState(newState, skipTimer = true) {
+  setMenuState(nextIsOpenState, skipDelay) {
     const { showDelay, hideDelay } = this.props;
 
     this.clearScheduled();
     this.conditionallyApplyDelay(
-      () => this.setState({ isOpen: newState }),
-      skipTimer,
-      newState ? showDelay : hideDelay
+      () => this.setState({ isOpen: nextIsOpenState }),
+      nextIsOpenState ? showDelay : hideDelay,
+      skipDelay
     );
   }
 
-  toggleMenu(skipTimer = true) {
+  toggleMenu(skipDelay) {
     const { isOpen } = this.state;
     const { showDelay, hideDelay } = this.props;
 
     this.clearScheduled();
     this.conditionallyApplyDelay(
       () => this.setState(prevState => ({ isOpen: !prevState.isOpen })),
-      skipTimer,
-      isOpen ? hideDelay : showDelay
+      isOpen ? hideDelay : showDelay,
+      skipDelay
     );
+  }
+
+  closeMenu(skipDelay) {
+    this.setMenuState(false, skipDelay);
+  }
+
+  openMenu(skipDelay) {
+    this.setMenuState(true, skipDelay);
   }
 
   clearScheduled() {
     clearTimeout(this.timeoutID);
   }
 
-  conditionallyApplyDelay(fnc, skipTimer, delay) {
-    if (!skipTimer) {
+  conditionallyApplyDelay(fnc, delay, skipDelay = true) {
+    if (!skipDelay) {
       this.timeoutID = setTimeout(fnc, delay);
     } else {
       fnc();
     }
-  }
-
-  closeMenu(skipTimer) {
-    this.setMenuState(false, skipTimer);
-  }
-
-  openMenu(skipTimer) {
-    this.setMenuState(true, skipTimer);
   }
 
   handleKeyDown(event) {

--- a/components/src/utils/withMenuState.js
+++ b/components/src/utils/withMenuState.js
@@ -97,4 +97,4 @@ const withMenuState = MenuComponentWithoutState => ({ showDelay = 0, hideDelay =
   </MenuState>
 );
 
-export { withMenuState };
+export default withMenuState;

--- a/components/src/utils/withMenuState.js
+++ b/components/src/utils/withMenuState.js
@@ -25,26 +25,31 @@ class MenuState extends React.Component {
     this.clearScheduled();
   }
 
-  clearScheduled() {
-    clearTimeout(this.timeoutID);
-  }
-
   setMenuState(newState, skipTimer = true) {
+    const { showDelay, hideDelay } = this.props;
+
     this.clearScheduled();
     this.conditionallyApplyDelay(
       () => this.setState({ isOpen: newState }),
       skipTimer,
-      newState ? this.props.showDelay : this.props.hideDelay
+      newState ? showDelay : hideDelay
     );
   }
 
   toggleMenu(skipTimer = true) {
+    const { isOpen } = this.state;
+    const { showDelay, hideDelay } = this.props;
+
     this.clearScheduled();
     this.conditionallyApplyDelay(
       () => this.setState(prevState => ({ isOpen: !prevState.isOpen })),
       skipTimer,
-      this.state.isOpen ? this.props.hideDelay : this.props.showDelay
+      isOpen ? hideDelay : showDelay
     );
+  }
+
+  clearScheduled() {
+    clearTimeout(this.timeoutID);
   }
 
   conditionallyApplyDelay(fnc, skipTimer, delay) {
@@ -88,13 +93,33 @@ class MenuState extends React.Component {
 }
 
 MenuState.propTypes = {
-  children: PropTypes.func.isRequired
+  children: PropTypes.func.isRequired,
+  showDelay: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  hideDelay: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
 };
 
-const withMenuState = MenuComponentWithoutState => ({ showDelay = 0, hideDelay = 0, ...props }) => (
-  <MenuState showDelay={showDelay} hideDelay={hideDelay}>
-    {menuState => <MenuComponentWithoutState menuState={menuState} {...props} />}
-  </MenuState>
-);
+MenuState.defaultProps = {
+  showDelay: 0,
+  hideDelay: 0
+};
+
+const withMenuState = MenuComponentWithoutState => {
+  const MenuComponent = ({ showDelay, hideDelay, ...props }) => (
+    <MenuState showDelay={showDelay} hideDelay={hideDelay}>
+      {menuState => <MenuComponentWithoutState menuState={menuState} {...props} />}
+    </MenuState>
+  );
+  MenuComponent.propTypes = {
+    showDelay: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    hideDelay: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
+
+  MenuComponent.defaultProps = {
+    showDelay: 0,
+    hideDelay: 0
+  };
+
+  return MenuComponent;
+};
 
 export default withMenuState;

--- a/components/src/utils/withMenuState.js
+++ b/components/src/utils/withMenuState.js
@@ -3,11 +3,13 @@ import PropTypes from "prop-types";
 import { keyCodes } from "../constants";
 
 class MenuState extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
+
+    console.log(this.props.defaultOpen);
 
     this.state = {
-      isOpen: false
+      isOpen: this.props.defaultOpen
     };
 
     this.handleKeyDown = this.handleKeyDown.bind(this);
@@ -95,28 +97,32 @@ class MenuState extends React.Component {
 MenuState.propTypes = {
   children: PropTypes.func.isRequired,
   showDelay: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  hideDelay: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  hideDelay: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  defaultOpen: PropTypes.bool
 };
 
 MenuState.defaultProps = {
   showDelay: 0,
-  hideDelay: 0
+  hideDelay: 0,
+  defaultOpen: false
 };
 
 const withMenuState = MenuComponentWithoutState => {
-  const MenuComponent = ({ showDelay, hideDelay, ...props }) => (
-    <MenuState showDelay={showDelay} hideDelay={hideDelay}>
+  const MenuComponent = ({ showDelay, hideDelay, defaultOpen, ...props }) => (
+    <MenuState showDelay={showDelay} hideDelay={hideDelay} defaultOpen={defaultOpen}>
       {menuState => <MenuComponentWithoutState menuState={menuState} {...props} />}
     </MenuState>
   );
   MenuComponent.propTypes = {
     showDelay: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    hideDelay: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    hideDelay: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    defaultOpen: PropTypes.bool
   };
 
   MenuComponent.defaultProps = {
     showDelay: 0,
-    hideDelay: 0
+    hideDelay: 0,
+    defaultOpen: false
   };
 
   return MenuComponent;

--- a/components/src/utils/withMenuState.js
+++ b/components/src/utils/withMenuState.js
@@ -6,8 +6,6 @@ class MenuState extends React.Component {
   constructor(props) {
     super(props);
 
-    console.log(this.props.defaultOpen);
-
     this.state = {
       isOpen: this.props.defaultOpen
     };

--- a/components/src/utils/withMenuState.js
+++ b/components/src/utils/withMenuState.js
@@ -6,8 +6,10 @@ class MenuState extends React.Component {
   constructor(props) {
     super(props);
 
+    const { defaultOpen } = this.props;
+
     this.state = {
-      isOpen: this.props.defaultOpen
+      isOpen: defaultOpen
     };
 
     this.handleKeyDown = this.handleKeyDown.bind(this);


### PR DESCRIPTION
This PR:
 - enhanced withMenuState HOC to allow for delay timers and default states
 - moves withMenuState to utils
 - removes state logic in Tooltip and MenuDropdown and uses withMenuState
 - creates NavBarMenuDropdown component specific to the NavBar
 - NavBarMenuDropdown allows SubMenuTrigger to open additional submenus on hover 