### PR TITLE
[NDS-1222] `Warning: Each child in a list should have a unique "key" prop when using TableFooter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
- 
+
 ### Added
 ### Changed
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Fixed bug that caused `Each child in a list should have a unique "key" prop` warning when using the table footer
+
 ### Security
 
 ## [0.16.3] - 2019-11-25

--- a/components/src/DemoPage/__snapshots__/DemoPage.story.storyshot
+++ b/components/src/DemoPage/__snapshots__/DemoPage.story.storyshot
@@ -12801,7 +12801,7 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                 },
                                                               ]
                                                             }
-                                                            keyField="id"
+                                                            keyField="c1"
                                                             loading={false}
                                                             rows={Array []}
                                                           >

--- a/components/src/StoriesForTests/__snapshots__/Table.story.storyshot
+++ b/components/src/StoriesForTests/__snapshots__/Table.story.storyshot
@@ -4782,7 +4782,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                   },
                                 ]
                               }
-                              keyField="id"
+                              keyField="c1"
                               loading={false}
                               rows={Array []}
                             >
@@ -7557,7 +7557,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                 },
                               ]
                             }
-                            keyField="id"
+                            keyField="c1"
                             loading={false}
                             rows={Array []}
                           >
@@ -17801,7 +17801,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                               },
                             ]
                           }
-                          keyField="id"
+                          keyField="c1"
                           loading={false}
                           rows={Array []}
                         >
@@ -36747,7 +36747,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                 },
                               ]
                             }
-                            keyField="id"
+                            keyField="c1"
                             loading={false}
                             rows={Array []}
                           >
@@ -41604,7 +41604,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                 },
                               ]
                             }
-                            keyField="id"
+                            keyField="c1"
                             loading={false}
                             rows={Array []}
                           >
@@ -45451,7 +45451,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                 },
                               ]
                             }
-                            keyField="id"
+                            keyField="c1"
                             loading={false}
                             rows={Array []}
                           >

--- a/components/src/Table/BaseTable.js
+++ b/components/src/Table/BaseTable.js
@@ -25,7 +25,7 @@ const BaseTable = ({ columns, rows, noRowsContent, keyField, id, loading, footer
       rowHovers={rowHovers}
       compact={compact}
     />
-    {footerRows && <TableFoot columns={columns} rows={footerRows} loading={loading} />}
+    {footerRows && <TableFoot columns={columns} rows={footerRows} keyField={keyField} loading={loading} />}
   </StyledTable>
 );
 

--- a/components/src/Table/Table.story.js
+++ b/components/src/Table/Table.story.js
@@ -89,14 +89,14 @@ const columnsWithEverything = [
 ];
 
 const rowData = [
-  { date: "2019-10-01", expectedQuantity: "2,025 eaches", actualQuantity: "1,800 eaches", id: "r1" },
-  { date: "2019-10-02", expectedQuantity: "2,475 eaches", actualQuantity: "2,250 eaches", id: "r2" },
-  { date: "2019-10-03", expectedQuantity: "2,475 eaches", actualQuantity: "1,425 eaches", id: "r3" },
-  { date: "2019-10-04", expectedQuantity: "2,475 eaches", actualQuantity: "675 eaches", id: "r4" },
-  { date: "2019-10-07", expectedQuantity: "2,475 eaches", actualQuantity: "1,575 eaches", id: "r5" },
-  { date: "2019-10-22", expectedQuantity: "1,725 eaches", actualQuantity: "-", id: "r6" },
-  { date: "2019-10-23", expectedQuantity: "2,475 eaches", actualQuantity: "-", id: "r7" },
-  { date: "2019-10-24", expectedQuantity: "2,475 eaches", actualQuantity: "-", id: "r8" }
+  { date: "2019-10-01", expectedQuantity: "2,025 eaches", actualQuantity: "1,800 eaches" },
+  { date: "2019-10-02", expectedQuantity: "2,475 eaches", actualQuantity: "2,250 eaches" },
+  { date: "2019-10-03", expectedQuantity: "2,475 eaches", actualQuantity: "1,425 eaches" },
+  { date: "2019-10-04", expectedQuantity: "2,475 eaches", actualQuantity: "675 eaches" },
+  { date: "2019-10-07", expectedQuantity: "2,475 eaches", actualQuantity: "1,575 eaches" },
+  { date: "2019-10-22", expectedQuantity: "1,725 eaches", actualQuantity: "-" },
+  { date: "2019-10-23", expectedQuantity: "2,475 eaches", actualQuantity: "-" },
+  { date: "2019-10-24", expectedQuantity: "2,475 eaches", actualQuantity: "-" }
 ];
 
 const rowDataWithWidths = [
@@ -158,8 +158,8 @@ const rowDataWithEverything = [
 ];
 
 const footerRowData = [
-  { date: "Total", expectedQuantity: "18,000 eaches", actualQuantity: "7,725 eaches", id: "r1" },
-  { date: "Attainment", expectedQuantity: "", actualQuantity: "41.5%", id: "r2" }
+  { date: "Total", expectedQuantity: "18,000 eaches", actualQuantity: "7,725 eaches" },
+  { date: "Attainment", expectedQuantity: "", actualQuantity: "41.5%" }
 ];
 
 storiesOf("Table", module)

--- a/components/src/Table/Table.story.js
+++ b/components/src/Table/Table.story.js
@@ -89,14 +89,14 @@ const columnsWithEverything = [
 ];
 
 const rowData = [
-  { date: "2019-10-01", expectedQuantity: "2,025 eaches", actualQuantity: "1,800 eaches" },
-  { date: "2019-10-02", expectedQuantity: "2,475 eaches", actualQuantity: "2,250 eaches" },
-  { date: "2019-10-03", expectedQuantity: "2,475 eaches", actualQuantity: "1,425 eaches" },
-  { date: "2019-10-04", expectedQuantity: "2,475 eaches", actualQuantity: "675 eaches" },
-  { date: "2019-10-07", expectedQuantity: "2,475 eaches", actualQuantity: "1,575 eaches" },
-  { date: "2019-10-22", expectedQuantity: "1,725 eaches", actualQuantity: "-" },
-  { date: "2019-10-23", expectedQuantity: "2,475 eaches", actualQuantity: "-" },
-  { date: "2019-10-24", expectedQuantity: "2,475 eaches", actualQuantity: "-" }
+  { date: "2019-10-01", expectedQuantity: "2,025 eaches", actualQuantity: "1,800 eaches", id: "r1" },
+  { date: "2019-10-02", expectedQuantity: "2,475 eaches", actualQuantity: "2,250 eaches", id: "r2" },
+  { date: "2019-10-03", expectedQuantity: "2,475 eaches", actualQuantity: "1,425 eaches", id: "r3" },
+  { date: "2019-10-04", expectedQuantity: "2,475 eaches", actualQuantity: "675 eaches", id: "r4" },
+  { date: "2019-10-07", expectedQuantity: "2,475 eaches", actualQuantity: "1,575 eaches", id: "r5" },
+  { date: "2019-10-22", expectedQuantity: "1,725 eaches", actualQuantity: "-", id: "r7" },
+  { date: "2019-10-23", expectedQuantity: "2,475 eaches", actualQuantity: "-", id: "r8" },
+  { date: "2019-10-24", expectedQuantity: "2,475 eaches", actualQuantity: "-", id: "r9" }
 ];
 
 const rowDataWithWidths = [

--- a/components/src/Table/Table.story.js
+++ b/components/src/Table/Table.story.js
@@ -214,9 +214,9 @@ storiesOf("Table", module)
   ))
   .add("with a footer", () => (
     <>
-      <Table columns={columns} rows={rowData} footerRows={footerRowData} />
+      <Table columns={columns} keyField="date" rows={rowData} footerRows={footerRowData} />
       <Text mt="x6">Loading state:</Text>
-      <Table columns={columns} rows={rowData} footerRows={footerRowData} loading />
+      <Table columns={columns} keyField="date" rows={rowData} footerRows={footerRowData} loading />
     </>
   ))
   .add("with lots of rows and columns", () => (


### PR DESCRIPTION
## Description

Actually pass the keyField to table footer like it's expecting. 

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [x] Changelog updated
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
