### PR TITLE
[NDS-752] Add behaviour tests for the NavBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fixes a navbar flashing issue
+  - When the screensize was for the "medium" navbar, it would initially
+    flash the "small" navbar. Now it properly detects the window size to
+    avoid the flashing.
+- Sets the viewport as the container for components using `Popper.js`
+  - `DropdownMenu`, `NavBarDropdown`, `IconicButton`, `Tooltips`
+
 ### Security
 
 ## [0.12.0] - 2019-08-26

--- a/components-e2e/cypress/integration/components/NavBar.spec.js
+++ b/components-e2e/cypress/integration/components/NavBar.spec.js
@@ -129,8 +129,42 @@ describe("NavBar", () => {
 
     it("renders the search component", () => {
       cy.renderFromStorybook("navbar--base");
-      cy.wait(100);
+
       cy.get("input[type='search']").should("exist");
+    });
+
+    it("renders text in the menu", () => {
+      cy.renderFromStorybook("navbar--custom-render-components");
+
+      cy.contains("Text").should("exist");
+      cy.contains("Text 2").should("exist");
+    });
+
+    it("renders custom components in the menu", () => {
+      cy.renderFromStorybook("navbar--custom-render-components");
+
+      cy.contains("Custom").should("exist");
+      cy.contains("Custom 2").should("exist");
+    });
+
+    it("renders text in the submenu", () => {
+      cy.renderFromStorybook("navbar--custom-render-components");
+
+      cy.contains("Button").click();
+      cy.contains("Submenu Text").should("exist");
+
+      cy.contains("Button 2").click();
+      cy.contains("Submenu Text 2").should("exist");
+    });
+
+    it("renders custom components in the submenu", () => {
+      cy.renderFromStorybook("navbar--custom-render-components");
+
+      cy.contains("Button").click();
+      cy.contains("Submenu Custom").should("exist");
+
+      cy.contains("Button 2").click();
+      cy.contains("Submenu Custom 2").should("exist");
     });
   });
 
@@ -211,12 +245,38 @@ describe("NavBar", () => {
       cy.get("header").should("have.prop", "scrollTop", 0);
     });
 
-    it.only("renders the search component", () => {
+    it("renders the search component", () => {
       cy.renderFromStorybook("navbar--base");
 
-      cy.wait(100);
-
       cy.get("input[type='search']").should("exist");
+    });
+
+    it("renders text in top level", () => {
+      cy.renderFromStorybook("navbar--custom-render-components");
+
+      cy.contains("Text").should("exist");
+      cy.contains("Text 2").should("exist");
+    });
+
+    it("renders custom components in top level", () => {
+      cy.renderFromStorybook("navbar--custom-render-components");
+
+      cy.contains("Custom").should("exist");
+      cy.contains("Custom 2").should("exist");
+    });
+
+    it("renders text in nested levels", () => {
+      cy.renderFromStorybook("navbar--custom-render-components");
+
+      cy.contains("Submenu Text").should("exist");
+      cy.contains("Submenu Text 2").should("exist");
+    });
+
+    it("renders custom components in nested levels", () => {
+      cy.renderFromStorybook("navbar--custom-render-components");
+
+      cy.contains("Submenu Custom").should("exist");
+      cy.contains("Submenu Custom 2").should("exist");
     });
   });
 });

--- a/components-e2e/cypress/integration/components/NavBar.spec.js
+++ b/components-e2e/cypress/integration/components/NavBar.spec.js
@@ -126,6 +126,12 @@ describe("NavBar", () => {
 
       cy.contains("Menu 2-1-1").should("not.exist");
     });
+
+    it("renders the search component", () => {
+      cy.renderFromStorybook("navbar--base");
+      cy.wait(100);
+      cy.get("input[type='search']").should("exist");
+    });
   });
 
   context("when in mobile mode", () => {
@@ -190,7 +196,7 @@ describe("NavBar", () => {
       cy.get("nav").should("not.exist");
     });
 
-    it.only("resets the scroll position of the menu when closed and opened", () => {
+    it("resets the scroll position of the menu when closed and opened", () => {
       cy.viewport("iphone-6");
 
       cy.renderFromStorybook("navbar--base");
@@ -203,6 +209,14 @@ describe("NavBar", () => {
       cy.get("svg[icon='menu']").click();
 
       cy.get("header").should("have.prop", "scrollTop", 0);
+    });
+
+    it.only("renders the search component", () => {
+      cy.renderFromStorybook("navbar--base");
+
+      cy.wait(100);
+
+      cy.get("input[type='search']").should("exist");
     });
   });
 });

--- a/components-e2e/cypress/integration/components/NavBar.spec.js
+++ b/components-e2e/cypress/integration/components/NavBar.spec.js
@@ -133,8 +133,28 @@ describe("NavBar", () => {
       cy.viewport("ipad-mini");
     });
 
-    it("renders", () => {
+    it("opens the menu when the button is clicked", () => {
       cy.renderFromStorybook("navbar--base");
+
+      cy.get("nav").should("not.exist");
+
+      cy.get("svg[icon='menu']").click();
+
+      cy.get("nav").should("exist");
+    });
+
+    it.only("closes the menu when the button is clicked and menu is open", () => {
+      cy.renderFromStorybook("navbar--base");
+
+      cy.get("nav").should("not.exist");
+
+      cy.get("svg[icon='menu']").click();
+
+      cy.get("nav").should("exist");
+
+      cy.get("svg[icon='close']").click();
+
+      cy.get("nav").should("not.exist");
     });
   });
 });

