### PR TITLE
Nds 1044 modal does not allow for no primary button

### DIFF
--- a/components/src/Modal/Modal.js
+++ b/components/src/Modal/Modal.js
@@ -82,7 +82,8 @@ const StyledReactModal = styled(ReactModal)(
     borderRadius: theme.radii.medium,
     border: null,
     width: "100%",
-    maxHeight: "70vh",
+    height: "auto",
+    maxHeight: `calc(100vh - ${theme.space.x4})`,
     margin: `0px ${theme.space.x2}`,
     padding: 0,
     [`@media only screen and (max-width: ${theme.breakpoints.small})`]: {

--- a/components/src/Modal/Modal.js
+++ b/components/src/Modal/Modal.js
@@ -132,6 +132,11 @@ class Modal extends React.Component {
 
   getPrimaryButton() {
     const { primaryButton, type } = this.props;
+
+    if (!primaryButton) {
+      return null;
+    }
+
     const PrimaryButtonComponent = this.getPrimaryButtonComponent(type);
 
     return <PrimaryButtonComponent {...primaryButton}>{primaryButton.label}</PrimaryButtonComponent>;


### PR DESCRIPTION
Fixed bug where the Modal component would cause an error if secondaryButtons were passed in as a prop but primaryButton was not.

Expected:
 - Modal has only secondary buttons

Also extended maxHeight of Modal from 70vh to 100vh - 32px. This reduces times where the modal is scrollable which is especially important for mobile where the background and modal can both scroll independently