### PR TITLE
Add compact table option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- [Table](https://nulogy.design/components/table) now supports compact mode the the compact boolean prop
+
 ### Changed
 
 - Restyled border colour of the active page button in [Pagination](https://nulogy.design/components/pagination).

--- a/components/src/DemoPage/__snapshots__/DemoPage.story.storyshot
+++ b/components/src/DemoPage/__snapshots__/DemoPage.story.storyshot
@@ -11992,6 +11992,7 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                       },
                                                     ]
                                                   }
+                                                  compact={false}
                                                   footerRows={Array []}
                                                   hasSelectableRows={false}
                                                   isHeaderSelected={false}
@@ -12033,6 +12034,7 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                         },
                                                       ]
                                                     }
+                                                    compact={false}
                                                     footerRows={Array []}
                                                     hasSelectableRows={false}
                                                     isHeaderSelected={false}
@@ -12106,6 +12108,7 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                 },
                                                               ]
                                                             }
+                                                            compact={false}
                                                           >
                                                             <thead>
                                                               <TableHead__StyledHeaderRow>
@@ -12139,27 +12142,29 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                   <tr
                                                                     className="TableHead__StyledHeaderRow-msr3t5-0 dCTkDK"
                                                                   >
-                                                                    <TableHead__StyledTh
+                                                                    <StyledTh
+                                                                      compact={false}
                                                                       key="c1"
                                                                       scope="col"
                                                                     >
                                                                       <StyledComponent
+                                                                        compact={false}
                                                                         forwardedComponent={
                                                                           Object {
                                                                             "$$typeof": Symbol(react.forward_ref),
                                                                             "attrs": Array [],
                                                                             "componentStyle": ComponentStyle {
-                                                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                                                               "isStatic": false,
-                                                                              "lastClassName": "bQoogK",
+                                                                              "lastClassName": "eunBIc",
                                                                               "rules": Array [
                                                                                 [Function],
                                                                               ],
                                                                             },
-                                                                            "displayName": "TableHead__StyledTh",
+                                                                            "displayName": "StyledTh",
                                                                             "foldedComponentIds": Array [],
                                                                             "render": [Function],
-                                                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                                                             "target": "th",
                                                                             "toString": [Function],
                                                                             "usesTheme": false,
@@ -12171,34 +12176,36 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                         scope="col"
                                                                       >
                                                                         <th
-                                                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                                                           scope="col"
                                                                         >
                                                                           Column 1
                                                                         </th>
                                                                       </StyledComponent>
-                                                                    </TableHead__StyledTh>
-                                                                    <TableHead__StyledTh
+                                                                    </StyledTh>
+                                                                    <StyledTh
+                                                                      compact={false}
                                                                       key="c2"
                                                                       scope="col"
                                                                     >
                                                                       <StyledComponent
+                                                                        compact={false}
                                                                         forwardedComponent={
                                                                           Object {
                                                                             "$$typeof": Symbol(react.forward_ref),
                                                                             "attrs": Array [],
                                                                             "componentStyle": ComponentStyle {
-                                                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                                                               "isStatic": false,
-                                                                              "lastClassName": "bQoogK",
+                                                                              "lastClassName": "eunBIc",
                                                                               "rules": Array [
                                                                                 [Function],
                                                                               ],
                                                                             },
-                                                                            "displayName": "TableHead__StyledTh",
+                                                                            "displayName": "StyledTh",
                                                                             "foldedComponentIds": Array [],
                                                                             "render": [Function],
-                                                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                                                             "target": "th",
                                                                             "toString": [Function],
                                                                             "usesTheme": false,
@@ -12210,34 +12217,36 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                         scope="col"
                                                                       >
                                                                         <th
-                                                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                                                           scope="col"
                                                                         >
                                                                           Column 2
                                                                         </th>
                                                                       </StyledComponent>
-                                                                    </TableHead__StyledTh>
-                                                                    <TableHead__StyledTh
+                                                                    </StyledTh>
+                                                                    <StyledTh
+                                                                      compact={false}
                                                                       key="c3"
                                                                       scope="col"
                                                                     >
                                                                       <StyledComponent
+                                                                        compact={false}
                                                                         forwardedComponent={
                                                                           Object {
                                                                             "$$typeof": Symbol(react.forward_ref),
                                                                             "attrs": Array [],
                                                                             "componentStyle": ComponentStyle {
-                                                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                                                               "isStatic": false,
-                                                                              "lastClassName": "bQoogK",
+                                                                              "lastClassName": "eunBIc",
                                                                               "rules": Array [
                                                                                 [Function],
                                                                               ],
                                                                             },
-                                                                            "displayName": "TableHead__StyledTh",
+                                                                            "displayName": "StyledTh",
                                                                             "foldedComponentIds": Array [],
                                                                             "render": [Function],
-                                                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                                                             "target": "th",
                                                                             "toString": [Function],
                                                                             "usesTheme": false,
@@ -12249,13 +12258,13 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                         scope="col"
                                                                       >
                                                                         <th
-                                                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                                                           scope="col"
                                                                         >
                                                                           Column 3
                                                                         </th>
                                                                       </StyledComponent>
-                                                                    </TableHead__StyledTh>
+                                                                    </StyledTh>
                                                                   </tr>
                                                                 </StyledComponent>
                                                               </TableHead__StyledHeaderRow>
@@ -12278,6 +12287,7 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                 },
                                                               ]
                                                             }
+                                                            compact={false}
                                                             keyField="c1"
                                                             loading={false}
                                                             noRowsContent="No records have been created for this table."
@@ -12315,6 +12325,7 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                     },
                                                                   ]
                                                                 }
+                                                                compact={false}
                                                                 key="r1c1"
                                                                 keyField="c1"
                                                                 row={
@@ -12368,6 +12379,7 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                             "label": "Column 1",
                                                                           }
                                                                         }
+                                                                        compact={false}
                                                                         key="c1"
                                                                         row={
                                                                           Object {
@@ -12377,8 +12389,11 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                           }
                                                                         }
                                                                       >
-                                                                        <TableCell__StyledTableCell>
+                                                                        <TableCell__StyledTableCell
+                                                                          compact={false}
+                                                                        >
                                                                           <StyledComponent
+                                                                            compact={false}
                                                                             forwardedComponent={
                                                                               Object {
                                                                                 "$$typeof": Symbol(react.forward_ref),
@@ -12421,6 +12436,7 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                             "label": "Column 2",
                                                                           }
                                                                         }
+                                                                        compact={false}
                                                                         key="c2"
                                                                         row={
                                                                           Object {
@@ -12430,8 +12446,11 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                           }
                                                                         }
                                                                       >
-                                                                        <TableCell__StyledTableCell>
+                                                                        <TableCell__StyledTableCell
+                                                                          compact={false}
+                                                                        >
                                                                           <StyledComponent
+                                                                            compact={false}
                                                                             forwardedComponent={
                                                                               Object {
                                                                                 "$$typeof": Symbol(react.forward_ref),
@@ -12474,6 +12493,7 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                             "label": "Column 3",
                                                                           }
                                                                         }
+                                                                        compact={false}
                                                                         key="c3"
                                                                         row={
                                                                           Object {
@@ -12483,8 +12503,11 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                           }
                                                                         }
                                                                       >
-                                                                        <TableCell__StyledTableCell>
+                                                                        <TableCell__StyledTableCell
+                                                                          compact={false}
+                                                                        >
                                                                           <StyledComponent
+                                                                            compact={false}
                                                                             forwardedComponent={
                                                                               Object {
                                                                                 "$$typeof": Symbol(react.forward_ref),
@@ -12539,6 +12562,7 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                     },
                                                                   ]
                                                                 }
+                                                                compact={false}
                                                                 key="r2c1"
                                                                 keyField="c1"
                                                                 row={
@@ -12592,6 +12616,7 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                             "label": "Column 1",
                                                                           }
                                                                         }
+                                                                        compact={false}
                                                                         key="c1"
                                                                         row={
                                                                           Object {
@@ -12601,8 +12626,11 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                           }
                                                                         }
                                                                       >
-                                                                        <TableCell__StyledTableCell>
+                                                                        <TableCell__StyledTableCell
+                                                                          compact={false}
+                                                                        >
                                                                           <StyledComponent
+                                                                            compact={false}
                                                                             forwardedComponent={
                                                                               Object {
                                                                                 "$$typeof": Symbol(react.forward_ref),
@@ -12645,6 +12673,7 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                             "label": "Column 2",
                                                                           }
                                                                         }
+                                                                        compact={false}
                                                                         key="c2"
                                                                         row={
                                                                           Object {
@@ -12654,8 +12683,11 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                           }
                                                                         }
                                                                       >
-                                                                        <TableCell__StyledTableCell>
+                                                                        <TableCell__StyledTableCell
+                                                                          compact={false}
+                                                                        >
                                                                           <StyledComponent
+                                                                            compact={false}
                                                                             forwardedComponent={
                                                                               Object {
                                                                                 "$$typeof": Symbol(react.forward_ref),
@@ -12698,6 +12730,7 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                             "label": "Column 3",
                                                                           }
                                                                         }
+                                                                        compact={false}
                                                                         key="c3"
                                                                         row={
                                                                           Object {
@@ -12707,8 +12740,11 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                           }
                                                                         }
                                                                       >
-                                                                        <TableCell__StyledTableCell>
+                                                                        <TableCell__StyledTableCell
+                                                                          compact={false}
+                                                                        >
                                                                           <StyledComponent
+                                                                            compact={false}
                                                                             forwardedComponent={
                                                                               Object {
                                                                                 "$$typeof": Symbol(react.forward_ref),

--- a/components/src/StoriesForTests/__snapshots__/Table.story.storyshot
+++ b/components/src/StoriesForTests/__snapshots__/Table.story.storyshot
@@ -417,6 +417,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                   },
                 ]
               }
+              compact={false}
               expandedRows={
                 Array [
                   "r2c1",
@@ -483,6 +484,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                     },
                   ]
                 }
+                compact={false}
                 expandedRows={
                   Array [
                     "r2c1",
@@ -549,6 +551,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                       },
                     ]
                   }
+                  compact={false}
                   expandedRows={
                     Array [
                       "r2c1",
@@ -622,6 +625,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                         },
                       ]
                     }
+                    compact={false}
                     expandedRows={
                       Array [
                         "r2c1",
@@ -703,6 +707,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                           },
                         ]
                       }
+                      compact={false}
                       expandedRows={
                         Array [
                           "r2c1",
@@ -818,6 +823,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                   },
                                 ]
                               }
+                              compact={false}
                             >
                               <thead>
                                 <TableHead__StyledHeaderRow>
@@ -851,28 +857,30 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                     <tr
                                       className="TableHead__StyledHeaderRow-msr3t5-0 dCTkDK"
                                     >
-                                      <TableHead__StyledTh
+                                      <StyledTh
+                                        compact={false}
                                         key="selected"
                                         scope="col"
                                         width="30px"
                                       >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
                                               "attrs": Array [],
                                               "componentStyle": ComponentStyle {
-                                                "componentId": "TableHead__StyledTh-msr3t5-1",
+                                                "componentId": "StyledTh-sc-10nzyk9-0",
                                                 "isStatic": false,
-                                                "lastClassName": "bQoogK",
+                                                "lastClassName": "eunBIc",
                                                 "rules": Array [
                                                   [Function],
                                                 ],
                                               },
-                                              "displayName": "TableHead__StyledTh",
+                                              "displayName": "StyledTh",
                                               "foldedComponentIds": Array [],
                                               "render": [Function],
-                                              "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                              "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                               "target": "th",
                                               "toString": [Function],
                                               "usesTheme": false,
@@ -885,7 +893,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                           width="30px"
                                         >
                                           <th
-                                            className="TableHead__StyledTh-msr3t5-1 lfTJRR"
+                                            className="StyledTh-sc-10nzyk9-0 sXJR"
                                             scope="col"
                                             width="30px"
                                           >
@@ -1445,29 +1453,31 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                             </Styled(BaseCheckbox)>
                                           </th>
                                         </StyledComponent>
-                                      </TableHead__StyledTh>
-                                      <TableHead__StyledTh
+                                      </StyledTh>
+                                      <StyledTh
+                                        compact={false}
                                         key="expanded"
                                         scope="col"
                                         width="30px"
                                       >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
                                               "attrs": Array [],
                                               "componentStyle": ComponentStyle {
-                                                "componentId": "TableHead__StyledTh-msr3t5-1",
+                                                "componentId": "StyledTh-sc-10nzyk9-0",
                                                 "isStatic": false,
-                                                "lastClassName": "bQoogK",
+                                                "lastClassName": "eunBIc",
                                                 "rules": Array [
                                                   [Function],
                                                 ],
                                               },
-                                              "displayName": "TableHead__StyledTh",
+                                              "displayName": "StyledTh",
                                               "foldedComponentIds": Array [],
                                               "render": [Function],
-                                              "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                              "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                               "target": "th",
                                               "toString": [Function],
                                               "usesTheme": false,
@@ -1480,33 +1490,35 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                           width="30px"
                                         >
                                           <th
-                                            className="TableHead__StyledTh-msr3t5-1 lfTJRR"
+                                            className="StyledTh-sc-10nzyk9-0 sXJR"
                                             scope="col"
                                             width="30px"
                                           />
                                         </StyledComponent>
-                                      </TableHead__StyledTh>
-                                      <TableHead__StyledTh
+                                      </StyledTh>
+                                      <StyledTh
+                                        compact={false}
                                         key="c1"
                                         scope="col"
                                       >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
                                               "attrs": Array [],
                                               "componentStyle": ComponentStyle {
-                                                "componentId": "TableHead__StyledTh-msr3t5-1",
+                                                "componentId": "StyledTh-sc-10nzyk9-0",
                                                 "isStatic": false,
-                                                "lastClassName": "bQoogK",
+                                                "lastClassName": "eunBIc",
                                                 "rules": Array [
                                                   [Function],
                                                 ],
                                               },
-                                              "displayName": "TableHead__StyledTh",
+                                              "displayName": "StyledTh",
                                               "foldedComponentIds": Array [],
                                               "render": [Function],
-                                              "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                              "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                               "target": "th",
                                               "toString": [Function],
                                               "usesTheme": false,
@@ -1518,34 +1530,36 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                           scope="col"
                                         >
                                           <th
-                                            className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                            className="StyledTh-sc-10nzyk9-0 eunBIc"
                                             scope="col"
                                           >
                                             Column 1
                                           </th>
                                         </StyledComponent>
-                                      </TableHead__StyledTh>
-                                      <TableHead__StyledTh
+                                      </StyledTh>
+                                      <StyledTh
+                                        compact={false}
                                         key="c2"
                                         scope="col"
                                       >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
                                               "attrs": Array [],
                                               "componentStyle": ComponentStyle {
-                                                "componentId": "TableHead__StyledTh-msr3t5-1",
+                                                "componentId": "StyledTh-sc-10nzyk9-0",
                                                 "isStatic": false,
-                                                "lastClassName": "bQoogK",
+                                                "lastClassName": "eunBIc",
                                                 "rules": Array [
                                                   [Function],
                                                 ],
                                               },
