### PR TITLE
[NDS-1029] Add focus styles for things that aren't buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Enhanced [NavBar](https://nulogy.design/components/navbar/) component behavior so that nested menus will open on hover
 - Reduced [NavBar](https://nulogy.design/components/navbar/) submenu font-size to 14px
+- Changed how focused [DropDownMenu](https://nulogy.design/components/dropdown-menu/) items look
 
 ### Deprecated
 
 ### Removed
+
+- Removed custom focus styles on [Links](https://nulogy.design/components/link) in favour of browser outline
 
 ### Fixed
 

--- a/components/src/Button/Button.js
+++ b/components/src/Button/Button.js
@@ -70,7 +70,7 @@ const Button = styled(BaseButton)(
     textDecoration: "none",
     verticalAlign: "middle",
     lineHeight: theme.lineHeights.base,
-    transition: ".2s",
+    transition: "background-color .2s",
     cursor: disabled ? "default" : "pointer",
     color: theme.colors.blue,
     backgroundColor: theme.colors.white,
@@ -92,7 +92,7 @@ const Button = styled(BaseButton)(
     },
     "&:active": {
       transform: "scale(0.98)",
-      transition: ".2s ease-in"
+      transition: "scale .2s ease-in"
     },
     "&:disabled": {
       opacity: ".5"

--- a/components/src/DropdownMenu/DropdownButton.js
+++ b/components/src/DropdownMenu/DropdownButton.js
@@ -15,6 +15,7 @@ const DropdownButton = styled.button(props => ({
   fontSize: theme.fontSizes.medium,
   transition: ".2s",
   padding: `${theme.space.x1} ${theme.space.x2}`,
+  borderLeft: `${theme.space.half} solid transparent`,
   "&:hover": {
     color: themeGet(`colors.${props.hoverColor}`, props.hoverColor)(props),
     backgroundColor: props.disabled
@@ -23,7 +24,9 @@ const DropdownButton = styled.button(props => ({
   },
   "&:focus": {
     outline: "none",
-    boxShadow: theme.shadows.focus
+    color: themeGet(`colors.${props.hoverColor}`, props.hoverColor)(props),
+    backgroundColor: themeGet(`colors.${props.bgHoverColor}`, props.bgHoverColor)(props),
+    borderLeft: `${theme.space.half}  solid ${theme.colors.blue}`
   },
   "&:disabled": {
     opacity: ".5"

--- a/components/src/DropdownMenu/DropdownLink.js
+++ b/components/src/DropdownMenu/DropdownLink.js
@@ -13,13 +13,16 @@ const DropdownLink = styled.a(props => ({
   fontSize: theme.fontSizes.medium,
   transition: ".2s",
   padding: `${theme.space.x1} ${theme.space.x2}`,
+  borderLeft: `${theme.space.half} solid transparent`,
   "&:hover": {
     color: themeGet(`colors.${props.hoverColor}`, props.hoverColor)(props),
     backgroundColor: themeGet(`colors.${props.bgHoverColor}`, props.bgHoverColor)(props)
   },
   "&:focus": {
     outline: "none",
-    boxShadow: theme.shadows.focus
+    color: themeGet(`colors.${props.hoverColor}`, props.hoverColor)(props),
+    backgroundColor: themeGet(`colors.${props.bgHoverColor}`, props.bgHoverColor)(props),
+    borderLeft: `${theme.space.half}  solid ${theme.colors.blue}`
   },
   "&:disabled": {
     opacity: ".5"

--- a/components/src/Link/Link.js
+++ b/components/src/Link/Link.js
@@ -21,10 +21,6 @@ const Link = styled.a(color, space, ({ underline, ...props }) => ({
   "&:hover": {
     cursor: "pointer",
     color: getHoverColor(props)
-  },
-  "&:focus": {
-    outline: "none",
-    boxShadow: theme.shadows.focus
   }
 }));
 

--- a/components/src/NavBar/MenuTrigger.js
+++ b/components/src/NavBar/MenuTrigger.js
@@ -17,7 +17,7 @@ const StyledButton = styled.button(({ color, hoverColor, hoverBackground }) => (
   textDecoration: "none",
   verticalAlign: "middle",
   lineHeight: theme.lineHeights.base,
-  transition: ".2s",
+  transition: "background-color .2s",
   fontSize: `${theme.fontSizes.medium}`,
   padding: `${theme.space.x1} 28px ${theme.space.x1} ${theme.space.x2}`,
   borderRadius: theme.radii.medium,

--- a/components/src/NavBar/SubMenuTrigger.js
+++ b/components/src/NavBar/SubMenuTrigger.js
@@ -14,6 +14,8 @@ const StyledButton = styled.button(({ isOpen }) => ({
   lineHeight: theme.lineHeights.smallTextBase,
   width: "100%",
   padding: `${theme.space.half} 28px ${theme.space.half} ${theme.space.x2}`,
+  border: "none",
+  borderLeft: `${theme.space.half} solid transparent`,
   "&:hover": {
     backgroundColor: theme.colors.lightGrey
   },
@@ -22,9 +24,10 @@ const StyledButton = styled.button(({ isOpen }) => ({
   },
   "&:focus": {
     outline: "none",
-    boxShadow: theme.shadows.focus
+    color: theme.colors.darkBlue,
+    backgroundColor: theme.colors.lightGrey,
+    borderLeft: `${theme.space.half}  solid ${theme.colors.blue}`
   },
-  border: "none",
   backgroundColor: isOpen ? theme.colors.lightGrey : "transparent",
   textDecoration: "none",
   textAlign: "left",

--- a/docs/src/components/Nav.js
+++ b/docs/src/components/Nav.js
@@ -27,6 +27,7 @@ const NavContainer = styled(Box)(({ isOpen }) => ({
   right: 0,
   bottom: 0,
   left: 0,
+  padding: `0 ${theme.space.x2}`,
   overflow: "scroll",
   zIndex: theme.zIndex.overlay,
   height: "100%",
@@ -45,6 +46,21 @@ NavContainer.propTypes = {
 NavContainer.defaultProps = {
   isOpen: null
 };
+
+const NavLink = styled(Link)({
+  transition: "background .2s",
+  padding: theme.space.x1,
+  marginLeft: theme.space.x1,
+  borderRadius: theme.radii.medium,
+  "&:hover": {
+    background: theme.colors.black
+  },
+  "&:focus": {
+    outline: "none",
+    background: theme.colors.black,
+    boxShadow: theme.shadows.focus
+  }
+});
 
 const NavItem = styled.li({
   margin: theme.space.x2,
@@ -104,7 +120,7 @@ class Navigation extends React.Component {
           <CloseButton isOpen={menuOpen} onClick={this.closeMenu}>
             <Icon icon="close" />
           </CloseButton>
-          <Link
+          <NavLink
             underline={false}
             style={{ display: "inline-block" }}
             mt="x4"
@@ -113,23 +129,23 @@ class Navigation extends React.Component {
             href="/"
           >
             <Branding mb="x4" logoColor="white" subtext="Design System" />
-          </Link>
-          <Box p="x4">
+          </NavLink>
+          <Box mt="x4">
             {menuData.map(menuItem => (
               <Box key={menuItem.name} mb="x6" p="0">
-                <SubsectionTitle color="whiteGrey">
+                <SubsectionTitle color="whiteGrey" ml="x2">
                   {menuItem.name}
                 </SubsectionTitle>
                 <List pl="0">
                   {menuItem.links.map(menuLink => (
                     <NavItem key={menuLink.href}>
-                      <Link
+                      <NavLink
                         color="white"
                         href={menuLink.href}
                         underline={false}
                       >
                         {menuLink.name}
-                      </Link>
+                      </NavLink>
                     </NavItem>
                   ))}
                 </List>


### PR DESCRIPTION
This PR does the following:

1. Removes any custom styling from our generic `Link` component, as the default outline is an expected behaviour
2. Adds a custom style for focused `DropDownMenu` styles as shadows aren't appropriate inside of the menu (which already has a shadow)
3. Matches the link styles in the documentation site navigation to the `NavBar` component
