### PR TITLE
Updates README.md font example so that it loads all supported font weights

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -12,7 +12,7 @@ Built with React, compononents make it easy to create interfaces that conform to
 Add [IBM Plex Sans](https://fonts.google.com/specimen/IBM+Plex+Sans:300,400,500,600) and [IBM Plex Mono](https://fonts.google.com/specimen/IBM+Plex+Sans) to your application
 
 ```html
-<link href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans:300,400,500,600" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono" rel="stylesheet">
 ```
 


### PR DESCRIPTION
This PR updates the font import example so that it includes all the font weights (300,400,500,600). If these aren't included, the typography components such as Title, SectionTitle, SubsectionTitle, etc do not render properly inside the app.