--- a/components-e2e/cypress/integration/components/NavBar.spec.js
+++ b/components-e2e/cypress/integration/components/NavBar.spec.js
@@ -146,8 +146,6 @@ describe("NavBar", () => {
     it("closes the menu when the button is clicked and menu is open", () => {
       cy.renderFromStorybook("navbar--base");
 
-      cy.get("nav").should("not.exist");
-
       cy.get("svg[icon='menu']").click();
 
       cy.get("nav").should("exist");
@@ -160,8 +158,6 @@ describe("NavBar", () => {
     it("renders all nested menu links", () => {
       cy.renderFromStorybook("navbar--base");
 
-      cy.get("nav").should("not.exist");
-
       cy.get("svg[icon='menu']").click();
 
       cy.contains("Menu 1").should("exist");
@@ -173,7 +169,17 @@ describe("NavBar", () => {
     it("closes the menu on escape key press", () => {
       cy.renderFromStorybook("navbar--base");
 
+      cy.get("svg[icon='menu']").click();
+
+      cy.get("nav").should("exist");
+
+      cy.get("body").type("{esc}");
+
       cy.get("nav").should("not.exist");
+    });
+
+    it("closes the menu on escape key press", () => {
+      cy.renderFromStorybook("navbar--base");
 
       cy.get("svg[icon='menu']").click();
 
@@ -182,6 +188,21 @@ describe("NavBar", () => {
       cy.get("body").type("{esc}");
 
       cy.get("nav").should("not.exist");
+    });
+
+    it("resets the scroll position of the menu when closed and opened", () => {
+      cy.viewport("iphone-6");
+
+      cy.renderFromStorybook("navbar--base");
+
+      cy.get("svg[icon='menu']").click();
+
+      cy.get("header").scrollTo("bottom");
+
+      cy.get("svg[icon='close']").click();
+      cy.get("svg[icon='menu']").click();
+
+      cy.get("header").should("have.prop", "scrollTop", 0);
     });
   });
 });

--- a/components-e2e/cypress/integration/components/NavBar.spec.js
+++ b/components-e2e/cypress/integration/components/NavBar.spec.js
@@ -1,13 +1,135 @@
 describe("NavBar", () => {
+  const renderNavBar = () => {
+    cy.renderFromStorybook("navbar--base");
+    cy.wait(500);
+  };
+
   context("when in desktop mode", () => {
     beforeEach(() => {
       cy.viewport("macbook-13");
     });
 
-    it("can be navigated using the keyboard", () => {
-      cy.renderFromStorybook("navbar--base");
+    it("can open a submenu on click", () => {
+      renderNavBar();
 
-      cy.wait(500);
+      cy.contains("Menu 1").click();
+
+      cy.contains("Menu 1-1").should("exist");
+    });
+
+    it("closes a first level submenu on click when one is open", () => {
+      renderNavBar();
+
+      cy.contains("Menu 1").click();
+
+      cy.contains("Menu 1-1").should("exist");
+
+      cy.contains("Menu 1").click();
+
+      cy.contains("Menu 1-1").should("not.exist");
+    });
+
+    it("can open multiple layers of submenus", () => {
+      renderNavBar();
+
+      cy.contains("Menu 2").click();
+
+      cy.contains("Menu 2-1").click();
+
+      cy.contains("Menu 2-1-2").click();
+
+      cy.contains("Menu 2-1-2-1").should("exist");
+    });
+
+    it("closes all open submenus on escape key press", () => {
+      renderNavBar();
+
+      cy.contains("Menu 2").click();
+
+      cy.contains("Menu 2-1").click();
+
+      cy.contains("Menu 2-1-2").click();
+
+      cy.get("body").type("{esc}");
+
+      cy.contains("Menu 2-1").should("not.exist");
+    });
+
+    it("closes all open submenus on click outside of menus", () => {
+      renderNavBar();
+
+      cy.contains("Menu 2").click();
+
+      cy.contains("Menu 2-1").click();
+
+      cy.contains("Menu 2-1-2").click();
+
+      cy.get("body").click();
+
+      cy.contains("Menu 2-1").should("not.exist");
+    });
+
+    it("opens nested submenus on mouse hover of the trigger", () => {
+      renderNavBar();
+
+      cy.contains("Menu 2").click();
+
+      cy.contains("Menu 2-1").trigger("mouseover");
+
+      cy.contains("Menu 2-1-2").should("exist");
+    });
+
+    it("closes nested submenus on mouse leave of the trigger", () => {
+      renderNavBar();
+
+      cy.contains("Menu 2").click();
+
+      cy.contains("Menu 2-1").trigger("mouseover");
+      cy.contains("Menu 2-1").trigger("mouseout");
+
+      cy.contains("Menu 2-1-2").should("not.exist");
+    });
+
+    it("closes all nested submenus when mouse leaves any nested submenu", () => {
+      renderNavBar();
+
+      cy.contains("Menu 2").click();
+
+      cy.contains("Menu 2-1").trigger("mouseover");
+      cy.contains("Menu 2-1-2").trigger("mouseover");
+
+      cy.contains("Menu 2-1-2-2").should("exist");
+
+      cy.contains("Menu 2-1-2").trigger("mouseout");
+
+      cy.contains("Menu 2-1-2").should("not.exist");
+      cy.contains("Menu 2-1").should("exist");
+    });
+
+    it("enforces one submenu tree is open at once", () => {
+      renderNavBar();
+
+      cy.contains("Menu 2").click();
+
+      cy.contains("Menu 2-1").should("exist");
+
+      cy.contains("Menu 1").click();
+
+      cy.contains("Menu 2-1").should("not.exist");
+    });
+
+    it("enforces one nested submenu tree is open at once", () => {
+      renderNavBar();
+
+      cy.contains("Menu 2").click();
+
+      cy.contains("Menu 2-1").click();
+
+      cy.contains("Menu 2-1-1").should("exist");
+
+      cy.contains("Menu 2-2").click();
+
+      cy.contains("Menu 2-1-1").should("not.exist");
     });
   });
 
@@ -17,9 +139,7 @@ describe("NavBar", () => {
     });
 
     it("renders", () => {
-      cy.renderFromStorybook("navbar--base");
-
-      cy.wait(500);
+      renderNavBar();
     });
   });
 });

--- a/components-e2e/cypress/integration/components/NavBar.spec.js
+++ b/components-e2e/cypress/integration/components/NavBar.spec.js
@@ -1,16 +1,11 @@
 describe("NavBar", () => {
-  const renderNavBar = () => {
-    cy.renderFromStorybook("navbar--base");
-    cy.wait(500);
-  };
-
   context("when in desktop mode", () => {
     beforeEach(() => {
       cy.viewport("macbook-13");
     });
 
     it("can open a submenu on click", () => {
-      renderNavBar();
+      cy.renderFromStorybook("navbar--base");
 
       cy.contains("Menu 1").click();
 
@@ -18,7 +13,7 @@ describe("NavBar", () => {
     });
 
     it("closes a first level submenu on click when one is open", () => {
-      renderNavBar();
+      cy.renderFromStorybook("navbar--base");
 
       cy.contains("Menu 1").click();
 
@@ -30,7 +25,7 @@ describe("NavBar", () => {
     });
 
     it("can open multiple layers of submenus", () => {
-      renderNavBar();
+      cy.renderFromStorybook("navbar--base");
 
       cy.contains("Menu 2").click();
 
@@ -42,7 +37,7 @@ describe("NavBar", () => {
     });
 
     it("closes all open submenus on escape key press", () => {
-      renderNavBar();
+      cy.renderFromStorybook("navbar--base");
 
       cy.contains("Menu 2").click();
 
@@ -56,7 +51,7 @@ describe("NavBar", () => {
     });
 
     it("closes all open submenus on click outside of menus", () => {
-      renderNavBar();
+      cy.renderFromStorybook("navbar--base");
 
       cy.contains("Menu 2").click();
 
@@ -70,7 +65,7 @@ describe("NavBar", () => {
     });
 
     it("opens nested submenus on mouse hover of the trigger", () => {
-      renderNavBar();
+      cy.renderFromStorybook("navbar--base");
 
       cy.contains("Menu 2").click();
 
@@ -80,7 +75,7 @@ describe("NavBar", () => {
     });
 
     it("closes nested submenus on mouse leave of the trigger", () => {
-      renderNavBar();
+      cy.renderFromStorybook("navbar--base");
 
       cy.contains("Menu 2").click();
 
@@ -91,7 +86,7 @@ describe("NavBar", () => {
     });
 
     it("closes all nested submenus when mouse leaves any nested submenu", () => {
-      renderNavBar();
+      cy.renderFromStorybook("navbar--base");
 
       cy.contains("Menu 2").click();
 
@@ -107,7 +102,7 @@ describe("NavBar", () => {
     });
 
     it("enforces one submenu tree is open at once", () => {
-      renderNavBar();
+      cy.renderFromStorybook("navbar--base");
 
       cy.contains("Menu 2").click();
 
@@ -119,7 +114,7 @@ describe("NavBar", () => {
     });
 
     it("enforces one nested submenu tree is open at once", () => {
-      renderNavBar();
+      cy.renderFromStorybook("navbar--base");
 
       cy.contains("Menu 2").click();
 
@@ -139,7 +134,7 @@ describe("NavBar", () => {
     });
 
     it("renders", () => {
-      renderNavBar();
+      cy.renderFromStorybook("navbar--base");
     });
   });
 });

--- a/components-e2e/cypress/integration/components/NavBar.spec.js
+++ b/components-e2e/cypress/integration/components/NavBar.spec.js
@@ -190,7 +190,7 @@ describe("NavBar", () => {
       cy.get("nav").should("not.exist");
     });
 
-    it("resets the scroll position of the menu when closed and opened", () => {
+    it.only("resets the scroll position of the menu when closed and opened", () => {
       cy.viewport("iphone-6");
 
       cy.renderFromStorybook("navbar--base");
@@ -199,7 +199,7 @@ describe("NavBar", () => {
 
       cy.get("header").scrollTo("bottom");
 
-      cy.get("svg[icon='close']").click();
+      cy.get("body").type("{esc}");
       cy.get("svg[icon='menu']").click();
 
       cy.get("header").should("have.prop", "scrollTop", 0);

--- a/components-e2e/cypress/integration/components/NavBar.spec.js
+++ b/components-e2e/cypress/integration/components/NavBar.spec.js
@@ -143,7 +143,7 @@ describe("NavBar", () => {
       cy.get("nav").should("exist");
     });
 
-    it.only("closes the menu when the button is clicked and menu is open", () => {
+    it("closes the menu when the button is clicked and menu is open", () => {
       cy.renderFromStorybook("navbar--base");
 
       cy.get("nav").should("not.exist");
@@ -153,6 +153,33 @@ describe("NavBar", () => {
       cy.get("nav").should("exist");
 
       cy.get("svg[icon='close']").click();
+
+      cy.get("nav").should("not.exist");
+    });
+
+    it("renders all nested menu links", () => {
+      cy.renderFromStorybook("navbar--base");
+
+      cy.get("nav").should("not.exist");
+
+      cy.get("svg[icon='menu']").click();
+
+      cy.contains("Menu 1").should("exist");
+      cy.contains("Menu 2-1-2-2").should("exist");
+      cy.contains("Menu 3").should("exist");
+      cy.contains("Menu 4-2").should("exist");
+    });
+
+    it("closes the menu on escape key press", () => {
+      cy.renderFromStorybook("navbar--base");
+
+      cy.get("nav").should("not.exist");
+
+      cy.get("svg[icon='menu']").click();
+
+      cy.get("nav").should("exist");
+
+      cy.get("body").type("{esc}");
 
       cy.get("nav").should("not.exist");
     });

--- a/components/src/Branding/Branding.js
+++ b/components/src/Branding/Branding.js
@@ -43,7 +43,7 @@ const BrandingWrap = styled.div(
     alignItems: getAlignment(alignment)
   }),
   ({ size }) => ({
-    padding: size === "large" ? null : "4px 0"
+    padding: size === "large" ? null : "2px 0"
   })
 );
 
@@ -70,7 +70,7 @@ const BaseBranding = ({ logoType, subtext, size, alignment, withLine, logoColor,
       <WordmarkLogo size={size} letterFill={getLogoColor(logoColor).letter} logoFill={getLogoColor(logoColor).logo} />
     )}
     {subtext && (
-      <Flex justifyContent={getAlignment(alignment)} width="100%" py={size === "large" ? "6px" : null}>
+      <Flex justifyContent={getAlignment(alignment)} width="100%" py={size === "large" ? "6px" : "2px"}>
         {alignment !== "left" && withLine && <Line logoColor={logoColor} />}
         <BrandingText
           logoColor={logoColor}

--- a/components/src/Button/IconicButton.js
+++ b/components/src/Button/IconicButton.js
@@ -81,7 +81,12 @@ const BaseIconicButton = React.forwardRef(({ children, icon, labelHidden, ...pro
   <WrapperButton ref={forwardedRef} aria-label={children} {...props}>
     <Manager>
       <Reference>{({ ref }) => <Icon ref={ref} size={theme.space.x4} icon={icon} p="half" />}</Reference>
-      <Popper placement="bottom">
+      <Popper
+        placement="bottom"
+        modifiers={{
+          preventOverflow: { enabled: true, padding: 8, boundariesElement: "viewport" }
+        }}
+      >
         {({ ref, style, placement }) =>
           labelHidden ? (
             <HoverText ref={ref} style={style} placement={placement}>

--- a/components/src/DropdownMenu/DropdownButton.js
+++ b/components/src/DropdownMenu/DropdownButton.js
@@ -14,7 +14,7 @@ const DropdownButton = styled.button(props => ({
   lineHeight: theme.lineHeights.base,
   fontSize: theme.fontSizes.medium,
   transition: ".2s",
-  padding: `${theme.space.x1} ${theme.space.x2}`,
+  padding: `${theme.space.x1} ${theme.space.x2} ${theme.space.x1} 12px`,
   borderLeft: `${theme.space.half} solid transparent`,
   "&:hover": {
     color: themeGet(`colors.${props.hoverColor}`, props.hoverColor)(props),

--- a/components/src/DropdownMenu/DropdownLink.js
+++ b/components/src/DropdownMenu/DropdownLink.js
@@ -12,7 +12,7 @@ const DropdownLink = styled.a(props => ({
   lineHeight: theme.lineHeights.base,
   fontSize: theme.fontSizes.medium,
   transition: ".2s",
-  padding: `${theme.space.x1} ${theme.space.x2}`,
+  padding: `${theme.space.x1} ${theme.space.x2} ${theme.space.x1} 12px`,
   borderLeft: `${theme.space.half} solid transparent`,
   "&:hover": {
     color: themeGet(`colors.${props.hoverColor}`, props.hoverColor)(props),

--- a/components/src/DropdownMenu/DropdownMenu.js
+++ b/components/src/DropdownMenu/DropdownMenu.js
@@ -153,7 +153,9 @@ StatelessDropdownMenu.defaultProps = {
   backgroundColor: undefined,
   showArrow: true,
   placement: "bottom-start",
-  modifiers: { flip: { behavior: ["bottom"] } }
+  modifiers: {
+    preventOverflow: { enabled: true, padding: 8, boundariesElement: "viewport" }
+  }
 };
 
 const DropdownMenu = withMenuState(StatelessDropdownMenu);

--- a/components/src/NavBar/MenuTrigger.js
+++ b/components/src/NavBar/MenuTrigger.js
@@ -78,6 +78,11 @@ const MenuTrigger = props => {
   return (
     <NavBarDropdownMenu
       {...otherProps}
+      placement="bottom-start"
+      modifiers={{
+        flip: { behavior: ["bottom"] },
+        preventOverflow: { enabled: true, padding: 8, boundariesElement: "viewport" }
+      }}
       trigger={() => (
         <MenuTriggerButton color={color} hoverColor={hoverColor} hoverBackground={hoverBackground} name={name} />
       )}

--- a/components/src/NavBar/NavBar.js
+++ b/components/src/NavBar/NavBar.js
@@ -238,11 +238,13 @@ SmallNavBarNoState.defaultProps = {
 
 const SmallNavBar = withMenuState(SmallNavBarNoState);
 
-const SelectNavBarBasedOnWidth = ({ width, breakpointUpper, ...props }) => {
-  if (width >= parseInt(breakpointUpper, 10)) {
+const SelectNavBarBasedOnWidth = ({ width, defaultOpen, breakpointUpper, ...props }) => {
+  let currentWidth = width || window.innerWidth;
+
+  if (currentWidth >= pixelDigitsFrom(breakpointUpper)) {
     return <MediumNavBar {...props} />;
   } else {
-    return <SmallNavBar {...props} width={width} />;
+    return <SmallNavBar {...props} width={currentWidth} defaultOpen={defaultOpen} />;
   }
 };
 

--- a/components/src/NavBar/NavBar.js
+++ b/components/src/NavBar/NavBar.js
@@ -239,7 +239,7 @@ SmallNavBarNoState.defaultProps = {
 const SmallNavBar = withMenuState(SmallNavBarNoState);
 
 const SelectNavBarBasedOnWidth = ({ width, defaultOpen, breakpointUpper, ...props }) => {
-  const currentWidth = width || window.innerWidth;
+  const currentWidth = width || (typeof window !== "undefined" && window.innerWidth);
 
   if (currentWidth >= pixelDigitsFrom(breakpointUpper)) {
     return <MediumNavBar {...props} />;

--- a/components/src/NavBar/NavBar.js
+++ b/components/src/NavBar/NavBar.js
@@ -239,7 +239,7 @@ SmallNavBarNoState.defaultProps = {
 const SmallNavBar = withMenuState(SmallNavBarNoState);
 
 const SelectNavBarBasedOnWidth = ({ width, defaultOpen, breakpointUpper, ...props }) => {
-  let currentWidth = width || window.innerWidth;
+  const currentWidth = width || window.innerWidth;
 
   if (currentWidth >= pixelDigitsFrom(breakpointUpper)) {
     return <MediumNavBar {...props} />;

--- a/components/src/NavBar/NavBarDropdownMenu.js
+++ b/components/src/NavBar/NavBarDropdownMenu.js
@@ -135,7 +135,7 @@ StatelessNavBarDropdownMenu.propTypes = {
 StatelessNavBarDropdownMenu.defaultProps = {
   showArrow: true,
   placement: "bottom-start",
-  modifiers: { flip: { behavior: ["bottom"] } },
+  modifiers: null,
   triggerTogglesMenuState: true,
   dropdownMenuContainerEventHandlers: () => {}
 };

--- a/components/src/NavBar/SubMenuTrigger.js
+++ b/components/src/NavBar/SubMenuTrigger.js
@@ -13,7 +13,7 @@ const StyledButton = styled.button(({ isOpen }) => ({
   fontSize: theme.fontSizes.small,
   lineHeight: theme.lineHeights.smallTextBase,
   width: "100%",
-  padding: `${theme.space.half} 28px ${theme.space.half} ${theme.space.x2}`,
+  padding: `${theme.space.half} 28px ${theme.space.half} 12px`,
   border: "none",
   borderLeft: `${theme.space.half} solid transparent`,
   "&:hover": {

--- a/components/src/StoriesForTests/NavBar.story.js
+++ b/components/src/StoriesForTests/NavBar.story.js
@@ -54,10 +54,88 @@ const secondaryMenu = [
   }
 ];
 
+const customPrimaryMenu = [
+  {
+    name: "Text"
+  },
+  {
+    name: "Link",
+    href: "/"
+  },
+  {
+    name: "Custom",
+    render: () => <span>Custom</span>
+  },
+  {
+    name: "Button",
+    items: [
+      {
+        name: "Submenu Text"
+      },
+      {
+        name: "Submenu Link",
+        href: "/"
+      },
+      {
+        name: "Submenu Custom",
+        render: () => <span>Submenu Custom</span>
+      },
+      {
+        name: "Submenu Button",
+        items: [
+          {
+            name: "Nested Submenu Text"
+          }
+        ]
+      }
+    ]
+  }
+];
+
+const customSecondaryMenu = [
+  {
+    name: "Text 2"
+  },
+  {
+    name: "Link 2",
+    href: "/"
+  },
+  {
+    name: "Custom 2",
+    render: () => <span>Custom 2</span>
+  },
+  {
+    name: "Button 2",
+    items: [
+      {
+        name: "Submenu Text 2"
+      },
+      {
+        name: "Submenu Link 2",
+        href: "/"
+      },
+      {
+        name: "Submenu Custom 2",
+        render: () => <span>Submenu Custom 2</span>
+      },
+      {
+        name: "Submenu Button 2",
+        items: [
+          {
+            name: "Nested Submenu Text 2"
+          }
+        ]
+      }
+    ]
+  }
+];
+
 const search = {
   onSubmit: () => {}
 };
 
-storiesOf("StoriesForTests/NavBar", module).add("Base", () => (
-  <NavBar menuData={{ primaryMenu, secondaryMenu, search }} />
-));
+storiesOf("StoriesForTests/NavBar", module)
+  .add("Base", () => <NavBar menuData={{ primaryMenu, secondaryMenu, search }} />)
+  .add("Custom Render Components", () => (
+    <NavBar defaultOpen menuData={{ primaryMenu: customPrimaryMenu, secondaryMenu: customSecondaryMenu }} />
+  ));

--- a/components/src/StoriesForTests/NavBar.story.js
+++ b/components/src/StoriesForTests/NavBar.story.js
@@ -26,14 +26,18 @@ const primaryMenu = [
     name: "Menu 2",
     items: [
       {
-        name: "SubMenu 1",
+        name: "Menu 2-1",
         items: [
-          { name: "SubMenu 1-1", href: "/" },
+          { name: "Menu 2-1-1", href: "/" },
           {
-            name: "SubSubMenu 1",
-            items: [{ name: "SubSubMenu 1-1", href: "/" }, { name: "SubSubMenu 1-2", href: "/" }]
+            name: "Menu 2-1-2",
+            items: [{ name: "Menu 2-1-2-1", href: "/" }, { name: "Menu 2-1-2-2", href: "/" }]
           }
         ]
+      },
+      {
+        name: "Menu 2-2",
+        items: [{ name: "Menu 2-2-1", href: "/" }]
       }
     ]
   }

--- a/components/src/Tooltip/Tooltip.js
+++ b/components/src/Tooltip/Tooltip.js
@@ -106,7 +106,10 @@ class StatelessTooltip extends React.Component {
             })
           }
         </Reference>
-        <Popper placement={this.props.placement}>
+        <Popper
+          placement={this.props.placement}
+          modifiers={{ preventOverflow: { enabled: true, padding: 8, boundariesElement: "viewport" } }}
+        >
           {({ ref, style, placement, arrowProps }) => (
             <TooltipContainer
               maxWidth={this.props.maxWidth}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5104,32 +5104,14 @@ browserslist@4.5.4:
     electron-to-chromium "^1.3.122"
     node-releases "^1.1.13"
 
-browserslist@^4.0.0, browserslist@^4.3.4:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.4.2.tgz#6ea8a74d6464bb0bd549105f659b41197d8f0ba2"
-  integrity sha512-ISS/AIAiHERJ3d45Fz0AVYKkgcy+F/eJHzKEvv1j0wwKGKD9T3BrwKr/5g45L+Y4XIK5PlTqefHciRFcfE1Jxg==
+browserslist@^4.0.0, browserslist@^4.3.4, browserslist@^4.5.2, browserslist@^4.5.4, browserslist@^4.6.0, browserslist@^4.6.1:
+  version "4.6.6"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.6.6.tgz#6e4bf467cde520bc9dbdf3747dafa03531cec453"
+  integrity sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==
   dependencies:
-    caniuse-lite "^1.0.30000939"
-    electron-to-chromium "^1.3.113"
-    node-releases "^1.1.8"
-
-browserslist@^4.5.2, browserslist@^4.5.4:
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.5.5.tgz#fe1a352330d2490d5735574c149a85bc18ef9b82"
-  integrity sha512-0QFO1r/2c792Ohkit5XI8Cm8pDtZxgNl2H6HU4mHrpYz7314pEYcsAVVatM0l/YmxPnEzh9VygXouj4gkFUTKA==
-  dependencies:
-    caniuse-lite "^1.0.30000960"
-    electron-to-chromium "^1.3.124"
-    node-releases "^1.1.14"
-
-browserslist@^4.6.0, browserslist@^4.6.1:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.6.2.tgz#574c665950915c2ac73a4594b8537a9eba26203f"
-  integrity sha512-2neU/V0giQy9h3XMPwLhEY3+Ao0uHSwHvU8Q1Ea6AgLVL1sXbX3dzPrJ8NWe5Hi4PoTkCYXOtVR9rfRLI0J/8Q==
-  dependencies:
-    caniuse-lite "^1.0.30000974"
-    electron-to-chromium "^1.3.150"
-    node-releases "^1.1.23"
+    caniuse-lite "^1.0.30000984"
+    electron-to-chromium "^1.3.191"
+    node-releases "^1.1.25"
 
 bser@^2.0.0:
   version "2.0.0"
@@ -5425,20 +5407,20 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000939:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000844:
   version "1.0.30000941"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000941.tgz#f0810802b2ab8d27f4b625d4769a610e24d5a42c"
   integrity sha512-4vzGb2MfZcO20VMPj1j6nRAixhmtlhkypM4fL4zhgzEucQIYiRzSqPcWIu1OF8i0FETD93FMIPWfUJCAcFvrqA==
 
-caniuse-lite@^1.0.30000955, caniuse-lite@^1.0.30000971, caniuse-lite@^1.0.30000974:
+caniuse-lite@^1.0.30000955, caniuse-lite@^1.0.30000971:
   version "1.0.30000974"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000974.tgz#b7afe14ee004e97ce6dc73e3f878290a12928ad8"
   integrity sha512-xc3rkNS/Zc3CmpMKuczWEdY2sZgx09BkAxfvkxlAEBTqcMHeL8QnPqhKse+5sRTi3nrw2pJwToD2WvKn1Uhvww==
 
-caniuse-lite@^1.0.30000960:
-  version "1.0.30000962"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000962.tgz#6c10c3ab304b89bea905e66adf98c0905088ee44"
-  integrity sha512-WXYsW38HK+6eaj5IZR16Rn91TGhU3OhbwjKZvJ4HN/XBIABLKfbij9Mnd3pM0VEwZSlltWjoWg3I8FQ0DGgNOA==
+caniuse-lite@^1.0.30000984:
+  version "1.0.30000989"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz#b9193e293ccf7e4426c5245134b8f2a56c0ac4b9"
+  integrity sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==
 
 capture-exit@^1.2.0:
   version "1.2.0"
@@ -7532,20 +7514,20 @@ ejs@^2.6.1:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.6.1.tgz#498ec0d495655abc6f23cd61868d926464071aa0"
   integrity sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==
 
-electron-to-chromium@^1.3.113, electron-to-chromium@^1.3.47:
-  version "1.3.113"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.113.tgz#b1ccf619df7295aea17bc6951dc689632629e4a9"
-  integrity sha512-De+lPAxEcpxvqPTyZAXELNpRZXABRxf+uL/rSykstQhzj/B0l1150G/ExIIxKc16lI89Hgz81J0BHAcbTqK49g==
-
-electron-to-chromium@^1.3.122, electron-to-chromium@^1.3.150:
+electron-to-chromium@^1.3.122:
   version "1.3.159"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.159.tgz#4292643c5cb77678821ce01557ba6dd0f562db5e"
   integrity sha512-bhiEr8/A97GUBcUzNb9MFNhzQOjakbKmEKBEAa6UMY45zG2e8PM63LOgAPXEJE9bQiaQH6nOdYiYf8X821tZjQ==
 
-electron-to-chromium@^1.3.124:
-  version "1.3.125"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.125.tgz#dbde0e95e64ebe322db0eca764d951f885a5aff2"
-  integrity sha512-XxowpqQxJ4nDwUXHtVtmEhRqBpm2OnjBomZmZtHD0d2Eo0244+Ojezhk3sD/MBSSe2nxCdGQFRXHIsf/LUTL9A==
+electron-to-chromium@^1.3.191:
+  version "1.3.241"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.241.tgz#859dc49ab7f90773ed698767372d384190f60cb1"
+  integrity sha512-Gb9E6nWZlbgjDDNe5cAvMJixtn79krNJ70EDpq/M10lkGo7PGtBUe7Y0CYVHsBScRwi6ybCS+YetXAN9ysAHDg==
+
+electron-to-chromium@^1.3.47:
+  version "1.3.113"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.113.tgz#b1ccf619df7295aea17bc6951dc689632629e4a9"
+  integrity sha512-De+lPAxEcpxvqPTyZAXELNpRZXABRxf+uL/rSykstQhzj/B0l1150G/ExIIxKc16lI89Hgz81J0BHAcbTqK49g==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -14220,24 +14202,17 @@ node-pre-gyp@^0.10.0:
     semver "^5.3.0"
     tar "^4"
 
-node-releases@^1.1.13, node-releases@^1.1.23:
+node-releases@^1.1.13:
   version "1.1.23"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.23.tgz#de7409f72de044a2fa59c097f436ba89c39997f0"
   integrity sha512-uq1iL79YjfYC0WXoHbC/z28q/9pOl8kSHaXdWmAAc8No+bDwqkZbzIJz55g/MUsPgSGm9LZ7QSUbzTcH5tz47w==
   dependencies:
     semver "^5.3.0"
 
-node-releases@^1.1.14:
-  version "1.1.15"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.15.tgz#9e76a73b0eca3bf7801addaa0e6ce90c795f2b9a"
-  integrity sha512-cKV097BQaZr8LTSRUa2+oc/aX5L8UkZtPQrMSTgiJEeaW7ymTDCoRaGCoaTqk0lqnalcoSHu4wjSl0Cmj2+bMw==
-  dependencies:
-    semver "^5.3.0"
-
-node-releases@^1.1.8:
-  version "1.1.9"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.9.tgz#70d0985ec4bf7de9f08fc481f5dae111889ca482"
-  integrity sha512-oic3GT4OtbWWKfRolz5Syw0Xus0KRFxeorLNj0s93ofX6PWyuzKjsiGxsCtWktBwwmTF6DdRRf2KreGqeOk5KA==
+node-releases@^1.1.25:
+  version "1.1.28"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.28.tgz#503c3c70d0e4732b84e7aaa2925fbdde10482d4a"
+  integrity sha512-AQw4emh6iSXnCpDiFe0phYcThiccmkNWMZnFZ+lDJjAP8J0m2fVd59duvUUyuTirQOhIAajTFkzG6FHCLBO59g==
   dependencies:
     semver "^5.3.0"
 


### PR DESCRIPTION
This PR:
 - Adds some cypress tests for the desktop and movile NavBar:
   https://trello.com/b/uL9nYlpW/nds-752-add-behaviour-tests-for-the-navbar
 - Fixes:
    - Alignment on dropdown menu items
    - Adds viewport as containing element for all popper.js component (DropdownMenu, NavBarDropdown, IconicButton, Tooltips)
    - Alignment fix on Branding component
    - Fixes NavBar so that it renders the SmallNavBar or MediumNavBar initially based on window.innerWidth, it used to render with undefined width causing SmallNavBar to always render first and switch to MediumNavBar causing content to flash