### PR TITLE
[NDS-1223] stop footer cells from being affected by column cellrenderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
 ## [Unreleased]
 
 ### Added
+
 ### Changed
+
+- Table footer headers will always be displayed in the first column even when combined with selectable and expandable options
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
 
+- Fixed bug where cellRenderers on columns were being applied in the table footer
 - Fixed bug that caused `Each child in a list should have a unique "key" prop` warning when using the table footer
 
 ### Security

--- a/components/src/Checkbox/Checkbox.story.js
+++ b/components/src/Checkbox/Checkbox.story.js
@@ -2,6 +2,47 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import { Checkbox } from "../index";
 
+class CheckboxWithState extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = { checkbox1: props.selectedCheckbox == "checkbox1", checkbox2: props.selectedCheckbox == "checkbox2" };
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  handleChange(key) {
+    console.log(key);
+    this.setState(state => ({
+      ...state,
+      [key]: !state[key]
+    }));
+  }
+
+  clearSelection() {
+    this.setState({ selectedValue: "" });
+  }
+
+  render() {
+    const { checkbox1, checkbox2 } = this.state;
+    return (
+      <>
+        <Checkbox
+          id="checkbox-1"
+          checked={checkbox1}
+          onChange={() => this.handleChange("checkbox1")}
+          labelText="I am controlled and checked"
+        />
+        <Checkbox
+          id="checkbox-2"
+          checked={checkbox2}
+          onChange={() => this.handleChange("checkbox2")}
+          labelText="I am controlled and unchecked"
+        />
+      </>
+    );
+  }
+}
+
 storiesOf("Checkbox", module)
   .add("Checkbox", () => <Checkbox id="checkbox" labelText="I am a checkbox" />)
   .add("Set to defaultChecked", () => <Checkbox id="checkbox" defaultChecked labelText="I am checked by default" />)
@@ -27,9 +68,8 @@ storiesOf("Checkbox", module)
       <Checkbox id="checkbox" labelText="I am a checkbox" required />
     </>
   ))
-  .add("Controlled", () => (
+  .add("With state", () => (
     <>
-      <Checkbox id="checkbox-1" checked onChange={() => {}} labelText="I am controlled and checked" />
-      <Checkbox id="checkbox-2" checked={false} onChange={() => {}} labelText="I am controlled and unchecked" />
+      <CheckboxWithState selectedCheckbox="checkbox1" />
     </>
   ));

--- a/components/src/Checkbox/Checkbox.story.js
+++ b/components/src/Checkbox/Checkbox.story.js
@@ -6,21 +6,15 @@ class CheckboxWithState extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = { checkbox1: props.selectedCheckbox == "checkbox1", checkbox2: props.selectedCheckbox == "checkbox2" };
-    this.handleChange = this.handleChange.bind(this);
+    this.state = { checkbox1: false, checkbox2: false };
   }
 
-  handleChange(key) {
-    console.log(key);
+  handleChange = key => {
     this.setState(state => ({
       ...state,
       [key]: !state[key]
     }));
-  }
-
-  clearSelection() {
-    this.setState({ selectedValue: "" });
-  }
+  };
 
   render() {
     const { checkbox1, checkbox2 } = this.state;
@@ -70,6 +64,6 @@ storiesOf("Checkbox", module)
   ))
   .add("With state", () => (
     <>
-      <CheckboxWithState selectedCheckbox="checkbox1" />
+      <CheckboxWithState />
     </>
   ));

--- a/components/src/Checkbox/__snapshots__/Checkbox.story.storyshot
+++ b/components/src/Checkbox/__snapshots__/Checkbox.story.storyshot
@@ -1935,1654 +1935,6 @@ exports[`Storyshots Checkbox Checkbox with no label 1`] = `
 </div>
 `;
 
