### PR TITLE
Align pagination to the right only in Table 

### DIFF
--- a/components/src/Pagination/Pagination.js
+++ b/components/src/Pagination/Pagination.js
@@ -95,7 +95,7 @@ const Pagination = props => {
   const { currentPage, totalPages, onNext, onPrevious, onSelectPage, ...restProps } = props;
 
   return (
-    <Flex as="nav" aria-label="Pagination navigation" justifyContent="flex-end" {...restProps}>
+    <Flex as="nav" aria-label="Pagination navigation" {...restProps}>
       <PreviousButton disabled={currentPage === 1} onClick={onPrevious} />
       {getPageItemstoDisplay(totalPages, currentPage).map((page, index) => {
         const isCurrentPage = currentPage === page;

--- a/components/src/Table/StatefulTable.js
+++ b/components/src/Table/StatefulTable.js
@@ -158,6 +158,7 @@ class StatefulTable extends React.Component {
             onSelectPage={this.goToPage}
             onNext={this.goToNextPage}
             onPrevious={this.goToPrevPage}
+            justifyContent="flex-end"
           />
         )}
       </>


### PR DESCRIPTION
We currently have `flex-end` set on our Pagination component causing it to always be right-aligned, even when used on its own. This PR changes this to only apply `flex-end` on the Pagination component when used inside the Table. 