-                                              "displayName": "TableHead__StyledTh",
+                                              "displayName": "StyledTh",
                                               "foldedComponentIds": Array [],
                                               "render": [Function],
-                                              "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                              "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                               "target": "th",
                                               "toString": [Function],
                                               "usesTheme": false,
@@ -1557,34 +1571,36 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                           scope="col"
                                         >
                                           <th
-                                            className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                            className="StyledTh-sc-10nzyk9-0 eunBIc"
                                             scope="col"
                                           >
                                             Column 2
                                           </th>
                                         </StyledComponent>
-                                      </TableHead__StyledTh>
-                                      <TableHead__StyledTh
+                                      </StyledTh>
+                                      <StyledTh
+                                        compact={false}
                                         key="c3"
                                         scope="col"
                                       >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
                                               "attrs": Array [],
                                               "componentStyle": ComponentStyle {
-                                                "componentId": "TableHead__StyledTh-msr3t5-1",
+                                                "componentId": "StyledTh-sc-10nzyk9-0",
                                                 "isStatic": false,
-                                                "lastClassName": "bQoogK",
+                                                "lastClassName": "eunBIc",
                                                 "rules": Array [
                                                   [Function],
                                                 ],
                                               },
-                                              "displayName": "TableHead__StyledTh",
+                                              "displayName": "StyledTh",
                                               "foldedComponentIds": Array [],
                                               "render": [Function],
-                                              "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                              "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                               "target": "th",
                                               "toString": [Function],
                                               "usesTheme": false,
@@ -1596,34 +1612,36 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                           scope="col"
                                         >
                                           <th
-                                            className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                            className="StyledTh-sc-10nzyk9-0 eunBIc"
                                             scope="col"
                                           >
                                             Column 3
                                           </th>
                                         </StyledComponent>
-                                      </TableHead__StyledTh>
-                                      <TableHead__StyledTh
+                                      </StyledTh>
+                                      <StyledTh
+                                        compact={false}
                                         key="c4"
                                         scope="col"
                                       >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
                                               "attrs": Array [],
                                               "componentStyle": ComponentStyle {
-                                                "componentId": "TableHead__StyledTh-msr3t5-1",
+                                                "componentId": "StyledTh-sc-10nzyk9-0",
                                                 "isStatic": false,
-                                                "lastClassName": "bQoogK",
+                                                "lastClassName": "eunBIc",
                                                 "rules": Array [
                                                   [Function],
                                                 ],
                                               },
-                                              "displayName": "TableHead__StyledTh",
+                                              "displayName": "StyledTh",
                                               "foldedComponentIds": Array [],
                                               "render": [Function],
-                                              "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                              "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                               "target": "th",
                                               "toString": [Function],
                                               "usesTheme": false,
@@ -1635,34 +1653,36 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                           scope="col"
                                         >
                                           <th
-                                            className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                            className="StyledTh-sc-10nzyk9-0 eunBIc"
                                             scope="col"
                                           >
                                             Column 4
                                           </th>
                                         </StyledComponent>
-                                      </TableHead__StyledTh>
-                                      <TableHead__StyledTh
+                                      </StyledTh>
+                                      <StyledTh
+                                        compact={false}
                                         key="c5"
                                         scope="col"
                                       >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
                                               "attrs": Array [],
                                               "componentStyle": ComponentStyle {
-                                                "componentId": "TableHead__StyledTh-msr3t5-1",
+                                                "componentId": "StyledTh-sc-10nzyk9-0",
                                                 "isStatic": false,
-                                                "lastClassName": "bQoogK",
+                                                "lastClassName": "eunBIc",
                                                 "rules": Array [
                                                   [Function],
                                                 ],
                                               },
-                                              "displayName": "TableHead__StyledTh",
+                                              "displayName": "StyledTh",
                                               "foldedComponentIds": Array [],
                                               "render": [Function],
-                                              "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                              "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                               "target": "th",
                                               "toString": [Function],
                                               "usesTheme": false,
@@ -1674,34 +1694,36 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                           scope="col"
                                         >
                                           <th
-                                            className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                            className="StyledTh-sc-10nzyk9-0 eunBIc"
                                             scope="col"
                                           >
                                             Column 5
                                           </th>
                                         </StyledComponent>
-                                      </TableHead__StyledTh>
-                                      <TableHead__StyledTh
+                                      </StyledTh>
+                                      <StyledTh
+                                        compact={false}
                                         key="c6"
                                         scope="col"
                                       >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
                                               "attrs": Array [],
                                               "componentStyle": ComponentStyle {
-                                                "componentId": "TableHead__StyledTh-msr3t5-1",
+                                                "componentId": "StyledTh-sc-10nzyk9-0",
                                                 "isStatic": false,
-                                                "lastClassName": "bQoogK",
+                                                "lastClassName": "eunBIc",
                                                 "rules": Array [
                                                   [Function],
                                                 ],
                                               },
-                                              "displayName": "TableHead__StyledTh",
+                                              "displayName": "StyledTh",
                                               "foldedComponentIds": Array [],
                                               "render": [Function],
-                                              "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                              "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                               "target": "th",
                                               "toString": [Function],
                                               "usesTheme": false,
@@ -1713,13 +1735,13 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                           scope="col"
                                         >
                                           <th
-                                            className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                            className="StyledTh-sc-10nzyk9-0 eunBIc"
                                             scope="col"
                                           >
                                             Column 6
                                           </th>
                                         </StyledComponent>
-                                      </TableHead__StyledTh>
+                                      </StyledTh>
                                     </tr>
                                   </StyledComponent>
                                 </TableHead__StyledHeaderRow>
@@ -1765,6 +1787,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                   },
                                 ]
                               }
+                              compact={false}
                               keyField="c1"
                               loading={false}
                               noRowsContent="No records have been created for this table."
@@ -1832,6 +1855,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                       },
                                     ]
                                   }
+                                  compact={false}
                                   key="row 1 cell 1"
                                   keyField="c1"
                                   row={
@@ -1890,6 +1914,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                               "width": "30px",
                                             }
                                           }
+                                          compact={false}
                                           key="selected"
                                           row={
                                             Object {
@@ -1902,8 +1927,11 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                             }
                                           }
                                         >
-                                          <TableCell__StyledTableCell>
+                                          <TableCell__StyledTableCell
+                                            compact={false}
+                                          >
                                             <StyledComponent
+                                              compact={false}
                                               forwardedComponent={
                                                 Object {
                                                   "$$typeof": Symbol(react.forward_ref),
@@ -2523,6 +2551,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                               "width": "30px",
                                             }
                                           }
+                                          compact={false}
                                           key="expanded"
                                           row={
                                             Object {
@@ -2535,8 +2564,11 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                             }
                                           }
                                         >
-                                          <TableCell__StyledTableCell>
+                                          <TableCell__StyledTableCell
+                                            compact={false}
+                                          >
                                             <StyledComponent
+                                              compact={false}
                                               forwardedComponent={
                                                 Object {
                                                   "$$typeof": Symbol(react.forward_ref),
@@ -2599,6 +2631,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                               "label": "Column 1",
                                             }
                                           }
+                                          compact={false}
                                           key="c1"
                                           row={
                                             Object {
@@ -2611,8 +2644,11 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                             }
                                           }
                                         >
-                                          <TableCell__StyledTableCell>
+                                          <TableCell__StyledTableCell
+                                            compact={false}
+                                          >
                                             <StyledComponent
+                                              compact={false}
                                               forwardedComponent={
                                                 Object {
                                                   "$$typeof": Symbol(react.forward_ref),
@@ -2655,6 +2691,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                               "label": "Column 2",
                                             }
                                           }
+                                          compact={false}
                                           key="c2"
                                           row={
                                             Object {
@@ -2667,8 +2704,11 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                             }
                                           }
                                         >
-                                          <TableCell__StyledTableCell>
+                                          <TableCell__StyledTableCell
+                                            compact={false}
+                                          >
                                             <StyledComponent
+                                              compact={false}
                                               forwardedComponent={
                                                 Object {
                                                   "$$typeof": Symbol(react.forward_ref),
@@ -2711,6 +2751,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                               "label": "Column 3",
                                             }
                                           }
+                                          compact={false}
                                           key="c3"
                                           row={
                                             Object {
@@ -2723,8 +2764,11 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                             }
                                           }
                                         >
-                                          <TableCell__StyledTableCell>
+                                          <TableCell__StyledTableCell
+                                            compact={false}
+                                          >
                                             <StyledComponent
+                                              compact={false}
                                               forwardedComponent={
                                                 Object {
                                                   "$$typeof": Symbol(react.forward_ref),
@@ -2767,6 +2811,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                               "label": "Column 4",
                                             }
                                           }
+                                          compact={false}
                                           key="c4"
                                           row={
                                             Object {
@@ -2779,8 +2824,11 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                             }
                                           }
                                         >
-                                          <TableCell__StyledTableCell>
+                                          <TableCell__StyledTableCell
+                                            compact={false}
+                                          >
                                             <StyledComponent
+                                              compact={false}
                                               forwardedComponent={
                                                 Object {
                                                   "$$typeof": Symbol(react.forward_ref),
@@ -2821,6 +2869,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                               "label": "Column 5",
                                             }
                                           }
+                                          compact={false}
                                           key="c5"
                                           row={
                                             Object {
@@ -2833,8 +2882,11 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                             }
                                           }
                                         >
-                                          <TableCell__StyledTableCell>
+                                          <TableCell__StyledTableCell
+                                            compact={false}
+                                          >
                                             <StyledComponent
+                                              compact={false}
                                               forwardedComponent={
                                                 Object {
                                                   "$$typeof": Symbol(react.forward_ref),
@@ -2875,6 +2927,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                               "label": "Column 6",
                                             }
                                           }
+                                          compact={false}
                                           key="c6"
                                           row={
                                             Object {
@@ -2887,8 +2940,11 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                             }
                                           }
                                         >
-                                          <TableCell__StyledTableCell>
+                                          <TableCell__StyledTableCell
+                                            compact={false}
+                                          >
                                             <StyledComponent
+                                              compact={false}
                                               forwardedComponent={
                                                 Object {
                                                   "$$typeof": Symbol(react.forward_ref),
@@ -2964,6 +3020,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                       },
                                     ]
                                   }
+                                  compact={false}
                                   key="r2c1"
                                   keyField="c1"
                                   row={
@@ -3023,6 +3080,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                               "width": "30px",
                                             }
                                           }
+                                          compact={false}
                                           key="selected"
                                           row={
                                             Object {
@@ -3036,8 +3094,11 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                             }
                                           }
                                         >
-                                          <TableCell__StyledTableCell>
+                                          <TableCell__StyledTableCell
+                                            compact={false}
+                                          >
                                             <StyledComponent
+                                              compact={false}
                                               forwardedComponent={
                                                 Object {
                                                   "$$typeof": Symbol(react.forward_ref),
@@ -3658,6 +3719,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                               "width": "30px",
                                             }
                                           }
+                                          compact={false}
                                           key="expanded"
                                           row={
                                             Object {
@@ -3671,8 +3733,11 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                             }
                                           }
                                         >
-                                          <TableCell__StyledTableCell>
+                                          <TableCell__StyledTableCell
+                                            compact={false}
+                                          >
                                             <StyledComponent
+                                              compact={false}
                                               forwardedComponent={
                                                 Object {
                                                   "$$typeof": Symbol(react.forward_ref),
@@ -3890,6 +3955,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                               "label": "Column 1",
                                             }
                                           }
+                                          compact={false}
                                           key="c1"
                                           row={
                                             Object {
@@ -3903,8 +3969,11 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                             }
                                           }
                                         >
-                                          <TableCell__StyledTableCell>
+                                          <TableCell__StyledTableCell
+                                            compact={false}
+                                          >
                                             <StyledComponent
+                                              compact={false}
                                               forwardedComponent={
                                                 Object {
                                                   "$$typeof": Symbol(react.forward_ref),
@@ -3947,6 +4016,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                               "label": "Column 2",
                                             }
                                           }
+                                          compact={false}
                                           key="c2"
                                           row={
                                             Object {
@@ -3960,8 +4030,11 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                             }
                                           }
                                         >
-                                          <TableCell__StyledTableCell>
+                                          <TableCell__StyledTableCell
+                                            compact={false}
+                                          >
                                             <StyledComponent
+                                              compact={false}
                                               forwardedComponent={
                                                 Object {
                                                   "$$typeof": Symbol(react.forward_ref),
@@ -4004,6 +4077,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                               "label": "Column 3",
                                             }
                                           }
+                                          compact={false}
                                           key="c3"
                                           row={
                                             Object {
@@ -4017,8 +4091,11 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                             }
                                           }
                                         >
-                                          <TableCell__StyledTableCell>
+                                          <TableCell__StyledTableCell
+                                            compact={false}
+                                          >
                                             <StyledComponent
+                                              compact={false}
                                               forwardedComponent={
                                                 Object {
                                                   "$$typeof": Symbol(react.forward_ref),
@@ -4061,6 +4138,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                               "label": "Column 4",
                                             }
                                           }
+                                          compact={false}
                                           key="c4"
                                           row={
                                             Object {
@@ -4074,8 +4152,11 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                             }
                                           }
                                         >
-                                          <TableCell__StyledTableCell>
+                                          <TableCell__StyledTableCell
+                                            compact={false}
+                                          >
                                             <StyledComponent
+                                              compact={false}
                                               forwardedComponent={
                                                 Object {
                                                   "$$typeof": Symbol(react.forward_ref),
@@ -4116,6 +4197,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                               "label": "Column 5",
                                             }
                                           }
+                                          compact={false}
                                           key="c5"
                                           row={
                                             Object {
@@ -4129,8 +4211,11 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                             }
                                           }
                                         >
-                                          <TableCell__StyledTableCell>
+                                          <TableCell__StyledTableCell
+                                            compact={false}
+                                          >
                                             <StyledComponent
+                                              compact={false}
                                               forwardedComponent={
                                                 Object {
                                                   "$$typeof": Symbol(react.forward_ref),
@@ -4171,6 +4256,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                               "label": "Column 6",
                                             }
                                           }
+                                          compact={false}
                                           key="c6"
                                           row={
                                             Object {
@@ -4184,8 +4270,11 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                             }
                                           }
                                         >
-                                          <TableCell__StyledTableCell>
+                                          <TableCell__StyledTableCell
+                                            compact={false}
+                                          >
                                             <StyledComponent
+                                              compact={false}
                                               forwardedComponent={
                                                 Object {
                                                   "$$typeof": Symbol(react.forward_ref),
@@ -5132,6 +5221,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                   },
                 ]
               }
+              compact={false}
               expandedRows={
                 Array [
                   "r2c1",
@@ -5194,6 +5284,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                     },
                   ]
                 }
+                compact={false}
                 expandedRows={
                   Array [
                     "r2c1",
@@ -5256,6 +5347,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                       },
                     ]
                   }
+                  compact={false}
                   expandedRows={
                     Array [
                       "r2c1",
@@ -5323,6 +5415,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                         },
                       ]
                     }
+                    compact={false}
                     expandedRows={
                       Array [
                         "r2c1",
@@ -5424,6 +5517,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                 },
                               ]
                             }
