### PR TITLE
NDS-1162 Fixes height issue with blank select option

### DIFF
--- a/components/src/Select/Select.story.js
+++ b/components/src/Select/Select.story.js
@@ -67,6 +67,12 @@ storiesOf("Select", module)
       labelText="Inventory status"
     />
   ))
+  .add("with a blank value", () => {
+    const optionsWithBlank = [{ value: null, label: "" }, ...options];
+    return (
+      <Select placeholder="Please select inventory status" options={optionsWithBlank} labelText="Inventory status" />
+    );
+  })
   .add("with an option selected", () => (
     <>
       <Select
@@ -85,6 +91,7 @@ storiesOf("Select", module)
       />
     </>
   ))
+
   .add("as a controlled component", () => (
     <SelectWithState placeholder="Please select inventory status" options={options} labelText="Inventory status" />
   ))

--- a/components/src/Select/customReactSelectStyles.js
+++ b/components/src/Select/customReactSelectStyles.js
@@ -30,6 +30,7 @@ const customStyles = error => {
       padding: subPx(theme.space.x1),
       fontWeight: state.isSelected ? theme.fontWeights.medium : theme.fontWeights.normal,
       background: state.isFocused ? theme.colors.lightBlue : null,
+      minHeight: theme.space.x4,
       "&:last-child": {
         borderBottomLeftRadius: theme.radii.medium,
         borderBottomRightRadius: theme.radii.medium


### PR DESCRIPTION
Set a min height on the options so a blank value is the same size as the other selects.

If they need to set the placeholder back when selecting a blank option, this should work as long as the selectedValue passed to the select is null.

<img width="416" alt="Screen Shot 2019-10-17 at 12 59 37 PM" src="https://user-images.githubusercontent.com/8175052/67041080-da7eb680-f0f2-11e9-93ed-ddb119157464.png">

