### PR TITLE
NDS-1160 Support links inside help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- [HelpText](https://storybook.nulogy.design/?path=/story/fieldlabel--with-helptext) can now accept a React node to be able to pass in links
 - Table
   - [**Breaking Change**] `cellFormatter`'s API has been updated
     - Before: `cellFormatter({rowData, dataKey})`

--- a/components/src/Checkbox/CheckboxGroup.js
+++ b/components/src/Checkbox/CheckboxGroup.js
@@ -77,7 +77,7 @@ BaseCheckboxGroup.propTypes = {
   onChange: PropTypes.func,
   className: PropTypes.string,
   id: PropTypes.string,
-  helpText: PropTypes.string,
+  helpText: PropTypes.node,
   requirementText: PropTypes.string
 };
 

--- a/components/src/FieldLabel/FieldLabel.js
+++ b/components/src/FieldLabel/FieldLabel.js
@@ -41,7 +41,7 @@ BaseFieldLabel.propTypes = {
   labelText: PropTypes.string.isRequired,
   children: PropTypes.node,
   requirementText: PropTypes.string,
-  helpText: PropTypes.string,
+  helpText: PropTypes.node,
   id: PropTypes.string,
   ...space.PropTypes
 };

--- a/components/src/FieldLabel/FieldLabel.story.js
+++ b/components/src/FieldLabel/FieldLabel.story.js
@@ -7,7 +7,7 @@ const CustomInput = props => <Input {...props} />;
 
 const helpTextWithLink = (
   <>
-    I am help text. I can be a string or a node that includes a <Link href="#">link</Link>.
+    I am help text. I can be a string or a node that includes a <Link href="http://nulogy.design">link</Link>.
   </>
 );
 

--- a/components/src/FieldLabel/FieldLabel.story.js
+++ b/components/src/FieldLabel/FieldLabel.story.js
@@ -1,14 +1,19 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import { FieldLabel, Input } from "../index";
+import { Link } from "../Link";
 
 const CustomInput = props => <Input {...props} />;
 
+const helpTextWithLink = (
+  <>
+    I am help text. I can be a string or a node that includes a <Link href="#">link</Link>.
+  </>
+);
+
 storiesOf("FieldLabel", module)
   .add("FieldLabel", () => <FieldLabel labelText="Default label" />)
-  .add("with HelpText", () => (
-    <FieldLabel labelText="Default label" helpText="I am help text. I can give more details on the input below!" />
-  ))
+  .add("with HelpText", () => <FieldLabel labelText="Default label" helpText={helpTextWithLink} />)
   .add("with RequirementText", () => <FieldLabel labelText="Default label" requirementText="(Required)" />)
   .add("with all additional text", () => (
     <FieldLabel

--- a/components/src/FieldLabel/HelpText.js
+++ b/components/src/FieldLabel/HelpText.js
@@ -1,11 +1,20 @@
 import React from "react";
 import PropTypes from "prop-types";
+import styled from "styled-components";
 import { Text } from "../Type";
+import { Link } from "../Link";
 import theme from "../theme";
 
-const HelpText = props => (
-  <Text fontSize={theme.fontSizes.small} lineHeight={theme.lineHeights.smallTextBase} {...props} />
-);
+const HelpTextContent = styled(Text)({
+  fontSize: theme.fontSizes.small,
+  lineHeight: theme.lineHeights.smallTextBase,
+
+  [`${Link}`]: {
+    fontSize: theme.fontSizes.small
+  }
+});
+
+const HelpText = props => <HelpTextContent {...props} />;
 
 HelpText.propTypes = {
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node])

--- a/components/src/Input/Input.js
+++ b/components/src/Input/Input.js
@@ -94,7 +94,7 @@ Input.propTypes = {
   errorList: PropTypes.arrayOf(PropTypes.string),
   required: PropTypes.bool,
   labelText: PropTypes.string,
-  helpText: PropTypes.string,
+  helpText: PropTypes.node,
   requirementText: PropTypes.string,
   ...space.PropTypes
 };

--- a/components/src/Radio/RadioGroup.js
+++ b/components/src/Radio/RadioGroup.js
@@ -68,7 +68,7 @@ BaseRadioGroup.propTypes = {
   onChange: PropTypes.func,
   className: PropTypes.string,
   id: PropTypes.string,
-  helpText: PropTypes.string,
+  helpText: PropTypes.node,
   requirementText: PropTypes.string
 };
 

--- a/components/src/Select/Select.js
+++ b/components/src/Select/Select.js
@@ -82,7 +82,7 @@ ReactSelect.propTypes = {
   errorMessage: PropTypes.string,
   errorList: PropTypes.arrayOf(PropTypes.string),
   labelText: PropTypes.string,
-  helpText: PropTypes.string,
+  helpText: PropTypes.node,
   noOptionsMessage: PropTypes.func,
   requirementText: PropTypes.string,
   id: PropTypes.string,

--- a/components/src/Textarea/Textarea.js
+++ b/components/src/Textarea/Textarea.js
@@ -97,7 +97,7 @@ Textarea.propTypes = {
   errorList: PropTypes.arrayOf(PropTypes.string),
   required: PropTypes.bool,
   labelText: PropTypes.string,
-  helpText: PropTypes.string,
+  helpText: PropTypes.node,
   requirementText: PropTypes.string,
   rows: PropTypes.number,
   ...space.PropTypes

--- a/components/src/Toggle/Toggle.js
+++ b/components/src/Toggle/Toggle.js
@@ -33,7 +33,7 @@ MaybeToggleTitle.propTypes = {
   labelText: PropTypes.string,
   children: PropTypes.node,
   requirementText: PropTypes.string,
-  helpText: PropTypes.string
+  helpText: PropTypes.node
 };
 
 MaybeToggleTitle.defaultProps = {
@@ -131,7 +131,7 @@ BaseToggle.propTypes = {
   value: PropTypes.string,
   className: PropTypes.string,
   required: PropTypes.bool,
-  helpText: PropTypes.string,
+  helpText: PropTypes.node,
   labelText: PropTypes.string,
   requirementText: PropTypes.string
 };

--- a/docs/src/shared/inputProps.js
+++ b/docs/src/shared/inputProps.js
@@ -43,7 +43,7 @@ const inputProps = [
   },
   {
     name: "helpText",
-    type: "String",
+    type: "Node",
     defaultValue: "null",
     description:
       "Placed below the label to provide assistance on how to fill out a field or the expected format. It can also provide an explanation of why the information is needed and how it will be used."


### PR DESCRIPTION
This PR turns the `helpText` prop into a React node instead of a string so that content with `Links` can be passed, as requested by CPI. 
