### PR TITLE
Remove label attribute on buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - [Button](https://nulogy.design/components/buttons/) now uses the proper border colour (`blue`)
+- [IconicButton](https://nulogy.design/components/iconic-button/) now uses the `aria-label` attribute instead of the `label` attribute
 
 - NavBar bug fixes
 

--- a/components/src/Button/CloseButton.js
+++ b/components/src/Button/CloseButton.js
@@ -46,7 +46,7 @@ const WrapperButton = styled.button(({ disabled }) => ({
 }));
 
 const BaseCloseButton = React.forwardRef(({ ...props }, ref) => (
-  <WrapperButton aria-label="close" ref={ref} label="close" {...props}>
+  <WrapperButton aria-label="close" ref={ref} {...props}>
     <Icon size={theme.space.x4} icon="close" p="half" />
   </WrapperButton>
 ));

--- a/components/src/Button/IconicButton.js
+++ b/components/src/Button/IconicButton.js
@@ -78,7 +78,7 @@ const WrapperButton = styled.button(space, ({ disabled }) => ({
 }));
 
 const BaseIconicButton = React.forwardRef(({ children, icon, labelHidden, ...props }, forwardedRef) => (
-  <WrapperButton ref={forwardedRef} label={children} {...props}>
+  <WrapperButton ref={forwardedRef} aria-label={children} {...props}>
     <Manager>
       <Reference>{({ ref }) => <Icon ref={ref} size={theme.space.x4} icon={icon} p="half" />}</Reference>
       <Popper placement="bottom">


### PR DESCRIPTION
This PR fixes error where IconicButton and CloseButton had the label attribute instead of just the aria-label attribute.