+                            compact={false}
                           >
                             <thead>
                               <TableHead__StyledHeaderRow>
@@ -5457,28 +5551,30 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                   <tr
                                     className="TableHead__StyledHeaderRow-msr3t5-0 dCTkDK"
                                   >
-                                    <TableHead__StyledTh
+                                    <StyledTh
+                                      compact={false}
                                       key="expanded"
                                       scope="col"
                                       width="30px"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -5491,33 +5587,35 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                         width="30px"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 lfTJRR"
+                                          className="StyledTh-sc-10nzyk9-0 sXJR"
                                           scope="col"
                                           width="30px"
                                         />
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c1"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -5529,34 +5627,36 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 1
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c2"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -5568,34 +5668,36 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 2
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c3"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -5607,34 +5709,36 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 3
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c4"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -5646,34 +5750,36 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 4
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c5"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -5685,34 +5791,36 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 5
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c6"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -5724,13 +5832,13 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 6
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
+                                    </StyledTh>
                                   </tr>
                                 </StyledComponent>
                               </TableHead__StyledHeaderRow>
@@ -5770,6 +5878,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                 },
                               ]
                             }
+                            compact={false}
                             keyField="c1"
                             loading={false}
                             noRowsContent="No records have been created for this table."
@@ -5829,6 +5938,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                     },
                                   ]
                                 }
+                                compact={false}
                                 key="row 1 cell 1"
                                 keyField="c1"
                                 row={
@@ -5885,6 +5995,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                             "width": "30px",
                                           }
                                         }
+                                        compact={false}
                                         key="expanded"
                                         row={
                                           Object {
@@ -5896,8 +6007,11 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -5959,6 +6073,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                             "label": "Column 1",
                                           }
                                         }
+                                        compact={false}
                                         key="c1"
                                         row={
                                           Object {
@@ -5970,8 +6085,11 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -6014,6 +6132,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                             "label": "Column 2",
                                           }
                                         }
+                                        compact={false}
                                         key="c2"
                                         row={
                                           Object {
@@ -6025,8 +6144,11 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -6069,6 +6191,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                             "label": "Column 3",
                                           }
                                         }
+                                        compact={false}
                                         key="c3"
                                         row={
                                           Object {
@@ -6080,8 +6203,11 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -6124,6 +6250,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                             "label": "Column 4",
                                           }
                                         }
+                                        compact={false}
                                         key="c4"
                                         row={
                                           Object {
@@ -6135,8 +6262,11 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -6177,6 +6307,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                             "label": "Column 5",
                                           }
                                         }
+                                        compact={false}
                                         key="c5"
                                         row={
                                           Object {
@@ -6188,8 +6319,11 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -6230,6 +6364,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                             "label": "Column 6",
                                           }
                                         }
+                                        compact={false}
                                         key="c6"
                                         row={
                                           Object {
@@ -6241,8 +6376,11 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -6312,6 +6450,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                     },
                                   ]
                                 }
+                                compact={false}
                                 key="r2c1"
                                 keyField="c1"
                                 row={
@@ -6369,6 +6508,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                             "width": "30px",
                                           }
                                         }
+                                        compact={false}
                                         key="expanded"
                                         row={
                                           Object {
@@ -6381,8 +6521,11 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -6599,6 +6742,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                             "label": "Column 1",
                                           }
                                         }
+                                        compact={false}
                                         key="c1"
                                         row={
                                           Object {
@@ -6611,8 +6755,11 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -6655,6 +6802,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                             "label": "Column 2",
                                           }
                                         }
+                                        compact={false}
                                         key="c2"
                                         row={
                                           Object {
@@ -6667,8 +6815,11 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -6711,6 +6862,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                             "label": "Column 3",
                                           }
                                         }
+                                        compact={false}
                                         key="c3"
                                         row={
                                           Object {
@@ -6723,8 +6875,11 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -6767,6 +6922,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                             "label": "Column 4",
                                           }
                                         }
+                                        compact={false}
                                         key="c4"
                                         row={
                                           Object {
@@ -6779,8 +6935,11 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -6821,6 +6980,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                             "label": "Column 5",
                                           }
                                         }
+                                        compact={false}
                                         key="c5"
                                         row={
                                           Object {
@@ -6833,8 +6993,11 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -6875,6 +7038,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                             "label": "Column 6",
                                           }
                                         }
+                                        compact={false}
                                         key="c6"
                                         row={
                                           Object {
@@ -6887,8 +7051,11 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -7888,6 +8055,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                   },
                 ]
               }
+              compact={false}
               footerRows={Array []}
               hasSelectableRows={false}
               isHeaderSelected={false}
@@ -8544,6 +8712,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                     },
                   ]
                 }
+                compact={false}
                 footerRows={Array []}
                 hasSelectableRows={false}
                 isHeaderSelected={false}
@@ -9200,6 +9369,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                       },
                     ]
                   }
+                  compact={false}
                   footerRows={Array []}
                   hasSelectableRows={false}
                   isHeaderSelected={false}
@@ -9432,6 +9602,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                               },
                             ]
                           }
+                          compact={false}
                         >
                           <thead>
                             <TableHead__StyledHeaderRow>
@@ -9465,27 +9636,29 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                 <tr
                                   className="TableHead__StyledHeaderRow-msr3t5-0 dCTkDK"
                                 >
-                                  <TableHead__StyledTh
+                                  <StyledTh
+                                    compact={false}
                                     key="c1"
                                     scope="col"
                                   >
                                     <StyledComponent
