### PR TITLE
fixes cell data being entered as an array

### DIFF
--- a/components/src/Table/TableBody.js
+++ b/components/src/Table/TableBody.js
@@ -27,9 +27,7 @@ const renderRows = (rows, columns, keyField, noRowsContent) =>
 
 const TableBodyRow = ({ row, columns }) => {
   const renderAllCells = () =>
-    columns.map(column => (
-      <TableCell key={column.dataKey} row={row} column={column} cellData={[row[column.dataKey]]} />
-    ));
+    columns.map(column => <TableCell key={column.dataKey} row={row} column={column} cellData={row[column.dataKey]} />);
   return (
     <StyledTr>
       {row.heading ? <TableCell row={row} colSpan={columns.length} cellData={row.heading} /> : renderAllCells()}


### PR DESCRIPTION
cell data was returning an array around the cellData.
This bug didn't cause an issue for our examples OR proptypes since its still a react node that can be rendered but it might be breaking some other implementations when teams are consuming the Table component.