### PR TITLE
Make links always black in alerts and add examples

### DIFF
--- a/components/src/Alert/Alert.js
+++ b/components/src/Alert/Alert.js
@@ -28,6 +28,12 @@ const alertColours = {
   }
 };
 
+const alertStyles = {
+  [`${Link}`]: {
+    color: theme.colors.black
+  }
+};
+
 class BaseAlert extends React.Component {
   constructor() {
     super();
@@ -87,6 +93,6 @@ BaseAlert.defaultProps = {
   type: "informative"
 };
 
-const Alert = styled(BaseAlert)(space);
+const Alert = styled(BaseAlert)(space, alertStyles);
 
 export default Alert;

--- a/components/src/Alert/Alert.story.js
+++ b/components/src/Alert/Alert.story.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import { Alert } from "../index";
+import { Link } from "../Link";
 
 storiesOf("Alert", module)
   .add("Danger", () => <Alert type="danger">Danger alert</Alert>)
@@ -11,5 +12,10 @@ storiesOf("Alert", module)
   .add("With a title", () => (
     <Alert title="Danger title!" type="danger">
       Danger alert
+    </Alert>
+  ))
+  .add("With a link", () => (
+    <Alert>
+      An alert with <Link href="/">linked details</Link>.
     </Alert>
   ));

--- a/docs/src/pages/components/alerts.js
+++ b/docs/src/pages/components/alerts.js
@@ -125,6 +125,21 @@ export default () => (
         <Alert type="warning">Text</Alert>
         <Highlight className="js">{`<Alert type="warning">Text</Alert>`}</Highlight>
       </Box>
+      <Box mb="x6">
+        <SubsectionTitle>Alert with Link</SubsectionTitle>
+        <Text>
+          A link may be added to the content of an alert. Within alerts, link
+          text is always displayed in black.
+        </Text>
+        <Alert>
+          Alert text with <Link href="/">linked details</Link>.
+        </Alert>
+        <Highlight className="js">
+          {`<Alert>
+  Alert text <Link href="/">linked details</Link>.
+</Alert>`}
+        </Highlight>
+      </Box>
       {/* <Box mb="x6">
         <SubsectionTitle>With a title</SubsectionTitle>
         <Alert title="Alert title">Text</Alert>


### PR DESCRIPTION
- Overrides the color for all links within <Alert> to be black (even if a color is set on the <Link>)
- added an example of alerts with links to both storybook and the docs