+                                      compact={false}
                                       forwardedComponent={
                                         Object {
                                           "$$typeof": Symbol(react.forward_ref),
                                           "attrs": Array [],
                                           "componentStyle": ComponentStyle {
-                                            "componentId": "TableHead__StyledTh-msr3t5-1",
+                                            "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "bQoogK",
+                                            "lastClassName": "eunBIc",
                                             "rules": Array [
                                               [Function],
                                             ],
                                           },
-                                          "displayName": "TableHead__StyledTh",
+                                          "displayName": "StyledTh",
                                           "foldedComponentIds": Array [],
                                           "render": [Function],
-                                          "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                          "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                           "target": "th",
                                           "toString": [Function],
                                           "usesTheme": false,
@@ -9497,34 +9670,36 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
                                         scope="col"
                                       >
                                         Column 1
                                       </th>
                                     </StyledComponent>
-                                  </TableHead__StyledTh>
-                                  <TableHead__StyledTh
+                                  </StyledTh>
+                                  <StyledTh
+                                    compact={false}
                                     key="c2"
                                     scope="col"
                                   >
                                     <StyledComponent
+                                      compact={false}
                                       forwardedComponent={
                                         Object {
                                           "$$typeof": Symbol(react.forward_ref),
                                           "attrs": Array [],
                                           "componentStyle": ComponentStyle {
-                                            "componentId": "TableHead__StyledTh-msr3t5-1",
+                                            "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "bQoogK",
+                                            "lastClassName": "eunBIc",
                                             "rules": Array [
                                               [Function],
                                             ],
                                           },
-                                          "displayName": "TableHead__StyledTh",
+                                          "displayName": "StyledTh",
                                           "foldedComponentIds": Array [],
                                           "render": [Function],
-                                          "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                          "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                           "target": "th",
                                           "toString": [Function],
                                           "usesTheme": false,
@@ -9536,34 +9711,36 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
                                         scope="col"
                                       >
                                         Column 2
                                       </th>
                                     </StyledComponent>
-                                  </TableHead__StyledTh>
-                                  <TableHead__StyledTh
+                                  </StyledTh>
+                                  <StyledTh
+                                    compact={false}
                                     key="c3"
                                     scope="col"
                                   >
                                     <StyledComponent
+                                      compact={false}
                                       forwardedComponent={
                                         Object {
                                           "$$typeof": Symbol(react.forward_ref),
                                           "attrs": Array [],
                                           "componentStyle": ComponentStyle {
-                                            "componentId": "TableHead__StyledTh-msr3t5-1",
+                                            "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "bQoogK",
+                                            "lastClassName": "eunBIc",
                                             "rules": Array [
                                               [Function],
                                             ],
                                           },
-                                          "displayName": "TableHead__StyledTh",
+                                          "displayName": "StyledTh",
                                           "foldedComponentIds": Array [],
                                           "render": [Function],
-                                          "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                          "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                           "target": "th",
                                           "toString": [Function],
                                           "usesTheme": false,
@@ -9575,34 +9752,36 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
                                         scope="col"
                                       >
                                         Column 3
                                       </th>
                                     </StyledComponent>
-                                  </TableHead__StyledTh>
-                                  <TableHead__StyledTh
+                                  </StyledTh>
+                                  <StyledTh
+                                    compact={false}
                                     key="c4"
                                     scope="col"
                                   >
                                     <StyledComponent
+                                      compact={false}
                                       forwardedComponent={
                                         Object {
                                           "$$typeof": Symbol(react.forward_ref),
                                           "attrs": Array [],
                                           "componentStyle": ComponentStyle {
-                                            "componentId": "TableHead__StyledTh-msr3t5-1",
+                                            "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "bQoogK",
+                                            "lastClassName": "eunBIc",
                                             "rules": Array [
                                               [Function],
                                             ],
                                           },
-                                          "displayName": "TableHead__StyledTh",
+                                          "displayName": "StyledTh",
                                           "foldedComponentIds": Array [],
                                           "render": [Function],
-                                          "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                          "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                           "target": "th",
                                           "toString": [Function],
                                           "usesTheme": false,
@@ -9614,34 +9793,36 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
                                         scope="col"
                                       >
                                         Column 4
                                       </th>
                                     </StyledComponent>
-                                  </TableHead__StyledTh>
-                                  <TableHead__StyledTh
+                                  </StyledTh>
+                                  <StyledTh
+                                    compact={false}
                                     key="c5"
                                     scope="col"
                                   >
                                     <StyledComponent
+                                      compact={false}
                                       forwardedComponent={
                                         Object {
                                           "$$typeof": Symbol(react.forward_ref),
                                           "attrs": Array [],
                                           "componentStyle": ComponentStyle {
-                                            "componentId": "TableHead__StyledTh-msr3t5-1",
+                                            "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "bQoogK",
+                                            "lastClassName": "eunBIc",
                                             "rules": Array [
                                               [Function],
                                             ],
                                           },
-                                          "displayName": "TableHead__StyledTh",
+                                          "displayName": "StyledTh",
                                           "foldedComponentIds": Array [],
                                           "render": [Function],
-                                          "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                          "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                           "target": "th",
                                           "toString": [Function],
                                           "usesTheme": false,
@@ -9653,34 +9834,36 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
                                         scope="col"
                                       >
                                         Column 5
                                       </th>
                                     </StyledComponent>
-                                  </TableHead__StyledTh>
-                                  <TableHead__StyledTh
+                                  </StyledTh>
+                                  <StyledTh
+                                    compact={false}
                                     key="c6"
                                     scope="col"
                                   >
                                     <StyledComponent
+                                      compact={false}
                                       forwardedComponent={
                                         Object {
                                           "$$typeof": Symbol(react.forward_ref),
                                           "attrs": Array [],
                                           "componentStyle": ComponentStyle {
-                                            "componentId": "TableHead__StyledTh-msr3t5-1",
+                                            "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "bQoogK",
+                                            "lastClassName": "eunBIc",
                                             "rules": Array [
                                               [Function],
                                             ],
                                           },
-                                          "displayName": "TableHead__StyledTh",
+                                          "displayName": "StyledTh",
                                           "foldedComponentIds": Array [],
                                           "render": [Function],
-                                          "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                          "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                           "target": "th",
                                           "toString": [Function],
                                           "usesTheme": false,
@@ -9692,34 +9875,36 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
                                         scope="col"
                                       >
                                         Column 6
                                       </th>
                                     </StyledComponent>
-                                  </TableHead__StyledTh>
-                                  <TableHead__StyledTh
+                                  </StyledTh>
+                                  <StyledTh
+                                    compact={false}
                                     key="c7"
                                     scope="col"
                                   >
                                     <StyledComponent
+                                      compact={false}
                                       forwardedComponent={
                                         Object {
                                           "$$typeof": Symbol(react.forward_ref),
                                           "attrs": Array [],
                                           "componentStyle": ComponentStyle {
-                                            "componentId": "TableHead__StyledTh-msr3t5-1",
+                                            "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "bQoogK",
+                                            "lastClassName": "eunBIc",
                                             "rules": Array [
                                               [Function],
                                             ],
                                           },
-                                          "displayName": "TableHead__StyledTh",
+                                          "displayName": "StyledTh",
                                           "foldedComponentIds": Array [],
                                           "render": [Function],
-                                          "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                          "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                           "target": "th",
                                           "toString": [Function],
                                           "usesTheme": false,
@@ -9731,34 +9916,36 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
                                         scope="col"
                                       >
                                         Column 7
                                       </th>
                                     </StyledComponent>
-                                  </TableHead__StyledTh>
-                                  <TableHead__StyledTh
+                                  </StyledTh>
+                                  <StyledTh
+                                    compact={false}
                                     key="c8"
                                     scope="col"
                                   >
                                     <StyledComponent
+                                      compact={false}
                                       forwardedComponent={
                                         Object {
                                           "$$typeof": Symbol(react.forward_ref),
                                           "attrs": Array [],
                                           "componentStyle": ComponentStyle {
-                                            "componentId": "TableHead__StyledTh-msr3t5-1",
+                                            "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "bQoogK",
+                                            "lastClassName": "eunBIc",
                                             "rules": Array [
                                               [Function],
                                             ],
                                           },
-                                          "displayName": "TableHead__StyledTh",
+                                          "displayName": "StyledTh",
                                           "foldedComponentIds": Array [],
                                           "render": [Function],
-                                          "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                          "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                           "target": "th",
                                           "toString": [Function],
                                           "usesTheme": false,
@@ -9770,34 +9957,36 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
                                         scope="col"
                                       >
                                         Column 8
                                       </th>
                                     </StyledComponent>
-                                  </TableHead__StyledTh>
-                                  <TableHead__StyledTh
+                                  </StyledTh>
+                                  <StyledTh
+                                    compact={false}
                                     key="c9"
                                     scope="col"
                                   >
                                     <StyledComponent
+                                      compact={false}
                                       forwardedComponent={
                                         Object {
                                           "$$typeof": Symbol(react.forward_ref),
                                           "attrs": Array [],
                                           "componentStyle": ComponentStyle {
-                                            "componentId": "TableHead__StyledTh-msr3t5-1",
+                                            "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "bQoogK",
+                                            "lastClassName": "eunBIc",
                                             "rules": Array [
                                               [Function],
                                             ],
                                           },
-                                          "displayName": "TableHead__StyledTh",
+                                          "displayName": "StyledTh",
                                           "foldedComponentIds": Array [],
                                           "render": [Function],
-                                          "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                          "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                           "target": "th",
                                           "toString": [Function],
                                           "usesTheme": false,
@@ -9809,34 +9998,36 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
                                         scope="col"
                                       >
                                         Column 9
                                       </th>
                                     </StyledComponent>
-                                  </TableHead__StyledTh>
-                                  <TableHead__StyledTh
+                                  </StyledTh>
+                                  <StyledTh
+                                    compact={false}
                                     key="c10"
                                     scope="col"
                                   >
                                     <StyledComponent
+                                      compact={false}
                                       forwardedComponent={
                                         Object {
                                           "$$typeof": Symbol(react.forward_ref),
                                           "attrs": Array [],
                                           "componentStyle": ComponentStyle {
-                                            "componentId": "TableHead__StyledTh-msr3t5-1",
+                                            "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "bQoogK",
+                                            "lastClassName": "eunBIc",
                                             "rules": Array [
                                               [Function],
                                             ],
                                           },
-                                          "displayName": "TableHead__StyledTh",
+                                          "displayName": "StyledTh",
                                           "foldedComponentIds": Array [],
                                           "render": [Function],
-                                          "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                          "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                           "target": "th",
                                           "toString": [Function],
                                           "usesTheme": false,
@@ -9848,34 +10039,36 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
                                         scope="col"
                                       >
                                         Column 10
                                       </th>
                                     </StyledComponent>
-                                  </TableHead__StyledTh>
-                                  <TableHead__StyledTh
+                                  </StyledTh>
+                                  <StyledTh
+                                    compact={false}
                                     key="c11"
                                     scope="col"
                                   >
                                     <StyledComponent
+                                      compact={false}
                                       forwardedComponent={
                                         Object {
                                           "$$typeof": Symbol(react.forward_ref),
                                           "attrs": Array [],
                                           "componentStyle": ComponentStyle {
-                                            "componentId": "TableHead__StyledTh-msr3t5-1",
+                                            "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "bQoogK",
+                                            "lastClassName": "eunBIc",
                                             "rules": Array [
                                               [Function],
                                             ],
                                           },
-                                          "displayName": "TableHead__StyledTh",
+                                          "displayName": "StyledTh",
                                           "foldedComponentIds": Array [],
                                           "render": [Function],
-                                          "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                          "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                           "target": "th",
                                           "toString": [Function],
                                           "usesTheme": false,
@@ -9887,34 +10080,36 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
                                         scope="col"
                                       >
                                         Column 11
                                       </th>
                                     </StyledComponent>
-                                  </TableHead__StyledTh>
-                                  <TableHead__StyledTh
+                                  </StyledTh>
+                                  <StyledTh
+                                    compact={false}
                                     key="c12"
                                     scope="col"
                                   >
                                     <StyledComponent
+                                      compact={false}
                                       forwardedComponent={
                                         Object {
                                           "$$typeof": Symbol(react.forward_ref),
                                           "attrs": Array [],
                                           "componentStyle": ComponentStyle {
-                                            "componentId": "TableHead__StyledTh-msr3t5-1",
+                                            "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "bQoogK",
+                                            "lastClassName": "eunBIc",
                                             "rules": Array [
                                               [Function],
                                             ],
                                           },
-                                          "displayName": "TableHead__StyledTh",
+                                          "displayName": "StyledTh",
                                           "foldedComponentIds": Array [],
                                           "render": [Function],
-                                          "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                          "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                           "target": "th",
                                           "toString": [Function],
                                           "usesTheme": false,
@@ -9926,34 +10121,36 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
                                         scope="col"
                                       >
                                         Column 12
                                       </th>
                                     </StyledComponent>
-                                  </TableHead__StyledTh>
-                                  <TableHead__StyledTh
+                                  </StyledTh>
+                                  <StyledTh
+                                    compact={false}
                                     key="c13"
                                     scope="col"
                                   >
                                     <StyledComponent
+                                      compact={false}
                                       forwardedComponent={
                                         Object {
                                           "$$typeof": Symbol(react.forward_ref),
                                           "attrs": Array [],
                                           "componentStyle": ComponentStyle {
-                                            "componentId": "TableHead__StyledTh-msr3t5-1",
+                                            "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "bQoogK",
+                                            "lastClassName": "eunBIc",
                                             "rules": Array [
                                               [Function],
                                             ],
                                           },
-                                          "displayName": "TableHead__StyledTh",
+                                          "displayName": "StyledTh",
                                           "foldedComponentIds": Array [],
                                           "render": [Function],
-                                          "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                          "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                           "target": "th",
                                           "toString": [Function],
                                           "usesTheme": false,
@@ -9965,34 +10162,36 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
                                         scope="col"
                                       >
                                         Column 13
                                       </th>
                                     </StyledComponent>
-                                  </TableHead__StyledTh>
-                                  <TableHead__StyledTh
+                                  </StyledTh>
+                                  <StyledTh
+                                    compact={false}
                                     key="c14"
                                     scope="col"
                                   >
                                     <StyledComponent
+                                      compact={false}
                                       forwardedComponent={
                                         Object {
                                           "$$typeof": Symbol(react.forward_ref),
                                           "attrs": Array [],
                                           "componentStyle": ComponentStyle {
-                                            "componentId": "TableHead__StyledTh-msr3t5-1",
+                                            "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "bQoogK",
+                                            "lastClassName": "eunBIc",
                                             "rules": Array [
                                               [Function],
                                             ],
                                           },
-                                          "displayName": "TableHead__StyledTh",
+                                          "displayName": "StyledTh",
                                           "foldedComponentIds": Array [],
                                           "render": [Function],
-                                          "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                          "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                           "target": "th",
                                           "toString": [Function],
                                           "usesTheme": false,
@@ -10004,34 +10203,36 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
                                         scope="col"
                                       >
                                         Column 14
                                       </th>
                                     </StyledComponent>
-                                  </TableHead__StyledTh>
-                                  <TableHead__StyledTh
+                                  </StyledTh>
+                                  <StyledTh
+                                    compact={false}
                                     key="c15"
                                     scope="col"
                                   >
                                     <StyledComponent
+                                      compact={false}
                                       forwardedComponent={
                                         Object {
                                           "$$typeof": Symbol(react.forward_ref),
                                           "attrs": Array [],
                                           "componentStyle": ComponentStyle {
-                                            "componentId": "TableHead__StyledTh-msr3t5-1",
+                                            "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "bQoogK",
+                                            "lastClassName": "eunBIc",
                                             "rules": Array [
                                               [Function],
                                             ],
                                           },
-                                          "displayName": "TableHead__StyledTh",
+                                          "displayName": "StyledTh",
                                           "foldedComponentIds": Array [],
                                           "render": [Function],
-                                          "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                          "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                           "target": "th",
                                           "toString": [Function],
                                           "usesTheme": false,
@@ -10043,34 +10244,36 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
                                         scope="col"
                                       >
                                         Column 15
                                       </th>
                                     </StyledComponent>
-                                  </TableHead__StyledTh>
-                                  <TableHead__StyledTh
+                                  </StyledTh>
+                                  <StyledTh
+                                    compact={false}
                                     key="c16"
                                     scope="col"
                                   >
                                     <StyledComponent
+                                      compact={false}
                                       forwardedComponent={
                                         Object {
                                           "$$typeof": Symbol(react.forward_ref),
                                           "attrs": Array [],
                                           "componentStyle": ComponentStyle {
-                                            "componentId": "TableHead__StyledTh-msr3t5-1",
+                                            "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "bQoogK",
+                                            "lastClassName": "eunBIc",
                                             "rules": Array [
                                               [Function],
                                             ],
                                           },
-                                          "displayName": "TableHead__StyledTh",
+                                          "displayName": "StyledTh",
                                           "foldedComponentIds": Array [],
                                           "render": [Function],
-                                          "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                          "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                           "target": "th",
                                           "toString": [Function],
                                           "usesTheme": false,
@@ -10082,34 +10285,36 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
                                         scope="col"
                                       >
                                         Column 16
                                       </th>
                                     </StyledComponent>
-                                  </TableHead__StyledTh>
-                                  <TableHead__StyledTh
+                                  </StyledTh>
+                                  <StyledTh
+                                    compact={false}
                                     key="c17"
                                     scope="col"
                                   >
                                     <StyledComponent
+                                      compact={false}
                                       forwardedComponent={
                                         Object {
                                           "$$typeof": Symbol(react.forward_ref),
                                           "attrs": Array [],
                                           "componentStyle": ComponentStyle {
-                                            "componentId": "TableHead__StyledTh-msr3t5-1",
+                                            "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "bQoogK",
+                                            "lastClassName": "eunBIc",
                                             "rules": Array [
                                               [Function],
                                             ],
                                           },
-                                          "displayName": "TableHead__StyledTh",
+                                          "displayName": "StyledTh",
                                           "foldedComponentIds": Array [],
                                           "render": [Function],
-                                          "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                          "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                           "target": "th",
                                           "toString": [Function],
                                           "usesTheme": false,
@@ -10121,34 +10326,36 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
                                         scope="col"
                                       >
                                         Column 17
                                       </th>
                                     </StyledComponent>
-                                  </TableHead__StyledTh>
-                                  <TableHead__StyledTh
+                                  </StyledTh>
+                                  <StyledTh
+                                    compact={false}
                                     key="c18"
                                     scope="col"
                                   >
                                     <StyledComponent
+                                      compact={false}
                                       forwardedComponent={
                                         Object {
                                           "$$typeof": Symbol(react.forward_ref),
                                           "attrs": Array [],
                                           "componentStyle": ComponentStyle {
-                                            "componentId": "TableHead__StyledTh-msr3t5-1",
+                                            "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "bQoogK",
+                                            "lastClassName": "eunBIc",
                                             "rules": Array [
                                               [Function],
                                             ],
                                           },
-                                          "displayName": "TableHead__StyledTh",
+                                          "displayName": "StyledTh",
                                           "foldedComponentIds": Array [],
                                           "render": [Function],
-                                          "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                          "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                           "target": "th",
                                           "toString": [Function],
                                           "usesTheme": false,
@@ -10160,34 +10367,36 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
                                         scope="col"
                                       >
                                         Column 18
                                       </th>
                                     </StyledComponent>
-                                  </TableHead__StyledTh>
-                                  <TableHead__StyledTh
+                                  </StyledTh>
+                                  <StyledTh
+                                    compact={false}
                                     key="c19"
                                     scope="col"
                                   >
                                     <StyledComponent
+                                      compact={false}
                                       forwardedComponent={
                                         Object {
                                           "$$typeof": Symbol(react.forward_ref),
                                           "attrs": Array [],
                                           "componentStyle": ComponentStyle {
-                                            "componentId": "TableHead__StyledTh-msr3t5-1",
+                                            "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "bQoogK",
+                                            "lastClassName": "eunBIc",
                                             "rules": Array [
                                               [Function],
                                             ],
                                           },
-                                          "displayName": "TableHead__StyledTh",
+                                          "displayName": "StyledTh",
                                           "foldedComponentIds": Array [],
                                           "render": [Function],
-                                          "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                          "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                           "target": "th",
                                           "toString": [Function],
                                           "usesTheme": false,
@@ -10199,34 +10408,36 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
                                         scope="col"
                                       >
                                         Column 19
                                       </th>
                                     </StyledComponent>
-                                  </TableHead__StyledTh>
-                                  <TableHead__StyledTh
+                                  </StyledTh>
+                                  <StyledTh
+                                    compact={false}
                                     key="c20"
                                     scope="col"
                                   >
                                     <StyledComponent
+                                      compact={false}
                                       forwardedComponent={
                                         Object {
                                           "$$typeof": Symbol(react.forward_ref),
                                           "attrs": Array [],
                                           "componentStyle": ComponentStyle {
-                                            "componentId": "TableHead__StyledTh-msr3t5-1",
+                                            "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "bQoogK",
+                                            "lastClassName": "eunBIc",
                                             "rules": Array [
                                               [Function],
                                             ],
                                           },
-                                          "displayName": "TableHead__StyledTh",
+                                          "displayName": "StyledTh",
                                           "foldedComponentIds": Array [],
                                           "render": [Function],
-                                          "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                          "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                           "target": "th",
                                           "toString": [Function],
                                           "usesTheme": false,
@@ -10238,34 +10449,36 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
                                         scope="col"
                                       >
                                         Column 20
                                       </th>
                                     </StyledComponent>
-                                  </TableHead__StyledTh>
-                                  <TableHead__StyledTh
+                                  </StyledTh>
+                                  <StyledTh
+                                    compact={false}
                                     key="c21"
                                     scope="col"
                                   >
                                     <StyledComponent
+                                      compact={false}
                                       forwardedComponent={
                                         Object {
                                           "$$typeof": Symbol(react.forward_ref),
                                           "attrs": Array [],
                                           "componentStyle": ComponentStyle {
-                                            "componentId": "TableHead__StyledTh-msr3t5-1",
+                                            "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "bQoogK",
+                                            "lastClassName": "eunBIc",
                                             "rules": Array [
                                               [Function],
                                             ],
                                           },
-                                          "displayName": "TableHead__StyledTh",
+                                          "displayName": "StyledTh",
                                           "foldedComponentIds": Array [],
                                           "render": [Function],
-                                          "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                          "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                           "target": "th",
                                           "toString": [Function],
                                           "usesTheme": false,
@@ -10277,13 +10490,13 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
                                         scope="col"
                                       >
                                         Column 21
                                       </th>
                                     </StyledComponent>
-                                  </TableHead__StyledTh>
+                                  </StyledTh>
                                 </tr>
                               </StyledComponent>
                             </TableHead__StyledHeaderRow>
@@ -10378,6 +10591,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                               },
                             ]
                           }
+                          compact={false}
                           keyField="c1"
                           loading={false}
                           noRowsContent="No records have been created for this table."
@@ -10573,6 +10787,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                   },
                                 ]
                               }
+                              compact={false}
                               key="some data 0"
                               keyField="c1"
                               row={
@@ -10645,6 +10860,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 1",
                                         }
                                       }
+                                      compact={false}
                                       key="c1"
                                       row={
                                         Object {
@@ -10673,8 +10889,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -10717,6 +10936,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 2",
                                         }
                                       }
+                                      compact={false}
                                       key="c2"
                                       row={
                                         Object {
@@ -10745,8 +10965,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -10789,6 +11012,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 3",
                                         }
                                       }
+                                      compact={false}
                                       key="c3"
                                       row={
                                         Object {
@@ -10817,8 +11041,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -10861,6 +11088,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 4",
                                         }
                                       }
+                                      compact={false}
                                       key="c4"
                                       row={
                                         Object {
@@ -10889,8 +11117,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -10933,6 +11164,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 5",
                                         }
                                       }
+                                      compact={false}
                                       key="c5"
                                       row={
                                         Object {
@@ -10961,8 +11193,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -11005,6 +11240,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 6",
                                         }
                                       }
+                                      compact={false}
                                       key="c6"
                                       row={
                                         Object {
@@ -11033,8 +11269,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -11077,6 +11316,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 7",
                                         }
                                       }
+                                      compact={false}
                                       key="c7"
                                       row={
                                         Object {
@@ -11105,8 +11345,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -11149,6 +11392,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 8",
                                         }
                                       }
+                                      compact={false}
                                       key="c8"
                                       row={
                                         Object {
@@ -11177,8 +11421,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -11221,6 +11468,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 9",
                                         }
                                       }
+                                      compact={false}
                                       key="c9"
                                       row={
                                         Object {
@@ -11249,8 +11497,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -11293,6 +11544,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 10",
                                         }
                                       }
+                                      compact={false}
                                       key="c10"
                                       row={
                                         Object {
@@ -11321,8 +11573,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -11365,6 +11620,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 11",
                                         }
                                       }
+                                      compact={false}
                                       key="c11"
                                       row={
                                         Object {
@@ -11393,8 +11649,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -11437,6 +11696,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 12",
                                         }
                                       }
+                                      compact={false}
                                       key="c12"
                                       row={
                                         Object {
@@ -11465,8 +11725,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -11509,6 +11772,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 13",
                                         }
                                       }
+                                      compact={false}
                                       key="c13"
                                       row={
                                         Object {
@@ -11537,8 +11801,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -11581,6 +11848,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 14",
                                         }
                                       }
+                                      compact={false}
                                       key="c14"
                                       row={
                                         Object {
@@ -11609,8 +11877,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -11653,6 +11924,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 15",
                                         }
                                       }
+                                      compact={false}
                                       key="c15"
                                       row={
                                         Object {
@@ -11681,8 +11953,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -11725,6 +12000,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 16",
                                         }
                                       }
+                                      compact={false}
                                       key="c16"
                                       row={
                                         Object {
@@ -11753,8 +12029,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -11797,6 +12076,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 17",
                                         }
                                       }
+                                      compact={false}
                                       key="c17"
                                       row={
                                         Object {
@@ -11825,8 +12105,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -11869,6 +12152,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 18",
                                         }
                                       }
+                                      compact={false}
                                       key="c18"
                                       row={
                                         Object {
@@ -11897,8 +12181,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -11941,6 +12228,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 19",
                                         }
                                       }
+                                      compact={false}
                                       key="c19"
                                       row={
                                         Object {
@@ -11969,8 +12257,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -12013,6 +12304,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 20",
                                         }
                                       }
+                                      compact={false}
                                       key="c20"
                                       row={
                                         Object {
@@ -12041,8 +12333,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -12085,6 +12380,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 21",
                                         }
                                       }
+                                      compact={false}
                                       key="c21"
                                       row={
                                         Object {
@@ -12113,8 +12409,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -12241,6 +12540,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                   },
                                 ]
                               }
+                              compact={false}
                               key="some data 1"
                               keyField="c1"
                               row={
@@ -12313,6 +12613,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 1",
                                         }
                                       }
+                                      compact={false}
                                       key="c1"
                                       row={
                                         Object {
@@ -12341,8 +12642,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -12385,6 +12689,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 2",
                                         }
                                       }
+                                      compact={false}
                                       key="c2"
                                       row={
                                         Object {
@@ -12413,8 +12718,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -12457,6 +12765,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 3",
                                         }
                                       }
+                                      compact={false}
                                       key="c3"
                                       row={
                                         Object {
@@ -12485,8 +12794,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -12529,6 +12841,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 4",
                                         }
                                       }
+                                      compact={false}
                                       key="c4"
                                       row={
                                         Object {
@@ -12557,8 +12870,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -12601,6 +12917,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 5",
                                         }
                                       }
+                                      compact={false}
                                       key="c5"
                                       row={
                                         Object {
@@ -12629,8 +12946,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -12673,6 +12993,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 6",
                                         }
                                       }
+                                      compact={false}
                                       key="c6"
                                       row={
                                         Object {
@@ -12701,8 +13022,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -12745,6 +13069,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 7",
                                         }
                                       }
+                                      compact={false}
                                       key="c7"
                                       row={
                                         Object {
@@ -12773,8 +13098,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -12817,6 +13145,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 8",
                                         }
                                       }
+                                      compact={false}
                                       key="c8"
                                       row={
                                         Object {
@@ -12845,8 +13174,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -12889,6 +13221,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 9",
                                         }
                                       }
+                                      compact={false}
                                       key="c9"
                                       row={
                                         Object {
@@ -12917,8 +13250,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -12961,6 +13297,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 10",
                                         }
                                       }
+                                      compact={false}
                                       key="c10"
                                       row={
                                         Object {
@@ -12989,8 +13326,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -13033,6 +13373,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 11",
                                         }
                                       }
+                                      compact={false}
                                       key="c11"
                                       row={
                                         Object {
@@ -13061,8 +13402,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -13105,6 +13449,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 12",
                                         }
                                       }
+                                      compact={false}
                                       key="c12"
                                       row={
                                         Object {
@@ -13133,8 +13478,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -13177,6 +13525,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 13",
                                         }
                                       }
+                                      compact={false}
                                       key="c13"
                                       row={
                                         Object {
@@ -13205,8 +13554,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -13249,6 +13601,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 14",
                                         }
                                       }
+                                      compact={false}
                                       key="c14"
                                       row={
                                         Object {
@@ -13277,8 +13630,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -13321,6 +13677,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 15",
                                         }
                                       }
+                                      compact={false}
                                       key="c15"
                                       row={
                                         Object {
@@ -13349,8 +13706,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -13393,6 +13753,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 16",
                                         }
                                       }
+                                      compact={false}
                                       key="c16"
                                       row={
                                         Object {
@@ -13421,8 +13782,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -13465,6 +13829,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 17",
                                         }
                                       }
+                                      compact={false}
                                       key="c17"
                                       row={
                                         Object {
@@ -13493,8 +13858,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -13537,6 +13905,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 18",
                                         }
                                       }
+                                      compact={false}
                                       key="c18"
                                       row={
                                         Object {
@@ -13565,8 +13934,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -13609,6 +13981,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 19",
                                         }
                                       }
+                                      compact={false}
                                       key="c19"
                                       row={
                                         Object {
@@ -13637,8 +14010,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -13681,6 +14057,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 20",
                                         }
                                       }
+                                      compact={false}
                                       key="c20"
                                       row={
                                         Object {
@@ -13709,8 +14086,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -13753,6 +14133,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 21",
                                         }
                                       }
+                                      compact={false}
                                       key="c21"
                                       row={
                                         Object {
@@ -13781,8 +14162,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -13909,6 +14293,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                   },
                                 ]
                               }
+                              compact={false}
                               key="some data 2"
                               keyField="c1"
                               row={
@@ -13981,6 +14366,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 1",
                                         }
                                       }
+                                      compact={false}
                                       key="c1"
                                       row={
                                         Object {
@@ -14009,8 +14395,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -14053,6 +14442,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 2",
                                         }
                                       }
+                                      compact={false}
                                       key="c2"
                                       row={
                                         Object {
@@ -14081,8 +14471,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -14125,6 +14518,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 3",
                                         }
                                       }
+                                      compact={false}
                                       key="c3"
                                       row={
                                         Object {
@@ -14153,8 +14547,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -14197,6 +14594,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 4",
                                         }
                                       }
+                                      compact={false}
                                       key="c4"
                                       row={
                                         Object {
@@ -14225,8 +14623,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -14269,6 +14670,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 5",
                                         }
                                       }
+                                      compact={false}
                                       key="c5"
                                       row={
                                         Object {
@@ -14297,8 +14699,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -14341,6 +14746,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 6",
                                         }
                                       }
+                                      compact={false}
                                       key="c6"
                                       row={
                                         Object {
@@ -14369,8 +14775,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -14413,6 +14822,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 7",
                                         }
                                       }
+                                      compact={false}
                                       key="c7"
                                       row={
                                         Object {
@@ -14441,8 +14851,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -14485,6 +14898,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 8",
                                         }
                                       }
+                                      compact={false}
                                       key="c8"
                                       row={
                                         Object {
@@ -14513,8 +14927,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -14557,6 +14974,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 9",
                                         }
                                       }
+                                      compact={false}
                                       key="c9"
                                       row={
                                         Object {
@@ -14585,8 +15003,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -14629,6 +15050,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 10",
                                         }
                                       }
+                                      compact={false}
                                       key="c10"
                                       row={
                                         Object {
@@ -14657,8 +15079,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -14701,6 +15126,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 11",
                                         }
                                       }
+                                      compact={false}
                                       key="c11"
                                       row={
                                         Object {
@@ -14729,8 +15155,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -14773,6 +15202,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 12",
                                         }
                                       }
+                                      compact={false}
                                       key="c12"
                                       row={
                                         Object {
@@ -14801,8 +15231,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -14845,6 +15278,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 13",
                                         }
                                       }
+                                      compact={false}
                                       key="c13"
                                       row={
                                         Object {
@@ -14873,8 +15307,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -14917,6 +15354,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 14",
                                         }
                                       }
+                                      compact={false}
                                       key="c14"
                                       row={
                                         Object {
@@ -14945,8 +15383,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -14989,6 +15430,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 15",
                                         }
                                       }
+                                      compact={false}
                                       key="c15"
                                       row={
                                         Object {
@@ -15017,8 +15459,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -15061,6 +15506,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 16",
                                         }
                                       }
+                                      compact={false}
                                       key="c16"
                                       row={
                                         Object {
@@ -15089,8 +15535,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -15133,6 +15582,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 17",
                                         }
                                       }
+                                      compact={false}
                                       key="c17"
                                       row={
                                         Object {
@@ -15161,8 +15611,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -15205,6 +15658,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 18",
                                         }
                                       }
+                                      compact={false}
                                       key="c18"
                                       row={
                                         Object {
@@ -15233,8 +15687,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -15277,6 +15734,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 19",
                                         }
                                       }
+                                      compact={false}
                                       key="c19"
                                       row={
                                         Object {
@@ -15305,8 +15763,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -15349,6 +15810,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 20",
                                         }
                                       }
+                                      compact={false}
                                       key="c20"
                                       row={
                                         Object {
@@ -15377,8 +15839,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -15421,6 +15886,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 21",
                                         }
                                       }
+                                      compact={false}
                                       key="c21"
                                       row={
                                         Object {
@@ -15449,8 +15915,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -15577,6 +16046,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                   },
                                 ]
                               }
+                              compact={false}
                               key="some data 3"
                               keyField="c1"
                               row={
@@ -15649,6 +16119,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 1",
                                         }
                                       }
+                                      compact={false}
                                       key="c1"
                                       row={
                                         Object {
@@ -15677,8 +16148,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -15721,6 +16195,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 2",
                                         }
                                       }
+                                      compact={false}
                                       key="c2"
                                       row={
                                         Object {
@@ -15749,8 +16224,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -15793,6 +16271,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 3",
                                         }
                                       }
+                                      compact={false}
                                       key="c3"
                                       row={
                                         Object {
@@ -15821,8 +16300,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -15865,6 +16347,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 4",
                                         }
                                       }
+                                      compact={false}
                                       key="c4"
                                       row={
                                         Object {
@@ -15893,8 +16376,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -15937,6 +16423,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 5",
                                         }
                                       }
+                                      compact={false}
                                       key="c5"
                                       row={
                                         Object {
@@ -15965,8 +16452,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -16009,6 +16499,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 6",
                                         }
                                       }
+                                      compact={false}
                                       key="c6"
                                       row={
                                         Object {
@@ -16037,8 +16528,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -16081,6 +16575,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 7",
                                         }
                                       }
+                                      compact={false}
                                       key="c7"
                                       row={
                                         Object {
@@ -16109,8 +16604,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -16153,6 +16651,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 8",
                                         }
                                       }
+                                      compact={false}
                                       key="c8"
                                       row={
                                         Object {
@@ -16181,8 +16680,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -16225,6 +16727,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 9",
                                         }
                                       }
+                                      compact={false}
                                       key="c9"
                                       row={
                                         Object {
@@ -16253,8 +16756,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -16297,6 +16803,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 10",
                                         }
                                       }
+                                      compact={false}
                                       key="c10"
                                       row={
                                         Object {
@@ -16325,8 +16832,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -16369,6 +16879,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 11",
                                         }
                                       }
+                                      compact={false}
                                       key="c11"
                                       row={
                                         Object {
@@ -16397,8 +16908,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -16441,6 +16955,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 12",
                                         }
                                       }
+                                      compact={false}
                                       key="c12"
                                       row={
                                         Object {
@@ -16469,8 +16984,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -16513,6 +17031,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 13",
                                         }
                                       }
+                                      compact={false}
                                       key="c13"
                                       row={
                                         Object {
@@ -16541,8 +17060,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -16585,6 +17107,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 14",
                                         }
                                       }
+                                      compact={false}
                                       key="c14"
                                       row={
                                         Object {
@@ -16613,8 +17136,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -16657,6 +17183,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 15",
                                         }
                                       }
+                                      compact={false}
                                       key="c15"
                                       row={
                                         Object {
@@ -16685,8 +17212,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -16729,6 +17259,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 16",
                                         }
                                       }
+                                      compact={false}
                                       key="c16"
                                       row={
                                         Object {
@@ -16757,8 +17288,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -16801,6 +17335,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 17",
                                         }
                                       }
+                                      compact={false}
                                       key="c17"
                                       row={
                                         Object {
@@ -16829,8 +17364,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -16873,6 +17411,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 18",
                                         }
                                       }
+                                      compact={false}
                                       key="c18"
                                       row={
                                         Object {
@@ -16901,8 +17440,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -16945,6 +17487,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 19",
                                         }
                                       }
+                                      compact={false}
                                       key="c19"
                                       row={
                                         Object {
@@ -16973,8 +17516,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -17017,6 +17563,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 20",
                                         }
                                       }
+                                      compact={false}
                                       key="c20"
                                       row={
                                         Object {
@@ -17045,8 +17592,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -17089,6 +17639,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "label": "Column 21",
                                         }
                                       }
+                                      compact={false}
                                       key="c21"
                                       row={
                                         Object {
@@ -17117,8 +17668,11 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                         }
                                       }
                                     >
-                                      <TableCell__StyledTableCell>
+                                      <TableCell__StyledTableCell
+                                        compact={false}
+                                      >
                                         <StyledComponent
+                                          compact={false}
                                           forwardedComponent={
                                             Object {
                                               "$$typeof": Symbol(react.forward_ref),
@@ -18694,6 +19248,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                   },
                 ]
               }
+              compact={false}
               footerRows={Array []}
               hasSelectableRows={true}
               isHeaderSelected={false}
@@ -20146,6 +20701,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                     },
                   ]
                 }
+                compact={false}
                 footerRows={Array []}
                 hasSelectableRows={true}
                 isHeaderSelected={false}
@@ -21598,6 +22154,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                       },
                     ]
                   }
+                  compact={false}
                   footerRows={Array []}
                   hasSelectableRows={true}
                   isHeaderSelected={false}
@@ -21830,6 +22387,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                         },
                       ]
                     }
+                    compact={false}
                     footerRows={Array []}
                     hasSelectableRows={true}
                     isHeaderSelected={false}
@@ -22099,6 +22657,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                 },
                               ]
                             }
+                            compact={false}
                           >
                             <thead>
                               <TableHead__StyledHeaderRow>
@@ -22132,28 +22691,30 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                   <tr
                                     className="TableHead__StyledHeaderRow-msr3t5-0 dCTkDK"
                                   >
-                                    <TableHead__StyledTh
+                                    <StyledTh
+                                      compact={false}
                                       key="selected"
                                       scope="col"
                                       width="30px"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -22166,7 +22727,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         width="30px"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 lfTJRR"
+                                          className="StyledTh-sc-10nzyk9-0 sXJR"
                                           scope="col"
                                           width="30px"
                                         >
@@ -22726,28 +23287,30 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           </Styled(BaseCheckbox)>
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c1"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -22759,34 +23322,36 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 1
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c2"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -22798,34 +23363,36 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 2
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c3"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -22837,34 +23404,36 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 3
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c4"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -22876,34 +23445,36 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 4
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c5"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -22915,34 +23486,36 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 5
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c6"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -22954,34 +23527,36 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 6
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c7"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -22993,34 +23568,36 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 7
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c8"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -23032,34 +23609,36 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 8
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c9"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -23071,34 +23650,36 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 9
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c10"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -23110,34 +23691,36 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 10
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c11"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -23149,34 +23732,36 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 11
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c12"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -23188,34 +23773,36 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 12
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c13"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -23227,34 +23814,36 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 13
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c14"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -23266,34 +23855,36 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 14
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c15"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -23305,34 +23896,36 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 15
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c16"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -23344,34 +23937,36 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 16
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c17"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -23383,34 +23978,36 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 17
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c18"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -23422,34 +24019,36 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 18
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c19"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -23461,34 +24060,36 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 19
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c20"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -23500,34 +24101,36 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 20
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c21"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -23539,13 +24142,13 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 21
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
+                                    </StyledTh>
                                   </tr>
                                 </StyledComponent>
                               </TableHead__StyledHeaderRow>
@@ -23646,6 +24249,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                 },
                               ]
                             }
+                            compact={false}
                             keyField="c1"
                             loading={false}
                             noRowsContent="No records have been created for this table."
@@ -23876,6 +24480,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                     },
                                   ]
                                 }
+                                compact={false}
                                 key="some data 0"
                                 keyField="c1"
                                 row={
@@ -23951,6 +24556,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "width": "30px",
                                           }
                                         }
+                                        compact={false}
                                         key="selected"
                                         row={
                                           Object {
@@ -23980,8 +24586,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -24617,6 +25226,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 1",
                                           }
                                         }
+                                        compact={false}
                                         key="c1"
                                         row={
                                           Object {
@@ -24646,8 +25256,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -24690,6 +25303,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 2",
                                           }
                                         }
+                                        compact={false}
                                         key="c2"
                                         row={
                                           Object {
@@ -24719,8 +25333,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -24763,6 +25380,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 3",
                                           }
                                         }
+                                        compact={false}
                                         key="c3"
                                         row={
                                           Object {
@@ -24792,8 +25410,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -24836,6 +25457,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 4",
                                           }
                                         }
+                                        compact={false}
                                         key="c4"
                                         row={
                                           Object {
@@ -24865,8 +25487,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -24909,6 +25534,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 5",
                                           }
                                         }
+                                        compact={false}
                                         key="c5"
                                         row={
                                           Object {
@@ -24938,8 +25564,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -24982,6 +25611,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 6",
                                           }
                                         }
+                                        compact={false}
                                         key="c6"
                                         row={
                                           Object {
@@ -25011,8 +25641,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -25055,6 +25688,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 7",
                                           }
                                         }
+                                        compact={false}
                                         key="c7"
                                         row={
                                           Object {
@@ -25084,8 +25718,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -25128,6 +25765,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 8",
                                           }
                                         }
+                                        compact={false}
                                         key="c8"
                                         row={
                                           Object {
@@ -25157,8 +25795,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -25201,6 +25842,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 9",
                                           }
                                         }
+                                        compact={false}
                                         key="c9"
                                         row={
                                           Object {
@@ -25230,8 +25872,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -25274,6 +25919,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 10",
                                           }
                                         }
+                                        compact={false}
                                         key="c10"
                                         row={
                                           Object {
@@ -25303,8 +25949,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -25347,6 +25996,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 11",
                                           }
                                         }
+                                        compact={false}
                                         key="c11"
                                         row={
                                           Object {
@@ -25376,8 +26026,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -25420,6 +26073,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 12",
                                           }
                                         }
+                                        compact={false}
                                         key="c12"
                                         row={
                                           Object {
@@ -25449,8 +26103,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -25493,6 +26150,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 13",
                                           }
                                         }
+                                        compact={false}
                                         key="c13"
                                         row={
                                           Object {
@@ -25522,8 +26180,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -25566,6 +26227,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 14",
                                           }
                                         }
+                                        compact={false}
                                         key="c14"
                                         row={
                                           Object {
@@ -25595,8 +26257,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -25639,6 +26304,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 15",
                                           }
                                         }
+                                        compact={false}
                                         key="c15"
                                         row={
                                           Object {
@@ -25668,8 +26334,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -25712,6 +26381,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 16",
                                           }
                                         }
+                                        compact={false}
                                         key="c16"
                                         row={
                                           Object {
@@ -25741,8 +26411,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -25785,6 +26458,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 17",
                                           }
                                         }
+                                        compact={false}
                                         key="c17"
                                         row={
                                           Object {
@@ -25814,8 +26488,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -25858,6 +26535,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 18",
                                           }
                                         }
+                                        compact={false}
                                         key="c18"
                                         row={
                                           Object {
@@ -25887,8 +26565,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -25931,6 +26612,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 19",
                                           }
                                         }
+                                        compact={false}
                                         key="c19"
                                         row={
                                           Object {
@@ -25960,8 +26642,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -26004,6 +26689,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 20",
                                           }
                                         }
+                                        compact={false}
                                         key="c20"
                                         row={
                                           Object {
@@ -26033,8 +26719,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -26077,6 +26766,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 21",
                                           }
                                         }
+                                        compact={false}
                                         key="c21"
                                         row={
                                           Object {
@@ -26106,8 +26796,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -26240,6 +26933,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                     },
                                   ]
                                 }
+                                compact={false}
                                 key="some data 1"
                                 keyField="c1"
                                 row={
@@ -26315,6 +27009,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "width": "30px",
                                           }
                                         }
+                                        compact={false}
                                         key="selected"
                                         row={
                                           Object {
@@ -26344,8 +27039,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -26981,6 +27679,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 1",
                                           }
                                         }
+                                        compact={false}
                                         key="c1"
                                         row={
                                           Object {
@@ -27010,8 +27709,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -27054,6 +27756,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 2",
                                           }
                                         }
+                                        compact={false}
                                         key="c2"
                                         row={
                                           Object {
@@ -27083,8 +27786,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -27127,6 +27833,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 3",
                                           }
                                         }
+                                        compact={false}
                                         key="c3"
                                         row={
                                           Object {
@@ -27156,8 +27863,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -27200,6 +27910,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 4",
                                           }
                                         }
+                                        compact={false}
                                         key="c4"
                                         row={
                                           Object {
@@ -27229,8 +27940,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -27273,6 +27987,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 5",
                                           }
                                         }
+                                        compact={false}
                                         key="c5"
                                         row={
                                           Object {
@@ -27302,8 +28017,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -27346,6 +28064,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 6",
                                           }
                                         }
+                                        compact={false}
                                         key="c6"
                                         row={
                                           Object {
@@ -27375,8 +28094,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -27419,6 +28141,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 7",
                                           }
                                         }
+                                        compact={false}
                                         key="c7"
                                         row={
                                           Object {
@@ -27448,8 +28171,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -27492,6 +28218,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 8",
                                           }
                                         }
+                                        compact={false}
                                         key="c8"
                                         row={
                                           Object {
@@ -27521,8 +28248,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -27565,6 +28295,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 9",
                                           }
                                         }
+                                        compact={false}
                                         key="c9"
                                         row={
                                           Object {
@@ -27594,8 +28325,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -27638,6 +28372,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 10",
                                           }
                                         }
+                                        compact={false}
                                         key="c10"
                                         row={
                                           Object {
@@ -27667,8 +28402,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -27711,6 +28449,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 11",
                                           }
                                         }
+                                        compact={false}
                                         key="c11"
                                         row={
                                           Object {
@@ -27740,8 +28479,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -27784,6 +28526,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 12",
                                           }
                                         }
+                                        compact={false}
                                         key="c12"
                                         row={
                                           Object {
@@ -27813,8 +28556,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -27857,6 +28603,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 13",
                                           }
                                         }
+                                        compact={false}
                                         key="c13"
                                         row={
                                           Object {
@@ -27886,8 +28633,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -27930,6 +28680,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 14",
                                           }
                                         }
+                                        compact={false}
                                         key="c14"
                                         row={
                                           Object {
@@ -27959,8 +28710,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -28003,6 +28757,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 15",
                                           }
                                         }
+                                        compact={false}
                                         key="c15"
                                         row={
                                           Object {
@@ -28032,8 +28787,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -28076,6 +28834,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 16",
                                           }
                                         }
+                                        compact={false}
                                         key="c16"
                                         row={
                                           Object {
@@ -28105,8 +28864,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -28149,6 +28911,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 17",
                                           }
                                         }
+                                        compact={false}
                                         key="c17"
                                         row={
                                           Object {
@@ -28178,8 +28941,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -28222,6 +28988,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 18",
                                           }
                                         }
+                                        compact={false}
                                         key="c18"
                                         row={
                                           Object {
@@ -28251,8 +29018,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -28295,6 +29065,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 19",
                                           }
                                         }
+                                        compact={false}
                                         key="c19"
                                         row={
                                           Object {
@@ -28324,8 +29095,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -28368,6 +29142,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 20",
                                           }
                                         }
+                                        compact={false}
                                         key="c20"
                                         row={
                                           Object {
@@ -28397,8 +29172,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -28441,6 +29219,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 21",
                                           }
                                         }
+                                        compact={false}
                                         key="c21"
                                         row={
                                           Object {
@@ -28470,8 +29249,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -28604,6 +29386,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                     },
                                   ]
                                 }
+                                compact={false}
                                 key="some data 2"
                                 keyField="c1"
                                 row={
@@ -28679,6 +29462,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "width": "30px",
                                           }
                                         }
+                                        compact={false}
                                         key="selected"
                                         row={
                                           Object {
@@ -28708,8 +29492,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -29345,6 +30132,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 1",
                                           }
                                         }
+                                        compact={false}
                                         key="c1"
                                         row={
                                           Object {
@@ -29374,8 +30162,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -29418,6 +30209,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 2",
                                           }
                                         }
+                                        compact={false}
                                         key="c2"
                                         row={
                                           Object {
@@ -29447,8 +30239,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -29491,6 +30286,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 3",
                                           }
                                         }
+                                        compact={false}
                                         key="c3"
                                         row={
                                           Object {
@@ -29520,8 +30316,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -29564,6 +30363,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 4",
                                           }
                                         }
+                                        compact={false}
                                         key="c4"
                                         row={
                                           Object {
@@ -29593,8 +30393,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -29637,6 +30440,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 5",
                                           }
                                         }
+                                        compact={false}
                                         key="c5"
                                         row={
                                           Object {
@@ -29666,8 +30470,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -29710,6 +30517,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 6",
                                           }
                                         }
+                                        compact={false}
                                         key="c6"
                                         row={
                                           Object {
@@ -29739,8 +30547,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -29783,6 +30594,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 7",
                                           }
                                         }
+                                        compact={false}
                                         key="c7"
                                         row={
                                           Object {
@@ -29812,8 +30624,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -29856,6 +30671,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 8",
                                           }
                                         }
+                                        compact={false}
                                         key="c8"
                                         row={
                                           Object {
@@ -29885,8 +30701,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -29929,6 +30748,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 9",
                                           }
                                         }
+                                        compact={false}
                                         key="c9"
                                         row={
                                           Object {
@@ -29958,8 +30778,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -30002,6 +30825,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 10",
                                           }
                                         }
+                                        compact={false}
                                         key="c10"
                                         row={
                                           Object {
@@ -30031,8 +30855,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -30075,6 +30902,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 11",
                                           }
                                         }
+                                        compact={false}
                                         key="c11"
                                         row={
                                           Object {
@@ -30104,8 +30932,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -30148,6 +30979,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 12",
                                           }
                                         }
+                                        compact={false}
                                         key="c12"
                                         row={
                                           Object {
@@ -30177,8 +31009,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -30221,6 +31056,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 13",
                                           }
                                         }
+                                        compact={false}
                                         key="c13"
                                         row={
                                           Object {
@@ -30250,8 +31086,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -30294,6 +31133,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 14",
                                           }
                                         }
+                                        compact={false}
                                         key="c14"
                                         row={
                                           Object {
@@ -30323,8 +31163,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -30367,6 +31210,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 15",
                                           }
                                         }
+                                        compact={false}
                                         key="c15"
                                         row={
                                           Object {
@@ -30396,8 +31240,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -30440,6 +31287,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 16",
                                           }
                                         }
+                                        compact={false}
                                         key="c16"
                                         row={
                                           Object {
@@ -30469,8 +31317,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -30513,6 +31364,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 17",
                                           }
                                         }
+                                        compact={false}
                                         key="c17"
                                         row={
                                           Object {
@@ -30542,8 +31394,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -30586,6 +31441,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 18",
                                           }
                                         }
+                                        compact={false}
                                         key="c18"
                                         row={
                                           Object {
@@ -30615,8 +31471,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -30659,6 +31518,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 19",
                                           }
                                         }
+                                        compact={false}
                                         key="c19"
                                         row={
                                           Object {
@@ -30688,8 +31548,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -30732,6 +31595,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 20",
                                           }
                                         }
+                                        compact={false}
                                         key="c20"
                                         row={
                                           Object {
@@ -30761,8 +31625,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -30805,6 +31672,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 21",
                                           }
                                         }
+                                        compact={false}
                                         key="c21"
                                         row={
                                           Object {
@@ -30834,8 +31702,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -30968,6 +31839,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                     },
                                   ]
                                 }
+                                compact={false}
                                 key="some data 3"
                                 keyField="c1"
                                 row={
@@ -31043,6 +31915,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "width": "30px",
                                           }
                                         }
+                                        compact={false}
                                         key="selected"
                                         row={
                                           Object {
@@ -31072,8 +31945,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -31709,6 +32585,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 1",
                                           }
                                         }
+                                        compact={false}
                                         key="c1"
                                         row={
                                           Object {
@@ -31738,8 +32615,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -31782,6 +32662,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 2",
                                           }
                                         }
+                                        compact={false}
                                         key="c2"
                                         row={
                                           Object {
@@ -31811,8 +32692,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -31855,6 +32739,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 3",
                                           }
                                         }
+                                        compact={false}
                                         key="c3"
                                         row={
                                           Object {
@@ -31884,8 +32769,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -31928,6 +32816,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 4",
                                           }
                                         }
+                                        compact={false}
                                         key="c4"
                                         row={
                                           Object {
@@ -31957,8 +32846,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -32001,6 +32893,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 5",
                                           }
                                         }
+                                        compact={false}
                                         key="c5"
                                         row={
                                           Object {
@@ -32030,8 +32923,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -32074,6 +32970,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 6",
                                           }
                                         }
+                                        compact={false}
                                         key="c6"
                                         row={
                                           Object {
@@ -32103,8 +33000,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -32147,6 +33047,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 7",
                                           }
                                         }
+                                        compact={false}
                                         key="c7"
                                         row={
                                           Object {
@@ -32176,8 +33077,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -32220,6 +33124,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 8",
                                           }
                                         }
+                                        compact={false}
                                         key="c8"
                                         row={
                                           Object {
@@ -32249,8 +33154,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -32293,6 +33201,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 9",
                                           }
                                         }
+                                        compact={false}
                                         key="c9"
                                         row={
                                           Object {
@@ -32322,8 +33231,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -32366,6 +33278,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 10",
                                           }
                                         }
+                                        compact={false}
                                         key="c10"
                                         row={
                                           Object {
@@ -32395,8 +33308,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -32439,6 +33355,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 11",
                                           }
                                         }
+                                        compact={false}
                                         key="c11"
                                         row={
                                           Object {
@@ -32468,8 +33385,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -32512,6 +33432,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 12",
                                           }
                                         }
+                                        compact={false}
                                         key="c12"
                                         row={
                                           Object {
@@ -32541,8 +33462,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -32585,6 +33509,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 13",
                                           }
                                         }
+                                        compact={false}
                                         key="c13"
                                         row={
                                           Object {
@@ -32614,8 +33539,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -32658,6 +33586,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 14",
                                           }
                                         }
+                                        compact={false}
                                         key="c14"
                                         row={
                                           Object {
@@ -32687,8 +33616,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -32731,6 +33663,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 15",
                                           }
                                         }
+                                        compact={false}
                                         key="c15"
                                         row={
                                           Object {
@@ -32760,8 +33693,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -32804,6 +33740,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 16",
                                           }
                                         }
+                                        compact={false}
                                         key="c16"
                                         row={
                                           Object {
@@ -32833,8 +33770,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -32877,6 +33817,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 17",
                                           }
                                         }
+                                        compact={false}
                                         key="c17"
                                         row={
                                           Object {
@@ -32906,8 +33847,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -32950,6 +33894,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 18",
                                           }
                                         }
+                                        compact={false}
                                         key="c18"
                                         row={
                                           Object {
@@ -32979,8 +33924,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -33023,6 +33971,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 19",
                                           }
                                         }
+                                        compact={false}
                                         key="c19"
                                         row={
                                           Object {
@@ -33052,8 +34001,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -33096,6 +34048,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 20",
                                           }
                                         }
+                                        compact={false}
                                         key="c20"
                                         row={
                                           Object {
@@ -33125,8 +34078,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -33169,6 +34125,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 21",
                                           }
                                         }
+                                        compact={false}
                                         key="c21"
                                         row={
                                           Object {
@@ -33198,8 +34155,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -33332,6 +34292,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                     },
                                   ]
                                 }
+                                compact={false}
                                 key="some data 4"
                                 keyField="c1"
                                 row={
@@ -33407,6 +34368,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "width": "30px",
                                           }
                                         }
+                                        compact={false}
                                         key="selected"
                                         row={
                                           Object {
@@ -33436,8 +34398,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -34073,6 +35038,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 1",
                                           }
                                         }
+                                        compact={false}
                                         key="c1"
                                         row={
                                           Object {
@@ -34102,8 +35068,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -34146,6 +35115,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 2",
                                           }
                                         }
+                                        compact={false}
                                         key="c2"
                                         row={
                                           Object {
@@ -34175,8 +35145,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -34219,6 +35192,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 3",
                                           }
                                         }
+                                        compact={false}
                                         key="c3"
                                         row={
                                           Object {
@@ -34248,8 +35222,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -34292,6 +35269,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 4",
                                           }
                                         }
+                                        compact={false}
                                         key="c4"
                                         row={
                                           Object {
@@ -34321,8 +35299,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -34365,6 +35346,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 5",
                                           }
                                         }
+                                        compact={false}
                                         key="c5"
                                         row={
                                           Object {
@@ -34394,8 +35376,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -34438,6 +35423,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 6",
                                           }
                                         }
+                                        compact={false}
                                         key="c6"
                                         row={
                                           Object {
@@ -34467,8 +35453,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -34511,6 +35500,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 7",
                                           }
                                         }
+                                        compact={false}
                                         key="c7"
                                         row={
                                           Object {
@@ -34540,8 +35530,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -34584,6 +35577,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 8",
                                           }
                                         }
+                                        compact={false}
                                         key="c8"
                                         row={
                                           Object {
@@ -34613,8 +35607,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -34657,6 +35654,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 9",
                                           }
                                         }
+                                        compact={false}
                                         key="c9"
                                         row={
                                           Object {
@@ -34686,8 +35684,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -34730,6 +35731,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 10",
                                           }
                                         }
+                                        compact={false}
                                         key="c10"
                                         row={
                                           Object {
@@ -34759,8 +35761,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -34803,6 +35808,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 11",
                                           }
                                         }
+                                        compact={false}
                                         key="c11"
                                         row={
                                           Object {
@@ -34832,8 +35838,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -34876,6 +35885,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 12",
                                           }
                                         }
+                                        compact={false}
                                         key="c12"
                                         row={
                                           Object {
@@ -34905,8 +35915,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -34949,6 +35962,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 13",
                                           }
                                         }
+                                        compact={false}
                                         key="c13"
                                         row={
                                           Object {
@@ -34978,8 +35992,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -35022,6 +36039,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 14",
                                           }
                                         }
+                                        compact={false}
                                         key="c14"
                                         row={
                                           Object {
@@ -35051,8 +36069,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -35095,6 +36116,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 15",
                                           }
                                         }
+                                        compact={false}
                                         key="c15"
                                         row={
                                           Object {
@@ -35124,8 +36146,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -35168,6 +36193,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 16",
                                           }
                                         }
+                                        compact={false}
                                         key="c16"
                                         row={
                                           Object {
@@ -35197,8 +36223,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -35241,6 +36270,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 17",
                                           }
                                         }
+                                        compact={false}
                                         key="c17"
                                         row={
                                           Object {
@@ -35270,8 +36300,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -35314,6 +36347,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 18",
                                           }
                                         }
+                                        compact={false}
                                         key="c18"
                                         row={
                                           Object {
@@ -35343,8 +36377,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -35387,6 +36424,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 19",
                                           }
                                         }
+                                        compact={false}
                                         key="c19"
                                         row={
                                           Object {
@@ -35416,8 +36454,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -35460,6 +36501,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 20",
                                           }
                                         }
+                                        compact={false}
                                         key="c20"
                                         row={
                                           Object {
@@ -35489,8 +36531,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -35533,6 +36578,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "label": "Column 21",
                                           }
                                         }
+                                        compact={false}
                                         key="c21"
                                         row={
                                           Object {
@@ -35562,8 +36608,11 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -37162,6 +38211,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                   },
                 ]
               }
