### PR TITLE
Adds menu open/close props to Select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
- 
+
 ### Added
+
+- [Select](http://nulogy.design/components/select) now supports `menuIsOpen`, `onMenuOpen`, and `onMenuClose`
 
 ### Changed
 

--- a/components/src/Select/Select.js
+++ b/components/src/Select/Select.js
@@ -53,7 +53,10 @@ const ReactSelect = ({
   defaultValue,
   className,
   classNamePrefix,
-  onBlur
+  onBlur,
+  menuIsOpen,
+  onMenuOpen,
+  onMenuClose
 }) => (
   <Field>
     <MaybeFieldLabel labelText={labelText} requirementText={requirementText} helpText={helpText}>
@@ -78,6 +81,9 @@ const ReactSelect = ({
         value={getReactSelectValue(options, value)}
         name={name}
         isMulti={multiselect}
+        menuIsOpen={menuIsOpen}
+        onMenuOpen={onMenuOpen}
+        onMenuClose={onMenuClose}
       />
       <InlineValidation mt="x1" errorMessage={errorMessage} errorList={errorList} />
     </MaybeFieldLabel>
@@ -107,7 +113,10 @@ ReactSelect.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
   defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
   className: PropTypes.string,
-  classNamePrefix: PropTypes.string
+  classNamePrefix: PropTypes.string,
+  menuIsOpen: PropTypes.bool,
+  onMenuOpen: PropTypes.func,
+  onMenuClose: PropTypes.func
 };
 
 ReactSelect.defaultProps = {
@@ -132,7 +141,10 @@ ReactSelect.defaultProps = {
   required: false,
   value: undefined,
   className: null,
-  classNamePrefix: undefined
+  classNamePrefix: undefined,
+  menuIsOpen: undefined,
+  onMenuOpen: undefined,
+  onMenuClose: undefined
 };
 
 export default ReactSelect;

--- a/docs/src/pages/components/select.js
+++ b/docs/src/pages/components/select.js
@@ -63,6 +63,25 @@ const propsRows = [
     defaultValue: "",
     description: "Default value of input"
   },
+  {
+    name: "menuIsOpen",
+    type: "Boolean",
+    defaultValue: "undefined",
+    description:
+      "Controls whether the menu is open; If unset, then NDS controls this implicitly instead"
+  },
+  {
+    name: "onMenuOpen",
+    type: "Function",
+    defaultValue: "undefined",
+    description: "Event handler for when the menu is opened"
+  },
+  {
+    name: "onMenuClose",
+    type: "Function",
+    defaultValue: "undefined",
+    description: "Event handler for when the menu is closed"
+  },
   ...inputProps
 ];
 


### PR DESCRIPTION
## Description

This whitelists the `menuIsOpen`, `onMenuOpen`, and `onMenuClose` props on the `<Select>` component, which effectively allows these props to be forwarded to the underlying react-select component. This enables use cases where an app prefers to control the menu behaviour itself, or when handlers need to be attached to the open/close actions.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [x] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [x] Changelog updated
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
