### PR TITLE
[NDS-1143] Support custom column widths

### DIFF
--- a/components-e2e/cypress/integration/components/Table.spec.js
+++ b/components-e2e/cypress/integration/components/Table.spec.js
@@ -47,4 +47,23 @@ describe("Table", () => {
       cy.get(headerCheckboxInputSelector).should("be.checked");
     });
   });
+
+  it("selects a row on click", () => {
+    cy.renderFromStorybook("table--with-preselected-rows");
+    cy.get("tbody input[type='checkbox']")
+      .first()
+      .click();
+    cy.get("tbody input[type='checkbox']")
+      .first()
+      .should("be.checked");
+  });
+
+  it("selects a row on click", () => {
+    cy.renderFromStorybook("table--with-preselected-rows");
+    cy.get("th input[type='checkbox']").click();
+    selectAllCheckbox().should("be.checked");
+    cy.get("tbody input[type='checkbox']").should("be.checked");
+    cy.get("th input[type='checkbox']").click();
+    selectAllCheckbox().should("not.be.checked");
+  });
 });

--- a/components-e2e/cypress/integration/components/Table.spec.js
+++ b/components-e2e/cypress/integration/components/Table.spec.js
@@ -47,23 +47,4 @@ describe("Table", () => {
       cy.get(headerCheckboxInputSelector).should("be.checked");
     });
   });
-
-  it("selects a row on click", () => {
-    cy.renderFromStorybook("table--with-preselected-rows");
-    cy.get("tbody input[type='checkbox']")
-      .first()
-      .click();
-    cy.get("tbody input[type='checkbox']")
-      .first()
-      .should("be.checked");
-  });
-
-  it("selects a row on click", () => {
-    cy.renderFromStorybook("table--with-preselected-rows");
-    cy.get("th input[type='checkbox']").click();
-    selectAllCheckbox().should("be.checked");
-    cy.get("tbody input[type='checkbox']").should("be.checked");
-    cy.get("th input[type='checkbox']").click();
-    selectAllCheckbox().should("not.be.checked");
-  });
 });

--- a/components-e2e/cypress/integration/components/Table.spec.js
+++ b/components-e2e/cypress/integration/components/Table.spec.js
@@ -46,5 +46,13 @@ describe("Table", () => {
         .click();
       cy.get(headerCheckboxInputSelector).should("be.checked");
     });
+    it("becomes selected if all rows are selected", () => {
+      cy.renderFromStorybook("table--with-preselected-rows");
+
+      cy.get("tbody input[type='checkbox']")
+        .first()
+        .click();
+      getSelectAllCheckbox().should("be.checked");
+    });
   });
 });

--- a/components/src/Table/BaseTable.js
+++ b/components/src/Table/BaseTable.js
@@ -25,7 +25,8 @@ BaseTable.propTypes = {
       dataKey: PropTypes.string.isRequired,
       cellFormatter: PropTypes.func,
       cellRenderer: PropTypes.func,
-      headerRenderer: PropTypes.func
+      headerRenderer: PropTypes.func,
+      width: PropTypes.string
     })
   ).isRequired,
   rows: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.bool])))

--- a/components/src/Table/Table.story.js
+++ b/components/src/Table/Table.story.js
@@ -35,6 +35,12 @@ const columnsWithAlignment = [
   { label: "Column 3", dataKey: "c3", align: "right" }
 ];
 
+const columnsWithWidths = [
+  { label: "Column 1", dataKey: "c1", width: "30%" },
+  { label: "Column 2", dataKey: "c2", width: "60%" },
+  { label: "Column 3", dataKey: "c3", width: "10%" }
+];
+
 const columnsWithFormatter = [
   { label: "Column 1", dataKey: "c1" },
   { label: "Column 2", dataKey: "c2" },
@@ -126,4 +132,5 @@ storiesOf("Table", module)
       keyField="c1"
       onRowSelectionChange={() => {}}
     />
-  ));
+  ))
+  .add("with custom column widths", () => <Table columns={columnsWithWidths} rows={rowData} />);

--- a/components/src/Table/TableBody.js
+++ b/components/src/Table/TableBody.js
@@ -11,7 +11,8 @@ const columnType = PropTypes.shape({
   dataKey: PropTypes.string.isRequired,
   cellFormatter: PropTypes.func,
   cellRenderer: PropTypes.func,
-  headerRenderer: PropTypes.func
+  headerRenderer: PropTypes.func,
+  width: PropTypes.string
 });
 
 const StyledNoRowsContainer = styled(Box)({
@@ -26,12 +27,13 @@ const StyledTextCell = styled.div(({ align }) => ({
   textAlign: align
 }));
 
-const StyledTd = styled.td({
+const StyledTd = styled.td(({ width }) => ({
+  width,
   paddingRight: theme.space.x2,
   "&:first-of-type": {
     paddingLeft: theme.space.x2
   }
-});
+}));
 
 const StyledTr = styled.tr({
   "&:hover": {
@@ -67,7 +69,9 @@ const renderAllRows = (rows, columns, keyField) =>
 const TableBodyRow = ({ row, columns }) => (
   <StyledTr>
     {columns.map(column => (
-      <StyledTd key={column.dataKey}>{renderCellContent(row, column)}</StyledTd>
+      <StyledTd key={column.dataKey} width={column.width}>
+        {renderCellContent(row, column)}
+      </StyledTd>
     ))}
   </StyledTr>
 );

--- a/docs/src/pages/components/table.js
+++ b/docs/src/pages/components/table.js
@@ -96,6 +96,12 @@ const columnsWithFormatter = [
   { label: "Column 3", dataKey: "c3", cellFormatter: dateToString }
 ];
 
+const columnsWithWidths = [
+  { label: "Column 1", dataKey: "c1", width: "30%" },
+  { label: "Column 2", dataKey: "c2", width: "60%" },
+  { label: "Column 3", dataKey: "c3", width: "10%" }
+];
+
 const rows = [
   { c1: "row 1 cell 1", c2: "r1c2", c3: "2019-09-21" },
   { c1: "r2c1", c2: "r2c2", c3: "2019-09-22" }
@@ -228,6 +234,24 @@ const rows = [{ c1: "row 1 cell 1", c2: "r1c2", c3: "2019-09-21" }, { c1: "r2c1"
 
 <Table hasSelectableRows columns={columns} rows={rows} keyField="c1" onRowSelectionChange={selectedRows => selectedRows}/>
 `}
+      </Highlight>
+    </DocSection>
+    <DocSection>
+      <SectionTitle>With custom column widths</SectionTitle>
+      <Text>
+        A width for a column can be set (as px or %) inside the column data.
+      </Text>
+      <Table columns={columnsWithWidths} rows={rows} />
+      <Highlight className="js">
+        {`const columnsWithWidths = [
+  { label: "Column 1", dataKey: "c1", width: "30%" },
+  { label: "Column 2", dataKey: "c2", width: "60%" },
+  { label: "Column 3", dataKey: "c3", width: "10%" }
+];
+
+const rows = [{ c1: "row 1 cell 1", c2: "r1c2", c3: "2019-09-21" }, { c1: "r2c1", c2: "r2c2", c3: "2019-09-22" }];
+
+<Table columns={columnsWithWidths} rows={rows} />`}
       </Highlight>
     </DocSection>
 


### PR DESCRIPTION
This PR adds support for passing in a width (in `px` or `%`) that gets applied to the column and behaves exactly as widths in standard HTML tables behave. 

This branch was based off #403 and will need to be rebased before merge after that story is complete. 