### PR TITLE
Optional row hovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Restyled border colour of the active page button in [Pagination](https://nulogy.design/components/pagination).
 - [Table](https://nulogy.design/components/table) now has a white background instead of transparent
+- [Table](http://nulogy.design/components/table) now allows setting `rowHovers={false}` to remove the light grey background when hovering a row
 
 ### Deprecated
 

--- a/components/src/DemoPage/__snapshots__/DemoPage.story.storyshot
+++ b/components/src/DemoPage/__snapshots__/DemoPage.story.storyshot
@@ -11999,6 +11999,7 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                   loading={false}
                                                   noRowsContent="No records have been created for this table."
                                                   onRowExpansionChange={null}
+                                                  rowHovers={true}
                                                   rows={
                                                     Array [
                                                       Object {
@@ -12039,6 +12040,7 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                     loading={false}
                                                     noRowsContent="No records have been created for this table."
                                                     onRowExpansionChange={null}
+                                                    rowHovers={true}
                                                     rows={
                                                       Array [
                                                         Object {
@@ -12279,6 +12281,7 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                             keyField="c1"
                                                             loading={false}
                                                             noRowsContent="No records have been created for this table."
+                                                            rowHovers={true}
                                                             rows={
                                                               Array [
                                                                 Object {
@@ -12321,8 +12324,11 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                     "c3": "r1c3",
                                                                   }
                                                                 }
+                                                                rowHovers={true}
                                                               >
-                                                                <TableBody__StyledTr>
+                                                                <TableBody__StyledTr
+                                                                  rowHovers={true}
+                                                                >
                                                                   <StyledComponent
                                                                     forwardedComponent={
                                                                       Object {
@@ -12333,9 +12339,7 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                           "isStatic": false,
                                                                           "lastClassName": "gvDwxX",
                                                                           "rules": Array [
-                                                                            "&:hover {",
-                                                                            "background-color: #f0f2f5;",
-                                                                            "}",
+                                                                            [Function],
                                                                           ],
                                                                         },
                                                                         "displayName": "TableBody__StyledTr",
@@ -12350,6 +12354,7 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                       }
                                                                     }
                                                                     forwardedRef={null}
+                                                                    rowHovers={true}
                                                                   >
                                                                     <tr
                                                                       className="TableBody__StyledTr-sc-1amzhx8-0 gvDwxX"
@@ -12543,8 +12548,11 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                     "c3": "r2c3",
                                                                   }
                                                                 }
+                                                                rowHovers={true}
                                                               >
-                                                                <TableBody__StyledTr>
+                                                                <TableBody__StyledTr
+                                                                  rowHovers={true}
+                                                                >
                                                                   <StyledComponent
                                                                     forwardedComponent={
                                                                       Object {
@@ -12555,9 +12563,7 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                           "isStatic": false,
                                                                           "lastClassName": "gvDwxX",
                                                                           "rules": Array [
-                                                                            "&:hover {",
-                                                                            "background-color: #f0f2f5;",
-                                                                            "}",
+                                                                            [Function],
                                                                           ],
                                                                         },
                                                                         "displayName": "TableBody__StyledTr",
@@ -12572,6 +12578,7 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                       }
                                                                     }
                                                                     forwardedRef={null}
+                                                                    rowHovers={true}
                                                                   >
                                                                     <tr
                                                                       className="TableBody__StyledTr-sc-1amzhx8-0 gvDwxX"

--- a/components/src/StoriesForTests/__snapshots__/Table.story.storyshot
+++ b/components/src/StoriesForTests/__snapshots__/Table.story.storyshot
@@ -430,6 +430,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
               loading={false}
               noRowsContent="No records have been created for this table."
               onRowExpansionChange={[Function]}
+              rowHovers={true}
               rows={
                 Array [
                   Object {
@@ -495,6 +496,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                 loading={false}
                 noRowsContent="No records have been created for this table."
                 onRowExpansionChange={[Function]}
+                rowHovers={true}
                 rows={
                   Array [
                     Object {
@@ -562,6 +564,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                   onRowExpansionChange={[Function]}
                   onSelectHeader={[Function]}
                   onSelectRow={[Function]}
+                  rowHovers={true}
                   rows={
                     Array [
                       Object {
@@ -634,6 +637,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                     onRowExpansionChange={[Function]}
                     onSelectHeader={[Function]}
                     onSelectRow={[Function]}
+                    rowHovers={true}
                     rows={
                       Array [
                         Object {
@@ -714,6 +718,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                       onRowExpansionChange={[Function]}
                       onSelectHeader={[Function]}
                       onSelectRow={[Function]}
+                      rowHovers={true}
                       rows={
                         Array [
                           Object {
@@ -1763,6 +1768,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                               keyField="c1"
                               loading={false}
                               noRowsContent="No records have been created for this table."
+                              rowHovers={true}
                               rows={
                                 Array [
                                   Object {
@@ -1838,8 +1844,11 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                       "selected": false,
                                     }
                                   }
+                                  rowHovers={true}
                                 >
-                                  <TableBody__StyledTr>
+                                  <TableBody__StyledTr
+                                    rowHovers={true}
+                                  >
                                     <StyledComponent
                                       forwardedComponent={
                                         Object {
@@ -1850,9 +1859,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                             "isStatic": false,
                                             "lastClassName": "gvDwxX",
                                             "rules": Array [
-                                              "&:hover {",
-                                              "background-color: #f0f2f5;",
-                                              "}",
+                                              [Function],
                                             ],
                                           },
                                           "displayName": "TableBody__StyledTr",
@@ -1867,6 +1874,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                         }
                                       }
                                       forwardedRef={null}
+                                      rowHovers={true}
                                     >
                                       <tr
                                         className="TableBody__StyledTr-sc-1amzhx8-0 gvDwxX"
@@ -2969,8 +2977,11 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                       "selected": true,
                                     }
                                   }
+                                  rowHovers={true}
                                 >
-                                  <TableBody__StyledTr>
+                                  <TableBody__StyledTr
+                                    rowHovers={true}
+                                  >
                                     <StyledComponent
                                       forwardedComponent={
                                         Object {
@@ -2981,9 +2992,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                             "isStatic": false,
                                             "lastClassName": "gvDwxX",
                                             "rules": Array [
-                                              "&:hover {",
-                                              "background-color: #f0f2f5;",
-                                              "}",
+                                              [Function],
                                             ],
                                           },
                                           "displayName": "TableBody__StyledTr",
@@ -2998,6 +3007,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                         }
                                       }
                                       forwardedRef={null}
+                                      rowHovers={true}
                                     >
                                       <tr
                                         className="TableBody__StyledTr-sc-1amzhx8-0 gvDwxX"
@@ -5135,6 +5145,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
               loading={false}
               noRowsContent="No records have been created for this table."
               onRowExpansionChange={null}
+              rowHovers={true}
               rows={
                 Array [
                   Object {
@@ -5196,6 +5207,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                 loading={false}
                 noRowsContent="No records have been created for this table."
                 onRowExpansionChange={null}
+                rowHovers={true}
                 rows={
                   Array [
                     Object {
@@ -5257,6 +5269,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                   loading={false}
                   noRowsContent="No records have been created for this table."
                   onRowExpansionChange={[Function]}
+                  rowHovers={true}
                   rows={
                     Array [
                       Object {
@@ -5323,6 +5336,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                     loading={false}
                     noRowsContent="No records have been created for this table."
                     onRowExpansionChange={[Function]}
+                    rowHovers={true}
                     rows={
                       Array [
                         Object {
@@ -5759,6 +5773,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                             keyField="c1"
                             loading={false}
                             noRowsContent="No records have been created for this table."
+                            rowHovers={true}
                             rows={
                               Array [
                                 Object {
@@ -5825,8 +5840,11 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                     "id": "r1",
                                   }
                                 }
+                                rowHovers={true}
                               >
-                                <TableBody__StyledTr>
+                                <TableBody__StyledTr
+                                  rowHovers={true}
+                                >
                                   <StyledComponent
                                     forwardedComponent={
                                       Object {
@@ -5837,9 +5855,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                           "isStatic": false,
                                           "lastClassName": "gvDwxX",
                                           "rules": Array [
-                                            "&:hover {",
-                                            "background-color: #f0f2f5;",
-                                            "}",
+                                            [Function],
                                           ],
                                         },
                                         "displayName": "TableBody__StyledTr",
@@ -5854,6 +5870,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                       }
                                     }
                                     forwardedRef={null}
+                                    rowHovers={true}
                                   >
                                     <tr
                                       className="TableBody__StyledTr-sc-1amzhx8-0 gvDwxX"
@@ -6307,8 +6324,11 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                     "id": "r2",
                                   }
                                 }
+                                rowHovers={true}
                               >
-                                <TableBody__StyledTr>
+                                <TableBody__StyledTr
+                                  rowHovers={true}
+                                >
                                   <StyledComponent
                                     forwardedComponent={
                                       Object {
@@ -6319,9 +6339,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                           "isStatic": false,
                                           "lastClassName": "gvDwxX",
                                           "rules": Array [
-                                            "&:hover {",
-                                            "background-color: #f0f2f5;",
-                                            "}",
+                                            [Function],
                                           ],
                                         },
                                         "displayName": "TableBody__StyledTr",
@@ -6336,6 +6354,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                       }
                                     }
                                     forwardedRef={null}
+                                    rowHovers={true}
                                   >
                                     <tr
                                       className="TableBody__StyledTr-sc-1amzhx8-0 gvDwxX"
@@ -7876,6 +7895,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
               loading={false}
               noRowsContent="No records have been created for this table."
               onRowExpansionChange={null}
+              rowHovers={true}
               rows={
                 Array [
                   Object {
@@ -8531,6 +8551,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                 loading={false}
                 noRowsContent="No records have been created for this table."
                 onRowExpansionChange={null}
+                rowHovers={true}
                 rows={
                   Array [
                     Object {
@@ -9186,6 +9207,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                   loading={false}
                   noRowsContent="No records have been created for this table."
                   onRowExpansionChange={null}
+                  rowHovers={true}
                   rows={
                     Array [
                       Object {
@@ -10359,6 +10381,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                           keyField="c1"
                           loading={false}
                           noRowsContent="No records have been created for this table."
+                          rowHovers={true}
                           rows={
                             Array [
                               Object {
@@ -10578,8 +10601,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                   "id": 0,
                                 }
                               }
+                              rowHovers={true}
                             >
-                              <TableBody__StyledTr>
+                              <TableBody__StyledTr
+                                rowHovers={true}
+                              >
                                 <StyledComponent
                                   forwardedComponent={
                                     Object {
@@ -10590,9 +10616,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         "isStatic": false,
                                         "lastClassName": "gvDwxX",
                                         "rules": Array [
-                                          "&:hover {",
-                                          "background-color: #f0f2f5;",
-                                          "}",
+                                          [Function],
                                         ],
                                       },
                                       "displayName": "TableBody__StyledTr",
@@ -10607,6 +10631,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                     }
                                   }
                                   forwardedRef={null}
+                                  rowHovers={true}
                                 >
                                   <tr
                                     className="TableBody__StyledTr-sc-1amzhx8-0 gvDwxX"
@@ -12244,8 +12269,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                   "id": 1,
                                 }
                               }
+                              rowHovers={true}
                             >
-                              <TableBody__StyledTr>
+                              <TableBody__StyledTr
+                                rowHovers={true}
+                              >
                                 <StyledComponent
                                   forwardedComponent={
                                     Object {
@@ -12256,9 +12284,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         "isStatic": false,
                                         "lastClassName": "gvDwxX",
                                         "rules": Array [
-                                          "&:hover {",
-                                          "background-color: #f0f2f5;",
-                                          "}",
+                                          [Function],
                                         ],
                                       },
                                       "displayName": "TableBody__StyledTr",
@@ -12273,6 +12299,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                     }
                                   }
                                   forwardedRef={null}
+                                  rowHovers={true}
                                 >
                                   <tr
                                     className="TableBody__StyledTr-sc-1amzhx8-0 gvDwxX"
@@ -13910,8 +13937,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                   "id": 2,
                                 }
                               }
+                              rowHovers={true}
                             >
-                              <TableBody__StyledTr>
+                              <TableBody__StyledTr
+                                rowHovers={true}
+                              >
                                 <StyledComponent
                                   forwardedComponent={
                                     Object {
@@ -13922,9 +13952,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         "isStatic": false,
                                         "lastClassName": "gvDwxX",
                                         "rules": Array [
-                                          "&:hover {",
-                                          "background-color: #f0f2f5;",
-                                          "}",
+                                          [Function],
                                         ],
                                       },
                                       "displayName": "TableBody__StyledTr",
@@ -13939,6 +13967,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                     }
                                   }
                                   forwardedRef={null}
+                                  rowHovers={true}
                                 >
                                   <tr
                                     className="TableBody__StyledTr-sc-1amzhx8-0 gvDwxX"
@@ -15576,8 +15605,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                   "id": 3,
                                 }
                               }
+                              rowHovers={true}
                             >
-                              <TableBody__StyledTr>
+                              <TableBody__StyledTr
+                                rowHovers={true}
+                              >
                                 <StyledComponent
                                   forwardedComponent={
                                     Object {
@@ -15588,9 +15620,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         "isStatic": false,
                                         "lastClassName": "gvDwxX",
                                         "rules": Array [
-                                          "&:hover {",
-                                          "background-color: #f0f2f5;",
-                                          "}",
+                                          [Function],
                                         ],
                                       },
                                       "displayName": "TableBody__StyledTr",
@@ -15605,6 +15635,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                     }
                                   }
                                   forwardedRef={null}
+                                  rowHovers={true}
                                 >
                                   <tr
                                     className="TableBody__StyledTr-sc-1amzhx8-0 gvDwxX"
@@ -18670,6 +18701,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
               loading={false}
               noRowsContent="No records have been created for this table."
               onRowExpansionChange={null}
+              rowHovers={true}
               rows={
                 Array [
                   Object {
@@ -20121,6 +20153,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                 loading={false}
                 noRowsContent="No records have been created for this table."
                 onRowExpansionChange={null}
+                rowHovers={true}
                 rows={
                   Array [
                     Object {
@@ -21574,6 +21607,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                   onRowExpansionChange={null}
                   onSelectHeader={[Function]}
                   onSelectRow={[Function]}
+                  rowHovers={true}
                   rows={
                     Array [
                       Object {
@@ -21805,6 +21839,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                     onRowExpansionChange={null}
                     onSelectHeader={[Function]}
                     onSelectRow={[Function]}
+                    rowHovers={true}
                     rows={
                       Array [
                         Object {
@@ -23614,6 +23649,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                             keyField="c1"
                             loading={false}
                             noRowsContent="No records have been created for this table."
+                            rowHovers={true}
                             rows={
                               Array [
                                 Object {
@@ -23869,8 +23905,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                     "selected": false,
                                   }
                                 }
+                                rowHovers={true}
                               >
-                                <TableBody__StyledTr>
+                                <TableBody__StyledTr
+                                  rowHovers={true}
+                                >
                                   <StyledComponent
                                     forwardedComponent={
                                       Object {
@@ -23881,9 +23920,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           "isStatic": false,
                                           "lastClassName": "gvDwxX",
                                           "rules": Array [
-                                            "&:hover {",
-                                            "background-color: #f0f2f5;",
-                                            "}",
+                                            [Function],
                                           ],
                                         },
                                         "displayName": "TableBody__StyledTr",
@@ -23898,6 +23935,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                       }
                                     }
                                     forwardedRef={null}
+                                    rowHovers={true}
                                   >
                                     <tr
                                       className="TableBody__StyledTr-sc-1amzhx8-0 gvDwxX"
@@ -26231,8 +26269,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                     "selected": false,
                                   }
                                 }
+                                rowHovers={true}
                               >
-                                <TableBody__StyledTr>
+                                <TableBody__StyledTr
+                                  rowHovers={true}
+                                >
                                   <StyledComponent
                                     forwardedComponent={
                                       Object {
@@ -26243,9 +26284,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           "isStatic": false,
                                           "lastClassName": "gvDwxX",
                                           "rules": Array [
-                                            "&:hover {",
-                                            "background-color: #f0f2f5;",
-                                            "}",
+                                            [Function],
                                           ],
                                         },
                                         "displayName": "TableBody__StyledTr",
@@ -26260,6 +26299,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                       }
                                     }
                                     forwardedRef={null}
+                                    rowHovers={true}
                                   >
                                     <tr
                                       className="TableBody__StyledTr-sc-1amzhx8-0 gvDwxX"
@@ -28593,8 +28633,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                     "selected": false,
                                   }
                                 }
+                                rowHovers={true}
                               >
-                                <TableBody__StyledTr>
+                                <TableBody__StyledTr
+                                  rowHovers={true}
+                                >
                                   <StyledComponent
                                     forwardedComponent={
                                       Object {
@@ -28605,9 +28648,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           "isStatic": false,
                                           "lastClassName": "gvDwxX",
                                           "rules": Array [
-                                            "&:hover {",
-                                            "background-color: #f0f2f5;",
-                                            "}",
+                                            [Function],
                                           ],
                                         },
                                         "displayName": "TableBody__StyledTr",
@@ -28622,6 +28663,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                       }
                                     }
                                     forwardedRef={null}
+                                    rowHovers={true}
                                   >
                                     <tr
                                       className="TableBody__StyledTr-sc-1amzhx8-0 gvDwxX"
@@ -30955,8 +30997,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                     "selected": false,
                                   }
                                 }
+                                rowHovers={true}
                               >
-                                <TableBody__StyledTr>
+                                <TableBody__StyledTr
+                                  rowHovers={true}
+                                >
                                   <StyledComponent
                                     forwardedComponent={
                                       Object {
@@ -30967,9 +31012,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           "isStatic": false,
                                           "lastClassName": "gvDwxX",
                                           "rules": Array [
-                                            "&:hover {",
-                                            "background-color: #f0f2f5;",
-                                            "}",
+                                            [Function],
                                           ],
                                         },
                                         "displayName": "TableBody__StyledTr",
@@ -30984,6 +31027,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                       }
                                     }
                                     forwardedRef={null}
+                                    rowHovers={true}
                                   >
                                     <tr
                                       className="TableBody__StyledTr-sc-1amzhx8-0 gvDwxX"
@@ -33317,8 +33361,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                     "selected": false,
                                   }
                                 }
+                                rowHovers={true}
                               >
-                                <TableBody__StyledTr>
+                                <TableBody__StyledTr
+                                  rowHovers={true}
+                                >
                                   <StyledComponent
                                     forwardedComponent={
                                       Object {
@@ -33329,9 +33376,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           "isStatic": false,
                                           "lastClassName": "gvDwxX",
                                           "rules": Array [
-                                            "&:hover {",
-                                            "background-color: #f0f2f5;",
-                                            "}",
+                                            [Function],
                                           ],
                                         },
                                         "displayName": "TableBody__StyledTr",
@@ -33346,6 +33391,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                       }
                                     }
                                     forwardedRef={null}
+                                    rowHovers={true}
                                   >
                                     <tr
                                       className="TableBody__StyledTr-sc-1amzhx8-0 gvDwxX"
@@ -37123,6 +37169,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
               loading={false}
               noRowsContent="No records have been created for this table."
               onRowExpansionChange={null}
+              rowHovers={true}
               rows={
                 Array [
                   Object {
@@ -37177,6 +37224,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                 loading={false}
                 noRowsContent="No records have been created for this table."
                 onRowExpansionChange={null}
+                rowHovers={true}
                 rows={
                   Array [
                     Object {
@@ -37233,6 +37281,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                   onRowExpansionChange={null}
                   onSelectHeader={[Function]}
                   onSelectRow={[Function]}
+                  rowHovers={true}
                   rows={
                     Array [
                       Object {
@@ -37295,6 +37344,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                     onRowExpansionChange={null}
                     onSelectHeader={[Function]}
                     onSelectRow={[Function]}
+                    rowHovers={true}
                     rows={
                       Array [
                         Object {
@@ -38287,6 +38337,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                             keyField="c1"
                             loading={false}
                             noRowsContent="No records have been created for this table."
+                            rowHovers={true}
                             rows={
                               Array [
                                 Object {
@@ -38353,8 +38404,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                     "selected": false,
                                   }
                                 }
+                                rowHovers={true}
                               >
-                                <TableBody__StyledTr>
+                                <TableBody__StyledTr
+                                  rowHovers={true}
+                                >
                                   <StyledComponent
                                     forwardedComponent={
                                       Object {
@@ -38365,9 +38419,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                           "isStatic": false,
                                           "lastClassName": "gvDwxX",
                                           "rules": Array [
-                                            "&:hover {",
-                                            "background-color: #f0f2f5;",
-                                            "}",
+                                            [Function],
                                           ],
                                         },
                                         "displayName": "TableBody__StyledTr",
@@ -38382,6 +38434,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                       }
                                     }
                                     forwardedRef={null}
+                                    rowHovers={true}
                                   >
                                     <tr
                                       className="TableBody__StyledTr-sc-1amzhx8-0 gvDwxX"
@@ -39392,8 +39445,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                     "selected": false,
                                   }
                                 }
+                                rowHovers={true}
                               >
-                                <TableBody__StyledTr>
+                                <TableBody__StyledTr
+                                  rowHovers={true}
+                                >
                                   <StyledComponent
                                     forwardedComponent={
                                       Object {
@@ -39404,9 +39460,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                           "isStatic": false,
                                           "lastClassName": "gvDwxX",
                                           "rules": Array [
-                                            "&:hover {",
-                                            "background-color: #f0f2f5;",
-                                            "}",
+                                            [Function],
                                           ],
                                         },
                                         "displayName": "TableBody__StyledTr",
@@ -39421,6 +39475,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                       }
                                     }
                                     forwardedRef={null}
+                                    rowHovers={true}
                                   >
                                     <tr
                                       className="TableBody__StyledTr-sc-1amzhx8-0 gvDwxX"
@@ -40867,6 +40922,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
               loading={false}
               noRowsContent="No records have been created for this table."
               onRowExpansionChange={null}
+              rowHovers={true}
               rows={
                 Array [
                   Object {
@@ -40925,6 +40981,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                 loading={false}
                 noRowsContent="No records have been created for this table."
                 onRowExpansionChange={null}
+                rowHovers={true}
                 rows={
                   Array [
                     Object {
@@ -40985,6 +41042,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                   onRowExpansionChange={null}
                   onSelectHeader={[Function]}
                   onSelectRow={[Function]}
+                  rowHovers={true}
                   rows={
                     Array [
                       Object {
@@ -41051,6 +41109,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                     onRowExpansionChange={null}
                     onSelectHeader={[Function]}
                     onSelectRow={[Function]}
+                    rowHovers={true}
                     rows={
                       Array [
                         Object {
@@ -42047,6 +42106,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                             keyField="c1"
                             loading={false}
                             noRowsContent="No records have been created for this table."
+                            rowHovers={true}
                             rows={
                               Array [
                                 Object {
@@ -42113,8 +42173,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                     "selected": false,
                                   }
                                 }
+                                rowHovers={true}
                               >
-                                <TableBody__StyledTr>
+                                <TableBody__StyledTr
+                                  rowHovers={true}
+                                >
                                   <StyledComponent
                                     forwardedComponent={
                                       Object {
@@ -42125,9 +42188,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                           "isStatic": false,
                                           "lastClassName": "gvDwxX",
                                           "rules": Array [
-                                            "&:hover {",
-                                            "background-color: #f0f2f5;",
-                                            "}",
+                                            [Function],
                                           ],
                                         },
                                         "displayName": "TableBody__StyledTr",
@@ -42142,6 +42203,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                       }
                                     }
                                     forwardedRef={null}
+                                    rowHovers={true}
                                   >
                                     <tr
                                       className="TableBody__StyledTr-sc-1amzhx8-0 gvDwxX"
@@ -43152,8 +43214,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                     "selected": true,
                                   }
                                 }
+                                rowHovers={true}
                               >
-                                <TableBody__StyledTr>
+                                <TableBody__StyledTr
+                                  rowHovers={true}
+                                >
                                   <StyledComponent
                                     forwardedComponent={
                                       Object {
@@ -43164,9 +43229,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                           "isStatic": false,
                                           "lastClassName": "gvDwxX",
                                           "rules": Array [
-                                            "&:hover {",
-                                            "background-color: #f0f2f5;",
-                                            "}",
+                                            [Function],
                                           ],
                                         },
                                         "displayName": "TableBody__StyledTr",
@@ -43181,6 +43244,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                       }
                                     }
                                     forwardedRef={null}
+                                    rowHovers={true}
                                   >
                                     <tr
                                       className="TableBody__StyledTr-sc-1amzhx8-0 gvDwxX"

--- a/components/src/Table/BaseTable.js
+++ b/components/src/Table/BaseTable.js
@@ -13,10 +13,17 @@ const StyledTable = styled.table({
   background: "white"
 });
 
-const BaseTable = ({ columns, rows, noRowsContent, keyField, id, loading, footerRows }) => (
+const BaseTable = ({ columns, rows, noRowsContent, keyField, id, loading, footerRows, rowHovers }) => (
   <StyledTable id={id}>
     <TableHead columns={columns} />
-    <TableBody columns={columns} rows={rows} keyField={keyField} noRowsContent={noRowsContent} loading={loading} />
+    <TableBody
+      columns={columns}
+      rows={rows}
+      keyField={keyField}
+      noRowsContent={noRowsContent}
+      loading={loading}
+      rowHovers={rowHovers}
+    />
     {footerRows && <TableFoot columns={columns} rows={footerRows} loading={loading} />}
   </StyledTable>
 );
@@ -28,7 +35,8 @@ BaseTable.propTypes = {
   keyField: PropTypes.string,
   id: PropTypes.string,
   loading: PropTypes.bool,
-  footerRows: rowsPropType
+  footerRows: rowsPropType,
+  rowHovers: PropTypes.bool
 };
 
 BaseTable.defaultProps = {
@@ -36,7 +44,8 @@ BaseTable.defaultProps = {
   keyField: "id",
   id: undefined,
   loading: false,
-  footerRows: []
+  footerRows: [],
+  rowHovers: true
 };
 
 export default BaseTable;

--- a/components/src/Table/Table.story.js
+++ b/components/src/Table/Table.story.js
@@ -117,6 +117,7 @@ const footerRowData = [
 
 storiesOf("Table", module)
   .add("Table with data", () => <Table columns={columns} rows={rowData} />)
+  .add("Table without row hovers", () => <Table columns={columns} rows={rowData} rowHovers={false} />)
   .add("Cell alignment", () => <Table columns={columnsWithAlignment} rows={rowData} />)
   .add("with no data", () => <Table columns={columns} rows={[]} />)
   .add("loading", () => <Table columns={columns} rows={rowData} loading />)

--- a/components/src/Table/TableBody.js
+++ b/components/src/Table/TableBody.js
@@ -47,7 +47,7 @@ const TableBodyRow = ({ row, columns, rowHovers }) => {
 TableBodyRow.propTypes = {
   row: rowPropType.isRequired,
   columns: columnsPropType.isRequired,
-  rowHovers: PropTypes.isRequired
+  rowHovers: PropTypes.bool.isRequired
 };
 
 const TableMessageContainer = ({ colSpan, children }) => (

--- a/components/src/Table/TableBody.js
+++ b/components/src/Table/TableBody.js
@@ -82,6 +82,7 @@ const TableBody = ({ rows, columns, keyField, noRowsContent, loading, rowHovers 
 TableBody.propTypes = {
   columns: columnsPropType.isRequired,
   rows: rowsPropType.isRequired,
+  rowHovers: PropTypes.bool.isRequired,
   noRowsContent: PropTypes.string,
   keyField: PropTypes.string,
   loading: PropTypes.bool

--- a/components/src/Table/TableBody.js
+++ b/components/src/Table/TableBody.js
@@ -12,25 +12,27 @@ const StyledMessageContainer = styled(Box)({
   color: theme.colors.darkGrey
 });
 
-const StyledTr = styled.tr({
+const StyledTr = styled.tr(({ rowHovers }) => ({
   "&:hover": {
-    backgroundColor: theme.colors.whiteGrey
+    backgroundColor: rowHovers ? theme.colors.whiteGrey : null
   }
-});
+}));
 
-const renderRows = (rows, columns, keyField, noRowsContent) =>
+const renderRows = (rows, columns, keyField, noRowsContent, rowHovers) =>
   rows.length > 0 ? (
-    rows.map(row => <TableBodyRow row={row} columns={columns} key={row[keyField]} keyField={keyField} />)
+    rows.map(row => (
+      <TableBodyRow row={row} columns={columns} key={row[keyField]} keyField={keyField} rowHovers={rowHovers} />
+    ))
   ) : (
     <TableMessageContainer colSpan={columns.length - 1}>{noRowsContent}</TableMessageContainer>
   );
 
-const TableBodyRow = ({ row, columns }) => {
+const TableBodyRow = ({ row, columns, rowHovers }) => {
   const renderAllCells = () =>
     columns.map(column => <TableCell key={column.dataKey} row={row} column={column} cellData={row[column.dataKey]} />);
   return (
     <>
-      <StyledTr>
+      <StyledTr rowHovers={rowHovers}>
         {row.heading ? <TableCell row={row} colSpan={columns.length} cellData={row.heading} /> : renderAllCells()}
       </StyledTr>
       {row.expandedContent && row.expanded && (
@@ -44,7 +46,8 @@ const TableBodyRow = ({ row, columns }) => {
 
 TableBodyRow.propTypes = {
   row: rowPropType.isRequired,
-  columns: columnsPropType.isRequired
+  columns: columnsPropType.isRequired,
+  rowHovers: PropTypes.isRequired
 };
 
 const TableMessageContainer = ({ colSpan, children }) => (
@@ -66,9 +69,13 @@ LoadingContent.propTypes = {
   colSpan: PropTypes.number.isRequired
 };
 
-const TableBody = ({ rows, columns, keyField, noRowsContent, loading }) => (
+const TableBody = ({ rows, columns, keyField, noRowsContent, loading, rowHovers }) => (
   <tbody>
-    {!loading ? renderRows(rows, columns, keyField, noRowsContent) : <LoadingContent colSpan={columns.length - 1} />}
+    {!loading ? (
+      renderRows(rows, columns, keyField, noRowsContent, rowHovers)
+    ) : (
+      <LoadingContent colSpan={columns.length - 1} />
+    )}
   </tbody>
 );
 

--- a/docs/src/pages/components/table.js
+++ b/docs/src/pages/components/table.js
@@ -191,6 +191,13 @@ const propsRows = [
     defaultValue: "none",
     description:
       "The function that should be called when a current page changes. The page number that is currently selected is passed in as an argument."
+  },
+  {
+    name: "rowHovers",
+    type: "boolean",
+    defaultValue: "true",
+    description:
+      "Whether or not to show a light grey background on a row when hovering it"
   }
 ];
 


### PR DESCRIPTION
## Description

This PR makes row hovers optional, turned on by default. This was requested by PM3. 

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [x] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [x] Docs updated with correct props and examples
- [x] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [x] Changelog updated
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
