### PR TITLE
Support array value props for multiselect

### DIFF
--- a/components/src/Select/Select.js
+++ b/components/src/Select/Select.js
@@ -6,10 +6,18 @@ import { MaybeFieldLabel } from "../FieldLabel";
 import { InlineValidation } from "../Validation";
 import customStyles from "./customReactSelectStyles";
 
-const getValue = (opts, val) => {
-  if (val === "") return val;
+const getOption = (options, value) => {
+  if (value == null || value === "") return value;
 
-  return opts.find(o => o.value === val);
+  return options.find(o => o.value === value);
+};
+
+const getReactSelectValue = (options, input) => {
+  if (Array.isArray(input)) {
+    return input.map(i => getOption(options, i));
+  }
+
+  return getOption(options, input);
 };
 
 const extractValue = (options, isMulti) => {
@@ -64,8 +72,8 @@ const ReactSelect = ({
         maxMenuHeight={maxHeight}
         inputId={id}
         onChange={onChange && (option => onChange(extractValue(option, multiselect)))}
-        defaultValue={getValue(options, defaultValue)}
-        value={getValue(options, value)}
+        defaultValue={getReactSelectValue(options, defaultValue)}
+        value={getReactSelectValue(options, value)}
         name={name}
         isMulti={multiselect}
       />
@@ -93,8 +101,8 @@ ReactSelect.propTypes = {
   onChange: PropTypes.func,
   placeholder: PropTypes.string,
   required: PropTypes.bool,
-  value: PropTypes.string,
-  defaultValue: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
   className: PropTypes.string,
   classNamePrefix: PropTypes.string
 };

--- a/components/src/Select/Select.spec.js
+++ b/components/src/Select/Select.spec.js
@@ -51,6 +51,19 @@ describe("multi select", () => {
 
     expect(callback).toHaveBeenCalledWith(["three", "two"]);
   });
+
+  it("selects the specified default values", () => {
+    const options = [
+      { label: "One", value: "one" },
+      { label: "Two", value: "two" },
+      { label: "Three", value: "three" }
+    ];
+
+    const { container } = render(<Select options={options} multiselect defaultValue={["one", "two"]} />);
+
+    expect(container).toHaveTextContent("One");
+    expect(container).toHaveTextContent("Two");
+  });
 });
 
 function openDropdown(container) {


### PR DESCRIPTION
This PR was created in coordination with @Fitzsimmons 

The props `defaultValue` and `value` in the `<Select>` component currently only support single elements, as the internal `getValue()` function would only find one option object matching the value before providing that option to the React-Select component. This means that being able pre-populate this component as a multi-select with > 1 value (either as a controlled component with `value` or an uncontrolled component with `defaultValue`) was not supported.

This PR addresses that issue by adding support to these props to optionally be an array. This PR also renames some variables and functions to make the code more clear.

## TODO

* [ ] I would like to add documentation for these new props. The problem is that `defaultValue` and `value` are documented in `docs/src/shared/inputProps.js`, so making a change for just `<Select>` would incorrectly affect all other NDS components that use these props. What is the correct way to document this?
* [ ] Does a storybook example for multiselect values need to be added?
* [ ] Does such an example also need to be added to the documentation page?