### PR TITLE
NDS-1161 client side pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Added [Pagination](http://nulogy.design/components/pagination) component
+- Added (http://nulogy.design/components/table) a pagination feature to the table
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Added [Pagination](http://nulogy.design/components/pagination) component
-- Added (http://nulogy.design/components/table) a pagination feature to the table
+- Added pagination feature to [table](http://nulogy.design/components/table)
 
 ### Changed
 

--- a/components-e2e/cypress/integration/components/Table.spec.js
+++ b/components-e2e/cypress/integration/components/Table.spec.js
@@ -2,49 +2,165 @@ describe("Table", () => {
   const headerCheckboxSelector = "th div[class*='Checkbox__VisualCheckbox']";
   const headerCheckboxInputSelector = "th input[type='checkbox']";
   const rowCheckboxSelector = "tbody div[class*='Checkbox__VisualCheckbox']";
-  const rowCheckboxInputSelector = "th input[type='checkbox']";
-  it("toggles the value of the header checkbox on click", () => {
-    cy.renderFromStorybook("table--with-preselected-rows");
+  const rowCheckboxInputSelector = "tbody input[type='checkbox']";
 
-    cy.get(headerCheckboxSelector).click();
-    cy.get(headerCheckboxInputSelector).should("be.checked");
-  });
+  const paginationButtonSelector =
+    "button[class*='Pagination__PaginationButton']";
+  const selectAll = () => cy.get(headerCheckboxSelector);
+  const selectAllInput = () => cy.get(headerCheckboxInputSelector);
+  const rowCheckboxes = () => cy.get(rowCheckboxSelector);
+  const rowCheckboxesInput = () => cy.get(rowCheckboxInputSelector);
+  const paginationButtons = () => cy.get(paginationButtonSelector);
 
-  it("selects a row on click", () => {
-    cy.renderFromStorybook("table--with-preselected-rows");
-
-    cy.get(rowCheckboxSelector)
-      .first()
-      .click();
-    cy.get(rowCheckboxInputSelector)
-      .first()
-      .should("be.checked");
-  });
-
-  describe("Select All Checkbox", () => {
-    it("selects all rows when there are unselected rows", () => {
+  describe("table--with-preselected-rows", () => {
+    it("toggles the value of the header checkbox on click", () => {
       cy.renderFromStorybook("table--with-preselected-rows");
 
-      cy.get(headerCheckboxSelector).click();
-      cy.get(headerCheckboxInputSelector).should("be.checked");
-      cy.get(rowCheckboxInputSelector).should("be.checked");
+      selectAll().click();
+      selectAllInput().should("be.checked");
     });
 
-    it("deselect all rows when all rows are selected", () => {
+    it("selects a row on click", () => {
       cy.renderFromStorybook("table--with-preselected-rows");
 
-      cy.get(headerCheckboxSelector)
-        .click()
-        .click();
-      cy.get(headerCheckboxInputSelector).should("not.be.checked");
-    });
-    it("becomes selected if all rows are selected", () => {
-      cy.renderFromStorybook("table--with-preselected-rows");
-
-      cy.get(rowCheckboxSelector)
+      rowCheckboxes()
         .first()
         .click();
-      cy.get(headerCheckboxInputSelector).should("be.checked");
+
+      rowCheckboxesInput()
+        .first()
+        .should("be.checked");
+    });
+
+    describe("Select All Checkbox", () => {
+      it("selects all rows when there are unselected rows", () => {
+        cy.renderFromStorybook("table--with-preselected-rows");
+
+        selectAll().click();
+
+        selectAllInput().should("be.checked");
+        rowCheckboxesInput().should("be.checked");
+      });
+
+      it("deselect all rows when all rows are selected", () => {
+        cy.renderFromStorybook("table--with-preselected-rows");
+
+        selectAll()
+          .click()
+          .click();
+
+        selectAllInput().should("not.be.checked");
+      });
+      it("becomes selected if all rows are selected", () => {
+        cy.renderFromStorybook("table--with-preselected-rows");
+
+        rowCheckboxes()
+          .first()
+          .click();
+
+        selectAllInput().should("be.checked");
+      });
+      it("becomes unselected if not all rows are selected", () => {
+        cy.renderFromStorybook("table--with-preselected-rows");
+
+        cy.renderFromStorybook("table--with-preselected-rows");
+
+        selectAll().click();
+
+        selectAllInput().should("be.checked");
+        rowCheckboxesInput().should("be.checked");
+
+        rowCheckboxes()
+          .first()
+          .click();
+
+        rowCheckboxesInput()
+          .first()
+          .should("not.be.checked");
+        rowCheckboxesInput()
+          .last()
+          .should("be.checked");
+        selectAllInput().should("not.be.checked");
+      });
+    });
+  });
+  describe("table--with-pagination", () => {
+    it("navigates to next page when next button is clicked", () => {
+      cy.renderFromStorybook("table--with-pagination");
+
+      paginationButtons()
+        .last()
+        .click();
+
+      cy.get("tbody").should("contain", "some data 4");
+    });
+    it("navigates to previous page when previous button is clicked", () => {
+      cy.renderFromStorybook("table--with-pagination");
+
+      paginationButtons()
+        .last()
+        .click();
+      cy.get("tbody").should("contain", "some data 4");
+      paginationButtons()
+        .first()
+        .click();
+
+      cy.get("tbody").should("contain", "some data 0");
+      paginationButtons().should("be.disabled");
+    });
+    it("navigates to specific page when a page button is clicked", () => {
+      cy.renderFromStorybook("table--with-pagination");
+
+      paginationButtons()
+        .eq(5)
+        .click();
+
+      cy.get("tbody").should("contain", "some data 1");
+      paginationButtons()
+        .eq(5)
+        .should("be.disabled");
+    });
+    it("disables next button when on last page", () => {
+      cy.renderFromStorybook("table--with-pagination");
+
+      paginationButtons()
+        .eq(-2)
+        .click();
+
+      cy.get("tbody").should("contain", "some data 20");
+      paginationButtons()
+        .eq(-2)
+        .should("be.disabled");
+      paginationButtons()
+        .last()
+        .should("be.disabled");
+    });
+  });
+  describe("table--with-pagination-and-selectable-rows", () => {
+    it("saves selections on between pages", () => {
+      cy.renderFromStorybook("table--with-pagination-and-selectable-rows");
+
+      selectAll().click();
+
+      selectAllInput().should("be.checked");
+      rowCheckboxesInput().should("be.checked");
+
+      paginationButtons()
+        .last()
+        .click();
+      selectAll().click();
+      selectAll().click();
+
+      cy.get("tbody").should("contain", "some data 5");
+      selectAllInput().should("not.be.checked");
+      rowCheckboxesInput().should("not.be.checked");
+
+      paginationButtons()
+        .first()
+        .click();
+
+      selectAllInput().should("be.checked");
+      rowCheckboxesInput().should("be.checked");
     });
   });
 });

--- a/components/src/Pagination/Pagination.js
+++ b/components/src/Pagination/Pagination.js
@@ -80,32 +80,30 @@ const SEPERATOR = "...";
 
 const getPageItemstoDisplay = (totalPages, currentPage) => {
   const pages = Array.from({ length: totalPages }, (v, k) => k + 1);
-  if (totalPages <= 5) return pages;
-  if (currentPage === 1) return [...pages.slice(currentPage - 1, 2), SEPERATOR, totalPages];
-  if (currentPage === totalPages) return [1, SEPERATOR, ...pages.slice(totalPages - 2, totalPages)];
-  if (currentPage === 2) return [...pages.slice(currentPage - 2, 3), SEPERATOR, totalPages];
-  if (currentPage === totalPages - 1) return [1, SEPERATOR, ...pages.slice(totalPages - 3, totalPages)];
-  else {
-    const currentPageWithNeighbours = pages.slice(currentPage - 2, currentPage + 1);
-    if (currentPageWithNeighbours[0] === 2) return [1, ...currentPageWithNeighbours, SEPERATOR, totalPages];
-    else if (currentPageWithNeighbours[currentPageWithNeighbours.length - 1] === totalPages - 1)
-      return [1, SEPERATOR, ...currentPageWithNeighbours, totalPages];
-    return [1, SEPERATOR, ...currentPageWithNeighbours, SEPERATOR, totalPages];
+  const MAX_PAGES_TO_SHOW = 6;
+  if (totalPages <= MAX_PAGES_TO_SHOW) return pages;
+  if (currentPage <= MAX_PAGES_TO_SHOW - 1) {
+    return [...pages.slice(0, 5), SEPERATOR, totalPages];
   }
+  if (currentPage > totalPages - 5) {
+    return [1, SEPERATOR, ...pages.slice(totalPages - 5)];
+  }
+  return [1, SEPERATOR, ...pages.slice(currentPage - 2, currentPage + 2), SEPERATOR, totalPages];
 };
 
 const Pagination = props => {
   const { currentPage, totalPages, onNext, onPrevious, onSelectPage } = props;
 
   return (
-    <Flex as="nav" aria-label="Pagination navigation">
+    <Flex as="nav" aria-label="Pagination navigation" justifyContent="flex-end">
       <PreviousButton disabled={currentPage === 1} onClick={onPrevious} />
-      {getPageItemstoDisplay(totalPages, currentPage).map(page => {
+      {getPageItemstoDisplay(totalPages, currentPage).map((page, index) => {
         const isCurrentPage = currentPage === page;
 
         if (page === SEPERATOR)
           return (
-            <Text py="x1" mr="x2" fontSize="small" lineHeight="smallTextBase">
+            // eslint-disable-next-line react/no-array-index-key
+            <Text key={`sep${index}`} py="x1" mr="x2" fontSize="small" lineHeight="smallTextBase">
               {SEPERATOR}
             </Text>
           );
@@ -117,7 +115,7 @@ const Pagination = props => {
               disabled={isCurrentPage}
               aria-label={isCurrentPage ? null : `Go to page ${page}`}
               key={page}
-              onClick={onSelectPage}
+              onClick={() => onSelectPage(page)}
             >
               {page}
             </PageNumber>

--- a/components/src/Pagination/Pagination.js
+++ b/components/src/Pagination/Pagination.js
@@ -92,10 +92,10 @@ export const getPageItemstoDisplay = (totalPages, currentPage) => {
 };
 
 const Pagination = props => {
-  const { currentPage, totalPages, onNext, onPrevious, onSelectPage } = props;
+  const { currentPage, totalPages, onNext, onPrevious, onSelectPage, ...restProps } = props;
 
   return (
-    <Flex as="nav" aria-label="Pagination navigation" justifyContent="flex-end">
+    <Flex as="nav" aria-label="Pagination navigation" justifyContent="flex-end" {...restProps}>
       <PreviousButton disabled={currentPage === 1} onClick={onPrevious} />
       {getPageItemstoDisplay(totalPages, currentPage).map((page, index) => {
         const isCurrentPage = currentPage === page;

--- a/components/src/Pagination/Pagination.js
+++ b/components/src/Pagination/Pagination.js
@@ -78,7 +78,7 @@ const PageNumber = styled(PaginationButton)(props => ({
 
 const SEPERATOR = "...";
 
-const getPageItemstoDisplay = (totalPages, currentPage) => {
+export const getPageItemstoDisplay = (totalPages, currentPage) => {
   const pages = Array.from({ length: totalPages }, (v, k) => k + 1);
   const MAX_PAGES_TO_SHOW = 6;
   if (totalPages <= MAX_PAGES_TO_SHOW) return pages;

--- a/components/src/Pagination/Pagination.spec.js
+++ b/components/src/Pagination/Pagination.spec.js
@@ -1,0 +1,96 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+import { Pagination } from ".";
+
+describe("Pagination", () => {
+  describe("callbacks", () => {
+    const onSelectPageCallback = jest.fn();
+    const onNextCallback = jest.fn();
+    const onPreviousCallback = jest.fn();
+
+    it("onSelectPage: returns current page when a page is selected", () => {
+      const { container } = render(
+        <Pagination
+          currentPage={1}
+          totalPages={5}
+          onNext={onNextCallback}
+          onPrevious={onPreviousCallback}
+          onSelectPage={onSelectPageCallback}
+        />
+      );
+      const clickPage = pageNum => {
+        fireEvent.click(container.querySelectorAll("button")[pageNum]);
+      };
+      clickPage(2);
+      expect(onSelectPageCallback).toHaveBeenCalledWith(2);
+      clickPage(3);
+      expect(onSelectPageCallback).toHaveBeenCalledWith(3);
+    });
+    it("onPrevious: prev button is disabled when current page is 1", () => {
+      const { container } = render(
+        <Pagination
+          currentPage={1}
+          totalPages={5}
+          onNext={onNextCallback}
+          onPrevious={onPreviousCallback}
+          onSelectPage={onSelectPageCallback}
+        />
+      );
+      const clickPrevious = () => {
+        fireEvent.click(container.querySelectorAll("button")[0]);
+      };
+      clickPrevious();
+      expect(onPreviousCallback).not.toHaveBeenCalled();
+    });
+    it("onPrevious: calls previous page handler when previous button is clicked", () => {
+      const { container } = render(
+        <Pagination
+          currentPage={2}
+          totalPages={5}
+          onNext={onNextCallback}
+          onPrevious={onPreviousCallback}
+          onSelectPage={onSelectPageCallback}
+        />
+      );
+      const clickPrevious = () => {
+        fireEvent.click(container.querySelectorAll("button")[0]);
+      };
+      clickPrevious();
+      expect(onPreviousCallback).toHaveBeenCalled();
+    });
+    it("onNext: calls next page handler when next button is clicked", () => {
+      const { container } = render(
+        <Pagination
+          currentPage={1}
+          totalPages={5}
+          onNext={onNextCallback}
+          onPrevious={onPreviousCallback}
+          onSelectPage={onSelectPageCallback}
+        />
+      );
+      const paginationButtons = container.querySelectorAll("button");
+      const clickNext = () => {
+        fireEvent.click(paginationButtons[paginationButtons.length - 1]);
+      };
+      clickNext();
+      expect(onNextCallback).toHaveBeenCalled();
+    });
+    // it("onNext: calls next page handler when next button is clicked", () => {
+    //   const { container } = render(
+    //     <Pagination
+    //       currentPage={10}
+    //       totalPages={10}
+    //       onNext={onNextCallback}
+    //       onPrevious={onPreviousCallback}
+    //       onSelectPage={onSelectPageCallback}
+    //     />
+    //   );
+    //   const paginationButtons = container.querySelectorAll("button");
+    //   const clickNext = () => {
+    //     fireEvent.click(paginationButtons[7]);
+    //   };
+    //   clickNext();
+    //   expect(onNextCallback).not.toHaveBeenCalled();
+    // });
+  });
+});

--- a/components/src/Pagination/Pagination.spec.js
+++ b/components/src/Pagination/Pagination.spec.js
@@ -1,8 +1,30 @@
 import React from "react";
 import { render, fireEvent } from "@testing-library/react";
 import { Pagination } from ".";
+import { getPageItemstoDisplay } from "./Pagination";
 
 describe("Pagination", () => {
+  describe("truncation", () => {
+    it("it returns an array of page numbers without truncation when there are less than 6 pages", () => {
+      expect(getPageItemstoDisplay(6, 2)).toEqual([1, 2, 3, 4, 5, 6]);
+      expect(getPageItemstoDisplay(1, 1)).toEqual([1]);
+      expect(getPageItemstoDisplay(5, 1)).toEqual([1, 2, 3, 4, 5]);
+    });
+    it("it returns an array of page numbers with truncation at the beginning when current page is 5 pages from the end", () => {
+      expect(getPageItemstoDisplay(12, 10)).toEqual([1, "...", 8, 9, 10, 11, 12]);
+      expect(getPageItemstoDisplay(20, 20)).toEqual([1, "...", 16, 17, 18, 19, 20]);
+      expect(getPageItemstoDisplay(12, 8)).toEqual([1, "...", 8, 9, 10, 11, 12]);
+    });
+    it("it returns an array of page numbers with truncation at the end when current page is 5 pages from the beginning", () => {
+      expect(getPageItemstoDisplay(15, 1)).toEqual([1, 2, 3, 4, 5, "...", 15]);
+      expect(getPageItemstoDisplay(7, 5)).toEqual([1, 2, 3, 4, 5, "...", 7]);
+      expect(getPageItemstoDisplay(8, 2)).toEqual([1, 2, 3, 4, 5, "...", 8]);
+    });
+    it("it returns an array of page numbers with truncation at the both sides is in the middle", () => {
+      expect(getPageItemstoDisplay(15, 6)).toEqual([1, "...", 5, 6, 7, 8, "...", 15]);
+      expect(getPageItemstoDisplay(15, 10)).toEqual([1, "...", 9, 10, 11, 12, "...", 15]);
+    });
+  });
   describe("callbacks", () => {
     const onSelectPageCallback = jest.fn();
     const onNextCallback = jest.fn();
@@ -75,22 +97,5 @@ describe("Pagination", () => {
       clickNext();
       expect(onNextCallback).toHaveBeenCalled();
     });
-    // it("onNext: calls next page handler when next button is clicked", () => {
-    //   const { container } = render(
-    //     <Pagination
-    //       currentPage={10}
-    //       totalPages={10}
-    //       onNext={onNextCallback}
-    //       onPrevious={onPreviousCallback}
-    //       onSelectPage={onSelectPageCallback}
-    //     />
-    //   );
-    //   const paginationButtons = container.querySelectorAll("button");
-    //   const clickNext = () => {
-    //     fireEvent.click(paginationButtons[7]);
-    //   };
-    //   clickNext();
-    //   expect(onNextCallback).not.toHaveBeenCalled();
-    // });
   });
 });

--- a/components/src/StoriesForTests/Table.story.js
+++ b/components/src/StoriesForTests/Table.story.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import { Table } from "..";
+import { getMockRows, mockColumns } from "../Table/Table.mock-utils";
 
 const columns = [
   { label: "Column 1", dataKey: "c1" },
@@ -16,6 +17,18 @@ const rowData = [
   { c1: "r2c1", c2: "r2c2", c3: "2019-09-22", id: "r2" }
 ];
 
-storiesOf("StoriesForTests/Table", module).add("with preselected rows", () => (
-  <Table columns={columns} rows={rowData} hasSelectableRows selectedRows={["r2c1"]} keyField="c1" />
-));
+storiesOf("StoriesForTests/Table", module)
+  .add("with preselected rows", () => (
+    <Table columns={columns} rows={rowData} hasSelectableRows selectedRows={["r2c1"]} keyField="c1" />
+  ))
+  .add("with pagination", () => <Table columns={mockColumns} rows={getMockRows(23)} rowsPerPage={4} keyField="c1" />)
+  .add("with pagination and selectable rows", () => (
+    <Table
+      columns={mockColumns}
+      rows={getMockRows(56)}
+      rowsPerPage={5}
+      hasSelectableRows
+      selectedRows={["r2c1"]}
+      keyField="c1"
+    />
+  ));

--- a/components/src/Table/StatefulTable.js
+++ b/components/src/Table/StatefulTable.js
@@ -2,71 +2,171 @@ import React from "react";
 import PropTypes from "prop-types";
 import withSelectableColumn from "./withSelectableColumn";
 import BaseTable from "./BaseTable";
+import { Pagination } from "../Pagination";
 
 const getAllRowKeys = (rows, keyField) => rows.map(row => row[keyField]);
+
+const paginateRows = (rows, rowsPerPage) =>
+  rowsPerPage
+    ? rows.reduce((acc, item, i) => (i % rowsPerPage ? acc : [...acc, rows.slice(i, i + rowsPerPage)]), [])
+    : [rows];
 
 class StatefulTable extends React.Component {
   constructor(props) {
     super(props);
-    const { selectedRows } = this.props;
+    const { selectedRows, rowsPerPage, rows } = this.props;
     this.state = {
       selectedRows,
-      isHeaderSelected: false
+      isHeaderSelected: false,
+      currentPage: 1,
+      paginatedRows: paginateRows(rows, rowsPerPage)
     };
   }
 
   onRowSelectionChangeHandler = () => {
     const { onRowSelectionChange } = this.props;
-    const { selectedRows } = this.state;
+    const { selectedRows, paginatedRows, currentPage } = this.state;
     if (onRowSelectionChange) {
-      onRowSelectionChange(selectedRows);
+      onRowSelectionChange(this.selectedRowsOnPage(selectedRows, paginatedRows, currentPage));
     }
   };
 
   onSelectRow = row => {
-    const { selectedRows } = this.state;
-    const { keyField, rows } = this.props;
-    const newSelectedRows = !row.selected
-      ? [...selectedRows, row[keyField]]
-      : selectedRows.filter(rowKey => rowKey !== row[keyField]);
+    const { paginatedRows, currentPage } = this.state;
+    const { keyField } = this.props;
+    const currentRowKey = row[keyField];
+    const newRowSelections = !row.selected
+      ? this.addRowToSelection(currentRowKey)
+      : this.removeRowFromSelection(currentRowKey);
     this.setState(
       {
-        selectedRows: newSelectedRows,
-        isHeaderSelected: newSelectedRows.length === rows.length
+        selectedRows: newRowSelections,
+        isHeaderSelected: this.allRowsSelectedOnPage(newRowSelections, paginatedRows, currentPage)
       },
       this.onRowSelectionChangeHandler
     );
   };
 
   onSelectHeader = () => {
-    const { isHeaderSelected, selectedRows } = this.state;
-    const { rows, keyField } = this.props;
+    const { isHeaderSelected, paginatedRows, currentPage } = this.state;
+    const { keyField } = this.props;
+    const currentRowKeys = getAllRowKeys(this.getRowsOnPage(paginatedRows, currentPage), keyField);
     this.setState(
       {
         isHeaderSelected: !isHeaderSelected,
-        selectedRows: selectedRows.length < rows.length ? getAllRowKeys(rows, keyField) : []
+        selectedRows: isHeaderSelected
+          ? this.removeRowsFromSelection(currentRowKeys)
+          : this.addRowsToSelection(currentRowKeys)
       },
       this.onRowSelectionChangeHandler
     );
   };
 
+  removeRowFromSelection = rowKeyToRemove => {
+    const { selectedRows } = this.state;
+    return selectedRows.filter(rowKey => rowKey !== rowKeyToRemove);
+  };
+
+  addRowToSelection = rowKeyToAdd => {
+    const { selectedRows } = this.state;
+    return [...selectedRows, rowKeyToAdd];
+  };
+
+  addRowsToSelection = rowsKeysToAdd => {
+    const { selectedRows } = this.state;
+    return [...selectedRows, ...rowsKeysToAdd];
+  };
+
+  removeRowsFromSelection = rowKeysToRemove => {
+    const { selectedRows } = this.state;
+    return selectedRows.filter(row => !rowKeysToRemove.includes(row));
+  };
+
+  getRowsOnPage = (rows, pageNumber) => {
+    return rows[pageNumber - 1];
+  };
+
+  goToPage = pageNumber => {
+    const { selectedRows, paginatedRows } = this.state;
+    this.setState(
+      {
+        currentPage: pageNumber,
+        isHeaderSelected: this.allRowsSelectedOnPage(selectedRows, paginatedRows, pageNumber)
+      },
+      this.onPageSelectionChangeHandler
+    );
+  };
+
+  selectedRowsOnPage = (selectedRows, paginatedRows, pageNumber) => {
+    const currentRows = this.getRowsOnPage(paginatedRows, pageNumber);
+    const { keyField } = this.props;
+    const allRowKeysOnPage = getAllRowKeys(currentRows, keyField);
+    return selectedRows.filter(rowKey => allRowKeysOnPage.includes(rowKey));
+  };
+
+  allRowsSelectedOnPage = (selectedRows, paginatedRows, pageNumber) => {
+    // TODO: needs degugging, not working when returning to a page
+    const { keyField } = this.props;
+    const currentRows = this.getRowsOnPage(paginatedRows, pageNumber);
+    const allRowKeysOnPage = getAllRowKeys(currentRows, keyField);
+    return allRowKeysOnPage.length === this.selectedRowsOnPage(selectedRows, paginatedRows, pageNumber).length;
+  };
+
+  goToPrevPage = () => {
+    const { currentPage } = this.state;
+    this.goToPage(currentPage - 1);
+  };
+
+  goToNextPage = () => {
+    const { currentPage } = this.state;
+    this.goToPage(currentPage + 1);
+  };
+
+  onPageSelectionChangeHandler = () => {
+    const { onPageChange } = this.props;
+    const { currentPage } = this.state;
+    if (onPageChange) {
+      onPageChange(currentPage);
+    }
+  };
+
   render() {
-    const { selectedRows, isHeaderSelected } = this.state;
+    const { selectedRows, isHeaderSelected, paginatedRows, currentPage } = this.state;
+    const { rowsPerPage, hasSelectableRows } = this.props;
     const props = {
       ...this.props,
-      onSelectRow: this.onSelectRow,
-      onSelectHeader: this.onSelectHeader,
-      selectedRows,
-      isHeaderSelected
+      rows: this.getRowsOnPage(paginatedRows, currentPage),
+      ...(hasSelectableRows && {
+        onSelectRow: this.onSelectRow,
+        onSelectHeader: this.onSelectHeader,
+        selectedRows: this.selectedRowsOnPage(selectedRows, paginatedRows, currentPage),
+        isHeaderSelected
+      })
     };
-    return withSelectableColumn(BaseTable)(props);
+    return (
+      <>
+        {hasSelectableRows ? withSelectableColumn(BaseTable)(props) : <BaseTable {...props} />}
+
+        {rowsPerPage && (
+          <Pagination
+            currentPage={currentPage}
+            totalPages={paginatedRows.length}
+            onSelectPage={this.goToPage}
+            onNext={this.goToNextPage}
+            onPrevious={this.goToPrevPage}
+          />
+        )}
+      </>
+    );
   }
 }
 
 StatefulTable.propTypes = {
   ...BaseTable.propTypes,
   selectedRows: PropTypes.arrayOf(PropTypes.string),
-  onRowSelectionChange: PropTypes.func
+  onRowSelectionChange: PropTypes.func,
+  rowsPerPage: PropTypes.number,
+  onPageChange: PropTypes.func
 };
 
 StatefulTable.defaultProps = {

--- a/components/src/Table/StatefulTable.js
+++ b/components/src/Table/StatefulTable.js
@@ -152,6 +152,7 @@ class StatefulTable extends React.Component {
 
         {rowsPerPage && (
           <Pagination
+            pt="x2"
             currentPage={currentPage}
             totalPages={paginatedRows.length}
             onSelectPage={this.goToPage}

--- a/components/src/Table/Table.js
+++ b/components/src/Table/Table.js
@@ -4,8 +4,8 @@ import StatefulTable from "./StatefulTable";
 import BaseTable from "./BaseTable";
 
 const Table = props => {
-  const { hasSelectableRows } = props;
-  return hasSelectableRows ? <StatefulTable {...props} /> : <BaseTable {...props} />;
+  const { hasSelectableRows, rowsPerPage } = props;
+  return hasSelectableRows || rowsPerPage ? <StatefulTable {...props} /> : <BaseTable {...props} />;
 };
 
 Table.propTypes = {

--- a/components/src/Table/Table.mock-utils.js
+++ b/components/src/Table/Table.mock-utils.js
@@ -1,0 +1,58 @@
+export const getMockRows = numRows => {
+  const rows = [];
+
+  for (let i = 0; i < numRows; i += 1) {
+    const row = {
+      id: i,
+      c1: `some data ${i}`,
+      c2: "some data",
+      c3: "some data",
+      c4: "some data",
+      c5: "some data",
+      c6: "some data",
+      c7: "some data",
+      c8: "some data",
+      c9: "some data",
+      c10: "some data",
+      c11: "some data",
+      c12: "some data",
+      c13: "some data",
+      c14: "some data",
+      c15: "some data",
+      c16: "some data",
+      c17: "some data",
+      c18: "some data",
+      c19: "some data",
+      c20: "some data",
+      c21: "some data"
+    };
+
+    rows.push(row);
+  }
+
+  return rows;
+};
+
+export const mockColumns = [
+  { label: "Column 1", dataKey: "c1" },
+  { label: "Column 2", dataKey: "c2" },
+  { label: "Column 3", dataKey: "c3" },
+  { label: "Column 4", dataKey: "c4" },
+  { label: "Column 5", dataKey: "c5" },
+  { label: "Column 6", dataKey: "c6" },
+  { label: "Column 7", dataKey: "c7" },
+  { label: "Column 8", dataKey: "c8" },
+  { label: "Column 9", dataKey: "c9" },
+  { label: "Column 10", dataKey: "c10" },
+  { label: "Column 11", dataKey: "c11" },
+  { label: "Column 12", dataKey: "c12" },
+  { label: "Column 13", dataKey: "c13" },
+  { label: "Column 14", dataKey: "c14" },
+  { label: "Column 15", dataKey: "c15" },
+  { label: "Column 16", dataKey: "c16" },
+  { label: "Column 17", dataKey: "c17" },
+  { label: "Column 18", dataKey: "c18" },
+  { label: "Column 19", dataKey: "c19" },
+  { label: "Column 20", dataKey: "c20" },
+  { label: "Column 21", dataKey: "c21" }
+];

--- a/components/src/Table/Table.spec.js
+++ b/components/src/Table/Table.spec.js
@@ -1,33 +1,119 @@
 import React from "react";
+import { mount } from "enzyme";
 import { render, fireEvent } from "@testing-library/react";
+
+import { Pagination } from "../Pagination";
 import { Table } from ".";
+import { mockColumns, getMockRows } from "./Table.mock-utils";
 
 describe("Table", () => {
-  it("returns the selected rows when the selection has changed", () => {
-    const columns = [{ label: "Column 1", dataKey: "c1" }];
-    const rowData = [{ c1: "r1c1" }, { c1: "r2c1" }];
-    const callback = jest.fn();
+  describe("row selections", () => {
+    describe("onRowSelectionChange:", () => {
+      it("returns the selected rows when the selection has changed", () => {
+        const columns = [{ label: "Column 1", dataKey: "c1" }];
+        const rowData = [{ c1: "r1c1" }, { c1: "r2c1" }];
+        const callback = jest.fn();
 
-    const { container } = render(
-      <Table columns={columns} rows={rowData} hasSelectableRows keyField="c1" onRowSelectionChange={callback} />
-    );
+        const { container } = render(
+          <Table columns={columns} rows={rowData} hasSelectableRows keyField="c1" onRowSelectionChange={callback} />
+        );
 
-    fireEvent.click(container.querySelectorAll("input")[1]);
+        fireEvent.click(container.querySelectorAll("input")[1]);
 
-    expect(callback).toHaveBeenCalledWith([rowData[0].c1]);
+        expect(callback).toHaveBeenCalledWith([rowData[0].c1]);
+      });
+      it("returns an empty array if no rows are selected", () => {
+        const columns = [{ label: "Column 1", dataKey: "c1" }];
+        const rowData = [{ c1: "r1c1" }, { c1: "r2c1" }];
+        const callback = jest.fn();
+
+        const { container } = render(
+          <Table columns={columns} rows={rowData} hasSelectableRows keyField="c1" onRowSelectionChange={callback} />
+        );
+
+        fireEvent.click(container.querySelectorAll("input")[0]);
+        expect(callback).toHaveBeenCalledWith([rowData[0].c1, rowData[1].c1]);
+        fireEvent.click(container.querySelectorAll("input")[0]);
+        expect(callback).toHaveBeenCalledWith([]);
+      });
+    });
   });
-  it("returns an empty array if no rows are selected", () => {
-    const columns = [{ label: "Column 1", dataKey: "c1" }];
-    const rowData = [{ c1: "r1c1" }, { c1: "r2c1" }];
-    const callback = jest.fn();
-
-    const { container } = render(
-      <Table columns={columns} rows={rowData} hasSelectableRows keyField="c1" onRowSelectionChange={callback} />
-    );
-
-    fireEvent.click(container.querySelectorAll("input")[0]);
-    expect(callback).toHaveBeenCalledWith([rowData[0].c1, rowData[1].c1]);
-    fireEvent.click(container.querySelectorAll("input")[0]);
-    expect(callback).toHaveBeenCalledWith([]);
+  describe("pagination", () => {
+    describe("onPageChange:", () => {
+      it("called when a new page is selected", () => {
+        const pageChangeCallback = jest.fn();
+        const wrapper = mount(
+          <Table
+            columns={mockColumns}
+            rows={getMockRows(20)}
+            hasSelectableRows
+            keyField="c1"
+            rowsPerPage={6}
+            onPageChange={pageChangeCallback}
+          />
+        );
+        const onClickPage = pageNum => {
+          wrapper
+            .find("button")
+            .at(pageNum)
+            .simulate("click");
+        };
+        expect(pageChangeCallback).not.toHaveBeenCalled();
+        onClickPage(3);
+        expect(pageChangeCallback).toHaveBeenCalledWith(3);
+      });
+      it("called when navigating to next page", () => {
+        const pageChangeCallback = jest.fn();
+        const wrapper = mount(
+          <Table
+            columns={mockColumns}
+            rows={getMockRows(20)}
+            hasSelectableRows
+            keyField="c1"
+            rowsPerPage={6}
+            onPageChange={pageChangeCallback}
+          />
+        );
+        const paginationButtons = wrapper.find("button");
+        const nextButton = paginationButtons.last();
+        expect(pageChangeCallback).not.toHaveBeenCalled();
+        nextButton.simulate("click");
+        expect(pageChangeCallback).toHaveBeenCalledWith(2);
+      });
+    });
+    describe("rowsPerPage", () => {
+      it("displays the correct number of rows", () => {
+        const pageChangeCallback = jest.fn();
+        const ROWS_PER_PAGE = 6;
+        const wrapper = mount(
+          <Table
+            columns={mockColumns}
+            rows={getMockRows(20)}
+            hasSelectableRows
+            keyField="c1"
+            rowsPerPage={6}
+            onPageChange={pageChangeCallback}
+          />
+        );
+        const rows = wrapper.find("tbody tr");
+        expect(rows.length).toEqual(ROWS_PER_PAGE);
+      });
+      it("renders the inner Pagination with correct props", () => {
+        const wrapper = mount(
+          <Table columns={mockColumns} rows={getMockRows(20)} hasSelectableRows keyField="c1" rowsPerPage={6} />
+        );
+        const pagination = wrapper.find(Pagination);
+        expect(pagination.length).toEqual(1);
+        expect(pagination.props().totalPages).toEqual(4);
+        expect(pagination.props().currentPage).toEqual(1);
+      });
+      it("does not display pagination when rowsPerPage is falsy", () => {
+        const wrapper = mount(<Table columns={mockColumns} rows={getMockRows(20)} hasSelectableRows keyField="c1" />);
+        const pagination = wrapper.find(Pagination);
+        const rows = wrapper.find("tbody tr");
+        expect(pagination.length).toEqual(0);
+        expect(rows.length).toEqual(20);
+      });
+    });
   });
 });

--- a/components/src/Table/Table.story.js
+++ b/components/src/Table/Table.story.js
@@ -3,6 +3,7 @@ import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import { Table } from ".";
 import { Box, IconicButton, DropdownButton, DropdownLink, DropdownMenu } from "..";
+import { getMockRows, mockColumns } from "./Table.mock-utils";
 
 const dateToString = cellData => {
   return new Date(cellData).toUTCString();
@@ -59,64 +60,6 @@ const rowData = [
   { c1: "row 1 cell 1", c2: "r1c2", c3: "2019-09-21", id: "r1" },
   { c1: "r2c1", c2: "r2c2", c3: "2019-09-22", id: "r2" }
 ];
-const lotsOfRows = numRows => {
-  const rows = [];
-
-  for (let i = 0; i < numRows; i += 1) {
-    const row = {
-      id: i,
-      c1: `some data ${i}`,
-      c2: "some data",
-      c3: "some data",
-      c4: "some data",
-      c5: "some data",
-      c6: "some data",
-      c7: "some data",
-      c8: "some data",
-      c9: "some data",
-      c10: "some data",
-      c11: "some data",
-      c12: "some data",
-      c13: "some data",
-      c14: "some data",
-      c15: "some data",
-      c16: "some data",
-      c17: "some data",
-      c18: "some data",
-      c19: "some data",
-      c20: "some data",
-      c21: "some data"
-    };
-
-    rows.push(row);
-  }
-
-  return rows;
-};
-
-const lotsOfColumns = [
-  { label: "Column 1", dataKey: "c1" },
-  { label: "Column 2", dataKey: "c2" },
-  { label: "Column 3", dataKey: "c3" },
-  { label: "Column 4", dataKey: "c4" },
-  { label: "Column 5", dataKey: "c5" },
-  { label: "Column 6", dataKey: "c6" },
-  { label: "Column 7", dataKey: "c7" },
-  { label: "Column 8", dataKey: "c8" },
-  { label: "Column 9", dataKey: "c9" },
-  { label: "Column 10", dataKey: "c10" },
-  { label: "Column 11", dataKey: "c11" },
-  { label: "Column 12", dataKey: "c12" },
-  { label: "Column 13", dataKey: "c13" },
-  { label: "Column 14", dataKey: "c14" },
-  { label: "Column 15", dataKey: "c15" },
-  { label: "Column 16", dataKey: "c16" },
-  { label: "Column 17", dataKey: "c17" },
-  { label: "Column 18", dataKey: "c18" },
-  { label: "Column 19", dataKey: "c19" },
-  { label: "Column 20", dataKey: "c20" },
-  { label: "Column 21", dataKey: "c21" }
-];
 
 storiesOf("Table", module)
   .add("Table with data", () => <Table columns={columns} rows={rowData} />)
@@ -139,8 +82,8 @@ storiesOf("Table", module)
   ))
   .add("with lots of rows and columns", () => (
     <Table
-      columns={lotsOfColumns}
-      rows={lotsOfRows(50)}
+      columns={mockColumns}
+      rows={getMockRows(50)}
       hasSelectableRows
       onRowSelectionChange={action("row selection changed")}
     />
@@ -158,10 +101,20 @@ storiesOf("Table", module)
   .add("with custom column widths", () => <Table columns={columnsWithWidths} rows={rowData} />)
   .add("with pagination", () => (
     <Table
-      columns={lotsOfColumns}
-      rows={lotsOfRows(120)}
+      columns={mockColumns}
+      rows={getMockRows(50)}
+      rowsPerPage={5}
+      onRowSelectionChange={action("row selection changed")}
+      onPageChange={action("page changed")}
+    />
+  ))
+  .add("with pagination and selectable rows", () => (
+    <Table
+      columns={mockColumns}
+      rows={getMockRows(50)}
       hasSelectableRows
       rowsPerPage={4}
-      onRowSelectionChange={row => console.log(row)}
+      onRowSelectionChange={action("row selection changed")}
+      onPageChange={action("page changed")}
     />
   ));

--- a/components/src/Table/Table.story.js
+++ b/components/src/Table/Table.story.js
@@ -65,7 +65,7 @@ const lotsOfRows = numRows => {
   for (let i = 0; i < numRows; i += 1) {
     const row = {
       id: i,
-      c1: "some data",
+      c1: `some data ${i}`,
       c2: "some data",
       c3: "some data",
       c4: "some data",
@@ -155,4 +155,13 @@ storiesOf("Table", module)
       onRowSelectionChange={action("row selection changed")}
     />
   ))
-  .add("with custom column widths", () => <Table columns={columnsWithWidths} rows={rowData} />);
+  .add("with custom column widths", () => <Table columns={columnsWithWidths} rows={rowData} />)
+  .add("with pagination", () => (
+    <Table
+      columns={lotsOfColumns}
+      rows={lotsOfRows(120)}
+      hasSelectableRows
+      rowsPerPage={4}
+      onRowSelectionChange={row => console.log(row)}
+    />
+  ));

--- a/docs/src/pages/components/table.js
+++ b/docs/src/pages/components/table.js
@@ -71,6 +71,19 @@ const propsRows = [
     defaultValue: "none",
     description:
       "The function that should be called when a row selection changes. The array of rows currently selected is passed in as an argument."
+  },
+  {
+    name: "rowsPerPage",
+    type: "number",
+    defaultValue: "none",
+    description: "The number of rows to display per page"
+  },
+  {
+    name: "onPageChange",
+    type: "function",
+    defaultValue: "none",
+    description:
+      "The function that should be called when a current page changes. The page number that is currently selected is passed in as an argument."
   }
 ];
 
@@ -108,6 +121,17 @@ const rows = [
   { c1: "r2c1", c2: "r2c2", c3: "2019-09-22" }
 ];
 
+const manyRowsForPagination = [
+  { c1: "row 1 cell 1", c2: "r1c2", c3: "2019-09-21" },
+  { c1: "r2c1", c2: "r2c2", c3: "2019-09-22" },
+  { c1: "r3c1", c2: "r3c2", c3: "2019-09-23" },
+  { c1: "r4c1", c2: "r4c2", c3: "2019-09-23" },
+  { c1: "r5c1", c2: "r5c2", c3: "2019-09-23" },
+  { c1: "r6c1", c2: "r6c2", c3: "2019-09-22" },
+  { c1: "r7c1", c2: "r7c2", c3: "2019-09-21" },
+  { c1: "r8c1", c2: "r8c2", c3: "2019-09-10" },
+  { c1: "r9c1", c2: "r9c2", c3: "2019-09-22" }
+];
 const columnsWithCellRenderer = [
   { label: "Column 1", dataKey: "c1" },
   { label: "Column 2", dataKey: "c2" },
@@ -256,6 +280,60 @@ const rows = [{ c1: "row 1 cell 1", c2: "r1c2", c3: "2019-09-21" }, { c1: "r2c1"
 const rows = [{ c1: "row 1 cell 1", c2: "r1c2", c3: "2019-09-21" }, { c1: "r2c1", c2: "r2c2", c3: "2019-09-22" }];
 
 <Table columns={columnsWithWidths} rows={rows} />`}
+      </Highlight>
+    </DocSection>
+
+    <DocSection>
+      <SectionTitle>With pagination</SectionTitle>
+      <Text>
+        Setting rowsPerPage on the Table will add a{" "}
+        <Link href="https://nulogy.design//components/pagination">
+          Pagination
+        </Link>{" "}
+        component to the table. A maximum of the specified rowsPerPage will be
+        shown on each page.
+      </Text>
+      <Text>
+        Providing a function to onPageChange will allow tracking of the current
+        page number. It is fired whenever the page changes and takes in the
+        current page number as an argument.
+      </Text>
+      <Table
+        columns={columns}
+        rows={manyRowsForPagination}
+        rowsPerPage={3}
+        keyField="c1"
+        onPageChange={pageNum => pageNum}
+      />
+      <Highlight className="js">
+        {`import {Table} from "@nulogy/table";
+
+const columns = [
+  { label: "Column 1", dataKey: "c1" },
+  { label: "Column 2", dataKey: "c2" },
+  { label: "Column 3", dataKey: "c3" },
+];
+
+const manyRowsForPagination = [
+  { c1: "row 1 cell 1", c2: "r1c2", c3: "2019-09-21" },
+  { c1: "r2c1", c2: "r2c2", c3: "2019-09-22" },
+  { c1: "r3c1", c2: "r3c2", c3: "2019-09-23" },
+  { c1: "r4c1", c2: "r4c2", c3: "2019-09-23" },
+  { c1: "r5c1", c2: "r5c2", c3: "2019-09-23" },
+  { c1: "r6c1", c2: "r6c2", c3: "2019-09-22" },
+  { c1: "r7c1", c2: "r7c2", c3: "2019-09-21" },
+  { c1: "r8c1", c2: "r8c2", c3: "2019-09-10" },
+  { c1: "r9c1", c2: "r9c2", c3: "2019-09-22" }
+];
+
+<Table
+        columns={columns}
+        rows={manyRowsForPagination}
+        rowsPerPage={3}
+        keyField="c1"
+        onPageChange={pageNum => pageNum}
+      />
+`}
       </Highlight>
     </DocSection>
 


### PR DESCRIPTION
- Adds client side pagination, which is determined by a rowsPerPage prop
- Supports client-side pagination in combination with selectable rows, and keeps track of the state of the checkboxes per page 
- Adds functional and unit tests for core functionality of pagination on its own and within the table
- cypress e2e tests created and cleaned up to test the paginated table and selectable row functionality