### PR TITLE
[NDS-1134] Add id support to non styled components

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -87,7 +87,7 @@
   "dependencies": {
     "@nulogy/tokens": "^0.13.1",
     "polished": "3.0.0",
-    "react-modal": "^3.8.2",
+    "react-modal": "^3.10.1",
     "react-popper": "^1.3.3",
     "react-resize-detector": "^4.2.0",
     "react-select": "^3.0.4",

--- a/components/src/Checkbox/CheckboxGroup.js
+++ b/components/src/Checkbox/CheckboxGroup.js
@@ -33,10 +33,19 @@ const getCheckboxButtons = props => {
   return checkboxButtons;
 };
 
-const BaseCheckboxGroup = ({ className, errorMessage, errorList, labelText, helpText, requirementText, ...props }) => {
+const BaseCheckboxGroup = ({
+  className,
+  id,
+  errorMessage,
+  errorList,
+  labelText,
+  helpText,
+  requirementText,
+  ...props
+}) => {
   const otherProps = { ...props, errorMessage, errorList };
   return (
-    <Fieldset className={className} hasHelpText={!!helpText}>
+    <Fieldset className={className} id={id} hasHelpText={!!helpText}>
       <legend style={{ marginBottom: theme.space.x1 }}>
         <span style={labelTextStyles}>{labelText}</span>
         {requirementText && <RequirementText>{requirementText}</RequirementText>}
@@ -67,6 +76,7 @@ BaseCheckboxGroup.propTypes = {
   checkedValue: PropTypes.arrayOf(PropTypes.string),
   onChange: PropTypes.func,
   className: PropTypes.string,
+  id: PropTypes.string,
   helpText: PropTypes.string,
   requirementText: PropTypes.string
 };
@@ -78,6 +88,7 @@ BaseCheckboxGroup.defaultProps = {
   checkedValue: undefined,
   onChange: undefined,
   className: undefined,
+  id: undefined,
   helpText: null,
   requirementText: null
 };

--- a/components/src/DropdownMenu/DropdownMenu.js
+++ b/components/src/DropdownMenu/DropdownMenu.js
@@ -52,6 +52,7 @@ class StatelessDropdownMenu extends React.Component {
       modifiers,
       showArrow,
       className,
+      id,
       menuState: { isOpen, closeMenu, openMenu }
     } = this.props;
     const childrenFnc = typeof children === "function" ? children : () => children;
@@ -85,6 +86,7 @@ class StatelessDropdownMenu extends React.Component {
             {popperProps => (
               <DropdownMenuContainer
                 className={className}
+                id={id}
                 onMouseDown={e => {
                   e.preventDefault();
                   e.target.focus();
@@ -123,6 +125,7 @@ class StatelessDropdownMenu extends React.Component {
 StatelessDropdownMenu.propTypes = {
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
   className: PropTypes.string,
+  id: PropTypes.string,
   menuState: PropTypes.shape({
     isOpen: PropTypes.bool,
     openMenu: PropTypes.func,
@@ -153,6 +156,7 @@ StatelessDropdownMenu.propTypes = {
 StatelessDropdownMenu.defaultProps = {
   disabled: false,
   className: undefined,
+  id: undefined,
   trigger: () => <IconicButton icon="more" />,
   backgroundColor: undefined,
   showArrow: true,

--- a/components/src/Modal/Modal.js
+++ b/components/src/Modal/Modal.js
@@ -205,6 +205,7 @@ class Modal extends React.Component {
       portalClassName,
       overlayClassName,
       className,
+      id,
       maxWidth,
       appElement,
       ariaHideApp
@@ -221,6 +222,7 @@ class Modal extends React.Component {
         portalClassName={portalClassName}
         overlayClassName={overlayClassName}
         className={className}
+        id={id}
         aria={{
           labelledby: title ? "modal-title" : undefined,
           describedby: ariaDescribedBy
@@ -278,6 +280,7 @@ Modal.propTypes = {
   portalClassName: PropTypes.string,
   overlayClassName: PropTypes.string,
   className: PropTypes.string,
+  id: PropTypes.string,
   appElement: PropTypes.element,
   ariaHideApp: PropTypes.bool
 };
@@ -300,6 +303,7 @@ Modal.defaultProps = {
   portalClassName: undefined,
   overlayClassName: undefined,
   className: undefined,
+  id: undefined,
   appElement: undefined,
   ariaHideApp: true
 };

--- a/components/src/Radio/RadioGroup.js
+++ b/components/src/Radio/RadioGroup.js
@@ -33,10 +33,10 @@ const getRadioButtons = props => {
   return radioButtons;
 };
 
-const BaseRadioGroup = ({ className, errorMessage, errorList, labelText, helpText, requirementText, ...props }) => {
+const BaseRadioGroup = ({ className, id, errorMessage, errorList, labelText, helpText, requirementText, ...props }) => {
   const otherProps = { ...props, errorMessage, errorList };
   return (
-    <Fieldset className={className} hasHelpText={!!helpText}>
+    <Fieldset className={className} id={id} hasHelpText={!!helpText}>
       <legend style={{ marginBottom: theme.space.x1 }}>
         <span style={labelTextStyles}>{labelText}</span>
         {requirementText && <RequirementText>{requirementText}</RequirementText>}
@@ -67,6 +67,7 @@ BaseRadioGroup.propTypes = {
   checkedValue: PropTypes.string,
   onChange: PropTypes.func,
   className: PropTypes.string,
+  id: PropTypes.string,
   helpText: PropTypes.string,
   requirementText: PropTypes.string
 };
@@ -78,6 +79,7 @@ BaseRadioGroup.defaultProps = {
   checkedValue: undefined,
   onChange: undefined,
   className: undefined,
+  id: undefined,
   helpText: null,
   requirementText: null
 };

--- a/components/src/Validation/HeaderValidation.js
+++ b/components/src/Validation/HeaderValidation.js
@@ -4,8 +4,8 @@ import styled from "styled-components";
 import { Alert } from "../Alert";
 import mapErrorsToList from "./mapErrorsToList";
 
-const BaseHeaderValidation = ({ className, title, errorMessage, errorList, children, mb }) => (
-  <Alert mb={mb} className={className} title={title} type="danger">
+const BaseHeaderValidation = ({ className, id, title, errorMessage, errorList, children, mb }) => (
+  <Alert mb={mb} className={className} id={id} title={title} type="danger">
     {errorMessage}
     {mapErrorsToList(errorList)}
     {children}
@@ -16,6 +16,7 @@ const HeaderValidation = styled(BaseHeaderValidation)({});
 
 BaseHeaderValidation.propTypes = {
   className: PropTypes.string,
+  id: PropTypes.string,
   title: PropTypes.string.isRequired,
   errorMessage: PropTypes.string.isRequired,
   errorList: PropTypes.arrayOf(PropTypes.string),
@@ -25,6 +26,7 @@ BaseHeaderValidation.propTypes = {
 
 BaseHeaderValidation.defaultProps = {
   className: undefined,
+  id: undefined,
   errorList: null,
   children: null,
   mb: "x2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17401,10 +17401,10 @@ react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-modal@^3.8.2:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.8.2.tgz#c47397a8602beb7aae0059a3b404f20416241d03"
-  integrity sha512-wxNk94wy/DMh2LyJa8K+LyOQDhQfhKuBrZ4SxS091p75cpW+STfY+9GpAuvl6P6Yt2r/+wxYH8Z3G5Ww/L8Tiw==
+react-modal@^3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.10.1.tgz#ba37927871830c798f51404aa6bc71ff7a5e4c16"
+  integrity sha512-2DKIfdOc8+WY+SYJ/xf/WBwOYMmNAYAyGkYlc4e1TCs9rk1xY4QBz04hB3UHGcrLChh7ce77rHAe6VPNmuLYsQ==
   dependencies:
     exenv "^1.2.0"
     prop-types "^15.5.10"


### PR DESCRIPTION
Most of our components already supported IDs (they are automatically supported for styled-components and we manually added IDs to all our inputs), but a few of our components wouldn't allow IDs to be passed to them: 
* DropdownMenu
* HeaderValidation
* Modal
* RadioGroup
* CheckboxGroup 

This PR fixes that. 
