### PR TITLE
NDS-1236 add on input change prop to select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- [Select](http://nulogy.design/components/select) now supports `onInputChange`
+
 ### Changed
 
 - Table footer headers will always be displayed in the first column even when combined with selectable and expandable options

--- a/components/src/Select/Select.js
+++ b/components/src/Select/Select.js
@@ -56,7 +56,8 @@ const ReactSelect = ({
   onBlur,
   menuIsOpen,
   onMenuOpen,
-  onMenuClose
+  onMenuClose,
+  onInputChange
 }) => (
   <Field>
     <MaybeFieldLabel labelText={labelText} requirementText={requirementText} helpText={helpText}>
@@ -84,6 +85,7 @@ const ReactSelect = ({
         menuIsOpen={menuIsOpen}
         onMenuOpen={onMenuOpen}
         onMenuClose={onMenuClose}
+        onInputChange={onInputChange}
       />
       <InlineValidation mt="x1" errorMessage={errorMessage} errorList={errorList} />
     </MaybeFieldLabel>
@@ -116,7 +118,8 @@ ReactSelect.propTypes = {
   classNamePrefix: PropTypes.string,
   menuIsOpen: PropTypes.bool,
   onMenuOpen: PropTypes.func,
-  onMenuClose: PropTypes.func
+  onMenuClose: PropTypes.func,
+  onInputChange: PropTypes.func
 };
 
 ReactSelect.defaultProps = {
@@ -144,7 +147,8 @@ ReactSelect.defaultProps = {
   classNamePrefix: undefined,
   menuIsOpen: undefined,
   onMenuOpen: undefined,
-  onMenuClose: undefined
+  onMenuClose: undefined,
+  onInputChange: undefined
 };
 
 export default ReactSelect;

--- a/components/src/Select/Select.story.js
+++ b/components/src/Select/Select.story.js
@@ -75,6 +75,7 @@ storiesOf("Select", module)
       onBlur={action("blurred")}
       options={options}
       labelText="Inventory status"
+      onInputChange={action("typed input value changed")}
     />
   ))
   .add("with a defaultValue", () => (
@@ -85,6 +86,7 @@ storiesOf("Select", module)
       onBlur={action("blurred")}
       options={options}
       labelText="Inventory status"
+      onInputChange={action("typed input value changed")}
     />
   ))
   .add("with a blank value", () => {
@@ -96,6 +98,7 @@ storiesOf("Select", module)
         onBlur={action("blurred")}
         options={optionsWithBlank}
         labelText="Inventory status"
+        onInputChange={action("typed input value changed")}
       />
     );
   })
@@ -108,6 +111,8 @@ storiesOf("Select", module)
         labelText="Inventory status"
         onChange={action("selection changed")}
         onBlur={action("blurred")}
+        onInputChange={action("typed input value changed")}
+        loading
       />
       <br />
       <Select
@@ -118,6 +123,7 @@ storiesOf("Select", module)
         initialIsOpen
         onChange={action("selection changed")}
         onBlur={action("blurred")}
+        onInputChange={action("typed input value changed")}
       />
     </>
   ))
@@ -133,6 +139,7 @@ storiesOf("Select", module)
       onBlur={action("blurred")}
       disabled
       labelText="Inventory status"
+      onInputChange={action("typed input value changed")}
     />
   ))
   .add("with error message", () => (
@@ -144,6 +151,7 @@ storiesOf("Select", module)
         labelText="Inventory status"
         onChange={action("selection changed")}
         onBlur={action("blurred")}
+        onInputChange={action("typed input value changed")}
       />
       <br />
       <Select
@@ -153,6 +161,7 @@ storiesOf("Select", module)
         initialIsOpen
         onChange={action("selection changed")}
         onBlur={action("blurred")}
+        onInputChange={action("typed input value changed")}
       />
     </>
   ))
@@ -166,6 +175,7 @@ storiesOf("Select", module)
         labelText="Inventory status"
         onChange={action("selection changed")}
         onBlur={action("blurred")}
+        onInputChange={action("typed input value changed")}
       />
       <br />
       <Select
@@ -176,6 +186,7 @@ storiesOf("Select", module)
         initialIsOpen
         onChange={action("selection changed")}
         onBlur={action("blurred")}
+        onInputChange={action("typed input value changed")}
       />
     </>
   ))
@@ -191,6 +202,7 @@ storiesOf("Select", module)
         labelText="Inventory status"
         onChange={action("selection changed")}
         onBlur={action("blurred")}
+        onInputChange={action("typed input value changed")}
       />
       <PrimaryButton mt="x1" type="submit">
         Submit
@@ -208,6 +220,7 @@ storiesOf("Select", module)
         onChange={action("selection changed")}
         onBlur={action("blurred")}
         multiselect
+        onInputChange={action("typed input value changed")}
       />
       <Box width="300px">
         <Select
@@ -219,6 +232,7 @@ storiesOf("Select", module)
           onChange={action("selection changed")}
           onBlur={action("blurred")}
           multiselect
+          onInputChange={action("typed input value changed")}
         />
       </Box>
       <Box width="400px">
@@ -231,6 +245,7 @@ storiesOf("Select", module)
           onChange={action("selection changed")}
           onBlur={action("blurred")}
           multiselect
+          onInputChange={action("typed input value changed")}
         />
       </Box>
     </>
@@ -243,6 +258,7 @@ storiesOf("Select", module)
       helpText="Additional information about input"
       onChange={action("selection changed")}
       onBlur={action("blurred")}
+      onInputChange={action("typed input value changed")}
     />
   ))
   .add("with custom id", () => (
@@ -254,6 +270,7 @@ storiesOf("Select", module)
       helpText="Additional information about input"
       onChange={action("selection changed")}
       onBlur={action("blurred")}
+      onInputChange={action("typed input value changed")}
     />
   ))
   .add("with smaller maxHeight", () => (
@@ -266,6 +283,7 @@ storiesOf("Select", module)
       labelText="Inventory status"
       onChange={action("selection changed")}
       onBlur={action("blurred")}
+      onInputChange={action("typed input value changed")}
     />
   ))
   .add("With wrapping text", () => (
@@ -277,5 +295,6 @@ storiesOf("Select", module)
       labelText="Inventory status"
       onChange={action("selection changed")}
       onBlur={action("blurred")}
+      onInputChange={action("typed input value changed")}
     />
   ));

--- a/docs/src/pages/components/select.js
+++ b/docs/src/pages/components/select.js
@@ -82,6 +82,12 @@ const propsRows = [
     defaultValue: "undefined",
     description: "Event handler for when the menu is closed"
   },
+  {
+    name: "onInputChange",
+    type: "Function",
+    defaultValue: "undefined",
+    description: "Event handler for when the value typed into the input changes"
+  },
   ...inputProps
 ];
 


### PR DESCRIPTION
## Description

Adds support on the onInputChange prop already provided in react-select to the select component. 
(This was a requested change in the design-system channel from the GO - Ecosystems team, who will later need support of the Async component provided by React-select).

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [x] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [x] Docs updated with correct props and examples
- [x] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [x] Changelog updated
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