+              compact={false}
               footerRows={Array []}
               hasSelectableRows={true}
               isHeaderSelected={false}
@@ -37217,6 +38267,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                     },
                   ]
                 }
+                compact={false}
                 footerRows={Array []}
                 hasSelectableRows={true}
                 isHeaderSelected={false}
@@ -37272,6 +38323,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                       },
                     ]
                   }
+                  compact={false}
                   footerRows={Array []}
                   hasSelectableRows={true}
                   isHeaderSelected={false}
@@ -37335,6 +38387,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                         },
                       ]
                     }
+                    compact={false}
                     footerRows={Array []}
                     hasSelectableRows={true}
                     isHeaderSelected={false}
@@ -37432,6 +38485,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                 },
                               ]
                             }
+                            compact={false}
                           >
                             <thead>
                               <TableHead__StyledHeaderRow>
@@ -37465,28 +38519,30 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                   <tr
                                     className="TableHead__StyledHeaderRow-msr3t5-0 dCTkDK"
                                   >
-                                    <TableHead__StyledTh
+                                    <StyledTh
+                                      compact={false}
                                       key="selected"
                                       scope="col"
                                       width="30px"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -37499,7 +38555,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                         width="30px"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 lfTJRR"
+                                          className="StyledTh-sc-10nzyk9-0 sXJR"
                                           scope="col"
                                           width="30px"
                                         >
