### PR TITLE
adds white background to Table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Restyled border colour of the active page button in pagination.
+- Restyled border colour of the active page button in [Pagination](https://nulogy.design/components/pagination).
+- [Table](https://nulogy.design/components/table) now has a white background instead of transparent
 
 ### Deprecated
 

--- a/components/src/DemoPage/__snapshots__/DemoPage.story.storyshot
+++ b/components/src/DemoPage/__snapshots__/DemoPage.story.storyshot
@@ -12064,10 +12064,11 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                             "componentStyle": ComponentStyle {
                                                               "componentId": "BaseTable__StyledTable-sc-10lnp9m-0",
                                                               "isStatic": false,
-                                                              "lastClassName": "fLepcs",
+                                                              "lastClassName": "ycode",
                                                               "rules": Array [
                                                                 "border-collapse: collapse;",
                                                                 "width: 100%;",
+                                                                "background: white;",
                                                               ],
                                                             },
                                                             "displayName": "BaseTable__StyledTable",
@@ -12084,7 +12085,7 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                         forwardedRef={null}
                                                       >
                                                         <table
-                                                          className="BaseTable__StyledTable-sc-10lnp9m-0 fLepcs"
+                                                          className="BaseTable__StyledTable-sc-10lnp9m-0 ycode"
                                                         >
                                                           <TableHead
                                                             columns={

--- a/components/src/StoriesForTests/__snapshots__/Table.story.storyshot
+++ b/components/src/StoriesForTests/__snapshots__/Table.story.storyshot
@@ -750,10 +750,11 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                               "componentStyle": ComponentStyle {
                                 "componentId": "BaseTable__StyledTable-sc-10lnp9m-0",
                                 "isStatic": false,
-                                "lastClassName": "fLepcs",
+                                "lastClassName": "ycode",
                                 "rules": Array [
                                   "border-collapse: collapse;",
                                   "width: 100%;",
+                                  "background: white;",
                                 ],
                               },
                               "displayName": "BaseTable__StyledTable",
@@ -770,7 +771,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                           forwardedRef={null}
                         >
                           <table
-                            className="BaseTable__StyledTable-sc-10lnp9m-0 fLepcs"
+                            className="BaseTable__StyledTable-sc-10lnp9m-0 ycode"
                           >
                             <TableHead
                               columns={
@@ -5352,10 +5353,11 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                             "componentStyle": ComponentStyle {
                               "componentId": "BaseTable__StyledTable-sc-10lnp9m-0",
                               "isStatic": false,
-                              "lastClassName": "fLepcs",
+                              "lastClassName": "ycode",
                               "rules": Array [
                                 "border-collapse: collapse;",
                                 "width: 100%;",
+                                "background: white;",
                               ],
                             },
                             "displayName": "BaseTable__StyledTable",
@@ -5372,7 +5374,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                         forwardedRef={null}
                       >
                         <table
-                          className="BaseTable__StyledTable-sc-10lnp9m-0 fLepcs"
+                          className="BaseTable__StyledTable-sc-10lnp9m-0 ycode"
                         >
                           <TableHead
                             columns={
@@ -9296,10 +9298,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                           "componentStyle": ComponentStyle {
                             "componentId": "BaseTable__StyledTable-sc-10lnp9m-0",
                             "isStatic": false,
-                            "lastClassName": "fLepcs",
+                            "lastClassName": "ycode",
                             "rules": Array [
                               "border-collapse: collapse;",
                               "width: 100%;",
+                              "background: white;",
                             ],
                           },
                           "displayName": "BaseTable__StyledTable",
@@ -9316,7 +9319,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                       forwardedRef={null}
                     >
                       <table
-                        className="BaseTable__StyledTable-sc-10lnp9m-0 fLepcs"
+                        className="BaseTable__StyledTable-sc-10lnp9m-0 ycode"
                       >
                         <TableHead
                           columns={
@@ -21943,10 +21946,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                             "componentStyle": ComponentStyle {
                               "componentId": "BaseTable__StyledTable-sc-10lnp9m-0",
                               "isStatic": false,
-                              "lastClassName": "fLepcs",
+                              "lastClassName": "ycode",
                               "rules": Array [
                                 "border-collapse: collapse;",
                                 "width: 100%;",
+                                "background: white;",
                               ],
                             },
                             "displayName": "BaseTable__StyledTable",
@@ -21963,7 +21967,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                         forwardedRef={null}
                       >
                         <table
-                          className="BaseTable__StyledTable-sc-10lnp9m-0 fLepcs"
+                          className="BaseTable__StyledTable-sc-10lnp9m-0 ycode"
                         >
                           <TableHead
                             columns={
@@ -37320,10 +37324,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                             "componentStyle": ComponentStyle {
                               "componentId": "BaseTable__StyledTable-sc-10lnp9m-0",
                               "isStatic": false,
-                              "lastClassName": "fLepcs",
+                              "lastClassName": "ycode",
                               "rules": Array [
                                 "border-collapse: collapse;",
                                 "width: 100%;",
+                                "background: white;",
                               ],
                             },
                             "displayName": "BaseTable__StyledTable",
@@ -37340,7 +37345,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                         forwardedRef={null}
                       >
                         <table
-                          className="BaseTable__StyledTable-sc-10lnp9m-0 fLepcs"
+                          className="BaseTable__StyledTable-sc-10lnp9m-0 ycode"
                         >
                           <TableHead
                             columns={
@@ -41079,10 +41084,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                             "componentStyle": ComponentStyle {
                               "componentId": "BaseTable__StyledTable-sc-10lnp9m-0",
                               "isStatic": false,
-                              "lastClassName": "fLepcs",
+                              "lastClassName": "ycode",
                               "rules": Array [
                                 "border-collapse: collapse;",
                                 "width: 100%;",
+                                "background: white;",
                               ],
                             },
                             "displayName": "BaseTable__StyledTable",
@@ -41099,7 +41105,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                         forwardedRef={null}
                       >
                         <table
-                          className="BaseTable__StyledTable-sc-10lnp9m-0 fLepcs"
+                          className="BaseTable__StyledTable-sc-10lnp9m-0 ycode"
                         >
                           <TableHead
                             columns={

--- a/components/src/Table/BaseTable.js
+++ b/components/src/Table/BaseTable.js
@@ -9,7 +9,8 @@ import { columnsPropType, rowsPropType } from "./Table.types";
 
 const StyledTable = styled.table({
   borderCollapse: "collapse",
-  width: "100%"
+  width: "100%",
+  background: "white"
 });
 
 const BaseTable = ({ columns, rows, noRowsContent, keyField, id, loading, footerRows }) => (


### PR DESCRIPTION
## Description

Our table was always on a white background so we didn't notice it was still transparent. This PR adds a white background to the Table so it can be placed on any colour background and still be readable. 

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [x] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [x] Changelog updated
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
