### PR TITLE
Update Button styles to match UI Kit 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- [Button](https://nulogy.design/components/buttons/) now uses the proper border colour (`blue`)
+
 - NavBar bug fixes
   - Fixes inconsistent focus styling in submenu triggers
   - Fixes inability to tell which submenu is open

--- a/components/src/Button/Button.js
+++ b/components/src/Button/Button.js
@@ -74,7 +74,7 @@ const Button = styled(BaseButton)(
     cursor: disabled ? "default" : "pointer",
     color: theme.colors.blue,
     backgroundColor: theme.colors.white,
-    border: `1px solid ${theme.colors.darkBlue}`,
+    border: `1px solid ${theme.colors.blue}`,
     borderRadius: theme.radii.medium,
     width: fullWidth ? "100%" : "auto",
     margin: theme.space.none,


### PR DESCRIPTION
We were using `darkBlue` for our `Button` border, when it should be `blue` according to the Sketch kit. :smile: 