-exports[`Storyshots Checkbox Controlled 1`] = `
-<div
-  style={
-    Object {
-      "padding": "24px",
-    }
-  }
->
-  <NDSProvider
-    theme={
-      Object {
-        "borders": Array [],
-        "breakpoints": Object {
-          "extraLarge": "1920px",
-          "extraSmall": "0px",
-          "large": "1360px",
-          "medium": "1024px",
-          "small": "768px",
-        },
-        "colors": Object {
-          "black": "#011e38",
-          "blackBlue": "#122b47",
-          "blue": "#216beb",
-          "darkBlue": "#00438f",
-          "darkGrey": "#434d59",
-          "green": "#008059",
-          "grey": "#c0c8d1",
-          "lightBlue": "#e1ebfa",
-          "lightGreen": "#e9f7f2",
-          "lightGrey": "#e4e7eb",
-          "lightRed": "#fae6ea",
-          "lightYellow": "#fcf5e3",
-          "red": "#cc1439",
-          "white": "#ffffff",
-          "whiteGrey": "#f0f2f5",
-          "yellow": "#ffbb00",
-        },
-        "fontSizes": Object {
-          "large": "20px",
-          "larger": "26px",
-          "largest": "46px",
-          "medium": "16px",
-          "small": "14px",
-          "smaller": "12px",
-        },
-        "fontWeights": Object {
-          "bold": "600",
-          "light": "300",
-          "medium": "500",
-          "normal": "400",
-        },
-        "fonts": Object {
-          "base": "'IBM Plex Sans', sans-serif",
-          "mono": "'IBM Plex Mono', monospace",
-        },
-        "lineHeights": Object {
-          "base": "1.5",
-          "sectionTitle": "1.23076923",
-          "smallTextBase": "1.71428571",
-          "smallTextCompressed": "1.14285714",
-          "smallerText": "1.33333333",
-          "subsectionTitle": "1.2",
-          "title": "1.04347826",
-        },
-        "radii": Object {
-          "circle": "50%",
-          "medium": "4px",
-          "small": "2px",
-        },
-        "shadows": Object {
-          "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-          "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-          "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-          "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-          "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-        },
-        "space": Object {
-          "half": "4px",
-          "none": "0px",
-          "x1": "8px",
-          "x2": "16px",
-          "x3": "24px",
-          "x4": "32px",
-          "x5": "40px",
-          "x6": "48px",
-          "x8": "64px",
-        },
-        "zIndex": Object {
-          "content": 100,
-          "overlay": 1000,
-          "tabsBar": 210,
-          "tabsScollIndicator": 200,
-        },
-      }
-    }
-  >
-    <GlobalStyleComponent />
-    <NDSProvider__GlobalStyles
-      theme={
-        Object {
-          "borders": Array [],
-          "breakpoints": Object {
-            "extraLarge": "1920px",
-            "extraSmall": "0px",
-            "large": "1360px",
-            "medium": "1024px",
-            "small": "768px",
-          },
-          "colors": Object {
-            "black": "#011e38",
-            "blackBlue": "#122b47",
-            "blue": "#216beb",
-            "darkBlue": "#00438f",
-            "darkGrey": "#434d59",
-            "green": "#008059",
-            "grey": "#c0c8d1",
-            "lightBlue": "#e1ebfa",
-            "lightGreen": "#e9f7f2",
-            "lightGrey": "#e4e7eb",
-            "lightRed": "#fae6ea",
-            "lightYellow": "#fcf5e3",
-            "red": "#cc1439",
-            "white": "#ffffff",
-            "whiteGrey": "#f0f2f5",
-            "yellow": "#ffbb00",
-          },
-          "fontSizes": Object {
-            "large": "20px",
-            "larger": "26px",
-            "largest": "46px",
-            "medium": "16px",
-            "small": "14px",
-            "smaller": "12px",
-          },
-          "fontWeights": Object {
-            "bold": "600",
-            "light": "300",
-            "medium": "500",
-            "normal": "400",
-          },
-          "fonts": Object {
-            "base": "'IBM Plex Sans', sans-serif",
-            "mono": "'IBM Plex Mono', monospace",
-          },
-          "lineHeights": Object {
-            "base": "1.5",
-            "sectionTitle": "1.23076923",
-            "smallTextBase": "1.71428571",
-            "smallTextCompressed": "1.14285714",
-            "smallerText": "1.33333333",
-            "subsectionTitle": "1.2",
-            "title": "1.04347826",
-          },
-          "radii": Object {
-            "circle": "50%",
-            "medium": "4px",
-            "small": "2px",
-          },
-          "shadows": Object {
-            "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-            "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-            "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-            "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-            "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-          },
-          "space": Object {
-            "half": "4px",
-            "none": "0px",
-            "x1": "8px",
-            "x2": "16px",
-            "x3": "24px",
-            "x4": "32px",
-            "x5": "40px",
-            "x6": "48px",
-            "x8": "64px",
-          },
-          "zIndex": Object {
-            "content": 100,
-            "overlay": 1000,
-            "tabsBar": 210,
-            "tabsScollIndicator": 200,
-          },
-        }
-      }
-    >
-      <StyledComponent
-        forwardedComponent={
-          Object {
-            "$$typeof": Symbol(react.forward_ref),
-            "attrs": Array [],
-            "componentStyle": ComponentStyle {
-              "componentId": "NDSProvider__GlobalStyles-f28eoq-0",
-              "isStatic": false,
-              "lastClassName": "gWUgWA",
-              "rules": Array [
-                [Function],
-              ],
-            },
-            "displayName": "NDSProvider__GlobalStyles",
-            "foldedComponentIds": Array [],
-            "render": [Function],
-            "styledComponentId": "NDSProvider__GlobalStyles-f28eoq-0",
-            "target": "div",
-            "toString": [Function],
-            "usesTheme": false,
-            "warnTooManyClasses": [Function],
-            "withComponent": [Function],
-          }
-        }
-        forwardedRef={null}
-        theme={
-          Object {
-            "borders": Array [],
-            "breakpoints": Object {
-              "extraLarge": "1920px",
-              "extraSmall": "0px",
-              "large": "1360px",
-              "medium": "1024px",
-              "small": "768px",
-            },
-            "colors": Object {
-              "black": "#011e38",
-              "blackBlue": "#122b47",
-              "blue": "#216beb",
-              "darkBlue": "#00438f",
-              "darkGrey": "#434d59",
-              "green": "#008059",
-              "grey": "#c0c8d1",
-              "lightBlue": "#e1ebfa",
-              "lightGreen": "#e9f7f2",
-              "lightGrey": "#e4e7eb",
-              "lightRed": "#fae6ea",
-              "lightYellow": "#fcf5e3",
-              "red": "#cc1439",
-              "white": "#ffffff",
-              "whiteGrey": "#f0f2f5",
-              "yellow": "#ffbb00",
-            },
-            "fontSizes": Object {
-              "large": "20px",
-              "larger": "26px",
-              "largest": "46px",
-              "medium": "16px",
-              "small": "14px",
-              "smaller": "12px",
-            },
-            "fontWeights": Object {
-              "bold": "600",
-              "light": "300",
-              "medium": "500",
-              "normal": "400",
-            },
-            "fonts": Object {
-              "base": "'IBM Plex Sans', sans-serif",
-              "mono": "'IBM Plex Mono', monospace",
-            },
-            "lineHeights": Object {
-              "base": "1.5",
-              "sectionTitle": "1.23076923",
-              "smallTextBase": "1.71428571",
-              "smallTextCompressed": "1.14285714",
-              "smallerText": "1.33333333",
-              "subsectionTitle": "1.2",
-              "title": "1.04347826",
-            },
-            "radii": Object {
-              "circle": "50%",
-              "medium": "4px",
-              "small": "2px",
-            },
-            "shadows": Object {
-              "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-              "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-              "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-              "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-              "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-            },
-            "space": Object {
-              "half": "4px",
-              "none": "0px",
-              "x1": "8px",
-              "x2": "16px",
-              "x3": "24px",
-              "x4": "32px",
-              "x5": "40px",
-              "x6": "48px",
-              "x8": "64px",
-            },
-            "zIndex": Object {
-              "content": 100,
-              "overlay": 1000,
-              "tabsBar": 210,
-              "tabsScollIndicator": 200,
-            },
-          }
-        }
-      >
-        <div
-          className="NDSProvider__GlobalStyles-f28eoq-0 gWUgWA"
-        >
-          <ThemeProvider
-            theme={
-              Object {
-                "borders": Array [],
-                "breakpoints": Object {
-                  "extraLarge": "1920px",
-                  "extraSmall": "0px",
-                  "large": "1360px",
-                  "medium": "1024px",
-                  "small": "768px",
-                },
-                "colors": Object {
-                  "black": "#011e38",
-                  "blackBlue": "#122b47",
-                  "blue": "#216beb",
-                  "darkBlue": "#00438f",
-                  "darkGrey": "#434d59",
-                  "green": "#008059",
-                  "grey": "#c0c8d1",
-                  "lightBlue": "#e1ebfa",
-                  "lightGreen": "#e9f7f2",
-                  "lightGrey": "#e4e7eb",
-                  "lightRed": "#fae6ea",
-                  "lightYellow": "#fcf5e3",
-                  "red": "#cc1439",
-                  "white": "#ffffff",
-                  "whiteGrey": "#f0f2f5",
-                  "yellow": "#ffbb00",
-                },
-                "fontSizes": Object {
-                  "large": "20px",
-                  "larger": "26px",
-                  "largest": "46px",
-                  "medium": "16px",
-                  "small": "14px",
-                  "smaller": "12px",
-                },
-                "fontWeights": Object {
-                  "bold": "600",
-                  "light": "300",
-                  "medium": "500",
-                  "normal": "400",
-                },
-                "fonts": Object {
-                  "base": "'IBM Plex Sans', sans-serif",
-                  "mono": "'IBM Plex Mono', monospace",
-                },
-                "lineHeights": Object {
-                  "base": "1.5",
-                  "sectionTitle": "1.23076923",
-                  "smallTextBase": "1.71428571",
-                  "smallTextCompressed": "1.14285714",
-                  "smallerText": "1.33333333",
-                  "subsectionTitle": "1.2",
-                  "title": "1.04347826",
-                },
-                "radii": Object {
-                  "circle": "50%",
-                  "medium": "4px",
-                  "small": "2px",
-                },
-                "shadows": Object {
-                  "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                  "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                  "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                  "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                  "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                },
-                "space": Object {
-                  "half": "4px",
-                  "none": "0px",
-                  "x1": "8px",
-                  "x2": "16px",
-                  "x3": "24px",
-                  "x4": "32px",
-                  "x5": "40px",
-                  "x6": "48px",
-                  "x8": "64px",
-                },
-                "zIndex": Object {
-                  "content": 100,
-                  "overlay": 1000,
-                  "tabsBar": 210,
-                  "tabsScollIndicator": 200,
-                },
-              }
-            }
-          >
-            <Styled(BaseCheckbox)
-              checked={true}
-              id="checkbox-1"
-              labelText="I am controlled and checked"
-              onChange={[Function]}
-            >
-              <StyledComponent
-                checked={true}
-                forwardedComponent={
-                  Object {
-                    "$$typeof": Symbol(react.forward_ref),
-                    "attrs": Array [],
-                    "componentStyle": ComponentStyle {
-                      "componentId": "sc-kkGfuU",
-                      "isStatic": false,
-                      "lastClassName": "fCpvZH",
-                      "rules": Array [
-                        "padding: 4px 0;",
-                        "& .sc-bxivhb {",
-                        "margin-left: 8px;",
-                        "}",
-                        [Function],
-                      ],
-                    },
-                    "displayName": "Styled(BaseCheckbox)",
-                    "foldedComponentIds": Array [],
-                    "render": [Function],
-                    "styledComponentId": "sc-kkGfuU",
-                    "target": [Function],
-                    "toString": [Function],
-                    "usesTheme": false,
-                    "warnTooManyClasses": [Function],
-                    "withComponent": [Function],
-                  }
-                }
-                forwardedRef={null}
-                id="checkbox-1"
-                labelText="I am controlled and checked"
-                onChange={[Function]}
-              >
-                <BaseCheckbox
-                  checked={true}
-                  className="sc-kkGfuU fCpvZH"
-                  disabled={false}
-                  error={false}
-                  id="checkbox-1"
-                  labelText="I am controlled and checked"
-                  onChange={[Function]}
-                  required={false}
-                >
-                  <Box
-                    className="sc-kkGfuU fCpvZH"
-                    theme={
-                      Object {
-                        "borders": Array [],
-                        "breakpoints": Object {
-                          "extraLarge": "1920px",
-                          "extraSmall": "0px",
-                          "large": "1360px",
-                          "medium": "1024px",
-                          "small": "768px",
-                        },
-                        "colors": Object {
-                          "black": "#011e38",
-                          "blackBlue": "#122b47",
-                          "blue": "#216beb",
-                          "darkBlue": "#00438f",
-                          "darkGrey": "#434d59",
-                          "green": "#008059",
-                          "grey": "#c0c8d1",
-                          "lightBlue": "#e1ebfa",
-                          "lightGreen": "#e9f7f2",
-                          "lightGrey": "#e4e7eb",
-                          "lightRed": "#fae6ea",
-                          "lightYellow": "#fcf5e3",
-                          "red": "#cc1439",
-                          "white": "#ffffff",
-                          "whiteGrey": "#f0f2f5",
-                          "yellow": "#ffbb00",
-                        },
-                        "fontSizes": Object {
-                          "large": "20px",
-                          "larger": "26px",
-                          "largest": "46px",
-                          "medium": "16px",
-                          "small": "14px",
-                          "smaller": "12px",
-                        },
-                        "fontWeights": Object {
-                          "bold": "600",
-                          "light": "300",
-                          "medium": "500",
-                          "normal": "400",
-                        },
-                        "fonts": Object {
-                          "base": "'IBM Plex Sans', sans-serif",
-                          "mono": "'IBM Plex Mono', monospace",
-                        },
-                        "lineHeights": Object {
-                          "base": "1.5",
-                          "sectionTitle": "1.23076923",
-                          "smallTextBase": "1.71428571",
-                          "smallTextCompressed": "1.14285714",
-                          "smallerText": "1.33333333",
-                          "subsectionTitle": "1.2",
-                          "title": "1.04347826",
-                        },
-                        "radii": Object {
-                          "circle": "50%",
-                          "medium": "4px",
-                          "small": "2px",
-                        },
-                        "shadows": Object {
-                          "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                          "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                          "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                          "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                          "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                        },
-                        "space": Object {
-                          "half": "4px",
-                          "none": "0px",
-                          "x1": "8px",
-                          "x2": "16px",
-                          "x3": "24px",
-                          "x4": "32px",
-                          "x5": "40px",
-                          "x6": "48px",
-                          "x8": "64px",
-                        },
-                        "zIndex": Object {
-                          "content": 100,
-                          "overlay": 1000,
-                          "tabsBar": 210,
-                          "tabsScollIndicator": 200,
-                        },
-                      }
-                    }
-                  >
-                    <StyledComponent
-                      className="sc-kkGfuU fCpvZH"
-                      forwardedComponent={
-                        Object {
-                          "$$typeof": Symbol(react.forward_ref),
-                          "_foldedDefaultProps": Object {
-                            "theme": Object {
-                              "borders": Array [],
-                              "breakpoints": Object {
-                                "extraLarge": "1920px",
-                                "extraSmall": "0px",
-                                "large": "1360px",
-                                "medium": "1024px",
-                                "small": "768px",
-                              },
-                              "colors": Object {
-                                "black": "#011e38",
-                                "blackBlue": "#122b47",
-                                "blue": "#216beb",
-                                "darkBlue": "#00438f",
-                                "darkGrey": "#434d59",
-                                "green": "#008059",
-                                "grey": "#c0c8d1",
-                                "lightBlue": "#e1ebfa",
-                                "lightGreen": "#e9f7f2",
-                                "lightGrey": "#e4e7eb",
-                                "lightRed": "#fae6ea",
-                                "lightYellow": "#fcf5e3",
-                                "red": "#cc1439",
-                                "white": "#ffffff",
-                                "whiteGrey": "#f0f2f5",
-                                "yellow": "#ffbb00",
-                              },
-                              "fontSizes": Object {
-                                "large": "20px",
-                                "larger": "26px",
-                                "largest": "46px",
-                                "medium": "16px",
-                                "small": "14px",
-                                "smaller": "12px",
-                              },
-                              "fontWeights": Object {
-                                "bold": "600",
-                                "light": "300",
-                                "medium": "500",
-                                "normal": "400",
-                              },
-                              "fonts": Object {
-                                "base": "'IBM Plex Sans', sans-serif",
-                                "mono": "'IBM Plex Mono', monospace",
-                              },
-                              "lineHeights": Object {
-                                "base": "1.5",
-                                "sectionTitle": "1.23076923",
-                                "smallTextBase": "1.71428571",
-                                "smallTextCompressed": "1.14285714",
-                                "smallerText": "1.33333333",
-                                "subsectionTitle": "1.2",
-                                "title": "1.04347826",
-                              },
-                              "radii": Object {
-                                "circle": "50%",
-                                "medium": "4px",
-                                "small": "2px",
-                              },
-                              "shadows": Object {
-                                "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                              },
-                              "space": Object {
-                                "half": "4px",
-                                "none": "0px",
-                                "x1": "8px",
-                                "x2": "16px",
-                                "x3": "24px",
-                                "x4": "32px",
-                                "x5": "40px",
-                                "x6": "48px",
-                                "x8": "64px",
-                              },
-                              "zIndex": Object {
-                                "content": 100,
-                                "overlay": 1000,
-                                "tabsBar": 210,
-                                "tabsScollIndicator": 200,
-                              },
-                            },
-                          },
-                          "attrs": Array [],
-                          "componentStyle": ComponentStyle {
-                            "componentId": "Box-sc-1qu1edy-0",
-                            "isStatic": false,
-                            "lastClassName": "dusExj",
-                            "rules": Array [
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                            ],
-                          },
-                          "displayName": "Box",
-                          "foldedComponentIds": Array [],
-                          "propTypes": Object {
-                            "bg": [Function],
-                            "border": [Function],
-                            "borderBottom": [Function],
-                            "borderLeft": [Function],
-                            "borderRadius": [Function],
-                            "borderRight": [Function],
-                            "borderTop": [Function],
-                            "boxShadow": [Function],
-                            "color": [Function],
-                            "display": [Function],
-                            "flexGrow": [Function],
-                            "height": [Function],
-                            "m": [Function],
-                            "maxHeight": [Function],
-                            "maxWidth": [Function],
-                            "mb": [Function],
-                            "minHeight": [Function],
-                            "minWidth": [Function],
-                            "ml": [Function],
-                            "mr": [Function],
-                            "mt": [Function],
-                            "mx": [Function],
-                            "my": [Function],
-                            "order": [Function],
-                            "p": [Function],
-                            "pb": [Function],
-                            "pl": [Function],
-                            "position": [Function],
-                            "pr": [Function],
-                            "pt": [Function],
-                            "px": [Function],
-                            "py": [Function],
-                            "textAlign": [Function],
-                            "width": [Function],
-                          },
-                          "render": [Function],
-                          "styledComponentId": "Box-sc-1qu1edy-0",
-                          "target": "div",
-                          "toString": [Function],
-                          "usesTheme": false,
-                          "warnTooManyClasses": [Function],
-                          "withComponent": [Function],
-                        }
-                      }
-                      forwardedRef={null}
-                      theme={
-                        Object {
-                          "borders": Array [],
-                          "breakpoints": Object {
-                            "extraLarge": "1920px",
-                            "extraSmall": "0px",
-                            "large": "1360px",
-                            "medium": "1024px",
-                            "small": "768px",
-                          },
-                          "colors": Object {
-                            "black": "#011e38",
-                            "blackBlue": "#122b47",
-                            "blue": "#216beb",
-                            "darkBlue": "#00438f",
-                            "darkGrey": "#434d59",
-                            "green": "#008059",
-                            "grey": "#c0c8d1",
-                            "lightBlue": "#e1ebfa",
-                            "lightGreen": "#e9f7f2",
-                            "lightGrey": "#e4e7eb",
-                            "lightRed": "#fae6ea",
-                            "lightYellow": "#fcf5e3",
-                            "red": "#cc1439",
-                            "white": "#ffffff",
-                            "whiteGrey": "#f0f2f5",
-                            "yellow": "#ffbb00",
-                          },
-                          "fontSizes": Object {
-                            "large": "20px",
-                            "larger": "26px",
-                            "largest": "46px",
-                            "medium": "16px",
-                            "small": "14px",
-                            "smaller": "12px",
-                          },
-                          "fontWeights": Object {
-                            "bold": "600",
-                            "light": "300",
-                            "medium": "500",
-                            "normal": "400",
-                          },
-                          "fonts": Object {
-                            "base": "'IBM Plex Sans', sans-serif",
-                            "mono": "'IBM Plex Mono', monospace",
-                          },
-                          "lineHeights": Object {
-                            "base": "1.5",
-                            "sectionTitle": "1.23076923",
-                            "smallTextBase": "1.71428571",
-                            "smallTextCompressed": "1.14285714",
-                            "smallerText": "1.33333333",
-                            "subsectionTitle": "1.2",
-                            "title": "1.04347826",
-                          },
-                          "radii": Object {
-                            "circle": "50%",
-                            "medium": "4px",
-                            "small": "2px",
-                          },
-                          "shadows": Object {
-                            "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                            "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                            "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                            "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                            "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                          },
-                          "space": Object {
-                            "half": "4px",
-                            "none": "0px",
-                            "x1": "8px",
-                            "x2": "16px",
-                            "x3": "24px",
-                            "x4": "32px",
-                            "x5": "40px",
-                            "x6": "48px",
-                            "x8": "64px",
-                          },
-                          "zIndex": Object {
-                            "content": 100,
-                            "overlay": 1000,
-                            "tabsBar": 210,
-                            "tabsScollIndicator": 200,
-                          },
-                        }
-                      }
-                    >
-                      <div
-                        className="Box-sc-1qu1edy-0 dusExj sc-kkGfuU fCpvZH"
-                      >
-                        <ClickInputLabel
-                          disabled={false}
-                        >
-                          <StyledComponent
-                            disabled={false}
-                            forwardedComponent={
-                              Object {
-                                "$$typeof": Symbol(react.forward_ref),
-                                "attrs": Array [],
-                                "componentStyle": ComponentStyle {
-                                  "componentId": "ClickInputLabel-j2axnv-0",
-                                  "isStatic": false,
-                                  "lastClassName": "eoyTaS",
-                                  "rules": Array [
-                                    [Function],
-                                  ],
-                                },
-                                "displayName": "ClickInputLabel",
-                                "foldedComponentIds": Array [],
-                                "render": [Function],
-                                "styledComponentId": "ClickInputLabel-j2axnv-0",
-                                "target": "label",
-                                "toString": [Function],
-                                "usesTheme": false,
-                                "warnTooManyClasses": [Function],
-                                "withComponent": [Function],
-                              }
-                            }
-                            forwardedRef={null}
-                          >
-                            <label
-                              className="ClickInputLabel-j2axnv-0 eoyTaS"
-                              disabled={false}
-                            >
-                              <Checkbox__CheckboxInput
-                                aria-invalid={false}
-                                aria-required={false}
-                                checked={true}
-                                className="sc-kkGfuU fCpvZH"
-                                disabled={false}
-                                error={false}
-                                id="checkbox-1"
-                                labelText="I am controlled and checked"
-                                onChange={[Function]}
-                                required={false}
-                                type="checkbox"
-                              >
-                                <StyledComponent
-                                  aria-invalid={false}
-                                  aria-required={false}
-                                  checked={true}
-                                  className="sc-kkGfuU fCpvZH"
-                                  disabled={false}
-                                  error={false}
-                                  forwardedComponent={
-                                    Object {
-                                      "$$typeof": Symbol(react.forward_ref),
-                                      "attrs": Array [],
-                                      "componentStyle": ComponentStyle {
-                                        "componentId": "Checkbox__CheckboxInput-sc-1nm58f1-1",
-                                        "isStatic": false,
-                                        "lastClassName": "hawbaw",
-                                        "rules": Array [
-                                          [Function],
-                                        ],
-                                      },
-                                      "displayName": "Checkbox__CheckboxInput",
-                                      "foldedComponentIds": Array [],
-                                      "render": [Function],
-                                      "styledComponentId": "Checkbox__CheckboxInput-sc-1nm58f1-1",
-                                      "target": "input",
-                                      "toString": [Function],
-                                      "usesTheme": false,
-                                      "warnTooManyClasses": [Function],
-                                      "withComponent": [Function],
-                                    }
-                                  }
-                                  forwardedRef={null}
-                                  id="checkbox-1"
-                                  labelText="I am controlled and checked"
-                                  onChange={[Function]}
-                                  required={false}
-                                  type="checkbox"
-                                >
-                                  <input
-                                    aria-invalid={false}
-                                    aria-required={false}
-                                    checked={true}
-                                    className="Checkbox__CheckboxInput-sc-1nm58f1-1 hawbaw sc-kkGfuU fCpvZH"
-                                    disabled={false}
-                                    id="checkbox-1"
-                                    onChange={[Function]}
-                                    required={false}
-                                    type="checkbox"
-                                  />
-                                </StyledComponent>
-                              </Checkbox__CheckboxInput>
-                              <Checkbox__VisualCheckbox
-                                checked={true}
-                                disabled={false}
-                              >
-                                <StyledComponent
-                                  checked={true}
-                                  disabled={false}
-                                  forwardedComponent={
-                                    Object {
-                                      "$$typeof": Symbol(react.forward_ref),
-                                      "attrs": Array [],
-                                      "componentStyle": ComponentStyle {
-                                        "componentId": "Checkbox__VisualCheckbox-sc-1nm58f1-0",
-                                        "isStatic": false,
-                                        "lastClassName": "klUiEr",
-                                        "rules": Array [
-                                          "min-width: 16px;",
-                                          "height: 16px;",
-                                          "border-radius: 2px;",
-                                          "border: solid 1px;",
-                                          "position: relative;",
-                                          "align-self: center;",
-                                          "&:before {",
-                                          "content: '';",
-                                          "display: none;",
-                                          "position: relative;",
-                                          "left: 4px;",
-                                          "width: 3px;",
-                                          "height: 9px;",
-                                          "border: solid #ffffff;",
-                                          "border-width: 0 3px 3px 0;",
-                                          "border-radius: 1px;",
-                                          "transform: rotate(45deg);",
-                                          "}",
-                                        ],
-                                      },
-                                      "displayName": "Checkbox__VisualCheckbox",
-                                      "foldedComponentIds": Array [],
-                                      "render": [Function],
-                                      "styledComponentId": "Checkbox__VisualCheckbox-sc-1nm58f1-0",
-                                      "target": "div",
-                                      "toString": [Function],
-                                      "usesTheme": false,
-                                      "warnTooManyClasses": [Function],
-                                      "withComponent": [Function],
-                                    }
-                                  }
-                                  forwardedRef={null}
-                                >
-                                  <div
-                                    checked={true}
-                                    className="Checkbox__VisualCheckbox-sc-1nm58f1-0 klUiEr"
-                                    disabled={false}
-                                  />
-                                </StyledComponent>
-                              </Checkbox__VisualCheckbox>
-                              <styled.p
-                                color="currentColor"
-                                disabled={false}
-                                fontSize="16px"
-                                inline={false}
-                                lineHeight="1.5"
-                                m={0}
-                              >
-                                <StyledComponent
-                                  color="currentColor"
-                                  disabled={false}
-                                  fontSize="16px"
-                                  forwardedComponent={
-                                    Object {
-                                      "$$typeof": Symbol(react.forward_ref),
-                                      "_foldedDefaultProps": Object {
-                                        "color": "currentColor",
-                                        "disabled": false,
-                                        "fontSize": "16px",
-                                        "inline": false,
-                                        "lineHeight": "1.5",
-                                        "m": 0,
-                                      },
-                                      "attrs": Array [
-                                        [Function],
-                                      ],
-                                      "componentStyle": ComponentStyle {
-                                        "componentId": "sc-bxivhb",
-                                        "isStatic": false,
-                                        "lastClassName": "bWRApy",
-                                        "rules": Array [
-                                          [Function],
-                                          [Function],
-                                          [Function],
-                                          [Function],
-                                          [Function],
-                                          [Function],
-                                          [Function],
-                                          [Function],
-                                        ],
-                                      },
-                                      "displayName": "styled.p",
-                                      "foldedComponentIds": Array [],
-                                      "propTypes": Object {
-                                        "disabled": [Function],
-                                        "inline": [Function],
-                                      },
-                                      "render": [Function],
-                                      "styledComponentId": "sc-bxivhb",
-                                      "target": "p",
-                                      "toString": [Function],
-                                      "usesTheme": false,
-                                      "warnTooManyClasses": [Function],
-                                      "withComponent": [Function],
-                                    }
-                                  }
-                                  forwardedRef={null}
-                                  inline={false}
-                                  lineHeight="1.5"
-                                  m={0}
-                                >
-                                  <p
-                                    className="sc-bxivhb bWRApy"
-                                    color="currentColor"
-                                    disabled={false}
-                                    fontSize="16px"
-                                  >
-                                    I am controlled and checked
-                                  </p>
-                                </StyledComponent>
-                              </styled.p>
-                            </label>
-                          </StyledComponent>
-                        </ClickInputLabel>
-                      </div>
-                    </StyledComponent>
-                  </Box>
-                </BaseCheckbox>
-              </StyledComponent>
-            </Styled(BaseCheckbox)>
-            <Styled(BaseCheckbox)
-              checked={false}
-              id="checkbox-2"
-              labelText="I am controlled and unchecked"
-              onChange={[Function]}
-            >
-              <StyledComponent
-                checked={false}
-                forwardedComponent={
-                  Object {
-                    "$$typeof": Symbol(react.forward_ref),
-                    "attrs": Array [],
-                    "componentStyle": ComponentStyle {
-                      "componentId": "sc-kkGfuU",
-                      "isStatic": false,
-                      "lastClassName": "fCpvZH",
-                      "rules": Array [
-                        "padding: 4px 0;",
-                        "& .sc-bxivhb {",
-                        "margin-left: 8px;",
-                        "}",
-                        [Function],
-                      ],
-                    },
-                    "displayName": "Styled(BaseCheckbox)",
-                    "foldedComponentIds": Array [],
-                    "render": [Function],
-                    "styledComponentId": "sc-kkGfuU",
-                    "target": [Function],
-                    "toString": [Function],
-                    "usesTheme": false,
-                    "warnTooManyClasses": [Function],
-                    "withComponent": [Function],
-                  }
-                }
-                forwardedRef={null}
-                id="checkbox-2"
-                labelText="I am controlled and unchecked"
-                onChange={[Function]}
-              >
-                <BaseCheckbox
-                  checked={false}
-                  className="sc-kkGfuU fCpvZH"
-                  disabled={false}
-                  error={false}
-                  id="checkbox-2"
-                  labelText="I am controlled and unchecked"
-                  onChange={[Function]}
-                  required={false}
-                >
-                  <Box
-                    className="sc-kkGfuU fCpvZH"
-                    theme={
-                      Object {
-                        "borders": Array [],
-                        "breakpoints": Object {
-                          "extraLarge": "1920px",
-                          "extraSmall": "0px",
-                          "large": "1360px",
-                          "medium": "1024px",
-                          "small": "768px",
-                        },
-                        "colors": Object {
-                          "black": "#011e38",
-                          "blackBlue": "#122b47",
-                          "blue": "#216beb",
-                          "darkBlue": "#00438f",
-                          "darkGrey": "#434d59",
-                          "green": "#008059",
-                          "grey": "#c0c8d1",
-                          "lightBlue": "#e1ebfa",
-                          "lightGreen": "#e9f7f2",
-                          "lightGrey": "#e4e7eb",
-                          "lightRed": "#fae6ea",
-                          "lightYellow": "#fcf5e3",
-                          "red": "#cc1439",
-                          "white": "#ffffff",
-                          "whiteGrey": "#f0f2f5",
-                          "yellow": "#ffbb00",
-                        },
-                        "fontSizes": Object {
-                          "large": "20px",
-                          "larger": "26px",
-                          "largest": "46px",
-                          "medium": "16px",
-                          "small": "14px",
-                          "smaller": "12px",
-                        },
-                        "fontWeights": Object {
-                          "bold": "600",
-                          "light": "300",
-                          "medium": "500",
-                          "normal": "400",
-                        },
-                        "fonts": Object {
-                          "base": "'IBM Plex Sans', sans-serif",
-                          "mono": "'IBM Plex Mono', monospace",
-                        },
-                        "lineHeights": Object {
-                          "base": "1.5",
-                          "sectionTitle": "1.23076923",
-                          "smallTextBase": "1.71428571",
-                          "smallTextCompressed": "1.14285714",
-                          "smallerText": "1.33333333",
-                          "subsectionTitle": "1.2",
-                          "title": "1.04347826",
-                        },
-                        "radii": Object {
-                          "circle": "50%",
-                          "medium": "4px",
-                          "small": "2px",
-                        },
-                        "shadows": Object {
-                          "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                          "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                          "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                          "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                          "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                        },
-                        "space": Object {
-                          "half": "4px",
-                          "none": "0px",
-                          "x1": "8px",
-                          "x2": "16px",
-                          "x3": "24px",
-                          "x4": "32px",
-                          "x5": "40px",
-                          "x6": "48px",
-                          "x8": "64px",
-                        },
-                        "zIndex": Object {
-                          "content": 100,
-                          "overlay": 1000,
-                          "tabsBar": 210,
-                          "tabsScollIndicator": 200,
-                        },
-                      }
-                    }
-                  >
-                    <StyledComponent
-                      className="sc-kkGfuU fCpvZH"
-                      forwardedComponent={
-                        Object {
-                          "$$typeof": Symbol(react.forward_ref),
-                          "_foldedDefaultProps": Object {
-                            "theme": Object {
-                              "borders": Array [],
-                              "breakpoints": Object {
-                                "extraLarge": "1920px",
-                                "extraSmall": "0px",
-                                "large": "1360px",
-                                "medium": "1024px",
-                                "small": "768px",
-                              },
-                              "colors": Object {
-                                "black": "#011e38",
-                                "blackBlue": "#122b47",
-                                "blue": "#216beb",
-                                "darkBlue": "#00438f",
-                                "darkGrey": "#434d59",
-                                "green": "#008059",
-                                "grey": "#c0c8d1",
-                                "lightBlue": "#e1ebfa",
-                                "lightGreen": "#e9f7f2",
-                                "lightGrey": "#e4e7eb",
-                                "lightRed": "#fae6ea",
-                                "lightYellow": "#fcf5e3",
-                                "red": "#cc1439",
-                                "white": "#ffffff",
-                                "whiteGrey": "#f0f2f5",
-                                "yellow": "#ffbb00",
-                              },
-                              "fontSizes": Object {
-                                "large": "20px",
-                                "larger": "26px",
-                                "largest": "46px",
-                                "medium": "16px",
-                                "small": "14px",
-                                "smaller": "12px",
-                              },
-                              "fontWeights": Object {
-                                "bold": "600",
-                                "light": "300",
-                                "medium": "500",
-                                "normal": "400",
-                              },
-                              "fonts": Object {
-                                "base": "'IBM Plex Sans', sans-serif",
-                                "mono": "'IBM Plex Mono', monospace",
-                              },
-                              "lineHeights": Object {
-                                "base": "1.5",
-                                "sectionTitle": "1.23076923",
-                                "smallTextBase": "1.71428571",
-                                "smallTextCompressed": "1.14285714",
-                                "smallerText": "1.33333333",
-                                "subsectionTitle": "1.2",
-                                "title": "1.04347826",
-                              },
-                              "radii": Object {
-                                "circle": "50%",
-                                "medium": "4px",
-                                "small": "2px",
-                              },
-                              "shadows": Object {
-                                "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                              },
-                              "space": Object {
-                                "half": "4px",
-                                "none": "0px",
-                                "x1": "8px",
-                                "x2": "16px",
-                                "x3": "24px",
-                                "x4": "32px",
-                                "x5": "40px",
-                                "x6": "48px",
-                                "x8": "64px",
-                              },
-                              "zIndex": Object {
-                                "content": 100,
-                                "overlay": 1000,
-                                "tabsBar": 210,
-                                "tabsScollIndicator": 200,
-                              },
-                            },
-                          },
-                          "attrs": Array [],
-                          "componentStyle": ComponentStyle {
-                            "componentId": "Box-sc-1qu1edy-0",
-                            "isStatic": false,
-                            "lastClassName": "dusExj",
-                            "rules": Array [
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                            ],
-                          },
-                          "displayName": "Box",
-                          "foldedComponentIds": Array [],
-                          "propTypes": Object {
-                            "bg": [Function],
-                            "border": [Function],
-                            "borderBottom": [Function],
-                            "borderLeft": [Function],
-                            "borderRadius": [Function],
-                            "borderRight": [Function],
-                            "borderTop": [Function],
-                            "boxShadow": [Function],
-                            "color": [Function],
-                            "display": [Function],
-                            "flexGrow": [Function],
-                            "height": [Function],
-                            "m": [Function],
-                            "maxHeight": [Function],
-                            "maxWidth": [Function],
-                            "mb": [Function],
-                            "minHeight": [Function],
-                            "minWidth": [Function],
-                            "ml": [Function],
-                            "mr": [Function],
-                            "mt": [Function],
-                            "mx": [Function],
-                            "my": [Function],
-                            "order": [Function],
-                            "p": [Function],
-                            "pb": [Function],
-                            "pl": [Function],
-                            "position": [Function],
-                            "pr": [Function],
-                            "pt": [Function],
-                            "px": [Function],
-                            "py": [Function],
-                            "textAlign": [Function],
-                            "width": [Function],
-                          },
-                          "render": [Function],
-                          "styledComponentId": "Box-sc-1qu1edy-0",
-                          "target": "div",
-                          "toString": [Function],
-                          "usesTheme": false,
-                          "warnTooManyClasses": [Function],
-                          "withComponent": [Function],
-                        }
-                      }
-                      forwardedRef={null}
-                      theme={
-                        Object {
-                          "borders": Array [],
-                          "breakpoints": Object {
-                            "extraLarge": "1920px",
-                            "extraSmall": "0px",
-                            "large": "1360px",
-                            "medium": "1024px",
-                            "small": "768px",
-                          },
-                          "colors": Object {
-                            "black": "#011e38",
-                            "blackBlue": "#122b47",
-                            "blue": "#216beb",
-                            "darkBlue": "#00438f",
-                            "darkGrey": "#434d59",
-                            "green": "#008059",
-                            "grey": "#c0c8d1",
-                            "lightBlue": "#e1ebfa",
-                            "lightGreen": "#e9f7f2",
-                            "lightGrey": "#e4e7eb",
-                            "lightRed": "#fae6ea",
-                            "lightYellow": "#fcf5e3",
-                            "red": "#cc1439",
-                            "white": "#ffffff",
-                            "whiteGrey": "#f0f2f5",
-                            "yellow": "#ffbb00",
-                          },
-                          "fontSizes": Object {
-                            "large": "20px",
-                            "larger": "26px",
-                            "largest": "46px",
-                            "medium": "16px",
-                            "small": "14px",
-                            "smaller": "12px",
-                          },
-                          "fontWeights": Object {
-                            "bold": "600",
-                            "light": "300",
-                            "medium": "500",
-                            "normal": "400",
-                          },
-                          "fonts": Object {
-                            "base": "'IBM Plex Sans', sans-serif",
-                            "mono": "'IBM Plex Mono', monospace",
-                          },
-                          "lineHeights": Object {
-                            "base": "1.5",
-                            "sectionTitle": "1.23076923",
-                            "smallTextBase": "1.71428571",
-                            "smallTextCompressed": "1.14285714",
-                            "smallerText": "1.33333333",
-                            "subsectionTitle": "1.2",
-                            "title": "1.04347826",
-                          },
-                          "radii": Object {
-                            "circle": "50%",
-                            "medium": "4px",
-                            "small": "2px",
-                          },
-                          "shadows": Object {
-                            "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                            "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                            "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                            "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                            "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                          },
-                          "space": Object {
-                            "half": "4px",
-                            "none": "0px",
-                            "x1": "8px",
-                            "x2": "16px",
-                            "x3": "24px",
-                            "x4": "32px",
-                            "x5": "40px",
-                            "x6": "48px",
-                            "x8": "64px",
-                          },
-                          "zIndex": Object {
-                            "content": 100,
-                            "overlay": 1000,
-                            "tabsBar": 210,
-                            "tabsScollIndicator": 200,
-                          },
-                        }
-                      }
-                    >
-                      <div
-                        className="Box-sc-1qu1edy-0 dusExj sc-kkGfuU fCpvZH"
-                      >
-                        <ClickInputLabel
-                          disabled={false}
-                        >
-                          <StyledComponent
-                            disabled={false}
-                            forwardedComponent={
-                              Object {
-                                "$$typeof": Symbol(react.forward_ref),
-                                "attrs": Array [],
-                                "componentStyle": ComponentStyle {
-                                  "componentId": "ClickInputLabel-j2axnv-0",
-                                  "isStatic": false,
-                                  "lastClassName": "eoyTaS",
-                                  "rules": Array [
-                                    [Function],
-                                  ],
-                                },
-                                "displayName": "ClickInputLabel",
-                                "foldedComponentIds": Array [],
-                                "render": [Function],
-                                "styledComponentId": "ClickInputLabel-j2axnv-0",
-                                "target": "label",
-                                "toString": [Function],
-                                "usesTheme": false,
-                                "warnTooManyClasses": [Function],
-                                "withComponent": [Function],
-                              }
-                            }
-                            forwardedRef={null}
-                          >
-                            <label
-                              className="ClickInputLabel-j2axnv-0 eoyTaS"
-                              disabled={false}
-                            >
-                              <Checkbox__CheckboxInput
-                                aria-invalid={false}
-                                aria-required={false}
-                                checked={false}
-                                className="sc-kkGfuU fCpvZH"
-                                disabled={false}
-                                error={false}
-                                id="checkbox-2"
-                                labelText="I am controlled and unchecked"
-                                onChange={[Function]}
-                                required={false}
-                                type="checkbox"
-                              >
-                                <StyledComponent
-                                  aria-invalid={false}
-                                  aria-required={false}
-                                  checked={false}
-                                  className="sc-kkGfuU fCpvZH"
-                                  disabled={false}
-                                  error={false}
-                                  forwardedComponent={
-                                    Object {
-                                      "$$typeof": Symbol(react.forward_ref),
-                                      "attrs": Array [],
-                                      "componentStyle": ComponentStyle {
-                                        "componentId": "Checkbox__CheckboxInput-sc-1nm58f1-1",
-                                        "isStatic": false,
-                                        "lastClassName": "hawbaw",
-                                        "rules": Array [
-                                          [Function],
-                                        ],
-                                      },
-                                      "displayName": "Checkbox__CheckboxInput",
-                                      "foldedComponentIds": Array [],
-                                      "render": [Function],
-                                      "styledComponentId": "Checkbox__CheckboxInput-sc-1nm58f1-1",
-                                      "target": "input",
-                                      "toString": [Function],
-                                      "usesTheme": false,
-                                      "warnTooManyClasses": [Function],
-                                      "withComponent": [Function],
-                                    }
-                                  }
-                                  forwardedRef={null}
-                                  id="checkbox-2"
-                                  labelText="I am controlled and unchecked"
-                                  onChange={[Function]}
-                                  required={false}
-                                  type="checkbox"
-                                >
-                                  <input
-                                    aria-invalid={false}
-                                    aria-required={false}
-                                    checked={false}
-                                    className="Checkbox__CheckboxInput-sc-1nm58f1-1 hawbaw sc-kkGfuU fCpvZH"
-                                    disabled={false}
-                                    id="checkbox-2"
-                                    onChange={[Function]}
-                                    required={false}
-                                    type="checkbox"
-                                  />
-                                </StyledComponent>
-                              </Checkbox__CheckboxInput>
-                              <Checkbox__VisualCheckbox
-                                checked={false}
-                                disabled={false}
-                              >
-                                <StyledComponent
-                                  checked={false}
-                                  disabled={false}
-                                  forwardedComponent={
-                                    Object {
-                                      "$$typeof": Symbol(react.forward_ref),
-                                      "attrs": Array [],
-                                      "componentStyle": ComponentStyle {
-                                        "componentId": "Checkbox__VisualCheckbox-sc-1nm58f1-0",
-                                        "isStatic": false,
-                                        "lastClassName": "klUiEr",
-                                        "rules": Array [
-                                          "min-width: 16px;",
-                                          "height: 16px;",
-                                          "border-radius: 2px;",
-                                          "border: solid 1px;",
-                                          "position: relative;",
-                                          "align-self: center;",
-                                          "&:before {",
-                                          "content: '';",
-                                          "display: none;",
-                                          "position: relative;",
-                                          "left: 4px;",
-                                          "width: 3px;",
-                                          "height: 9px;",
-                                          "border: solid #ffffff;",
-                                          "border-width: 0 3px 3px 0;",
-                                          "border-radius: 1px;",
-                                          "transform: rotate(45deg);",
-                                          "}",
-                                        ],
-                                      },
-                                      "displayName": "Checkbox__VisualCheckbox",
-                                      "foldedComponentIds": Array [],
-                                      "render": [Function],
-                                      "styledComponentId": "Checkbox__VisualCheckbox-sc-1nm58f1-0",
-                                      "target": "div",
-                                      "toString": [Function],
-                                      "usesTheme": false,
-                                      "warnTooManyClasses": [Function],
-                                      "withComponent": [Function],
-                                    }
-                                  }
-                                  forwardedRef={null}
-                                >
-                                  <div
-                                    checked={false}
-                                    className="Checkbox__VisualCheckbox-sc-1nm58f1-0 klUiEr"
-                                    disabled={false}
-                                  />
-                                </StyledComponent>
-                              </Checkbox__VisualCheckbox>
-                              <styled.p
-                                color="currentColor"
-                                disabled={false}
-                                fontSize="16px"
-                                inline={false}
-                                lineHeight="1.5"
-                                m={0}
-                              >
-                                <StyledComponent
-                                  color="currentColor"
-                                  disabled={false}
-                                  fontSize="16px"
-                                  forwardedComponent={
-                                    Object {
-                                      "$$typeof": Symbol(react.forward_ref),
-                                      "_foldedDefaultProps": Object {
-                                        "color": "currentColor",
-                                        "disabled": false,
-                                        "fontSize": "16px",
-                                        "inline": false,
-                                        "lineHeight": "1.5",
-                                        "m": 0,
-                                      },
-                                      "attrs": Array [
-                                        [Function],
-                                      ],
-                                      "componentStyle": ComponentStyle {
-                                        "componentId": "sc-bxivhb",
-                                        "isStatic": false,
-                                        "lastClassName": "bWRApy",
-                                        "rules": Array [
-                                          [Function],
-                                          [Function],
-                                          [Function],
-                                          [Function],
-                                          [Function],
-                                          [Function],
-                                          [Function],
-                                          [Function],
-                                        ],
-                                      },
-                                      "displayName": "styled.p",
-                                      "foldedComponentIds": Array [],
-                                      "propTypes": Object {
-                                        "disabled": [Function],
-                                        "inline": [Function],
-                                      },
-                                      "render": [Function],
-                                      "styledComponentId": "sc-bxivhb",
-                                      "target": "p",
-                                      "toString": [Function],
-                                      "usesTheme": false,
-                                      "warnTooManyClasses": [Function],
-                                      "withComponent": [Function],
-                                    }
-                                  }
-                                  forwardedRef={null}
-                                  inline={false}
-                                  lineHeight="1.5"
-                                  m={0}
-                                >
-                                  <p
-                                    className="sc-bxivhb bWRApy"
-                                    color="currentColor"
-                                    disabled={false}
-                                    fontSize="16px"
-                                  >
-                                    I am controlled and unchecked
-                                  </p>
-                                </StyledComponent>
-                              </styled.p>
-                            </label>
-                          </StyledComponent>
-                        </ClickInputLabel>
-                      </div>
-                    </StyledComponent>
-                  </Box>
-                </BaseCheckbox>
-              </StyledComponent>
-            </Styled(BaseCheckbox)>
-          </ThemeProvider>
-        </div>
-      </StyledComponent>
-    </NDSProvider__GlobalStyles>
-  </NDSProvider>
-</div>
-`;
-
 exports[`Storyshots Checkbox Set to defaultChecked 1`] = `
 <div
   style={
@@ -8856,6 +7208,1656 @@ exports[`Storyshots Checkbox Set to required 1`] = `
                 </BaseCheckbox>
               </StyledComponent>
             </Styled(BaseCheckbox)>
