### PR TITLE
NDS-1154 fixes scrollbar being visible when content does not overflow

### DIFF
--- a/components/src/Modal/Modal.js
+++ b/components/src/Modal/Modal.js
@@ -12,7 +12,7 @@ import { PreventBodyElementScrolling } from "../utils";
 const ModalContent = styled.div({
   marginTop: "-64px",
   marginBottom: "-80px",
-  overflow: "scroll",
+  overflow: "auto",
   paddingTop: "80px",
   paddingBottom: "94px",
   paddingLeft: theme.space.x3,

--- a/components/src/Modal/Modal.story.js
+++ b/components/src/Modal/Modal.story.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import { Modal as NDSModal, Button, Form, Input } from "../index";
+import { Text } from "../Type";
 
 const env = process.env.NODE_ENV;
 
@@ -79,9 +80,16 @@ storiesOf("Modal", module)
   ))
   .add("with scrolling content", () => (
     <Modal title="Modal Title" primaryButton={primaryButton} secondaryButtons={secondaryButtons}>
-      Content Content Content Content Content Content Content Content Content Content Content Content Content Content
-      Content Content Content Content Content Content Content Content Content Content Content Content Content Content
-      Content Content Content Content Content Content Content Content Content Content Content
+      <Text>
+        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+        Content Content Content Content Content Content Content Content Content Content Content
+      </Text>
+      <Text>
+        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+        Content Content Content Content Content Content Content Content Content Content Content
+      </Text>
     </Modal>
   ))
   .add("with danger type", () => (


### PR DESCRIPTION
- Sets overflow to "auto" rather than "scroll" so scrollbar only shows when  the content overflows
- Adds more content to the scrollable case in modal stories so it's easier to see the scrolling behaviour

Screenshots:
Before:
<img width="673" alt="NDS-1154-bug" src="https://user-images.githubusercontent.com/8175052/67796021-a772e600-fa55-11e9-80e6-7e3e7c37db8f.png">
After:
<img width="683" alt="NDS-1154-fixed" src="https://user-images.githubusercontent.com/8175052/67796025-a93ca980-fa55-11e9-8665-69371e4714ca.png">
