### PR TITLE
Add a labelless IconicButton example to storybook

### DIFF
--- a/components/src/Button/IconicButton.story.js
+++ b/components/src/Button/IconicButton.story.js
@@ -3,6 +3,7 @@ import { storiesOf } from "@storybook/react";
 import { IconicButton } from "../index";
 
 storiesOf("IconicButton", module)
+  .add("without a label", () => <IconicButton icon="delete" />)
   .add("with label", () => <IconicButton icon="delete">Delete</IconicButton>)
   .add("with a long label", () => (
     <IconicButton icon="user">I am an Iconic Button with a really really really long label</IconicButton>


### PR DESCRIPTION
It's valid and ok to use an `IconicButton` without a label (and there's an example on the docs site) but storybook implied it wasn't possible as all of the examples had labels. 