+          </ThemeProvider>
+        </div>
+      </StyledComponent>
+    </NDSProvider__GlobalStyles>
+  </NDSProvider>
+</div>
+`;
+
+exports[`Storyshots Checkbox With state 1`] = `
+<div
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
+>
+  <NDSProvider
+    theme={
+      Object {
+        "borders": Array [],
+        "breakpoints": Object {
+          "extraLarge": "1920px",
+          "extraSmall": "0px",
+          "large": "1360px",
+          "medium": "1024px",
+          "small": "768px",
+        },
+        "colors": Object {
+          "black": "#011e38",
+          "blackBlue": "#122b47",
+          "blue": "#216beb",
+          "darkBlue": "#00438f",
+          "darkGrey": "#434d59",
+          "green": "#008059",
+          "grey": "#c0c8d1",
+          "lightBlue": "#e1ebfa",
+          "lightGreen": "#e9f7f2",
+          "lightGrey": "#e4e7eb",
+          "lightRed": "#fae6ea",
+          "lightYellow": "#fcf5e3",
+          "red": "#cc1439",
+          "white": "#ffffff",
+          "whiteGrey": "#f0f2f5",
+          "yellow": "#ffbb00",
+        },
+        "fontSizes": Object {
+          "large": "20px",
+          "larger": "26px",
+          "largest": "46px",
+          "medium": "16px",
+          "small": "14px",
+          "smaller": "12px",
+        },
+        "fontWeights": Object {
+          "bold": "600",
+          "light": "300",
+          "medium": "500",
+          "normal": "400",
+        },
+        "fonts": Object {
+          "base": "'IBM Plex Sans', sans-serif",
+          "mono": "'IBM Plex Mono', monospace",
+        },
+        "lineHeights": Object {
+          "base": "1.5",
+          "sectionTitle": "1.23076923",
+          "smallTextBase": "1.71428571",
+          "smallTextCompressed": "1.14285714",
+          "smallerText": "1.33333333",
+          "subsectionTitle": "1.2",
+          "title": "1.04347826",
+        },
+        "radii": Object {
+          "circle": "50%",
+          "medium": "4px",
+          "small": "2px",
+        },
+        "shadows": Object {
+          "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+          "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+          "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+          "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+          "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+        },
+        "space": Object {
+          "half": "4px",
+          "none": "0px",
+          "x1": "8px",
+          "x2": "16px",
+          "x3": "24px",
+          "x4": "32px",
+          "x5": "40px",
+          "x6": "48px",
+          "x8": "64px",
+        },
+        "zIndex": Object {
+          "content": 100,
+          "overlay": 1000,
+          "tabsBar": 210,
+          "tabsScollIndicator": 200,
+        },
+      }
+    }
+  >
+    <GlobalStyleComponent />
+    <NDSProvider__GlobalStyles
+      theme={
+        Object {
+          "borders": Array [],
+          "breakpoints": Object {
+            "extraLarge": "1920px",
+            "extraSmall": "0px",
+            "large": "1360px",
+            "medium": "1024px",
+            "small": "768px",
+          },
+          "colors": Object {
+            "black": "#011e38",
+            "blackBlue": "#122b47",
+            "blue": "#216beb",
+            "darkBlue": "#00438f",
+            "darkGrey": "#434d59",
+            "green": "#008059",
+            "grey": "#c0c8d1",
+            "lightBlue": "#e1ebfa",
+            "lightGreen": "#e9f7f2",
+            "lightGrey": "#e4e7eb",
+            "lightRed": "#fae6ea",
+            "lightYellow": "#fcf5e3",
+            "red": "#cc1439",
+            "white": "#ffffff",
+            "whiteGrey": "#f0f2f5",
+            "yellow": "#ffbb00",
+          },
+          "fontSizes": Object {
+            "large": "20px",
+            "larger": "26px",
+            "largest": "46px",
+            "medium": "16px",
+            "small": "14px",
+            "smaller": "12px",
+          },
+          "fontWeights": Object {
+            "bold": "600",
+            "light": "300",
+            "medium": "500",
+            "normal": "400",
+          },
+          "fonts": Object {
+            "base": "'IBM Plex Sans', sans-serif",
+            "mono": "'IBM Plex Mono', monospace",
+          },
+          "lineHeights": Object {
+            "base": "1.5",
+            "sectionTitle": "1.23076923",
+            "smallTextBase": "1.71428571",
+            "smallTextCompressed": "1.14285714",
+            "smallerText": "1.33333333",
+            "subsectionTitle": "1.2",
+            "title": "1.04347826",
+          },
+          "radii": Object {
+            "circle": "50%",
+            "medium": "4px",
+            "small": "2px",
+          },
+          "shadows": Object {
+            "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+            "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+            "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+            "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+            "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+          },
+          "space": Object {
+            "half": "4px",
+            "none": "0px",
+            "x1": "8px",
+            "x2": "16px",
+            "x3": "24px",
+            "x4": "32px",
+            "x5": "40px",
+            "x6": "48px",
+            "x8": "64px",
+          },
+          "zIndex": Object {
+            "content": 100,
+            "overlay": 1000,
+            "tabsBar": 210,
+            "tabsScollIndicator": 200,
+          },
+        }
+      }
+    >
+      <StyledComponent
+        forwardedComponent={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "attrs": Array [],
+            "componentStyle": ComponentStyle {
+              "componentId": "NDSProvider__GlobalStyles-f28eoq-0",
+              "isStatic": false,
+              "lastClassName": "gWUgWA",
+              "rules": Array [
+                [Function],
+              ],
+            },
+            "displayName": "NDSProvider__GlobalStyles",
+            "foldedComponentIds": Array [],
+            "render": [Function],
+            "styledComponentId": "NDSProvider__GlobalStyles-f28eoq-0",
+            "target": "div",
+            "toString": [Function],
+            "usesTheme": false,
+            "warnTooManyClasses": [Function],
+            "withComponent": [Function],
+          }
+        }
+        forwardedRef={null}
+        theme={
+          Object {
+            "borders": Array [],
+            "breakpoints": Object {
+              "extraLarge": "1920px",
+              "extraSmall": "0px",
+              "large": "1360px",
+              "medium": "1024px",
+              "small": "768px",
+            },
+            "colors": Object {
+              "black": "#011e38",
+              "blackBlue": "#122b47",
+              "blue": "#216beb",
+              "darkBlue": "#00438f",
+              "darkGrey": "#434d59",
+              "green": "#008059",
+              "grey": "#c0c8d1",
+              "lightBlue": "#e1ebfa",
+              "lightGreen": "#e9f7f2",
+              "lightGrey": "#e4e7eb",
+              "lightRed": "#fae6ea",
+              "lightYellow": "#fcf5e3",
+              "red": "#cc1439",
+              "white": "#ffffff",
+              "whiteGrey": "#f0f2f5",
+              "yellow": "#ffbb00",
+            },
+            "fontSizes": Object {
+              "large": "20px",
+              "larger": "26px",
+              "largest": "46px",
+              "medium": "16px",
+              "small": "14px",
+              "smaller": "12px",
+            },
+            "fontWeights": Object {
+              "bold": "600",
+              "light": "300",
+              "medium": "500",
+              "normal": "400",
+            },
+            "fonts": Object {
+              "base": "'IBM Plex Sans', sans-serif",
+              "mono": "'IBM Plex Mono', monospace",
+            },
+            "lineHeights": Object {
+              "base": "1.5",
+              "sectionTitle": "1.23076923",
+              "smallTextBase": "1.71428571",
+              "smallTextCompressed": "1.14285714",
+              "smallerText": "1.33333333",
+              "subsectionTitle": "1.2",
+              "title": "1.04347826",
+            },
+            "radii": Object {
+              "circle": "50%",
+              "medium": "4px",
+              "small": "2px",
+            },
+            "shadows": Object {
+              "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+              "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+              "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+              "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+              "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+            },
+            "space": Object {
+              "half": "4px",
+              "none": "0px",
+              "x1": "8px",
+              "x2": "16px",
+              "x3": "24px",
+              "x4": "32px",
+              "x5": "40px",
+              "x6": "48px",
+              "x8": "64px",
+            },
+            "zIndex": Object {
+              "content": 100,
+              "overlay": 1000,
+              "tabsBar": 210,
+              "tabsScollIndicator": 200,
+            },
+          }
+        }
+      >
+        <div
+          className="NDSProvider__GlobalStyles-f28eoq-0 gWUgWA"
+        >
+          <ThemeProvider
+            theme={
+              Object {
+                "borders": Array [],
+                "breakpoints": Object {
+                  "extraLarge": "1920px",
+                  "extraSmall": "0px",
+                  "large": "1360px",
+                  "medium": "1024px",
+                  "small": "768px",
+                },
+                "colors": Object {
+                  "black": "#011e38",
+                  "blackBlue": "#122b47",
+                  "blue": "#216beb",
+                  "darkBlue": "#00438f",
+                  "darkGrey": "#434d59",
+                  "green": "#008059",
+                  "grey": "#c0c8d1",
+                  "lightBlue": "#e1ebfa",
+                  "lightGreen": "#e9f7f2",
+                  "lightGrey": "#e4e7eb",
+                  "lightRed": "#fae6ea",
+                  "lightYellow": "#fcf5e3",
+                  "red": "#cc1439",
+                  "white": "#ffffff",
+                  "whiteGrey": "#f0f2f5",
+                  "yellow": "#ffbb00",
+                },
+                "fontSizes": Object {
+                  "large": "20px",
+                  "larger": "26px",
+                  "largest": "46px",
+                  "medium": "16px",
+                  "small": "14px",
+                  "smaller": "12px",
+                },
+                "fontWeights": Object {
+                  "bold": "600",
+                  "light": "300",
+                  "medium": "500",
+                  "normal": "400",
+                },
+                "fonts": Object {
+                  "base": "'IBM Plex Sans', sans-serif",
+                  "mono": "'IBM Plex Mono', monospace",
+                },
+                "lineHeights": Object {
+                  "base": "1.5",
+                  "sectionTitle": "1.23076923",
+                  "smallTextBase": "1.71428571",
+                  "smallTextCompressed": "1.14285714",
+                  "smallerText": "1.33333333",
+                  "subsectionTitle": "1.2",
+                  "title": "1.04347826",
+                },
+                "radii": Object {
+                  "circle": "50%",
+                  "medium": "4px",
+                  "small": "2px",
+                },
+                "shadows": Object {
+                  "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                  "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                  "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                  "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                  "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                },
+                "space": Object {
+                  "half": "4px",
+                  "none": "0px",
+                  "x1": "8px",
+                  "x2": "16px",
+                  "x3": "24px",
+                  "x4": "32px",
+                  "x5": "40px",
+                  "x6": "48px",
+                  "x8": "64px",
+                },
+                "zIndex": Object {
+                  "content": 100,
+                  "overlay": 1000,
+                  "tabsBar": 210,
+                  "tabsScollIndicator": 200,
+                },
+              }
+            }
+          >
+            <CheckboxWithState>
+              <Styled(BaseCheckbox)
+                checked={false}
+                id="checkbox-1"
+                labelText="I am controlled and checked"
+                onChange={[Function]}
+              >
+                <StyledComponent
+                  checked={false}
+                  forwardedComponent={
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "sc-kkGfuU",
+                        "isStatic": false,
+                        "lastClassName": "fCpvZH",
+                        "rules": Array [
+                          "padding: 4px 0;",
+                          "& .sc-bxivhb {",
+                          "margin-left: 8px;",
+                          "}",
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Styled(BaseCheckbox)",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "sc-kkGfuU",
+                      "target": [Function],
+                      "toString": [Function],
+                      "usesTheme": false,
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    }
+                  }
+                  forwardedRef={null}
+                  id="checkbox-1"
+                  labelText="I am controlled and checked"
+                  onChange={[Function]}
+                >
+                  <BaseCheckbox
+                    checked={false}
+                    className="sc-kkGfuU fCpvZH"
+                    disabled={false}
+                    error={false}
+                    id="checkbox-1"
+                    labelText="I am controlled and checked"
+                    onChange={[Function]}
+                    required={false}
+                  >
+                    <Box
+                      className="sc-kkGfuU fCpvZH"
+                      theme={
+                        Object {
+                          "borders": Array [],
+                          "breakpoints": Object {
+                            "extraLarge": "1920px",
+                            "extraSmall": "0px",
+                            "large": "1360px",
+                            "medium": "1024px",
+                            "small": "768px",
+                          },
+                          "colors": Object {
+                            "black": "#011e38",
+                            "blackBlue": "#122b47",
+                            "blue": "#216beb",
+                            "darkBlue": "#00438f",
+                            "darkGrey": "#434d59",
+                            "green": "#008059",
+                            "grey": "#c0c8d1",
+                            "lightBlue": "#e1ebfa",
+                            "lightGreen": "#e9f7f2",
+                            "lightGrey": "#e4e7eb",
+                            "lightRed": "#fae6ea",
+                            "lightYellow": "#fcf5e3",
+                            "red": "#cc1439",
+                            "white": "#ffffff",
+                            "whiteGrey": "#f0f2f5",
+                            "yellow": "#ffbb00",
+                          },
+                          "fontSizes": Object {
+                            "large": "20px",
+                            "larger": "26px",
+                            "largest": "46px",
+                            "medium": "16px",
+                            "small": "14px",
+                            "smaller": "12px",
+                          },
+                          "fontWeights": Object {
+                            "bold": "600",
+                            "light": "300",
+                            "medium": "500",
+                            "normal": "400",
+                          },
+                          "fonts": Object {
+                            "base": "'IBM Plex Sans', sans-serif",
+                            "mono": "'IBM Plex Mono', monospace",
+                          },
+                          "lineHeights": Object {
+                            "base": "1.5",
+                            "sectionTitle": "1.23076923",
+                            "smallTextBase": "1.71428571",
+                            "smallTextCompressed": "1.14285714",
+                            "smallerText": "1.33333333",
+                            "subsectionTitle": "1.2",
+                            "title": "1.04347826",
+                          },
+                          "radii": Object {
+                            "circle": "50%",
+                            "medium": "4px",
+                            "small": "2px",
+                          },
+                          "shadows": Object {
+                            "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                            "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                            "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                            "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                            "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                          },
+                          "space": Object {
+                            "half": "4px",
+                            "none": "0px",
+                            "x1": "8px",
+                            "x2": "16px",
+                            "x3": "24px",
+                            "x4": "32px",
+                            "x5": "40px",
+                            "x6": "48px",
+                            "x8": "64px",
+                          },
+                          "zIndex": Object {
+                            "content": 100,
+                            "overlay": 1000,
+                            "tabsBar": 210,
+                            "tabsScollIndicator": 200,
+                          },
+                        }
+                      }
+                    >
+                      <StyledComponent
+                        className="sc-kkGfuU fCpvZH"
+                        forwardedComponent={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "_foldedDefaultProps": Object {
+                              "theme": Object {
+                                "borders": Array [],
+                                "breakpoints": Object {
+                                  "extraLarge": "1920px",
+                                  "extraSmall": "0px",
+                                  "large": "1360px",
+                                  "medium": "1024px",
+                                  "small": "768px",
+                                },
+                                "colors": Object {
+                                  "black": "#011e38",
+                                  "blackBlue": "#122b47",
+                                  "blue": "#216beb",
+                                  "darkBlue": "#00438f",
+                                  "darkGrey": "#434d59",
+                                  "green": "#008059",
+                                  "grey": "#c0c8d1",
+                                  "lightBlue": "#e1ebfa",
+                                  "lightGreen": "#e9f7f2",
+                                  "lightGrey": "#e4e7eb",
+                                  "lightRed": "#fae6ea",
+                                  "lightYellow": "#fcf5e3",
+                                  "red": "#cc1439",
+                                  "white": "#ffffff",
+                                  "whiteGrey": "#f0f2f5",
+                                  "yellow": "#ffbb00",
+                                },
+                                "fontSizes": Object {
+                                  "large": "20px",
+                                  "larger": "26px",
+                                  "largest": "46px",
+                                  "medium": "16px",
+                                  "small": "14px",
+                                  "smaller": "12px",
+                                },
+                                "fontWeights": Object {
+                                  "bold": "600",
+                                  "light": "300",
+                                  "medium": "500",
+                                  "normal": "400",
+                                },
+                                "fonts": Object {
+                                  "base": "'IBM Plex Sans', sans-serif",
+                                  "mono": "'IBM Plex Mono', monospace",
+                                },
+                                "lineHeights": Object {
+                                  "base": "1.5",
+                                  "sectionTitle": "1.23076923",
+                                  "smallTextBase": "1.71428571",
+                                  "smallTextCompressed": "1.14285714",
+                                  "smallerText": "1.33333333",
+                                  "subsectionTitle": "1.2",
+                                  "title": "1.04347826",
+                                },
+                                "radii": Object {
+                                  "circle": "50%",
+                                  "medium": "4px",
+                                  "small": "2px",
+                                },
+                                "shadows": Object {
+                                  "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                  "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                  "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                  "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                  "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                },
+                                "space": Object {
+                                  "half": "4px",
+                                  "none": "0px",
+                                  "x1": "8px",
+                                  "x2": "16px",
+                                  "x3": "24px",
+                                  "x4": "32px",
+                                  "x5": "40px",
+                                  "x6": "48px",
+                                  "x8": "64px",
+                                },
+                                "zIndex": Object {
+                                  "content": 100,
+                                  "overlay": 1000,
+                                  "tabsBar": 210,
+                                  "tabsScollIndicator": 200,
+                                },
+                              },
+                            },
+                            "attrs": Array [],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "Box-sc-1qu1edy-0",
+                              "isStatic": false,
+                              "lastClassName": "dusExj",
+                              "rules": Array [
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                              ],
+                            },
+                            "displayName": "Box",
+                            "foldedComponentIds": Array [],
+                            "propTypes": Object {
+                              "bg": [Function],
+                              "border": [Function],
+                              "borderBottom": [Function],
+                              "borderLeft": [Function],
+                              "borderRadius": [Function],
+                              "borderRight": [Function],
+                              "borderTop": [Function],
+                              "boxShadow": [Function],
+                              "color": [Function],
+                              "display": [Function],
+                              "flexGrow": [Function],
+                              "height": [Function],
+                              "m": [Function],
+                              "maxHeight": [Function],
+                              "maxWidth": [Function],
+                              "mb": [Function],
+                              "minHeight": [Function],
+                              "minWidth": [Function],
+                              "ml": [Function],
+                              "mr": [Function],
+                              "mt": [Function],
+                              "mx": [Function],
+                              "my": [Function],
+                              "order": [Function],
+                              "p": [Function],
+                              "pb": [Function],
+                              "pl": [Function],
+                              "position": [Function],
+                              "pr": [Function],
+                              "pt": [Function],
+                              "px": [Function],
+                              "py": [Function],
+                              "textAlign": [Function],
+                              "width": [Function],
+                            },
+                            "render": [Function],
+                            "styledComponentId": "Box-sc-1qu1edy-0",
+                            "target": "div",
+                            "toString": [Function],
+                            "usesTheme": false,
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          }
+                        }
+                        forwardedRef={null}
+                        theme={
+                          Object {
+                            "borders": Array [],
+                            "breakpoints": Object {
+                              "extraLarge": "1920px",
+                              "extraSmall": "0px",
+                              "large": "1360px",
+                              "medium": "1024px",
+                              "small": "768px",
+                            },
+                            "colors": Object {
+                              "black": "#011e38",
+                              "blackBlue": "#122b47",
+                              "blue": "#216beb",
+                              "darkBlue": "#00438f",
+                              "darkGrey": "#434d59",
+                              "green": "#008059",
+                              "grey": "#c0c8d1",
+                              "lightBlue": "#e1ebfa",
+                              "lightGreen": "#e9f7f2",
+                              "lightGrey": "#e4e7eb",
+                              "lightRed": "#fae6ea",
+                              "lightYellow": "#fcf5e3",
+                              "red": "#cc1439",
+                              "white": "#ffffff",
+                              "whiteGrey": "#f0f2f5",
+                              "yellow": "#ffbb00",
+                            },
+                            "fontSizes": Object {
+                              "large": "20px",
+                              "larger": "26px",
+                              "largest": "46px",
+                              "medium": "16px",
+                              "small": "14px",
+                              "smaller": "12px",
+                            },
+                            "fontWeights": Object {
+                              "bold": "600",
+                              "light": "300",
+                              "medium": "500",
+                              "normal": "400",
+                            },
+                            "fonts": Object {
+                              "base": "'IBM Plex Sans', sans-serif",
+                              "mono": "'IBM Plex Mono', monospace",
+                            },
+                            "lineHeights": Object {
+                              "base": "1.5",
+                              "sectionTitle": "1.23076923",
+                              "smallTextBase": "1.71428571",
+                              "smallTextCompressed": "1.14285714",
+                              "smallerText": "1.33333333",
+                              "subsectionTitle": "1.2",
+                              "title": "1.04347826",
+                            },
+                            "radii": Object {
+                              "circle": "50%",
+                              "medium": "4px",
+                              "small": "2px",
+                            },
+                            "shadows": Object {
+                              "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                              "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                              "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                              "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                              "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                            },
+                            "space": Object {
+                              "half": "4px",
+                              "none": "0px",
+                              "x1": "8px",
+                              "x2": "16px",
+                              "x3": "24px",
+                              "x4": "32px",
+                              "x5": "40px",
+                              "x6": "48px",
+                              "x8": "64px",
+                            },
+                            "zIndex": Object {
+                              "content": 100,
+                              "overlay": 1000,
+                              "tabsBar": 210,
+                              "tabsScollIndicator": 200,
+                            },
+                          }
+                        }
+                      >
+                        <div
+                          className="Box-sc-1qu1edy-0 dusExj sc-kkGfuU fCpvZH"
+                        >
+                          <ClickInputLabel
+                            disabled={false}
+                          >
+                            <StyledComponent
+                              disabled={false}
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "ClickInputLabel-j2axnv-0",
+                                    "isStatic": false,
+                                    "lastClassName": "eoyTaS",
+                                    "rules": Array [
+                                      [Function],
+                                    ],
+                                  },
+                                  "displayName": "ClickInputLabel",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "ClickInputLabel-j2axnv-0",
+                                  "target": "label",
+                                  "toString": [Function],
+                                  "usesTheme": false,
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                            >
+                              <label
+                                className="ClickInputLabel-j2axnv-0 eoyTaS"
+                                disabled={false}
+                              >
+                                <Checkbox__CheckboxInput
+                                  aria-invalid={false}
+                                  aria-required={false}
+                                  checked={false}
+                                  className="sc-kkGfuU fCpvZH"
+                                  disabled={false}
+                                  error={false}
+                                  id="checkbox-1"
+                                  labelText="I am controlled and checked"
+                                  onChange={[Function]}
+                                  required={false}
+                                  type="checkbox"
+                                >
+                                  <StyledComponent
+                                    aria-invalid={false}
+                                    aria-required={false}
+                                    checked={false}
+                                    className="sc-kkGfuU fCpvZH"
+                                    disabled={false}
+                                    error={false}
+                                    forwardedComponent={
+                                      Object {
+                                        "$$typeof": Symbol(react.forward_ref),
+                                        "attrs": Array [],
+                                        "componentStyle": ComponentStyle {
+                                          "componentId": "Checkbox__CheckboxInput-sc-1nm58f1-1",
+                                          "isStatic": false,
+                                          "lastClassName": "hawbaw",
+                                          "rules": Array [
+                                            [Function],
+                                          ],
+                                        },
+                                        "displayName": "Checkbox__CheckboxInput",
+                                        "foldedComponentIds": Array [],
+                                        "render": [Function],
+                                        "styledComponentId": "Checkbox__CheckboxInput-sc-1nm58f1-1",
+                                        "target": "input",
+                                        "toString": [Function],
+                                        "usesTheme": false,
+                                        "warnTooManyClasses": [Function],
+                                        "withComponent": [Function],
+                                      }
+                                    }
+                                    forwardedRef={null}
+                                    id="checkbox-1"
+                                    labelText="I am controlled and checked"
+                                    onChange={[Function]}
+                                    required={false}
+                                    type="checkbox"
+                                  >
+                                    <input
+                                      aria-invalid={false}
+                                      aria-required={false}
+                                      checked={false}
+                                      className="Checkbox__CheckboxInput-sc-1nm58f1-1 hawbaw sc-kkGfuU fCpvZH"
+                                      disabled={false}
+                                      id="checkbox-1"
+                                      onChange={[Function]}
+                                      required={false}
+                                      type="checkbox"
+                                    />
+                                  </StyledComponent>
+                                </Checkbox__CheckboxInput>
+                                <Checkbox__VisualCheckbox
+                                  checked={false}
+                                  disabled={false}
+                                >
+                                  <StyledComponent
+                                    checked={false}
+                                    disabled={false}
+                                    forwardedComponent={
+                                      Object {
+                                        "$$typeof": Symbol(react.forward_ref),
+                                        "attrs": Array [],
+                                        "componentStyle": ComponentStyle {
+                                          "componentId": "Checkbox__VisualCheckbox-sc-1nm58f1-0",
+                                          "isStatic": false,
+                                          "lastClassName": "klUiEr",
+                                          "rules": Array [
+                                            "min-width: 16px;",
+                                            "height: 16px;",
+                                            "border-radius: 2px;",
+                                            "border: solid 1px;",
+                                            "position: relative;",
+                                            "align-self: center;",
+                                            "&:before {",
+                                            "content: '';",
+                                            "display: none;",
+                                            "position: relative;",
+                                            "left: 4px;",
+                                            "width: 3px;",
+                                            "height: 9px;",
+                                            "border: solid #ffffff;",
+                                            "border-width: 0 3px 3px 0;",
+                                            "border-radius: 1px;",
+                                            "transform: rotate(45deg);",
+                                            "}",
+                                          ],
+                                        },
+                                        "displayName": "Checkbox__VisualCheckbox",
+                                        "foldedComponentIds": Array [],
+                                        "render": [Function],
+                                        "styledComponentId": "Checkbox__VisualCheckbox-sc-1nm58f1-0",
+                                        "target": "div",
+                                        "toString": [Function],
+                                        "usesTheme": false,
+                                        "warnTooManyClasses": [Function],
+                                        "withComponent": [Function],
+                                      }
+                                    }
+                                    forwardedRef={null}
+                                  >
+                                    <div
+                                      checked={false}
+                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 klUiEr"
+                                      disabled={false}
+                                    />
+                                  </StyledComponent>
+                                </Checkbox__VisualCheckbox>
+                                <styled.p
+                                  color="currentColor"
+                                  disabled={false}
+                                  fontSize="16px"
+                                  inline={false}
+                                  lineHeight="1.5"
+                                  m={0}
+                                >
+                                  <StyledComponent
+                                    color="currentColor"
+                                    disabled={false}
+                                    fontSize="16px"
+                                    forwardedComponent={
+                                      Object {
+                                        "$$typeof": Symbol(react.forward_ref),
+                                        "_foldedDefaultProps": Object {
+                                          "color": "currentColor",
+                                          "disabled": false,
+                                          "fontSize": "16px",
+                                          "inline": false,
+                                          "lineHeight": "1.5",
+                                          "m": 0,
+                                        },
+                                        "attrs": Array [
+                                          [Function],
+                                        ],
+                                        "componentStyle": ComponentStyle {
+                                          "componentId": "sc-bxivhb",
+                                          "isStatic": false,
+                                          "lastClassName": "bWRApy",
+                                          "rules": Array [
+                                            [Function],
+                                            [Function],
+                                            [Function],
+                                            [Function],
+                                            [Function],
+                                            [Function],
+                                            [Function],
+                                            [Function],
+                                          ],
+                                        },
+                                        "displayName": "styled.p",
+                                        "foldedComponentIds": Array [],
+                                        "propTypes": Object {
+                                          "disabled": [Function],
+                                          "inline": [Function],
+                                        },
+                                        "render": [Function],
+                                        "styledComponentId": "sc-bxivhb",
+                                        "target": "p",
+                                        "toString": [Function],
+                                        "usesTheme": false,
+                                        "warnTooManyClasses": [Function],
+                                        "withComponent": [Function],
+                                      }
+                                    }
+                                    forwardedRef={null}
+                                    inline={false}
+                                    lineHeight="1.5"
+                                    m={0}
+                                  >
+                                    <p
+                                      className="sc-bxivhb bWRApy"
+                                      color="currentColor"
+                                      disabled={false}
+                                      fontSize="16px"
+                                    >
+                                      I am controlled and checked
+                                    </p>
+                                  </StyledComponent>
+                                </styled.p>
+                              </label>
+                            </StyledComponent>
+                          </ClickInputLabel>
+                        </div>
+                      </StyledComponent>
+                    </Box>
+                  </BaseCheckbox>
+                </StyledComponent>
+              </Styled(BaseCheckbox)>
+              <Styled(BaseCheckbox)
+                checked={false}
+                id="checkbox-2"
+                labelText="I am controlled and unchecked"
+                onChange={[Function]}
+              >
+                <StyledComponent
+                  checked={false}
+                  forwardedComponent={
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "sc-kkGfuU",
+                        "isStatic": false,
+                        "lastClassName": "fCpvZH",
+                        "rules": Array [
+                          "padding: 4px 0;",
+                          "& .sc-bxivhb {",
+                          "margin-left: 8px;",
+                          "}",
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Styled(BaseCheckbox)",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "sc-kkGfuU",
+                      "target": [Function],
+                      "toString": [Function],
+                      "usesTheme": false,
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    }
+                  }
+                  forwardedRef={null}
+                  id="checkbox-2"
+                  labelText="I am controlled and unchecked"
+                  onChange={[Function]}
+                >
+                  <BaseCheckbox
+                    checked={false}
+                    className="sc-kkGfuU fCpvZH"
+                    disabled={false}
+                    error={false}
+                    id="checkbox-2"
+                    labelText="I am controlled and unchecked"
+                    onChange={[Function]}
+                    required={false}
+                  >
+                    <Box
+                      className="sc-kkGfuU fCpvZH"
+                      theme={
+                        Object {
+                          "borders": Array [],
+                          "breakpoints": Object {
+                            "extraLarge": "1920px",
+                            "extraSmall": "0px",
+                            "large": "1360px",
+                            "medium": "1024px",
+                            "small": "768px",
+                          },
+                          "colors": Object {
+                            "black": "#011e38",
+                            "blackBlue": "#122b47",
+                            "blue": "#216beb",
+                            "darkBlue": "#00438f",
+                            "darkGrey": "#434d59",
+                            "green": "#008059",
+                            "grey": "#c0c8d1",
+                            "lightBlue": "#e1ebfa",
+                            "lightGreen": "#e9f7f2",
+                            "lightGrey": "#e4e7eb",
+                            "lightRed": "#fae6ea",
+                            "lightYellow": "#fcf5e3",
+                            "red": "#cc1439",
+                            "white": "#ffffff",
+                            "whiteGrey": "#f0f2f5",
+                            "yellow": "#ffbb00",
+                          },
+                          "fontSizes": Object {
+                            "large": "20px",
+                            "larger": "26px",
+                            "largest": "46px",
+                            "medium": "16px",
+                            "small": "14px",
+                            "smaller": "12px",
+                          },
+                          "fontWeights": Object {
+                            "bold": "600",
+                            "light": "300",
+                            "medium": "500",
+                            "normal": "400",
+                          },
+                          "fonts": Object {
+                            "base": "'IBM Plex Sans', sans-serif",
+                            "mono": "'IBM Plex Mono', monospace",
+                          },
+                          "lineHeights": Object {
+                            "base": "1.5",
+                            "sectionTitle": "1.23076923",
+                            "smallTextBase": "1.71428571",
+                            "smallTextCompressed": "1.14285714",
+                            "smallerText": "1.33333333",
+                            "subsectionTitle": "1.2",
+                            "title": "1.04347826",
+                          },
+                          "radii": Object {
+                            "circle": "50%",
+                            "medium": "4px",
+                            "small": "2px",
+                          },
+                          "shadows": Object {
+                            "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                            "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                            "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                            "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                            "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                          },
+                          "space": Object {
+                            "half": "4px",
+                            "none": "0px",
+                            "x1": "8px",
+                            "x2": "16px",
+                            "x3": "24px",
+                            "x4": "32px",
+                            "x5": "40px",
+                            "x6": "48px",
+                            "x8": "64px",
+                          },
+                          "zIndex": Object {
+                            "content": 100,
+                            "overlay": 1000,
+                            "tabsBar": 210,
+                            "tabsScollIndicator": 200,
+                          },
+                        }
+                      }
+                    >
+                      <StyledComponent
+                        className="sc-kkGfuU fCpvZH"
+                        forwardedComponent={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "_foldedDefaultProps": Object {
+                              "theme": Object {
+                                "borders": Array [],
+                                "breakpoints": Object {
+                                  "extraLarge": "1920px",
+                                  "extraSmall": "0px",
+                                  "large": "1360px",
+                                  "medium": "1024px",
+                                  "small": "768px",
+                                },
+                                "colors": Object {
+                                  "black": "#011e38",
+                                  "blackBlue": "#122b47",
+                                  "blue": "#216beb",
+                                  "darkBlue": "#00438f",
+                                  "darkGrey": "#434d59",
+                                  "green": "#008059",
+                                  "grey": "#c0c8d1",
+                                  "lightBlue": "#e1ebfa",
+                                  "lightGreen": "#e9f7f2",
+                                  "lightGrey": "#e4e7eb",
+                                  "lightRed": "#fae6ea",
+                                  "lightYellow": "#fcf5e3",
+                                  "red": "#cc1439",
+                                  "white": "#ffffff",
+                                  "whiteGrey": "#f0f2f5",
+                                  "yellow": "#ffbb00",
+                                },
+                                "fontSizes": Object {
+                                  "large": "20px",
+                                  "larger": "26px",
+                                  "largest": "46px",
+                                  "medium": "16px",
+                                  "small": "14px",
+                                  "smaller": "12px",
+                                },
+                                "fontWeights": Object {
+                                  "bold": "600",
+                                  "light": "300",
+                                  "medium": "500",
+                                  "normal": "400",
+                                },
+                                "fonts": Object {
+                                  "base": "'IBM Plex Sans', sans-serif",
+                                  "mono": "'IBM Plex Mono', monospace",
+                                },
+                                "lineHeights": Object {
+                                  "base": "1.5",
+                                  "sectionTitle": "1.23076923",
+                                  "smallTextBase": "1.71428571",
+                                  "smallTextCompressed": "1.14285714",
+                                  "smallerText": "1.33333333",
+                                  "subsectionTitle": "1.2",
+                                  "title": "1.04347826",
+                                },
+                                "radii": Object {
+                                  "circle": "50%",
+                                  "medium": "4px",
+                                  "small": "2px",
+                                },
+                                "shadows": Object {
+                                  "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                  "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                  "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                  "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                  "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                },
+                                "space": Object {
+                                  "half": "4px",
+                                  "none": "0px",
+                                  "x1": "8px",
+                                  "x2": "16px",
+                                  "x3": "24px",
+                                  "x4": "32px",
+                                  "x5": "40px",
+                                  "x6": "48px",
+                                  "x8": "64px",
+                                },
+                                "zIndex": Object {
+                                  "content": 100,
+                                  "overlay": 1000,
+                                  "tabsBar": 210,
+                                  "tabsScollIndicator": 200,
+                                },
+                              },
+                            },
+                            "attrs": Array [],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "Box-sc-1qu1edy-0",
+                              "isStatic": false,
+                              "lastClassName": "dusExj",
+                              "rules": Array [
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                              ],
+                            },
+                            "displayName": "Box",
+                            "foldedComponentIds": Array [],
+                            "propTypes": Object {
+                              "bg": [Function],
+                              "border": [Function],
+                              "borderBottom": [Function],
+                              "borderLeft": [Function],
+                              "borderRadius": [Function],
+                              "borderRight": [Function],
+                              "borderTop": [Function],
+                              "boxShadow": [Function],
+                              "color": [Function],
+                              "display": [Function],
+                              "flexGrow": [Function],
+                              "height": [Function],
+                              "m": [Function],
+                              "maxHeight": [Function],
+                              "maxWidth": [Function],
+                              "mb": [Function],
+                              "minHeight": [Function],
+                              "minWidth": [Function],
+                              "ml": [Function],
+                              "mr": [Function],
+                              "mt": [Function],
+                              "mx": [Function],
+                              "my": [Function],
+                              "order": [Function],
+                              "p": [Function],
+                              "pb": [Function],
+                              "pl": [Function],
+                              "position": [Function],
+                              "pr": [Function],
+                              "pt": [Function],
+                              "px": [Function],
+                              "py": [Function],
+                              "textAlign": [Function],
+                              "width": [Function],
+                            },
+                            "render": [Function],
+                            "styledComponentId": "Box-sc-1qu1edy-0",
+                            "target": "div",
+                            "toString": [Function],
+                            "usesTheme": false,
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          }
+                        }
+                        forwardedRef={null}
+                        theme={
+                          Object {
+                            "borders": Array [],
+                            "breakpoints": Object {
+                              "extraLarge": "1920px",
+                              "extraSmall": "0px",
+                              "large": "1360px",
+                              "medium": "1024px",
+                              "small": "768px",
+                            },
+                            "colors": Object {
+                              "black": "#011e38",
+                              "blackBlue": "#122b47",
+                              "blue": "#216beb",
+                              "darkBlue": "#00438f",
+                              "darkGrey": "#434d59",
+                              "green": "#008059",
+                              "grey": "#c0c8d1",
+                              "lightBlue": "#e1ebfa",
+                              "lightGreen": "#e9f7f2",
+                              "lightGrey": "#e4e7eb",
+                              "lightRed": "#fae6ea",
+                              "lightYellow": "#fcf5e3",
+                              "red": "#cc1439",
+                              "white": "#ffffff",
+                              "whiteGrey": "#f0f2f5",
+                              "yellow": "#ffbb00",
+                            },
+                            "fontSizes": Object {
+                              "large": "20px",
+                              "larger": "26px",
+                              "largest": "46px",
+                              "medium": "16px",
+                              "small": "14px",
+                              "smaller": "12px",
+                            },
+                            "fontWeights": Object {
+                              "bold": "600",
+                              "light": "300",
+                              "medium": "500",
+                              "normal": "400",
+                            },
+                            "fonts": Object {
+                              "base": "'IBM Plex Sans', sans-serif",
+                              "mono": "'IBM Plex Mono', monospace",
+                            },
+                            "lineHeights": Object {
+                              "base": "1.5",
+                              "sectionTitle": "1.23076923",
+                              "smallTextBase": "1.71428571",
+                              "smallTextCompressed": "1.14285714",
+                              "smallerText": "1.33333333",
+                              "subsectionTitle": "1.2",
+                              "title": "1.04347826",
+                            },
+                            "radii": Object {
+                              "circle": "50%",
+                              "medium": "4px",
+                              "small": "2px",
+                            },
+                            "shadows": Object {
+                              "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                              "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                              "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                              "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                              "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                            },
+                            "space": Object {
+                              "half": "4px",
+                              "none": "0px",
+                              "x1": "8px",
+                              "x2": "16px",
+                              "x3": "24px",
+                              "x4": "32px",
+                              "x5": "40px",
+                              "x6": "48px",
+                              "x8": "64px",
+                            },
+                            "zIndex": Object {
+                              "content": 100,
+                              "overlay": 1000,
+                              "tabsBar": 210,
+                              "tabsScollIndicator": 200,
+                            },
+                          }
+                        }
+                      >
+                        <div
+                          className="Box-sc-1qu1edy-0 dusExj sc-kkGfuU fCpvZH"
+                        >
+                          <ClickInputLabel
+                            disabled={false}
+                          >
+                            <StyledComponent
+                              disabled={false}
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "ClickInputLabel-j2axnv-0",
+                                    "isStatic": false,
+                                    "lastClassName": "eoyTaS",
+                                    "rules": Array [
+                                      [Function],
+                                    ],
+                                  },
+                                  "displayName": "ClickInputLabel",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "ClickInputLabel-j2axnv-0",
+                                  "target": "label",
+                                  "toString": [Function],
+                                  "usesTheme": false,
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                            >
+                              <label
+                                className="ClickInputLabel-j2axnv-0 eoyTaS"
+                                disabled={false}
+                              >
+                                <Checkbox__CheckboxInput
+                                  aria-invalid={false}
+                                  aria-required={false}
+                                  checked={false}
+                                  className="sc-kkGfuU fCpvZH"
+                                  disabled={false}
+                                  error={false}
+                                  id="checkbox-2"
+                                  labelText="I am controlled and unchecked"
+                                  onChange={[Function]}
+                                  required={false}
+                                  type="checkbox"
+                                >
+                                  <StyledComponent
+                                    aria-invalid={false}
+                                    aria-required={false}
+                                    checked={false}
+                                    className="sc-kkGfuU fCpvZH"
+                                    disabled={false}
+                                    error={false}
+                                    forwardedComponent={
+                                      Object {
+                                        "$$typeof": Symbol(react.forward_ref),
+                                        "attrs": Array [],
+                                        "componentStyle": ComponentStyle {
+                                          "componentId": "Checkbox__CheckboxInput-sc-1nm58f1-1",
+                                          "isStatic": false,
+                                          "lastClassName": "hawbaw",
+                                          "rules": Array [
+                                            [Function],
+                                          ],
+                                        },
+                                        "displayName": "Checkbox__CheckboxInput",
+                                        "foldedComponentIds": Array [],
+                                        "render": [Function],
+                                        "styledComponentId": "Checkbox__CheckboxInput-sc-1nm58f1-1",
+                                        "target": "input",
+                                        "toString": [Function],
+                                        "usesTheme": false,
+                                        "warnTooManyClasses": [Function],
+                                        "withComponent": [Function],
+                                      }
+                                    }
+                                    forwardedRef={null}
+                                    id="checkbox-2"
+                                    labelText="I am controlled and unchecked"
+                                    onChange={[Function]}
+                                    required={false}
+                                    type="checkbox"
+                                  >
+                                    <input
+                                      aria-invalid={false}
+                                      aria-required={false}
+                                      checked={false}
+                                      className="Checkbox__CheckboxInput-sc-1nm58f1-1 hawbaw sc-kkGfuU fCpvZH"
+                                      disabled={false}
+                                      id="checkbox-2"
+                                      onChange={[Function]}
+                                      required={false}
+                                      type="checkbox"
+                                    />
+                                  </StyledComponent>
+                                </Checkbox__CheckboxInput>
+                                <Checkbox__VisualCheckbox
+                                  checked={false}
+                                  disabled={false}
+                                >
+                                  <StyledComponent
+                                    checked={false}
+                                    disabled={false}
+                                    forwardedComponent={
+                                      Object {
+                                        "$$typeof": Symbol(react.forward_ref),
+                                        "attrs": Array [],
+                                        "componentStyle": ComponentStyle {
+                                          "componentId": "Checkbox__VisualCheckbox-sc-1nm58f1-0",
+                                          "isStatic": false,
+                                          "lastClassName": "klUiEr",
+                                          "rules": Array [
+                                            "min-width: 16px;",
+                                            "height: 16px;",
+                                            "border-radius: 2px;",
+                                            "border: solid 1px;",
+                                            "position: relative;",
+                                            "align-self: center;",
+                                            "&:before {",
+                                            "content: '';",
+                                            "display: none;",
+                                            "position: relative;",
+                                            "left: 4px;",
+                                            "width: 3px;",
+                                            "height: 9px;",
+                                            "border: solid #ffffff;",
+                                            "border-width: 0 3px 3px 0;",
+                                            "border-radius: 1px;",
+                                            "transform: rotate(45deg);",
+                                            "}",
+                                          ],
+                                        },
+                                        "displayName": "Checkbox__VisualCheckbox",
+                                        "foldedComponentIds": Array [],
+                                        "render": [Function],
+                                        "styledComponentId": "Checkbox__VisualCheckbox-sc-1nm58f1-0",
+                                        "target": "div",
+                                        "toString": [Function],
+                                        "usesTheme": false,
+                                        "warnTooManyClasses": [Function],
+                                        "withComponent": [Function],
+                                      }
+                                    }
+                                    forwardedRef={null}
+                                  >
+                                    <div
+                                      checked={false}
+                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 klUiEr"
+                                      disabled={false}
+                                    />
+                                  </StyledComponent>
+                                </Checkbox__VisualCheckbox>
+                                <styled.p
+                                  color="currentColor"
+                                  disabled={false}
+                                  fontSize="16px"
+                                  inline={false}
+                                  lineHeight="1.5"
+                                  m={0}
+                                >
+                                  <StyledComponent
+                                    color="currentColor"
+                                    disabled={false}
+                                    fontSize="16px"
+                                    forwardedComponent={
+                                      Object {
+                                        "$$typeof": Symbol(react.forward_ref),
+                                        "_foldedDefaultProps": Object {
+                                          "color": "currentColor",
+                                          "disabled": false,
+                                          "fontSize": "16px",
+                                          "inline": false,
+                                          "lineHeight": "1.5",
+                                          "m": 0,
+                                        },
+                                        "attrs": Array [
+                                          [Function],
+                                        ],
+                                        "componentStyle": ComponentStyle {
+                                          "componentId": "sc-bxivhb",
+                                          "isStatic": false,
+                                          "lastClassName": "bWRApy",
+                                          "rules": Array [
+                                            [Function],
+                                            [Function],
+                                            [Function],
+                                            [Function],
+                                            [Function],
+                                            [Function],
+                                            [Function],
+                                            [Function],
+                                          ],
+                                        },
+                                        "displayName": "styled.p",
+                                        "foldedComponentIds": Array [],
+                                        "propTypes": Object {
+                                          "disabled": [Function],
+                                          "inline": [Function],
+                                        },
+                                        "render": [Function],
+                                        "styledComponentId": "sc-bxivhb",
+                                        "target": "p",
+                                        "toString": [Function],
+                                        "usesTheme": false,
+                                        "warnTooManyClasses": [Function],
+                                        "withComponent": [Function],
+                                      }
+                                    }
+                                    forwardedRef={null}
+                                    inline={false}
+                                    lineHeight="1.5"
+                                    m={0}
+                                  >
+                                    <p
+                                      className="sc-bxivhb bWRApy"
+                                      color="currentColor"
+                                      disabled={false}
+                                      fontSize="16px"
+                                    >
+                                      I am controlled and unchecked
+                                    </p>
+                                  </StyledComponent>
+                                </styled.p>
+                              </label>
+                            </StyledComponent>
+                          </ClickInputLabel>
+                        </div>
+                      </StyledComponent>
+                    </Box>
+                  </BaseCheckbox>
+                </StyledComponent>
+              </Styled(BaseCheckbox)>
+            </CheckboxWithState>
           </ThemeProvider>
         </div>
       </StyledComponent>

--- a/components/src/DemoPage/__snapshots__/DemoPage.story.storyshot
+++ b/components/src/DemoPage/__snapshots__/DemoPage.story.storyshot
@@ -12156,7 +12156,7 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                             "componentStyle": ComponentStyle {
                                                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                                                               "isStatic": false,
-                                                                              "lastClassName": "eunBIc",
+                                                                              "lastClassName": "PAzBv",
                                                                               "rules": Array [
                                                                                 [Function],
                                                                               ],
@@ -12176,7 +12176,7 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                         scope="col"
                                                                       >
                                                                         <th
-                                                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                                                           scope="col"
                                                                         >
                                                                           Column 1
@@ -12197,7 +12197,7 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                             "componentStyle": ComponentStyle {
                                                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                                                               "isStatic": false,
-                                                                              "lastClassName": "eunBIc",
+                                                                              "lastClassName": "PAzBv",
                                                                               "rules": Array [
                                                                                 [Function],
                                                                               ],
@@ -12217,7 +12217,7 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                         scope="col"
                                                                       >
                                                                         <th
-                                                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                                                           scope="col"
                                                                         >
                                                                           Column 2
@@ -12238,7 +12238,7 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                             "componentStyle": ComponentStyle {
                                                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                                                               "isStatic": false,
-                                                                              "lastClassName": "eunBIc",
+                                                                              "lastClassName": "PAzBv",
                                                                               "rules": Array [
                                                                                 [Function],
                                                                               ],
@@ -12258,7 +12258,7 @@ exports[`Storyshots DemoPage Demo Page 1`] = `
                                                                         scope="col"
                                                                       >
                                                                         <th
-                                                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                                                           scope="col"
                                                                         >
                                                                           Column 3

--- a/components/src/StoriesForTests/__snapshots__/Table.story.storyshot
+++ b/components/src/StoriesForTests/__snapshots__/Table.story.storyshot
@@ -872,7 +872,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                               "componentStyle": ComponentStyle {
                                                 "componentId": "StyledTh-sc-10nzyk9-0",
                                                 "isStatic": false,
-                                                "lastClassName": "eunBIc",
+                                                "lastClassName": "PAzBv",
                                                 "rules": Array [
                                                   [Function],
                                                 ],
@@ -893,7 +893,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                           width="30px"
                                         >
                                           <th
-                                            className="StyledTh-sc-10nzyk9-0 sXJR"
+                                            className="StyledTh-sc-10nzyk9-0 cziffQ"
                                             scope="col"
                                             width="30px"
                                           >
@@ -1469,7 +1469,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                               "componentStyle": ComponentStyle {
                                                 "componentId": "StyledTh-sc-10nzyk9-0",
                                                 "isStatic": false,
-                                                "lastClassName": "eunBIc",
+                                                "lastClassName": "PAzBv",
                                                 "rules": Array [
                                                   [Function],
                                                 ],
@@ -1490,7 +1490,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                           width="30px"
                                         >
                                           <th
-                                            className="StyledTh-sc-10nzyk9-0 sXJR"
+                                            className="StyledTh-sc-10nzyk9-0 cziffQ"
                                             scope="col"
                                             width="30px"
                                           />
@@ -1510,7 +1510,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                               "componentStyle": ComponentStyle {
                                                 "componentId": "StyledTh-sc-10nzyk9-0",
                                                 "isStatic": false,
-                                                "lastClassName": "eunBIc",
+                                                "lastClassName": "PAzBv",
                                                 "rules": Array [
                                                   [Function],
                                                 ],
@@ -1530,7 +1530,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                           scope="col"
                                         >
                                           <th
-                                            className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                            className="StyledTh-sc-10nzyk9-0 PAzBv"
                                             scope="col"
                                           >
                                             Column 1
@@ -1551,7 +1551,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                               "componentStyle": ComponentStyle {
                                                 "componentId": "StyledTh-sc-10nzyk9-0",
                                                 "isStatic": false,
-                                                "lastClassName": "eunBIc",
+                                                "lastClassName": "PAzBv",
                                                 "rules": Array [
                                                   [Function],
                                                 ],
@@ -1571,7 +1571,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                           scope="col"
                                         >
                                           <th
-                                            className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                            className="StyledTh-sc-10nzyk9-0 PAzBv"
                                             scope="col"
                                           >
                                             Column 2
@@ -1592,7 +1592,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                               "componentStyle": ComponentStyle {
                                                 "componentId": "StyledTh-sc-10nzyk9-0",
                                                 "isStatic": false,
-                                                "lastClassName": "eunBIc",
+                                                "lastClassName": "PAzBv",
                                                 "rules": Array [
                                                   [Function],
                                                 ],
@@ -1612,7 +1612,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                           scope="col"
                                         >
                                           <th
-                                            className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                            className="StyledTh-sc-10nzyk9-0 PAzBv"
                                             scope="col"
                                           >
                                             Column 3
@@ -1633,7 +1633,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                               "componentStyle": ComponentStyle {
                                                 "componentId": "StyledTh-sc-10nzyk9-0",
                                                 "isStatic": false,
-                                                "lastClassName": "eunBIc",
+                                                "lastClassName": "PAzBv",
                                                 "rules": Array [
                                                   [Function],
                                                 ],
@@ -1653,7 +1653,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                           scope="col"
                                         >
                                           <th
-                                            className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                            className="StyledTh-sc-10nzyk9-0 PAzBv"
                                             scope="col"
                                           >
                                             Column 4
@@ -1674,7 +1674,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                               "componentStyle": ComponentStyle {
                                                 "componentId": "StyledTh-sc-10nzyk9-0",
                                                 "isStatic": false,
-                                                "lastClassName": "eunBIc",
+                                                "lastClassName": "PAzBv",
                                                 "rules": Array [
                                                   [Function],
                                                 ],
@@ -1694,7 +1694,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                           scope="col"
                                         >
                                           <th
-                                            className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                            className="StyledTh-sc-10nzyk9-0 PAzBv"
                                             scope="col"
                                           >
                                             Column 5
@@ -1715,7 +1715,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                               "componentStyle": ComponentStyle {
                                                 "componentId": "StyledTh-sc-10nzyk9-0",
                                                 "isStatic": false,
-                                                "lastClassName": "eunBIc",
+                                                "lastClassName": "PAzBv",
                                                 "rules": Array [
                                                   [Function],
                                                 ],
@@ -1735,7 +1735,7 @@ exports[`Storyshots StoriesForTests/Table with expandable and selectable rows wi
                                           scope="col"
                                         >
                                           <th
-                                            className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                            className="StyledTh-sc-10nzyk9-0 PAzBv"
                                             scope="col"
                                           >
                                             Column 6
@@ -5566,7 +5566,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -5587,7 +5587,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                         width="30px"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 sXJR"
+                                          className="StyledTh-sc-10nzyk9-0 cziffQ"
                                           scope="col"
                                           width="30px"
                                         />
@@ -5607,7 +5607,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -5627,7 +5627,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 1
@@ -5648,7 +5648,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -5668,7 +5668,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 2
@@ -5689,7 +5689,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -5709,7 +5709,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 3
@@ -5730,7 +5730,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -5750,7 +5750,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 4
@@ -5771,7 +5771,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -5791,7 +5791,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 5
@@ -5812,7 +5812,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -5832,7 +5832,7 @@ exports[`Storyshots StoriesForTests/Table with expandable rows with defaults 1`]
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 6
@@ -9650,7 +9650,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "eunBIc",
+                                            "lastClassName": "PAzBv",
                                             "rules": Array [
                                               [Function],
                                             ],
@@ -9670,7 +9670,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                        className="StyledTh-sc-10nzyk9-0 PAzBv"
                                         scope="col"
                                       >
                                         Column 1
@@ -9691,7 +9691,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "eunBIc",
+                                            "lastClassName": "PAzBv",
                                             "rules": Array [
                                               [Function],
                                             ],
@@ -9711,7 +9711,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                        className="StyledTh-sc-10nzyk9-0 PAzBv"
                                         scope="col"
                                       >
                                         Column 2
@@ -9732,7 +9732,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "eunBIc",
+                                            "lastClassName": "PAzBv",
                                             "rules": Array [
                                               [Function],
                                             ],
@@ -9752,7 +9752,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                        className="StyledTh-sc-10nzyk9-0 PAzBv"
                                         scope="col"
                                       >
                                         Column 3
@@ -9773,7 +9773,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "eunBIc",
+                                            "lastClassName": "PAzBv",
                                             "rules": Array [
                                               [Function],
                                             ],
@@ -9793,7 +9793,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                        className="StyledTh-sc-10nzyk9-0 PAzBv"
                                         scope="col"
                                       >
                                         Column 4
@@ -9814,7 +9814,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "eunBIc",
+                                            "lastClassName": "PAzBv",
                                             "rules": Array [
                                               [Function],
                                             ],
@@ -9834,7 +9834,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                        className="StyledTh-sc-10nzyk9-0 PAzBv"
                                         scope="col"
                                       >
                                         Column 5
@@ -9855,7 +9855,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "eunBIc",
+                                            "lastClassName": "PAzBv",
                                             "rules": Array [
                                               [Function],
                                             ],
@@ -9875,7 +9875,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                        className="StyledTh-sc-10nzyk9-0 PAzBv"
                                         scope="col"
                                       >
                                         Column 6
@@ -9896,7 +9896,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "eunBIc",
+                                            "lastClassName": "PAzBv",
                                             "rules": Array [
                                               [Function],
                                             ],
@@ -9916,7 +9916,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                        className="StyledTh-sc-10nzyk9-0 PAzBv"
                                         scope="col"
                                       >
                                         Column 7
@@ -9937,7 +9937,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "eunBIc",
+                                            "lastClassName": "PAzBv",
                                             "rules": Array [
                                               [Function],
                                             ],
@@ -9957,7 +9957,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                        className="StyledTh-sc-10nzyk9-0 PAzBv"
                                         scope="col"
                                       >
                                         Column 8
@@ -9978,7 +9978,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "eunBIc",
+                                            "lastClassName": "PAzBv",
                                             "rules": Array [
                                               [Function],
                                             ],
@@ -9998,7 +9998,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                        className="StyledTh-sc-10nzyk9-0 PAzBv"
                                         scope="col"
                                       >
                                         Column 9
@@ -10019,7 +10019,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "eunBIc",
+                                            "lastClassName": "PAzBv",
                                             "rules": Array [
                                               [Function],
                                             ],
@@ -10039,7 +10039,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                        className="StyledTh-sc-10nzyk9-0 PAzBv"
                                         scope="col"
                                       >
                                         Column 10
@@ -10060,7 +10060,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "eunBIc",
+                                            "lastClassName": "PAzBv",
                                             "rules": Array [
                                               [Function],
                                             ],
@@ -10080,7 +10080,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                        className="StyledTh-sc-10nzyk9-0 PAzBv"
                                         scope="col"
                                       >
                                         Column 11
@@ -10101,7 +10101,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "eunBIc",
+                                            "lastClassName": "PAzBv",
                                             "rules": Array [
                                               [Function],
                                             ],
@@ -10121,7 +10121,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                        className="StyledTh-sc-10nzyk9-0 PAzBv"
                                         scope="col"
                                       >
                                         Column 12
@@ -10142,7 +10142,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "eunBIc",
+                                            "lastClassName": "PAzBv",
                                             "rules": Array [
                                               [Function],
                                             ],
@@ -10162,7 +10162,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                        className="StyledTh-sc-10nzyk9-0 PAzBv"
                                         scope="col"
                                       >
                                         Column 13
@@ -10183,7 +10183,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "eunBIc",
+                                            "lastClassName": "PAzBv",
                                             "rules": Array [
                                               [Function],
                                             ],
@@ -10203,7 +10203,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                        className="StyledTh-sc-10nzyk9-0 PAzBv"
                                         scope="col"
                                       >
                                         Column 14
@@ -10224,7 +10224,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "eunBIc",
+                                            "lastClassName": "PAzBv",
                                             "rules": Array [
                                               [Function],
                                             ],
@@ -10244,7 +10244,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                        className="StyledTh-sc-10nzyk9-0 PAzBv"
                                         scope="col"
                                       >
                                         Column 15
@@ -10265,7 +10265,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "eunBIc",
+                                            "lastClassName": "PAzBv",
                                             "rules": Array [
                                               [Function],
                                             ],
@@ -10285,7 +10285,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                        className="StyledTh-sc-10nzyk9-0 PAzBv"
                                         scope="col"
                                       >
                                         Column 16
@@ -10306,7 +10306,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "eunBIc",
+                                            "lastClassName": "PAzBv",
                                             "rules": Array [
                                               [Function],
                                             ],
@@ -10326,7 +10326,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                        className="StyledTh-sc-10nzyk9-0 PAzBv"
                                         scope="col"
                                       >
                                         Column 17
@@ -10347,7 +10347,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "eunBIc",
+                                            "lastClassName": "PAzBv",
                                             "rules": Array [
                                               [Function],
                                             ],
@@ -10367,7 +10367,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                        className="StyledTh-sc-10nzyk9-0 PAzBv"
                                         scope="col"
                                       >
                                         Column 18
@@ -10388,7 +10388,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "eunBIc",
+                                            "lastClassName": "PAzBv",
                                             "rules": Array [
                                               [Function],
                                             ],
@@ -10408,7 +10408,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                        className="StyledTh-sc-10nzyk9-0 PAzBv"
                                         scope="col"
                                       >
                                         Column 19
@@ -10429,7 +10429,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "eunBIc",
+                                            "lastClassName": "PAzBv",
                                             "rules": Array [
                                               [Function],
                                             ],
@@ -10449,7 +10449,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                        className="StyledTh-sc-10nzyk9-0 PAzBv"
                                         scope="col"
                                       >
                                         Column 20
@@ -10470,7 +10470,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "StyledTh-sc-10nzyk9-0",
                                             "isStatic": false,
-                                            "lastClassName": "eunBIc",
+                                            "lastClassName": "PAzBv",
                                             "rules": Array [
                                               [Function],
                                             ],
@@ -10490,7 +10490,7 @@ exports[`Storyshots StoriesForTests/Table with pagination 1`] = `
                                       scope="col"
                                     >
                                       <th
-                                        className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                        className="StyledTh-sc-10nzyk9-0 PAzBv"
                                         scope="col"
                                       >
                                         Column 21
@@ -22706,7 +22706,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -22727,7 +22727,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         width="30px"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 sXJR"
+                                          className="StyledTh-sc-10nzyk9-0 cziffQ"
                                           scope="col"
                                           width="30px"
                                         >
@@ -23302,7 +23302,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -23322,7 +23322,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 1
@@ -23343,7 +23343,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -23363,7 +23363,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 2
@@ -23384,7 +23384,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -23404,7 +23404,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 3
@@ -23425,7 +23425,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -23445,7 +23445,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 4
@@ -23466,7 +23466,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -23486,7 +23486,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 5
@@ -23507,7 +23507,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -23527,7 +23527,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 6
@@ -23548,7 +23548,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -23568,7 +23568,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 7
@@ -23589,7 +23589,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -23609,7 +23609,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 8
@@ -23630,7 +23630,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -23650,7 +23650,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 9
@@ -23671,7 +23671,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -23691,7 +23691,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 10
@@ -23712,7 +23712,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -23732,7 +23732,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 11
@@ -23753,7 +23753,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -23773,7 +23773,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 12
@@ -23794,7 +23794,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -23814,7 +23814,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 13
@@ -23835,7 +23835,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -23855,7 +23855,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 14
@@ -23876,7 +23876,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -23896,7 +23896,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 15
@@ -23917,7 +23917,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -23937,7 +23937,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 16
@@ -23958,7 +23958,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -23978,7 +23978,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 17
@@ -23999,7 +23999,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -24019,7 +24019,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 18
@@ -24040,7 +24040,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -24060,7 +24060,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 19
@@ -24081,7 +24081,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -24101,7 +24101,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 20
@@ -24122,7 +24122,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -24142,7 +24142,7 @@ exports[`Storyshots StoriesForTests/Table with pagination and selectable rows 1`
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 21
@@ -38534,7 +38534,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -38555,7 +38555,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                         width="30px"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 sXJR"
+                                          className="StyledTh-sc-10nzyk9-0 cziffQ"
                                           scope="col"
                                           width="30px"
                                         >
@@ -39130,7 +39130,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -39150,7 +39150,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 1
@@ -39171,7 +39171,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -39191,7 +39191,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 2
@@ -39212,7 +39212,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -39232,7 +39232,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 3
@@ -39253,7 +39253,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -39273,7 +39273,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 4
@@ -39294,7 +39294,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -39314,7 +39314,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 5
@@ -39335,7 +39335,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -39355,7 +39355,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows 1`] = `
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 6
@@ -42381,7 +42381,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -42402,7 +42402,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                         width="30px"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 sXJR"
+                                          className="StyledTh-sc-10nzyk9-0 cziffQ"
                                           scope="col"
                                           width="30px"
                                         >
@@ -42977,7 +42977,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -42997,7 +42997,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 1
@@ -43018,7 +43018,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -43038,7 +43038,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 2
@@ -43059,7 +43059,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -43079,7 +43079,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 3
@@ -43100,7 +43100,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -43120,7 +43120,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 4
@@ -43141,7 +43141,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -43161,7 +43161,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 5
@@ -43182,7 +43182,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                             "componentStyle": ComponentStyle {
                                               "componentId": "StyledTh-sc-10nzyk9-0",
                                               "isStatic": false,
-                                              "lastClassName": "eunBIc",
+                                              "lastClassName": "PAzBv",
                                               "rules": Array [
                                                 [Function],
                                               ],
@@ -43202,7 +43202,7 @@ exports[`Storyshots StoriesForTests/Table with selected rows with defaults 1`] =
                                         scope="col"
                                       >
                                         <th
-                                          className="StyledTh-sc-10nzyk9-0 eunBIc"
+                                          className="StyledTh-sc-10nzyk9-0 PAzBv"
                                           scope="col"
                                         >
                                           Column 6

--- a/components/src/Table/StyledTh.js
+++ b/components/src/Table/StyledTh.js
@@ -9,7 +9,7 @@ const StyledTh = styled.th(({ width, compact }) => {
     padding: `${padding} 0`,
     paddingRight: padding,
     color: theme.colors.darkGrey,
-    "&:first-of-type": {
+    "&:first-child": {
       paddingLeft: padding
     },
     width: width || "auto"

--- a/components/src/Table/TableFoot.js
+++ b/components/src/Table/TableFoot.js
@@ -15,19 +15,32 @@ const StyledFooterRow = styled.tr({
 const renderRows = (rows, columns, keyField, loading) =>
   rows.map(row => <TableFooterRow row={row} columns={columns} key={row[keyField]} loading={loading} />);
 
-const TableFooterRow = ({ row, columns, loading }) => (
-  <StyledFooterRow>
-    {columns.map((column, index) =>
-      index === 0 ? (
-        <StyledTh key={column.dataKey} scope="row">
-          {row[column.dataKey]}
-        </StyledTh>
-      ) : (
-        !loading && <TableCell key={column.dataKey} row={row} column={column} cellData={row[column.dataKey]} />
-      )
-    )}
-  </StyledFooterRow>
-);
+const TableFooterRow = ({ row, columns, loading }) => {
+  console.log(columns);
+  const columnsWithoutControls = columns.filter(
+    column => column.dataKey !== "selected" && column.dataKey !== "expanded"
+  );
+  return (
+    <StyledFooterRow>
+      {columnsWithoutControls.map((column, index) =>
+        index === 0 ? (
+          <StyledTh key={column.dataKey} scope="row">
+            {row[column.dataKey]}
+          </StyledTh>
+        ) : (
+          !loading && (
+            <TableCell
+              key={column.dataKey}
+              row={row}
+              column={{ dataKey: column.dataKey, label: column.label }}
+              cellData={row[column.dataKey]}
+            />
+          )
+        )
+      )}
+    </StyledFooterRow>
+  );
+};
 
 TableFooterRow.propTypes = {
   row: rowPropType.isRequired,

--- a/components/src/Table/TableFoot.js
+++ b/components/src/Table/TableFoot.js
@@ -1,5 +1,5 @@
 import React from "react";
-import PropTypes, { number } from "prop-types";
+import PropTypes from "prop-types";
 import styled from "styled-components";
 import theme from "../theme";
 import TableCell from "./TableCell";
@@ -20,13 +20,8 @@ const TableFooterRow = ({ row, columns, loading }) => {
     column => column.dataKey !== "selected" && column.dataKey !== "expanded"
   );
   const numberOfControlColumns = columns.length - columnsWithoutControls.length;
-  // const renderEmptyCells = () =>
-  //   Array(numberOfControlColumns)
-  //     .fill()
-  //     .map(() => <td />);
   return (
     <StyledFooterRow>
-      {/* {renderEmptyCells()} */}
       {columnsWithoutControls.map((column, index) =>
         index === 0 ? (
           <StyledTh key={column.dataKey} scope="row" colSpan={numberOfControlColumns + 1}>

--- a/components/src/Table/TableFoot.js
+++ b/components/src/Table/TableFoot.js
@@ -1,5 +1,5 @@
 import React from "react";
-import PropTypes from "prop-types";
+import PropTypes, { number } from "prop-types";
 import styled from "styled-components";
 import theme from "../theme";
 import TableCell from "./TableCell";
@@ -16,15 +16,20 @@ const renderRows = (rows, columns, keyField, loading) =>
   rows.map(row => <TableFooterRow row={row} columns={columns} key={row[keyField]} loading={loading} />);
 
 const TableFooterRow = ({ row, columns, loading }) => {
-  console.log(columns);
   const columnsWithoutControls = columns.filter(
     column => column.dataKey !== "selected" && column.dataKey !== "expanded"
   );
+  const numberOfControlColumns = columns.length - columnsWithoutControls.length;
+  // const renderEmptyCells = () =>
+  //   Array(numberOfControlColumns)
+  //     .fill()
+  //     .map(() => <td />);
   return (
     <StyledFooterRow>
+      {/* {renderEmptyCells()} */}
       {columnsWithoutControls.map((column, index) =>
         index === 0 ? (
-          <StyledTh key={column.dataKey} scope="row">
+          <StyledTh key={column.dataKey} scope="row" colSpan={numberOfControlColumns + 1}>
             {row[column.dataKey]}
           </StyledTh>
         ) : (


### PR DESCRIPTION
## Description

Table footers will no longer use the cellRenderer or cellFormatter defined on columns and the headers for the table footers have been moved to the left with the appropriate colSpan depending on whether there are control columns added (selectable column or expandable).


## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current 
functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [x] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [x] Changelog updated
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [x] Tested storybook deployment preview
- [x] Tested docs deployment preview