@@ -38059,28 +39115,30 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                           </Styled(BaseCheckbox)>
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c1"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -38092,34 +39150,36 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 1
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c2"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -38131,34 +39191,36 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 2
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c3"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -38170,34 +39232,36 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 3
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c4"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -38209,34 +39273,36 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 4
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c5"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -38248,34 +39314,36 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 5
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c6"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -38287,13 +39355,13 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 6
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
+                                    </StyledTh>
                                   </tr>
                                 </StyledComponent>
                               </TableHead__StyledHeaderRow>
@@ -38334,6 +39402,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                 },
                               ]
                             }
+                            compact={false}
                             keyField="c1"
                             loading={false}
                             noRowsContent="No records have been created for this table."
@@ -38393,6 +39462,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                     },
                                   ]
                                 }
+                                compact={false}
                                 key="row 1 cell 1"
                                 keyField="c1"
                                 row={
@@ -38450,6 +39520,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                             "width": "30px",
                                           }
                                         }
+                                        compact={false}
                                         key="selected"
                                         row={
                                           Object {
@@ -38461,8 +39532,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -39080,6 +40154,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                             "label": "Column 1",
                                           }
                                         }
+                                        compact={false}
                                         key="c1"
                                         row={
                                           Object {
@@ -39091,8 +40166,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -39135,6 +40213,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                             "label": "Column 2",
                                           }
                                         }
