### PR TITLE
Nds 1172 modal cuts off select options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Changed spacing in Modal [Modal](http://nulogy.design/components/modal) component
+
 ### Deprecated
 
 ### Removed

--- a/components/src/Modal/Modal.js
+++ b/components/src/Modal/Modal.js
@@ -11,7 +11,6 @@ import { PreventBodyElementScrolling } from "../utils";
 
 const ModalContent = styled.div({
   marginTop: "-64px",
-
   marginBottom: "-72px",
   overflow: "auto",
   paddingTop: "88px",

--- a/components/src/Modal/Modal.js
+++ b/components/src/Modal/Modal.js
@@ -77,7 +77,6 @@ const StyledReactModal = styled(ReactModal)(
     left: 0,
     right: 0,
     bottom: 0,
-    overflow: "hidden",
     backgroundColor: theme.colors.white,
     borderRadius: theme.radii.medium,
     border: null,

--- a/components/src/Modal/Modal.js
+++ b/components/src/Modal/Modal.js
@@ -27,6 +27,7 @@ const ModalHeader = styled.div(({ hasCloseButton }) => ({
   padding: `${theme.space.x2} ${getHeaderPaddingRight(hasCloseButton)} ${theme.space.x2} ${theme.space.x3}`,
   backgroundColor: transparentize(0.1, theme.colors.white),
   zIndex: 2,
+  borderRadius: `${theme.radii.medium} ${theme.radii.medium} 0 0`,
   ":after": {
     content: "''",
     position: "absolute",
@@ -44,6 +45,7 @@ const ModalFooter = styled.div({
   padding: `${theme.space.x2} ${theme.space.x3}`,
   backgroundColor: transparentize(0.1, theme.colors.white),
   zIndex: 2,
+  borderRadius: `0 0 ${theme.radii.medium} ${theme.radii.medium}`,
   ":after": {
     content: "''",
     position: "absolute",

--- a/components/src/Modal/Modal.js
+++ b/components/src/Modal/Modal.js
@@ -11,10 +11,11 @@ import { PreventBodyElementScrolling } from "../utils";
 
 const ModalContent = styled.div({
   marginTop: "-64px",
-  marginBottom: "-80px",
+
+  marginBottom: "-72px",
   overflow: "auto",
-  paddingTop: "80px",
-  paddingBottom: "94px",
+  paddingTop: "88px",
+  paddingBottom: "96px",
   paddingLeft: theme.space.x3,
   paddingRight: theme.space.x3
 });
@@ -82,7 +83,7 @@ const StyledReactModal = styled(ReactModal)(
     border: null,
     width: "100%",
     height: "auto",
-    maxHeight: `calc(100vh - ${theme.space.x4})`,
+    maxHeight: `calc(100vh - ${theme.space.x8})`,
     margin: `0px ${theme.space.x2}`,
     padding: 0,
     [`@media only screen and (max-width: ${theme.breakpoints.small})`]: {

--- a/components/src/Modal/Modal.story.js
+++ b/components/src/Modal/Modal.story.js
@@ -107,7 +107,30 @@ storiesOf("Modal", module)
       <Text>
         Content Content Content Content Content Content Content Content Content Content Content Content Content Content
         Content Content Content Content Content Content Content Content Content Content Content Content Content Content
-        Content Content Content Content Content Content Content Content Content Content Content
+        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+        Content Content Content Content Content Content Content ContentContent Content Content Content Content Content
+        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+        Content Content Content Content ContentContent Content Content Content Content Content Content Content Content
+        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+        Content ContentContent Content Content Content Content Content Content Content Content Content Content Content
+        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+        Content Content Content Content Content Content Content Content Content Content Content Content ContentContent
+        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+        Content Content Content Content Content Content Content Content Content ContentContent Content Content Content
+        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+        Content Content Content Content Content Content ContentContent Content Content Content Content Content Content
+        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+        Content Content Content ContentContent Content Content Content Content Content Content Content Content Content
+        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+        Content
       </Text>
       <PrimaryButton>Some text</PrimaryButton>
     </Modal>

--- a/components/src/Modal/Modal.story.js
+++ b/components/src/Modal/Modal.story.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { Modal as NDSModal, Button, Form, Input } from "../index";
-import { Text } from "../Type";
+import { Modal as NDSModal, Button, Form, Input, Select, Text } from "../index";
+import { PrimaryButton } from "../Button";
 
 const env = process.env.NODE_ENV;
 
@@ -16,6 +16,16 @@ const Modal = props => <NDSModal {...envProps} {...props} />;
 const primaryButton = { label: "Primary Action", onClick: () => {} };
 
 const secondaryButtons = [{ label: "Secondary Action", onClick: () => {} }];
+
+const options = [
+  { value: "accepted", label: "Accepted" },
+  { value: "assigned", label: "Assigned to a line" },
+  { value: "hold", label: "On hold" },
+  { value: "rejected", label: "Rejected" },
+  { value: "open", label: "Open" },
+  { value: "progress", label: "In progress" },
+  { value: "quarantine", label: "In quarantine" }
+];
 
 // Modal.setAppElement("#root")
 
@@ -92,6 +102,16 @@ storiesOf("Modal", module)
       </Text>
     </Modal>
   ))
+  .add("with scrolling content and no footer", () => (
+    <Modal title="Modal Title">
+      <Text>
+        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+        Content Content Content Content Content Content Content Content Content Content Content
+      </Text>
+      <PrimaryButton>Some text</PrimaryButton>
+    </Modal>
+  ))
   .add("with danger type", () => (
     <Modal title="Modal Title" type="danger" primaryButton={primaryButton} secondaryButtons={secondaryButtons}>
       Content Content Content
@@ -142,6 +162,58 @@ storiesOf("Modal", module)
       <Form id="myForm" mb="x2">
         <Input name="name" id="name" labelText="Name" />
         <Input type="number" name="age" id="age" labelText="Age" />
+      </Form>
+    </Modal>
+  ))
+  .add("with select", () => (
+    <Modal
+      title="Edit Profile"
+      onRequestClose={() => {}}
+      primaryButton={{ label: "Submit", type: "submit", form: "myForm" }}
+      secondaryButtons={[{ label: "Cancel", onClick: () => {} }]}
+      maxWidth="456px"
+    >
+      <Form id="myForm" mb="x2">
+        <Select placeholder="Please select inventory status" options={options} labelText="Inventory status" />
+      </Form>
+    </Modal>
+  ))
+  .add("with select and content after", () => (
+    <Modal
+      title="Edit Profile"
+      onRequestClose={() => {}}
+      primaryButton={{ label: "Submit", type: "submit", form: "myForm" }}
+      secondaryButtons={[{ label: "Cancel", onClick: () => {} }]}
+      maxWidth="456px"
+    >
+      <Form id="myForm" mb="x2">
+        <Select placeholder="Please select inventory status" options={options} labelText="Inventory status" />
+        <Input name="name" id="name" labelText="Name" />
+        <Input type="number" name="age" id="age" labelText="Age" />
+      </Form>
+    </Modal>
+  ))
+  .add("with select and content before", () => (
+    <Modal
+      title="Edit Profile"
+      onRequestClose={() => {}}
+      primaryButton={{ label: "Submit", type: "submit", form: "myForm" }}
+      secondaryButtons={[{ label: "Cancel", onClick: () => {} }]}
+      maxWidth="456px"
+    >
+      <Form id="myForm" mb="x2">
+        <Input name="name" id="name" labelText="Name" />
+        <Input type="number" name="age" id="age" labelText="Age" />
+        <Input name="name" id="name" labelText="Name" />
+        <Input type="number" name="age" id="age" labelText="Age" />
+        <Input name="name" id="name" labelText="Name" />
+        <Input type="number" name="age" id="age" labelText="Age" />
+        <Select
+          maxHeight="96px"
+          placeholder="Please select inventory status"
+          options={options}
+          labelText="Inventory status"
+        />
       </Form>
     </Modal>
   ))

--- a/components/src/Modal/Modal.story.js
+++ b/components/src/Modal/Modal.story.js
@@ -181,7 +181,7 @@ storiesOf("Modal", module)
       secondaryButtons={[{ label: "Cancel", onClick: () => {} }]}
       maxWidth="456px"
     >
-      <Form id="myForm" mb="x2">
+      <Form id="myForm">
         <Input name="name" id="name" labelText="Name" />
         <Input type="number" name="age" id="age" labelText="Age" />
         <Input name="name" id="name" labelText="Name" />

--- a/components/src/Modal/Modal.story.js
+++ b/components/src/Modal/Modal.story.js
@@ -181,7 +181,7 @@ storiesOf("Modal", module)
       secondaryButtons={[{ label: "Cancel", onClick: () => {} }]}
       maxWidth="456px"
     >
-      <Form id="myForm">
+      <Form id="myForm" mb="x2">
         <Input name="name" id="name" labelText="Name" />
         <Input type="number" name="age" id="age" labelText="Age" />
         <Input name="name" id="name" labelText="Name" />
@@ -199,12 +199,14 @@ storiesOf("Modal", module)
   ))
   .add("with select and no buttons", () => (
     <Modal title="Modal Title" onRequestClose={() => {}}>
-      <Select
-        maxHeight="94px"
-        placeholder="Please select inventory status"
-        options={options}
-        labelText="Inventory status"
-      />
+      <Form id="myForm" mb="x2">
+        <Select
+          maxHeight="96px"
+          placeholder="Please select inventory status"
+          options={options}
+          labelText="Inventory status"
+        />
+      </Form>
     </Modal>
   ))
   .add("example controlled modal", () => <ModalExample />);

--- a/components/src/Modal/Modal.story.js
+++ b/components/src/Modal/Modal.story.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import { Modal as NDSModal, Button, Form, Input, Select, Text } from "../index";
-import { PrimaryButton } from "../Button";
 
 const env = process.env.NODE_ENV;
 

--- a/components/src/Modal/Modal.story.js
+++ b/components/src/Modal/Modal.story.js
@@ -102,39 +102,6 @@ storiesOf("Modal", module)
       </Text>
     </Modal>
   ))
-  .add("with scrolling content and no footer", () => (
-    <Modal title="Modal Title">
-      <Text>
-        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
-        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
-        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
-        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
-        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
-        Content Content Content Content Content Content Content ContentContent Content Content Content Content Content
-        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
-        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
-        Content Content Content Content ContentContent Content Content Content Content Content Content Content Content
-        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
-        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
-        Content ContentContent Content Content Content Content Content Content Content Content Content Content Content
-        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
-        Content Content Content Content Content Content Content Content Content Content Content Content ContentContent
-        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
-        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
-        Content Content Content Content Content Content Content Content Content ContentContent Content Content Content
-        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
-        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
-        Content Content Content Content Content Content ContentContent Content Content Content Content Content Content
-        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
-        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
-        Content Content Content ContentContent Content Content Content Content Content Content Content Content Content
-        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
-        Content Content Content Content Content Content Content Content Content Content Content Content Content Content
-        Content
-      </Text>
-      <PrimaryButton>Some text</PrimaryButton>
-    </Modal>
-  ))
   .add("with danger type", () => (
     <Modal title="Modal Title" type="danger" primaryButton={primaryButton} secondaryButtons={secondaryButtons}>
       Content Content Content
@@ -197,26 +164,16 @@ storiesOf("Modal", module)
       maxWidth="456px"
     >
       <Form id="myForm" mb="x2">
-        <Select placeholder="Please select inventory status" options={options} labelText="Inventory status" />
+        <Select
+          maxHeight="96px"
+          placeholder="Please select inventory status"
+          options={options}
+          labelText="Inventory status"
+        />
       </Form>
     </Modal>
   ))
-  .add("with select and content after", () => (
-    <Modal
-      title="Edit Profile"
-      onRequestClose={() => {}}
-      primaryButton={{ label: "Submit", type: "submit", form: "myForm" }}
-      secondaryButtons={[{ label: "Cancel", onClick: () => {} }]}
-      maxWidth="456px"
-    >
-      <Form id="myForm" mb="x2">
-        <Select placeholder="Please select inventory status" options={options} labelText="Inventory status" />
-        <Input name="name" id="name" labelText="Name" />
-        <Input type="number" name="age" id="age" labelText="Age" />
-      </Form>
-    </Modal>
-  ))
-  .add("with select and content before", () => (
+  .add("with select and scrolling content", () => (
     <Modal
       title="Edit Profile"
       onRequestClose={() => {}}
@@ -238,6 +195,16 @@ storiesOf("Modal", module)
           labelText="Inventory status"
         />
       </Form>
+    </Modal>
+  ))
+  .add("with select and no buttons", () => (
+    <Modal title="Modal Title" onRequestClose={() => {}}>
+      <Select
+        maxHeight="94px"
+        placeholder="Please select inventory status"
+        options={options}
+        labelText="Inventory status"
+      />
     </Modal>
   ))
   .add("example controlled modal", () => <ModalExample />);

--- a/components/src/Select/Select.js
+++ b/components/src/Select/Select.js
@@ -119,7 +119,7 @@ ReactSelect.defaultProps = {
   noOptionsMessage: () => null,
   requirementText: null,
   id: null,
-  initialIsOpen: true,
+  initialIsOpen: undefined,
   maxHeight: "248px",
   multiselect: false,
   name: undefined,

--- a/components/src/Select/Select.js
+++ b/components/src/Select/Select.js
@@ -119,7 +119,7 @@ ReactSelect.defaultProps = {
   noOptionsMessage: () => null,
   requirementText: null,
   id: null,
-  initialIsOpen: undefined,
+  initialIsOpen: true,
   maxHeight: "248px",
   multiselect: false,
   name: undefined,


### PR DESCRIPTION
### What I did:

- Removed `overflow: hidden` from Modal wrapper and adjusted spacing
- Added stories with select (select, select with scrolling, select without actions ...)

### Solution
- Make elements that potentially bleed out of the screen (select options, date picker ...) small. Select should be 96px heigh.
- Use space after to provide more room (select options in this case)

With the proposed solution `overflow: auto` is preserved which allowed scrolling. The alternative of allowing content to bleed out with `overflow: visible` was considered but that broke scrolling. The chosen approach was considered superior because in the case when the content overflows modal it can also overflow the viewport and that content would not be accessible.

### Other possibilities

1. Providing specific styles and behaviors for the case when modal scrolls and when it doesn't
2. Removing max-height from Modal so there is no scrolling and we can use only `overflow: visible`. This would result in a modal header and footer going out of viewport when scrolled.