### PR TITLE
NDS-1149 add filtering support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Changed spacing in Modal [Modal](http://nulogy.design/components/modal) component
+- Table
+  - [**Breaking Change**] `cellFormatter` and `cellRenderer` APIs have been updated so arguments are within an object
+    - Before: `cellFormatter: (cellData, column, row) => {}`
+    - Now: `cellFormatter: ({cellData, column, row}) => {}`
+  - `cellFormatter` can now return a react component or a string instead of being limited to strings
 
 ### Deprecated
 

--- a/components/src/Table/Table.story.js
+++ b/components/src/Table/Table.story.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
@@ -10,7 +11,6 @@ const dateToString = ({ cellData }) => {
   return new Date(cellData).toUTCString();
 };
 
-// eslint-disable-next-line react/prop-types
 const iconicButtonCellRenderer = ({ cellData }) => <IconicButton icon="delete">{cellData}</IconicButton>;
 
 const buttonRenderer = ({ label }) => <Button onClick={action("button clicked")}>{label}</Button>;

--- a/components/src/Table/Table.story.js
+++ b/components/src/Table/Table.story.js
@@ -4,15 +4,18 @@ import { action } from "@storybook/addon-actions";
 import { Table } from ".";
 import { Box, IconicButton, DropdownButton, DropdownLink, DropdownMenu, Text } from "..";
 import { getMockRows, mockColumns } from "./Table.mock-utils";
+import { Button } from "../Button";
 
-const dateToString = cellData => {
+const dateToString = ({ cellData }) => {
   return new Date(cellData).toUTCString();
 };
 
 // eslint-disable-next-line react/prop-types
-const iconicButtonCellRenderer = cellData => <IconicButton icon="delete">{cellData}</IconicButton>;
+const iconicButtonCellRenderer = ({ cellData }) => <IconicButton icon="delete">{cellData}</IconicButton>;
 
-const dropdownCellRenderer = cellData => (
+const buttonRenderer = ({ label }) => <Button onClick={action("button clicked")}>{label}</Button>;
+
+const dropdownCellRenderer = ({ cellData }) => (
   <Box textAlign="right">
     <DropdownMenu>
       <DropdownLink href="/">See Date: {cellData}</DropdownLink>
@@ -36,6 +39,12 @@ const getColumnsWithCellRenderer = cellRenderer => [
   { label: "Column 1", dataKey: "c1" },
   { label: "Column 2", dataKey: "c2" },
   { label: "Column 3", dataKey: "c3", cellRenderer }
+];
+
+const getColumnsWithheaderFormatter = headerFormatter => [
+  { label: "Column 1", dataKey: "c1" },
+  { label: "Column 2", dataKey: "c2" },
+  { label: "Column 3", dataKey: "c3", headerFormatter }
 ];
 
 const columnsWithAlignment = [
@@ -72,11 +81,14 @@ storiesOf("Table", module)
   .add("with no data", () => <Table columns={columns} rows={[]} />)
   .add("loading", () => <Table columns={columns} rows={rowData} loading />)
   .add("with a cell formatter", () => <Table columns={columnsWithFormatter} rows={rowData} />)
-  .add("with a custom component: iconic button", () => (
+  .add("with a custom table cell component: iconic button", () => (
     <Table columns={getColumnsWithCellRenderer(iconicButtonCellRenderer)} rows={rowData} />
   ))
-  .add("with a custom component: dropdown", () => (
+  .add("with a custom table cell component: dropdown", () => (
     <Table columns={getColumnsWithCellRenderer(dropdownCellRenderer)} rows={rowData} />
+  ))
+  .add("with a custom column label component: button", () => (
+    <Table columns={getColumnsWithheaderFormatter(buttonRenderer)} rows={rowData} />
   ))
   .add("with wrapping text", () => (
     <Box width={400}>

--- a/components/src/Table/TableBody.js
+++ b/components/src/Table/TableBody.js
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import theme from "../theme";
 import { Box } from "../Box";
 import { rowsPropType, columnsPropType, rowPropType } from "./Table.types";
+import TableCell from "./TableCell";
 
 const StyledMessageContainer = styled(Box)({
   padding: `${theme.space.x3} 0`,
@@ -11,52 +12,11 @@ const StyledMessageContainer = styled(Box)({
   color: theme.colors.darkGrey
 });
 
-const StyledTextCell = styled.div(({ align }) => ({
-  paddingTop: theme.space.x2,
-  paddingBottom: theme.space.x2,
-  textAlign: align
-}));
-
-const StyledTd = styled.td(({ width }) => ({
-  width,
-  paddingRight: theme.space.x2,
-  "&:first-of-type": {
-    paddingLeft: theme.space.x2
-  }
-}));
-
 const StyledTr = styled.tr({
   "&:hover": {
     backgroundColor: theme.colors.whiteGrey
   }
 });
-
-const TextCell = ({ children, cellFormatter, align }) => {
-  return (
-    <StyledTextCell align={align}>{cellFormatter ? cellFormatter({ cellData: children }) : children}</StyledTextCell>
-  );
-};
-
-TextCell.propTypes = {
-  children: PropTypes.string,
-  align: PropTypes.string,
-  cellFormatter: PropTypes.func
-};
-
-TextCell.defaultProps = {
-  children: "",
-  align: "left",
-  cellFormatter: undefined
-};
-
-const renderCellContent = (row, { cellRenderer, dataKey, ...column }) =>
-  cellRenderer ? (
-    cellRenderer({ cellData: row[dataKey], column, row })
-  ) : (
-    <TextCell cellFormatter={column.cellFormatter} align={column.align}>
-      {row[dataKey]}
-    </TextCell>
-  );
 
 const renderRows = (rows, columns, keyField, noRowsContent) =>
   rows.length > 0 ? (
@@ -68,9 +28,7 @@ const renderRows = (rows, columns, keyField, noRowsContent) =>
 const TableBodyRow = ({ row, columns }) => (
   <StyledTr>
     {columns.map(column => (
-      <StyledTd key={column.dataKey} width={column.width}>
-        {renderCellContent(row, column)}
-      </StyledTd>
+      <TableCell key={column.dataKey} row={row} column={column} />
     ))}
   </StyledTr>
 );

--- a/components/src/Table/TableBody.js
+++ b/components/src/Table/TableBody.js
@@ -31,27 +31,32 @@ const StyledTr = styled.tr({
   }
 });
 
-const TextCell = ({ children, align }) => <StyledTextCell align={align}>{children}</StyledTextCell>;
+const TextCell = ({ children, cellFormatter, align }) => {
+  return (
+    <StyledTextCell align={align}>{cellFormatter ? cellFormatter({ cellData: children }) : children}</StyledTextCell>
+  );
+};
 
 TextCell.propTypes = {
   children: PropTypes.string,
-  align: PropTypes.string
+  align: PropTypes.string,
+  cellFormatter: PropTypes.func
 };
 
 TextCell.defaultProps = {
   children: "",
-  align: undefined
+  align: "left",
+  cellFormatter: undefined
 };
 
-const textCellRenderer = (cellData, { cellFormatter, align }) => (
-  <TextCell align={align}>{cellFormatter ? cellFormatter(cellData) : cellData}</TextCell>
-);
-
-const renderCellContent = (row, { cellRenderer, dataKey, ...columnOptions }) => {
-  const renderer = cellRenderer || textCellRenderer;
-
-  return renderer(row[dataKey], columnOptions, row);
-};
+const renderCellContent = (row, { cellRenderer, dataKey, ...column }) =>
+  cellRenderer ? (
+    cellRenderer({ cellData: row[dataKey], column, row })
+  ) : (
+    <TextCell cellFormatter={column.cellFormatter} align={column.align}>
+      {row[dataKey]}
+    </TextCell>
+  );
 
 const renderRows = (rows, columns, keyField, noRowsContent) =>
   rows.length > 0 ? (

--- a/components/src/Table/TableCell.js
+++ b/components/src/Table/TableCell.js
@@ -1,24 +1,35 @@
 import React from "react";
-import PropTypes from "prop-types";
 import styled from "styled-components";
 import theme from "../theme";
+import { columnPropType, rowPropType } from "./Table.types";
 
-const StyledTableCell = styled.div(({ align }) => ({
+const getDefaultTableCellStyles = align => ({
   paddingTop: theme.space.x2,
   paddingBottom: theme.space.x2,
   textAlign: align
+});
+
+const StyledTableCell = styled.td(({ align, isCustomCell }) => ({
+  paddingRight: theme.space.x2,
+  "&:first-of-type": {
+    paddingLeft: theme.space.x2
+  },
+  ...(isCustomCell ? null : getDefaultTableCellStyles(align))
 }));
 
-const TableCell = ({ children, align }) => <StyledTableCell align={align}>{children}</StyledTableCell>;
-
-TableCell.propTypes = {
-  children: PropTypes.string,
-  align: PropTypes.string
+const TableCell = ({ row, column }) => {
+  const isCustomCell = Boolean(column.cellRenderer);
+  const renderCellContent = (renderer, cellData) => (renderer ? renderer({ cellData, column, row }) : cellData);
+  return (
+    <StyledTableCell align={column.align} isCustomCell={isCustomCell}>
+      {renderCellContent(column.cellRenderer || column.cellFormatter, row[column.dataKey])}
+    </StyledTableCell>
+  );
 };
 
-TableCell.defaultProps = {
-  children: "",
-  align: undefined
+TableCell.propTypes = {
+  column: columnPropType.isRequired,
+  row: rowPropType.isRequired
 };
 
 export default TableCell;

--- a/components/src/Table/TableFoot.js
+++ b/components/src/Table/TableFoot.js
@@ -20,20 +20,6 @@ const StyledTh = styled.th({
   color: theme.colors.darkGrey
 });
 
-const StyledTd = styled.td(() => ({
-  paddingRight: theme.space.x2
-}));
-
-const tableCellRenderer = (cellData, { cellFormatter, align }) => (
-  <TableCell align={align}>{cellFormatter ? cellFormatter(cellData) : cellData}</TableCell>
-);
-
-const renderCellContent = (row, { cellRenderer, dataKey, ...columnOptions }) => {
-  const renderer = cellRenderer || tableCellRenderer;
-
-  return renderer(row[dataKey], columnOptions, row);
-};
-
 const renderRows = (rows, columns, keyField, loading) =>
   rows.map(row => <TableFooterRow row={row} columns={columns} key={row[keyField]} loading={loading} />);
 
@@ -45,11 +31,7 @@ const TableFooterRow = ({ row, columns, loading }) => (
           {row[column.dataKey]}
         </StyledTh>
       ) : (
-        !loading && (
-          <StyledTd key={column.dataKey} width={column.width}>
-            {renderCellContent(row, column)}
-          </StyledTd>
-        )
+        !loading && <TableCell key={column.dataKey} row={row} column={column} />
       )
     )}
   </StyledFooterRow>

--- a/components/src/Table/TableHead.js
+++ b/components/src/Table/TableHead.js
@@ -18,9 +18,9 @@ const StyledTh = styled.th({
   }
 });
 
-const defaultHeaderRenderer = ({ label }) => label;
+const defaultheaderFormatter = ({ label }) => label;
 
-const renderHeaderCellContent = ({ headerRenderer = defaultHeaderRenderer, ...column }) => headerRenderer(column);
+const renderHeaderCellContent = ({ headerFormatter = defaultheaderFormatter, ...column }) => headerFormatter(column);
 
 const renderColumns = columns =>
   columns.map(column => (
@@ -41,9 +41,9 @@ TableHead.propTypes = {
       align: PropTypes.oneOf(["right", "left", "center"]),
 
       dataKey: PropTypes.string.isRequired,
-      cellFormatter: PropTypes.func,
       cellRenderer: PropTypes.func,
-      headerRenderer: PropTypes.func
+      cellFormatter: PropTypes.func,
+      headerFormatter: PropTypes.func
     })
   ).isRequired
 };

--- a/components/src/Table/TableWithFiltering.story.js
+++ b/components/src/Table/TableWithFiltering.story.js
@@ -1,0 +1,62 @@
+/* eslint-disable react/prop-types */
+import React, { useState, useEffect } from "react";
+import { storiesOf } from "@storybook/react";
+import { Table } from "..";
+import { Input } from "../Input";
+
+const COLUMNS = [{ label: "Name", dataKey: "name" }, { label: "Description", dataKey: "description" }];
+
+const ROWS = [
+  { name: "Albert Einstein", description: "scientist, physist" },
+  { name: "Homer Simpson", description: "father, doh!" },
+  { name: "Jane Austen", description: "author" },
+  { name: "Charles Darwin", description: "biologist" },
+  { name: "Regina Phalange", description: "doctor, alias" },
+  { name: "Marie Curie", description: "scientist, chemist" },
+  { name: "Kawhi Leonard", description: "athlete, basketball" },
+  { name: "Rosalind Franklin", description: "scientist, chemist" },
+  { name: "F. Scott Fitzgerald", description: "author" }
+];
+
+const transformColumn = (column, onChange) => {
+  return {
+    ...column,
+    headerFormatter: ({ label, dataKey }) => (
+      <ColumnHeaderWithFilter onChange={e => onChange(dataKey, e)} label={label} />
+    )
+  };
+};
+
+const ColumnHeaderWithFilter = ({ onChange, label }) => <Input labelText={`Filter by ${label}`} onChange={onChange} />;
+
+const TableWithFilters = () => {
+  const [rows, setRows] = useState(ROWS);
+  const [filter, setFilter] = useState({});
+
+  const filterRows = filterObj => {
+    const filteredRows = Object.keys(filterObj).map(key =>
+      ROWS.filter(row => row[key].toLowerCase().includes(filterObj[key].toLowerCase()))
+    );
+    const filteredRowsByLength = filteredRows.sort((a, b) => a.length - b.length);
+    const commonRows =
+      filteredRowsByLength.length > 1
+        ? filteredRowsByLength[0].filter(row => filteredRowsByLength[1].includes(row))
+        : filteredRowsByLength[0] || ROWS;
+    setRows(commonRows);
+  };
+  useEffect(() => {
+    filterRows(filter);
+  }, [filter]);
+
+  const onFilterInputChange = (dataKey, e) => {
+    const filterValue = e.currentTarget.value;
+    return setFilter(state => ({
+      ...state,
+      [dataKey]: filterValue
+    }));
+  };
+  const columns = COLUMNS.map(column => transformColumn(column, onFilterInputChange));
+  return <Table columns={columns} rows={rows} keyField="name" />;
+};
+
+storiesOf("Table", module).add("with filtering (SkipStoryshot)", () => <TableWithFilters />);

--- a/components/src/Table/withSelectableColumn.js
+++ b/components/src/Table/withSelectableColumn.js
@@ -1,5 +1,7 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { Checkbox } from "../Checkbox";
+import { rowPropType } from "./Table.types";
 
 const SELECTABLE_COLUMN_DATA_KEY = "selected";
 
@@ -7,12 +9,23 @@ const selectHeaderFormatter = (onSelectHeader, isHeaderSelected) => () => (
   <Checkbox checked={isHeaderSelected} onChange={onSelectHeader} aria-label="toggle all row selections" />
 );
 
-const selectCellRenderer = onSelectRow => ({ cellData, columnData, row }) => {
+const SelectCell = ({ row, onSelectRow }) => {
   const selectRowHandler = () => onSelectRow(row);
   return (
     <Checkbox aria-label="toggle row selection" checked={row[SELECTABLE_COLUMN_DATA_KEY]} onChange={selectRowHandler} />
   );
 };
+
+SelectCell.propTypes = {
+  row: rowPropType.isRequired,
+  onSelectRow: PropTypes.func
+};
+
+SelectCell.defaultProps = {
+  onSelectRow: null
+};
+
+const selectCellRenderer = onSelectRow => props => <SelectCell onSelectRow={onSelectRow} {...props} />;
 
 const addSelectableColumn = ({
   columns,

--- a/components/src/Table/withSelectableColumn.js
+++ b/components/src/Table/withSelectableColumn.js
@@ -3,11 +3,11 @@ import { Checkbox } from "../Checkbox";
 
 const SELECTABLE_COLUMN_DATA_KEY = "selected";
 
-const selectHeaderRenderer = (onSelectHeader, isHeaderSelected) => () => (
+const selectHeaderFormatter = (onSelectHeader, isHeaderSelected) => () => (
   <Checkbox checked={isHeaderSelected} onChange={onSelectHeader} aria-label="toggle all row selections" />
 );
 
-const selectCellRenderer = onSelectRow => (cellData, columnData, row) => {
+const selectCellRenderer = onSelectRow => ({ cellData, columnData, row }) => {
   const selectRowHandler = () => onSelectRow(row);
   return (
     <Checkbox aria-label="toggle row selection" checked={row[SELECTABLE_COLUMN_DATA_KEY]} onChange={selectRowHandler} />
@@ -26,7 +26,7 @@ const addSelectableColumn = ({
   const selectableColumn = {
     dataKey: SELECTABLE_COLUMN_DATA_KEY,
     cellRenderer: selectCellRenderer(onSelectRow),
-    headerRenderer: selectHeaderRenderer(onSelectHeader, isHeaderSelected)
+    headerFormatter: selectHeaderFormatter(onSelectHeader, isHeaderSelected)
   };
   const selectableCellData = rowKey => ({
     [SELECTABLE_COLUMN_DATA_KEY]: selectedRows.includes(rowKey)

--- a/docs/src/components/PropsTable.js
+++ b/docs/src/components/PropsTable.js
@@ -8,6 +8,10 @@ const smallTextRenderer = ({ cellData }) => (
   </Text>
 );
 
+smallTextRenderer.propTypes = {
+  cellData: PropTypes.string.isRequired
+};
+
 const columns = [
   {
     label: "Name",

--- a/docs/src/components/PropsTable.js
+++ b/docs/src/components/PropsTable.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Table, Text } from "@nulogy/components";
 
-const smallTextRenderer = cellData => (
+const smallTextRenderer = ({ cellData }) => (
   <Text py="x1" fontSize="small">
     {cellData}
   </Text>

--- a/docs/src/pages/components/table.js
+++ b/docs/src/pages/components/table.js
@@ -487,10 +487,18 @@ const manyRowsForPagination = [
         </Link>
         .
       </Text>
-      <Table loading columns={columns} rows={rows} keyField="c1" />
-      <Highlight className="js">
-        {`<Table loading hasSelectableRows columns={columns} rows={rows} keyField="c1"/>`}
-      </Highlight>
+    </DocSection>
+
+    <DocSection>
+      <SectionTitle>Filtering</SectionTitle>
+      <Text>
+        Filtering can be implemented by passing filtered rows to the rows prop
+        of the table. See an example of filtering in
+        <Link href="https://storybook.nulogy.design/?path=/story/table--with-filtering-skipstoryshot">
+          Storybook
+        </Link>
+        .
+      </Text>
     </DocSection>
 
     <DocSection>

--- a/docs/src/pages/components/table.js
+++ b/docs/src/pages/components/table.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-unused-vars, quotes, react/self-closing-comp */
+/* eslint-disable no-unused-vars, quotes, react/self-closing-comp, react/prop-types */
 
 import React from "react";
 import { Helmet } from "react-helmet";
@@ -173,8 +173,6 @@ const propsRows = [
 const dateToString = ({ cellData }) => {
   return new Date(cellData).toDateString();
 };
-
-// eslint-disable-next-line react/prop-types
 const customCellRenderer = ({ cellData }) => (
   <>
     <IconicButton icon="delete">{cellData}</IconicButton>

--- a/docs/src/pages/components/table.js
+++ b/docs/src/pages/components/table.js
@@ -23,6 +23,51 @@ import {
   PropsTable
 } from "../../components";
 
+const columnKeys = [
+  {
+    name: "label",
+    type: "string",
+    defaultValue: "Required",
+    description: "The label used in the header of the table column"
+  },
+  {
+    name: "dataKey",
+    type: "string",
+    defaultValue: "Required",
+    description:
+      "Unique key for the column, used as the keys to define cell content for the column of each row"
+  },
+  {
+    name: "align",
+    type: "string enum ('left', 'right' or 'center')",
+    defaultValue: "left",
+    description:
+      "sets the alignment of the text for the column in the default cell"
+  },
+  {
+    name: "cellFormatter",
+    type: "function",
+    defaultValue: "undefined",
+    description:
+      "Used to format cell text. It should return a string or react component."
+  },
+  {
+    name: "cellRenderer",
+    type: "function",
+    description:
+      "Used to override the cell component. No padding or other styles will be added in this case. It should return a react component. "
+  }
+];
+
+const rowKeys = [
+  {
+    name: "id",
+    type: "string",
+    description:
+      "Unique id for each row, required if another keyField is not passed to the Table"
+  }
+];
+
 const propsRows = [
   {
     name: "columns",
@@ -94,12 +139,12 @@ const propsRows = [
   }
 ];
 
-const dateToString = cellData => {
+const dateToString = ({ cellData }) => {
   return new Date(cellData).toDateString();
 };
 
 // eslint-disable-next-line react/prop-types
-const customCellRenderer = cellData => (
+const customCellRenderer = ({ cellData }) => (
   <>
     <IconicButton icon="delete">{cellData}</IconicButton>
   </>
@@ -412,6 +457,21 @@ const manyRowsForPagination = [
     <DocSection>
       <SectionTitle>Props</SectionTitle>
       <PropsTable propsRows={propsRows} />
+    </DocSection>
+
+    <DocSection>
+      <SectionTitle>Column Type</SectionTitle>
+      <PropsTable propsRows={columnKeys} />
+    </DocSection>
+
+    <DocSection>
+      <SectionTitle>Row Type</SectionTitle>
+      <Text>
+        Rows should have keys corresponding to the dataKeys provided in the
+        columns. In addition, there are a few extra keys used by the table that
+        can be provided to each row
+      </Text>
+      <PropsTable propsRows={rowKeys} />
     </DocSection>
 
     <DocSection>

--- a/docs/src/pages/components/table.js
+++ b/docs/src/pages/components/table.js
@@ -47,15 +47,20 @@ const columnKeys = [
   {
     name: "cellFormatter",
     type: "function",
-    defaultValue: "undefined",
     description:
-      "Used to format cell text. It should return a string or react component."
+      "Used to format the table cell. It should return a string or react component."
   },
   {
     name: "cellRenderer",
     type: "function",
     description:
       "Used to override the cell component. No padding or other styles will be added in this case. It should return a react component. "
+  },
+  {
+    name: "headerFormatter",
+    type: "function",
+    description:
+      "Used to format the column's header. It should return a string or react component."
   }
 ];
 
@@ -65,6 +70,32 @@ const rowKeys = [
     type: "string",
     description:
       "Unique id for each row, required if another keyField is not passed to the Table"
+  }
+];
+
+const customCellArgumentKeys = [
+  {
+    name: "cellData",
+    type: "string",
+    description: "Text in the current cell, as passed in in the rows object"
+  },
+  {
+    name: "column",
+    type: "column",
+    description: "The column object the cell belongs to"
+  },
+  {
+    name: "row",
+    type: "row",
+    description: "The row object the cell belongs to"
+  }
+];
+
+const headerFormatterArgumentKeys = [
+  {
+    name: "column",
+    type: "column",
+    description: "The current column object"
   }
 ];
 
@@ -150,6 +181,12 @@ const customCellRenderer = ({ cellData }) => (
   </>
 );
 
+const customHeaderFormatter = ({ label }) => (
+  <>
+    <IconicButton icon="delete">{label}</IconicButton>
+  </>
+);
+
 const columns = [
   { label: "Column 1", dataKey: "c1" },
   { label: "Column 2", dataKey: "c2" },
@@ -184,10 +221,15 @@ const manyRowsForPagination = [
   { c1: "r8c1", c2: "r8c2", c3: "2019-09-10" },
   { c1: "r9c1", c2: "r9c2", c3: "2019-09-22" }
 ];
-const columnsWithCellRenderer = [
+const columnsWithCustomCells = [
   { label: "Column 1", dataKey: "c1" },
-  { label: "Column 2", dataKey: "c2" },
-  { label: "Column 3", dataKey: "c3", cellRenderer: customCellRenderer }
+  { label: "Date", dataKey: "c3", cellFormatter: dateToString },
+  {
+    label: "Actions",
+    dataKey: "c2",
+    headerFormatter: customHeaderFormatter,
+    cellRenderer: customCellRenderer
+  }
 ];
 
 const footerRowData = [
@@ -232,49 +274,48 @@ const rows = [{ c1: "row 1 cell 1", c2: "r1c2", c3: "2019-09-21" }, { c1: "r2c1"
     </DocSection>
 
     <DocSection>
-      <SectionTitle>With a cell formatter</SectionTitle>
+      <SectionTitle>With a custom component</SectionTitle>
       <Text>
-        Providing a cellFormatter function inside the column data will allow
-        formatting of the cell contents.
+        A custom component can be implemented using a Formatter or Renderer
+        function.
       </Text>
-      <Table columns={columnsWithFormatter} rows={rows} />
+      <Text>
+        The props that exist for custom components in cells are CellFormatter
+        and CellRenderer. Use CellFormatter to maintain the paddings and styles
+        on the cell. For completely custom styles, use the cellRenderer.
+      </Text>
+      <Text>
+        Similarly headers can be customized using the HeaderFormatter function
+        props. See{" "}
+        <Link href="https://storybook.nulogy.design/?path=/story/table--with-a-cell-formatter">
+          Storybook
+        </Link>{" "}
+        for other examples of implementing different custom components.
+      </Text>
+      <Table columns={columnsWithCustomCells} rows={rows} />
       <Highlight className="js">
-        {`const dateToString = (cellData) => {
+        {`const customCellRenderer = ({cellData}) => (
+    <IconicButton icon="delete">{cellData}</IconicButton>
+);
+const dateToString = ({cellData}) => {
   return new Date(cellData).toDateString();
 };
 
-const columnsWithFormatter = [
-  { label: "Column 1", dataKey: "c1" },
-  { label: "Column 2", dataKey: "c2" },
-  { label: "Column 3", dataKey: "c3", cellFormatter: dateToString }
-];
-
-const rows = [{ c1: "row 1 cell 1", c2: "r1c2", c3: "2019-09-21" }, { c1: "r2c1", c2: "r2c2", c3: "2019-09-22" }];
-
-<Table columns={columnsWithFormatter} rows={rows} />`}
-      </Highlight>
-    </DocSection>
-    <DocSection>
-      <SectionTitle>With a custom component</SectionTitle>
-      <Text>
-        Providing a cellRenderer function inside the column data will allow
-        display of arbitrary cell content. See{" "}
-        <Link href="https://storybook.nulogy.design/?path=/story/table--table-with-data">
-          Storybook
-        </Link>{" "}
-        for other examples of implementing different custom components using
-        cellRenderer.
-      </Text>
-      <Table columns={columnsWithCellRenderer} rows={rows} />
-      <Highlight className="js">
-        {`const customCellRenderer = (cellData) => (
-    <IconicButton icon="delete">{cellData}</IconicButton>
+const customHeaderFormatter = ({ label }) => (
+  <>
+    <IconicButton icon="delete">{label}</IconicButton>
+  </>
 );
 
-const columnsWithCellRenderer = [
+const columnsWithCustomCells = [
   { label: "Column 1", dataKey: "c1" },
-  { label: "Column 2", dataKey: "c2" },
-  { label: "Column 3", dataKey: "c3", cellRenderer: customCellRenderer }
+  { label: "Date", dataKey: "c3", cellFormatter: dateToString },
+  {
+    label: "Actions",
+    dataKey: "c2",
+    headerFormatter: customHeaderFormatter,
+    cellRenderer: customCellRenderer
+  }
 ];
 
 const rows = [
@@ -282,7 +323,7 @@ const rows = [
   { c1: "r2c1", c2: "r2c2", c3: "2019-09-22" }
 ];
 
-<Table columns={columnsWithCellRenderer} rows={rows} />
+<Table columns={columnsWithCustomCells} rows={rows} />
 `}
       </Highlight>
     </DocSection>
@@ -472,6 +513,25 @@ const manyRowsForPagination = [
         can be provided to each row
       </Text>
       <PropsTable propsRows={rowKeys} />
+    </DocSection>
+
+    <DocSection>
+      <SectionTitle>CellRenderer / CellFormatter Argument Type</SectionTitle>
+      <Text>
+        Use CellFormatter to maintain the styles within the cell while providing
+        a custom component or string. Use CellRenderer when using completely
+        custom styles.
+      </Text>
+      <PropsTable propsRows={customCellArgumentKeys} />
+    </DocSection>
+
+    <DocSection>
+      <SectionTitle>HeaderFormatter Argument Type</SectionTitle>
+      <Text>
+        Use HeaderFormatter to provide a custom header component. Styles on the
+        header cell will be maintained.
+      </Text>
+      <PropsTable propsRows={headerFormatterArgumentKeys} />
     </DocSection>
 
     <DocSection>


### PR DESCRIPTION
* adds an example of implementing filters by passing inputs as headers to the table
* modifies the table API to pass objects as arguments  to the formatter and renderer functions
* a distinction is made in function naming where: "____Formatter" allows the content within a cell to be changed but maintains the padding in the cell, "____Renderer" renders content within the cell without any padding. 
* Separates out all logic concerning individual TableCells into a Table Cell component which can easily be reused in the table body and footer. 