+                                        compact={false}
                                         key="c2"
                                         row={
                                           Object {
@@ -39146,8 +40225,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -39190,6 +40272,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                             "label": "Column 3",
                                           }
                                         }
+                                        compact={false}
                                         key="c3"
                                         row={
                                           Object {
@@ -39201,8 +40284,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -39245,6 +40331,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                             "label": "Column 4",
                                           }
                                         }
+                                        compact={false}
                                         key="c4"
                                         row={
                                           Object {
@@ -39256,8 +40343,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -39298,6 +40388,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                             "label": "Column 5",
                                           }
                                         }
+                                        compact={false}
                                         key="c5"
                                         row={
                                           Object {
@@ -39309,8 +40400,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -39351,6 +40445,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                             "label": "Column 6",
                                           }
                                         }
+                                        compact={false}
                                         key="c6"
                                         row={
                                           Object {
@@ -39362,8 +40457,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -39434,6 +40532,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                     },
                                   ]
                                 }
+                                compact={false}
                                 key="r2c1"
                                 keyField="c1"
                                 row={
@@ -39491,6 +40590,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                             "width": "30px",
                                           }
                                         }
+                                        compact={false}
                                         key="selected"
                                         row={
                                           Object {
@@ -39502,8 +40602,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -40121,6 +41224,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                             "label": "Column 1",
                                           }
                                         }
+                                        compact={false}
                                         key="c1"
                                         row={
                                           Object {
@@ -40132,8 +41236,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -40176,6 +41283,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                             "label": "Column 2",
                                           }
                                         }
+                                        compact={false}
                                         key="c2"
                                         row={
                                           Object {
@@ -40187,8 +41295,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -40231,6 +41342,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                             "label": "Column 3",
                                           }
                                         }
+                                        compact={false}
                                         key="c3"
                                         row={
                                           Object {
@@ -40242,8 +41354,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -40286,6 +41401,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                             "label": "Column 4",
                                           }
                                         }
+                                        compact={false}
                                         key="c4"
                                         row={
                                           Object {
@@ -40297,8 +41413,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -40339,6 +41458,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                             "label": "Column 5",
                                           }
                                         }
+                                        compact={false}
                                         key="c5"
                                         row={
                                           Object {
@@ -40350,8 +41470,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -40392,6 +41515,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                             "label": "Column 6",
                                           }
                                         }
+                                        compact={false}
                                         key="c6"
                                         row={
                                           Object {
@@ -40403,8 +41527,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -40915,6 +42042,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                   },
                 ]
               }
+              compact={false}
               footerRows={Array []}
               hasSelectableRows={true}
               isHeaderSelected={false}
@@ -40974,6 +42102,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                     },
                   ]
                 }
+                compact={false}
                 footerRows={Array []}
                 hasSelectableRows={true}
                 isHeaderSelected={false}
@@ -41033,6 +42162,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                       },
                     ]
                   }
+                  compact={false}
                   footerRows={Array []}
                   hasSelectableRows={true}
                   isHeaderSelected={false}
@@ -41100,6 +42230,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                         },
                       ]
                     }
+                    compact={false}
                     footerRows={Array []}
                     hasSelectableRows={true}
                     isHeaderSelected={false}
@@ -41201,6 +42332,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                 },
                               ]
                             }
+                            compact={false}
                           >
                             <thead>
                               <TableHead__StyledHeaderRow>
@@ -41234,28 +42366,30 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                   <tr
                                     className="TableHead__StyledHeaderRow-msr3t5-0 dCTkDK"
                                   >
-                                    <TableHead__StyledTh
+                                    <StyledTh
+                                      compact={false}
                                       key="selected"
                                       scope="col"
                                       width="30px"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -41268,7 +42402,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                         width="30px"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 lfTJRR"
+                                          className="StyledTh-sc-10nzyk9-0 sXJR"
                                           scope="col"
                                           width="30px"
                                         >
@@ -41828,28 +42962,30 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                           </Styled(BaseCheckbox)>
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c1"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -41861,34 +42997,36 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 1
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c2"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -41900,34 +43038,36 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 2
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c3"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -41939,34 +43079,36 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 3
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c4"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -41978,34 +43120,36 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 4
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c5"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -42017,34 +43161,36 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 5
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
-                                    <TableHead__StyledTh
+                                    </StyledTh>
+                                    <StyledTh
+                                      compact={false}
                                       key="c6"
                                       scope="col"
                                     >
                                       <StyledComponent
+                                        compact={false}
                                         forwardedComponent={
                                           Object {
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "TableHead__StyledTh-msr3t5-1",
+                                              "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "bQoogK",
+                                              "lastClassName": "eunBIc",
                                               "rules": Array [
                                                 [Function],
                                               ],
                                             },
-                                            "displayName": "TableHead__StyledTh",
+                                            "displayName": "StyledTh",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "TableHead__StyledTh-msr3t5-1",
+                                            "styledComponentId": "StyledTh-sc-10nzyk9-0",
                                             "target": "th",
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -42056,13 +43202,13 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                         scope="col"
                                       >
                                         <th
-                                          className="TableHead__StyledTh-msr3t5-1 bQoogK"
+                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
                                           scope="col"
                                         >
                                           Column 6
                                         </th>
                                       </StyledComponent>
-                                    </TableHead__StyledTh>
+                                    </StyledTh>
                                   </tr>
                                 </StyledComponent>
                               </TableHead__StyledHeaderRow>
@@ -42103,6 +43249,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                 },
                               ]
                             }
+                            compact={false}
                             keyField="c1"
                             loading={false}
                             noRowsContent="No records have been created for this table."
@@ -42162,6 +43309,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                     },
                                   ]
                                 }
+                                compact={false}
                                 key="row 1 cell 1"
                                 keyField="c1"
                                 row={
@@ -42219,6 +43367,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                             "width": "30px",
                                           }
                                         }
+                                        compact={false}
                                         key="selected"
                                         row={
                                           Object {
@@ -42230,8 +43379,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -42849,6 +44001,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                             "label": "Column 1",
                                           }
                                         }
