### PR TITLE
NDS-1157 Include only what is needed in our package

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -44,6 +44,9 @@
   },
   "main": "dist/main.js",
   "browser": "dist/main.browser.js",
+  "files": [
+    "/dist"
+  ],
   "peerDependencies": {
     "react": ">=16.3.2",
     "react-dom": ">=16.3.2"


### PR DESCRIPTION
We were shipping the entire design system folder when we should only be shipping our distribution files. 