### PR TITLE
[NDS-817] Spike use theme from themeprovider

### DIFF
--- a/components/src/Alert/Alert.js
+++ b/components/src/Alert/Alert.js
@@ -1,32 +1,12 @@
 import React from "react";
 import PropTypes from "prop-types";
-import styled from "styled-components";
+import styled, { withTheme } from "styled-components";
 import { space } from "styled-system";
 import { Box } from "../Box";
 import { Icon } from "../Icon";
 import { Link } from "../Link";
 import { Flex } from "../Flex";
 import { Text } from "../Type";
-import theme from "../theme";
-
-const alertColours = {
-  danger: {
-    borderColor: theme.colors.red,
-    backgroundColor: theme.colors.lightRed
-  },
-  informative: {
-    borderColor: theme.colors.blue,
-    backgroundColor: theme.colors.lightBlue
-  },
-  success: {
-    borderColor: theme.colors.green,
-    backgroundColor: theme.colors.lightGreen
-  },
-  warning: {
-    borderColor: theme.colors.yellow,
-    backgroundColor: theme.colors.lightYellow
-  }
-};
 
 class BaseAlert extends React.Component {
   constructor() {
@@ -41,14 +21,33 @@ class BaseAlert extends React.Component {
   }
 
   render() {
-    const { children, isCloseable, title, type, className, ...props } = this.props;
+    const { children, isCloseable, title, type, className, theme, ...props } = this.props;
     const { isVisible } = this.state;
+
+    const alertColours = {
+      danger: {
+        borderColor: theme.colors.red,
+        backgroundColor: theme.colors.lightRed
+      },
+      informative: {
+        borderColor: theme.colors.blue,
+        backgroundColor: theme.colors.lightBlue
+      },
+      success: {
+        borderColor: theme.colors.green,
+        backgroundColor: theme.colors.lightGreen
+      },
+      warning: {
+        borderColor: theme.colors.yellow,
+        backgroundColor: theme.colors.lightYellow
+      }
+    };
 
     return isVisible ? (
       <Flex
         bg={alertColours[type].backgroundColor}
         p="x2"
-        borderRadius={theme.radii.medium}
+        borderRadius="medium"
         borderLeft={`${theme.space.half} solid ${alertColours[type].borderColor}`}
         role="alert"
         className={className}
@@ -77,7 +76,8 @@ BaseAlert.propTypes = {
   className: PropTypes.string,
   isCloseable: PropTypes.node,
   title: PropTypes.string,
-  type: PropTypes.oneOf(["danger", "informative", "success", "warning"])
+  type: PropTypes.oneOf(["danger", "informative", "success", "warning"]),
+  theme: PropTypes.node.isRequired
 };
 
 BaseAlert.defaultProps = {
@@ -89,4 +89,4 @@ BaseAlert.defaultProps = {
 
 const Alert = styled(BaseAlert)(space);
 
-export default Alert;
+export default withTheme(Alert);

--- a/components/src/Button/QuietButton.js
+++ b/components/src/Button/QuietButton.js
@@ -1,11 +1,10 @@
 import styled from "styled-components";
 import Button from "./Button";
-import theme from "../theme";
 
-const QuietButton = styled(Button)({
-  color: theme.colors.blue,
+const QuietButton = styled(Button)(props => ({
+  color: props.theme.colors.blue,
   borderColor: "transparent",
   backgroundColor: "transparent"
-});
+}));
 
 export default QuietButton;

--- a/components/src/DropdownMenu/DropdownButton.js
+++ b/components/src/DropdownMenu/DropdownButton.js
@@ -1,7 +1,6 @@
 import styled from "styled-components";
 import PropTypes from "prop-types";
 import { themeGet } from "styled-system";
-import theme from "../theme";
 
 const DropdownButton = styled.button(props => ({
   display: "block",
@@ -11,11 +10,11 @@ const DropdownButton = styled.button(props => ({
   border: "none",
   textAlign: "left",
   backgroundColor: "transparent",
-  lineHeight: theme.lineHeights.base,
-  fontSize: theme.fontSizes.medium,
+  lineHeight: props.theme.lineHeights.base,
+  fontSize: props.theme.fontSizes.medium,
   transition: ".2s",
-  padding: `${theme.space.x1} ${theme.space.x2} ${theme.space.x1} 12px`,
-  borderLeft: `${theme.space.half} solid transparent`,
+  padding: `${props.theme.space.x1} ${props.theme.space.x2} ${props.theme.space.x1} 12px`,
+  borderLeft: `${props.theme.space.half} solid transparent`,
   "&:hover": {
     color: themeGet(`colors.${props.hoverColor}`, props.hoverColor)(props),
     backgroundColor: props.disabled
@@ -26,7 +25,7 @@ const DropdownButton = styled.button(props => ({
     outline: "none",
     color: themeGet(`colors.${props.hoverColor}`, props.hoverColor)(props),
     backgroundColor: themeGet(`colors.${props.bgHoverColor}`, props.bgHoverColor)(props),
-    borderLeft: `${theme.space.half}  solid ${theme.colors.blue}`
+    borderLeft: `${props.theme.space.half}  solid ${props.theme.colors.blue}`
   },
   "&:disabled": {
     opacity: ".5"
@@ -41,10 +40,10 @@ DropdownButton.propTypes = {
 };
 
 DropdownButton.defaultProps = {
-  color: theme.colors.darkBlue,
+  color: "darkBlue",
   disabled: false,
-  hoverColor: theme.colors.darkBlue,
-  bgHoverColor: theme.colors.lightGrey
+  hoverColor: "darkBlue",
+  bgHoverColor: "lightGrey"
 };
 
 export default DropdownButton;

--- a/components/src/DropdownMenu/DropdownItem.js
+++ b/components/src/DropdownMenu/DropdownItem.js
@@ -1,7 +1,6 @@
 import styled from "styled-components";
 import PropTypes from "prop-types";
 import { themeGet } from "styled-system";
-import theme from "../theme";
 
 const DropdownItem = styled.div(props => ({
   "*": {
@@ -12,10 +11,10 @@ const DropdownItem = styled.div(props => ({
     border: "none",
     textAlign: "left",
     backgroundColor: "transparent",
-    lineHeight: theme.lineHeights.base,
+    lineHeight: props.theme.lineHeights.base,
     transition: ".2s",
-    fontSize: `${theme.fontSizes.medium}`,
-    padding: `${theme.space.x1} ${theme.space.x2}`,
+    fontSize: props.theme.fontSizes.medium,
+    padding: `${props.theme.space.x1} ${props.theme.space.x2}`,
     "&:hover, &:focus": {
       outline: "none",
       color: themeGet(`colors.${props.hoverColor}`, props.hoverColor)(props),

--- a/components/src/DropdownMenu/DropdownLink.js
+++ b/components/src/DropdownMenu/DropdownLink.js
@@ -1,7 +1,6 @@
 import styled from "styled-components";
 import PropTypes from "prop-types";
 import { themeGet } from "styled-system";
-import theme from "../theme";
 
 const DropdownLink = styled.a(props => ({
   display: "block",
@@ -9,11 +8,11 @@ const DropdownLink = styled.a(props => ({
   color: themeGet(`colors.${props.color}`, props.color)(props),
   borderColor: "transparent",
   backgroundColor: "transparent",
-  lineHeight: theme.lineHeights.base,
-  fontSize: theme.fontSizes.medium,
+  lineHeight: props.theme.lineHeights.base,
+  fontSize: props.theme.fontSizes.medium,
   transition: ".2s",
-  padding: `${theme.space.x1} ${theme.space.x2} ${theme.space.x1} 12px`,
-  borderLeft: `${theme.space.half} solid transparent`,
+  padding: `${props.theme.space.x1} ${props.theme.space.x2} ${props.theme.space.x1} 12px`,
+  borderLeft: `${props.theme.space.half} solid transparent`,
   "&:hover": {
     color: themeGet(`colors.${props.hoverColor}`, props.hoverColor)(props),
     backgroundColor: themeGet(`colors.${props.bgHoverColor}`, props.bgHoverColor)(props)
@@ -22,7 +21,7 @@ const DropdownLink = styled.a(props => ({
     outline: "none",
     color: themeGet(`colors.${props.hoverColor}`, props.hoverColor)(props),
     backgroundColor: themeGet(`colors.${props.bgHoverColor}`, props.bgHoverColor)(props),
-    borderLeft: `${theme.space.half}  solid ${theme.colors.blue}`
+    borderLeft: `${props.theme.space.half}  solid ${props.theme.colors.blue}`
   },
   "&:disabled": {
     opacity: ".5"


### PR DESCRIPTION
This PR is not to be merged but includes an example of: 
* converting a styled component to use a theme passed as a prop (QuietButton)
* converting a non-styled component to use a theme using withTheme HOC (Alert)
* turning a component that could have been using a theme passed as a prop already into one (DropdownMenu)