+                                        compact={false}
                                         key="c1"
                                         row={
                                           Object {
@@ -42860,8 +44013,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -42904,6 +44060,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                             "label": "Column 2",
                                           }
                                         }
+                                        compact={false}
                                         key="c2"
                                         row={
                                           Object {
@@ -42915,8 +44072,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -42959,6 +44119,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                             "label": "Column 3",
                                           }
                                         }
+                                        compact={false}
                                         key="c3"
                                         row={
                                           Object {
@@ -42970,8 +44131,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -43014,6 +44178,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                             "label": "Column 4",
                                           }
                                         }
+                                        compact={false}
                                         key="c4"
                                         row={
                                           Object {
@@ -43025,8 +44190,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -43067,6 +44235,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                             "label": "Column 5",
                                           }
                                         }
+                                        compact={false}
                                         key="c5"
                                         row={
                                           Object {
@@ -43078,8 +44247,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -43120,6 +44292,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                             "label": "Column 6",
                                           }
                                         }
+                                        compact={false}
                                         key="c6"
                                         row={
                                           Object {
@@ -43131,8 +44304,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -43203,6 +44379,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                     },
                                   ]
                                 }
+                                compact={false}
                                 key="r2c1"
                                 keyField="c1"
                                 row={
@@ -43260,6 +44437,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                             "width": "30px",
                                           }
                                         }
+                                        compact={false}
                                         key="selected"
                                         row={
                                           Object {
@@ -43271,8 +44449,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -43890,6 +45071,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                             "label": "Column 1",
                                           }
                                         }
+                                        compact={false}
                                         key="c1"
                                         row={
                                           Object {
@@ -43901,8 +45083,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -43945,6 +45130,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                             "label": "Column 2",
                                           }
                                         }
+                                        compact={false}
                                         key="c2"
                                         row={
                                           Object {
@@ -43956,8 +45142,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -44000,6 +45189,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                             "label": "Column 3",
                                           }
                                         }
+                                        compact={false}
                                         key="c3"
                                         row={
                                           Object {
@@ -44011,8 +45201,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -44055,6 +45248,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                             "label": "Column 4",
                                           }
                                         }
+                                        compact={false}
                                         key="c4"
                                         row={
                                           Object {
@@ -44066,8 +45260,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -44108,6 +45305,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                             "label": "Column 5",
                                           }
                                         }
+                                        compact={false}
                                         key="c5"
                                         row={
                                           Object {
@@ -44119,8 +45317,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -44161,6 +45362,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                             "label": "Column 6",
                                           }
                                         }
+                                        compact={false}
                                         key="c6"
                                         row={
                                           Object {
@@ -44172,8 +45374,11 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                           }
                                         }
                                       >
-                                        <TableCell__StyledTableCell>
+                                        <TableCell__StyledTableCell
+                                          compact={false}
+                                        >
                                           <StyledComponent
+                                            compact={false}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),

--- a/components/src/Table/BaseTable.js
+++ b/components/src/Table/BaseTable.js
@@ -13,9 +13,9 @@ const StyledTable = styled.table({
   background: "white"
 });
 
-const BaseTable = ({ columns, rows, noRowsContent, keyField, id, loading, footerRows, rowHovers }) => (
+const BaseTable = ({ columns, rows, noRowsContent, keyField, id, loading, footerRows, rowHovers, compact }) => (
   <StyledTable id={id}>
-    <TableHead columns={columns} />
+    <TableHead columns={columns} compact={compact} />
     <TableBody
       columns={columns}
       rows={rows}
@@ -23,6 +23,7 @@ const BaseTable = ({ columns, rows, noRowsContent, keyField, id, loading, footer
       noRowsContent={noRowsContent}
       loading={loading}
       rowHovers={rowHovers}
+      compact={compact}
     />
     {footerRows && <TableFoot columns={columns} rows={footerRows} loading={loading} />}
   </StyledTable>
@@ -36,7 +37,8 @@ BaseTable.propTypes = {
   id: PropTypes.string,
   loading: PropTypes.bool,
   footerRows: rowsPropType,
-  rowHovers: PropTypes.bool
+  rowHovers: PropTypes.bool,
+  compact: PropTypes.bool
 };
 
 BaseTable.defaultProps = {
@@ -45,7 +47,8 @@ BaseTable.defaultProps = {
   id: undefined,
   loading: false,
   footerRows: [],
-  rowHovers: true
+  rowHovers: true,
+  compact: false
 };
 
 export default BaseTable;

--- a/components/src/Table/StyledTh.js
+++ b/components/src/Table/StyledTh.js
@@ -1,0 +1,19 @@
+import styled from "styled-components";
+import theme from "../theme";
+
+const StyledTh = styled.th(({ width, compact }) => {
+  const padding = compact ? theme.space.x1 : theme.space.x2;
+  return {
+    fontWeight: "normal",
+    textAlign: "left",
+    padding: `${padding} 0`,
+    paddingRight: padding,
+    color: theme.colors.darkGrey,
+    "&:first-of-type": {
+      paddingLeft: padding
+    },
+    width: width || "auto"
+  };
+});
+
+export default StyledTh;

--- a/components/src/Table/Table.story.js
+++ b/components/src/Table/Table.story.js
@@ -165,7 +165,7 @@ storiesOf("Table", module)
   .add("with no data and custom content", () => (
     <Table columns={columns} rows={[]} noRowsContent="No jobs are available" />
   ))
-
+  .add("with compact styling", () => <Table columns={columns} rows={rowData} compact />)
   .add("with custom column widths", () => <Table columns={columnsWithWidths} rows={rowDataWithWidths} />)
   .add("with full width section", () => <Table columns={columns} rows={rowDataWithSections} />)
   .add("with a custom cell component", () => (

--- a/components/src/Table/TableBody.js
+++ b/components/src/Table/TableBody.js
@@ -18,22 +18,35 @@ const StyledTr = styled.tr(({ rowHovers }) => ({
   }
 }));
 
-const renderRows = (rows, columns, keyField, noRowsContent, rowHovers) =>
+const renderRows = (rows, columns, keyField, noRowsContent, rowHovers, compact) =>
   rows.length > 0 ? (
     rows.map(row => (
-      <TableBodyRow row={row} columns={columns} key={row[keyField]} keyField={keyField} rowHovers={rowHovers} />
+      <TableBodyRow
+        row={row}
+        columns={columns}
+        key={row[keyField]}
+        keyField={keyField}
+        rowHovers={rowHovers}
+        compact={compact}
+      />
     ))
   ) : (
     <TableMessageContainer colSpan={columns.length - 1}>{noRowsContent}</TableMessageContainer>
   );
 
-const TableBodyRow = ({ row, columns, rowHovers }) => {
+const TableBodyRow = ({ row, columns, rowHovers, compact }) => {
   const renderAllCells = () =>
-    columns.map(column => <TableCell key={column.dataKey} row={row} column={column} cellData={row[column.dataKey]} />);
+    columns.map(column => (
+      <TableCell key={column.dataKey} row={row} column={column} cellData={row[column.dataKey]} compact={compact} />
+    ));
   return (
     <>
       <StyledTr rowHovers={rowHovers}>
-        {row.heading ? <TableCell row={row} colSpan={columns.length} cellData={row.heading} /> : renderAllCells()}
+        {row.heading ? (
+          <TableCell row={row} colSpan={columns.length} cellData={row.heading} compact={compact} />
+        ) : (
+          renderAllCells()
+        )}
       </StyledTr>
       {row.expandedContent && row.expanded && (
         <tr>
@@ -47,7 +60,8 @@ const TableBodyRow = ({ row, columns, rowHovers }) => {
 TableBodyRow.propTypes = {
   row: rowPropType.isRequired,
   columns: columnsPropType.isRequired,
-  rowHovers: PropTypes.bool.isRequired
+  rowHovers: PropTypes.bool.isRequired,
+  compact: PropTypes.isRequired
 };
 
 const TableMessageContainer = ({ colSpan, children }) => (
@@ -69,10 +83,10 @@ LoadingContent.propTypes = {
   colSpan: PropTypes.number.isRequired
 };
 
-const TableBody = ({ rows, columns, keyField, noRowsContent, loading, rowHovers }) => (
+const TableBody = ({ rows, columns, keyField, noRowsContent, loading, rowHovers, compact }) => (
   <tbody>
     {!loading ? (
-      renderRows(rows, columns, keyField, noRowsContent, rowHovers)
+      renderRows(rows, columns, keyField, noRowsContent, rowHovers, compact)
     ) : (
       <LoadingContent colSpan={columns.length - 1} />
     )}
@@ -85,7 +99,8 @@ TableBody.propTypes = {
   rowHovers: PropTypes.bool.isRequired,
   noRowsContent: PropTypes.string,
   keyField: PropTypes.string,
-  loading: PropTypes.bool
+  loading: PropTypes.bool,
+  compact: PropTypes.isRequired
 };
 TableBody.defaultProps = {
   noRowsContent: "No records have been created for this table.",

--- a/components/src/Table/TableCell.js
+++ b/components/src/Table/TableCell.js
@@ -4,17 +4,20 @@ import styled from "styled-components";
 import theme from "../theme";
 import { columnPropType, rowPropType } from "./Table.types";
 
-const StyledTableCell = styled.td(({ align }) => ({
-  paddingTop: theme.space.x2,
-  paddingBottom: theme.space.x2,
-  textAlign: align,
-  paddingRight: theme.space.x2,
-  "&:first-child": {
-    paddingLeft: theme.space.x2
-  }
-}));
+const StyledTableCell = styled.td(({ align, compact }) => {
+  const padding = compact ? theme.space.x1 : theme.space.x2;
+  return {
+    paddingTop: padding,
+    paddingBottom: padding,
+    textAlign: align,
+    paddingRight: padding,
+    "&:first-child": {
+      paddingLeft: padding
+    }
+  };
+});
 
-const TableCell = ({ row, column, colSpan, cellData }) => {
+const TableCell = ({ row, column, colSpan, cellData, compact }) => {
   const cellRenderer = row.cellRenderer || column.cellRenderer;
   const { cellFormatter } = column;
   const isCustomCell = Boolean(cellRenderer);
@@ -22,14 +25,19 @@ const TableCell = ({ row, column, colSpan, cellData }) => {
   if (isCustomCell) {
     return <td colSpan={colSpan}>{cellRenderer ? cellRenderer({ cellData, column, row }) : cellData}</td>;
   }
-  return <StyledTableCell align={column.align}>{cellContent}</StyledTableCell>;
+  return (
+    <StyledTableCell align={column.align} compact={compact}>
+      {cellContent}
+    </StyledTableCell>
+  );
 };
 
 TableCell.propTypes = {
   column: columnPropType,
   row: rowPropType,
   colSpan: PropTypes.number,
-  cellData: PropTypes.oneOfType([PropTypes.node, PropTypes.bool])
+  cellData: PropTypes.oneOfType([PropTypes.node, PropTypes.bool]),
+  compact: PropTypes.isRequired
 };
 
 TableCell.defaultProps = {

--- a/components/src/Table/TableFoot.js
+++ b/components/src/Table/TableFoot.js
@@ -3,21 +3,13 @@ import PropTypes from "prop-types";
 import styled from "styled-components";
 import theme from "../theme";
 import TableCell from "./TableCell";
+import StyledTh from "./StyledTh";
 import { columnsPropType, rowsPropType, rowPropType } from "./Table.types";
 
 const StyledFooterRow = styled.tr({
   "&:first-of-type": {
     borderTop: `1px solid ${theme.colors.lightGrey}`
   }
-});
-
-const StyledTh = styled.th({
-  fontWeight: "normal",
-  textAlign: "left",
-  padding: `${theme.space.x2} 0`,
-  paddingRight: theme.space.x2,
-  paddingLeft: theme.space.x2,
-  color: theme.colors.darkGrey
 });
 
 const renderRows = (rows, columns, keyField, loading) =>

--- a/components/src/Table/TableHead.js
+++ b/components/src/Table/TableHead.js
@@ -2,39 +2,30 @@ import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import theme from "../theme";
+import StyledTh from "./StyledTh";
 
 const StyledHeaderRow = styled.tr({
   color: theme.colors.darkGrey,
   borderBottom: `1px solid ${theme.colors.lightGrey}`
 });
 
-const StyledTh = styled.th(({ width }) => ({
-  fontWeight: "normal",
-  textAlign: "left",
-  padding: `${theme.space.x2} 0`,
-  paddingRight: theme.space.x2,
-  "&:first-of-type": {
-    paddingLeft: theme.space.x2
-  },
-  width: width || "auto"
-}));
-
 const defaultheaderFormatter = ({ label }) => label;
 
 const renderHeaderCellContent = ({ headerFormatter = defaultheaderFormatter, ...column }) => headerFormatter(column);
 
-const renderColumns = columns =>
-  columns.map(column => (
-    <StyledTh scope="col" key={column.dataKey} width={column.width}>
-      {renderHeaderCellContent(column)}
-    </StyledTh>
-  ));
-
-const TableHead = ({ columns }) => (
-  <thead>
-    <StyledHeaderRow>{renderColumns(columns)}</StyledHeaderRow>
-  </thead>
-);
+const TableHead = ({ columns, compact }) => {
+  const renderColumns = allColumns =>
+    allColumns.map(column => (
+      <StyledTh scope="col" key={column.dataKey} width={column.width} compact={compact}>
+        {renderHeaderCellContent(column)}
+      </StyledTh>
+    ));
+  return (
+    <thead>
+      <StyledHeaderRow>{renderColumns(columns)}</StyledHeaderRow>
+    </thead>
+  );
+};
 
 TableHead.propTypes = {
   columns: PropTypes.arrayOf(
@@ -46,7 +37,8 @@ TableHead.propTypes = {
       cellFormatter: PropTypes.func,
       headerFormatter: PropTypes.func
     })
-  ).isRequired
+  ).isRequired,
+  compact: PropTypes.isRequired
 };
 
 export default TableHead;

--- a/docs/src/pages/components/table.js
+++ b/docs/src/pages/components/table.js
@@ -534,9 +534,21 @@ const columnsWithCustomCells = [
         show rows when the <InlineCode>loading</InlineCode> prop is set to
         false.
       </Text>
-      <Table loading columns={[columns]} rows={rows} />
+      <Table loading columns={columns} rows={rows} />
       <Highlight className="js">
-        {`<Table loading columns={[columns]} rows={rows} />`}
+        {`<Table loading columns={columns} rows={rows} />`}
+      </Highlight>
+    </DocSection>
+
+    <DocSection>
+      <SectionTitle>Compact Styling</SectionTitle>
+      <Text>
+        The table can be set to use compact styling which decreases the paddings
+        when the <InlineCode>compact</InlineCode> prop is set to true.
+      </Text>
+      <Table columns={columns} rows={rows} compact />
+      <Highlight className="js">
+        {`<Table columns={columns} rows={rows} compact />`}
       </Highlight>
     </DocSection>
 


### PR DESCRIPTION
## Description

Adds a compact option to the table that decreases all the default paddings in the table so that the user can see more information in less space.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [x] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [x] Docs updated with correct props and examples
- [x] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interactions
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [x] Changelog updated
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [x] Tested storybook deployment preview
- [x] Tested docs deployment preview
