### PR TITLE
NDS-1076 add defaultOpen example of tooltip

### DIFF
--- a/components-e2e/cypress/integration/components/Tooltip.spec.js
+++ b/components-e2e/cypress/integration/components/Tooltip.spec.js
@@ -9,5 +9,29 @@ describe("Tooltip", () => {
 
     cy.get('[aria-haspopup="true"]').trigger("mouseover");
     cy.get('[role="tooltip"]').should("be.visible");
+    cy.isInViewport('[role="tooltip"]');
+  });
+  describe("can be open by default", () => {
+    it("shows content initially", () => {
+      cy.renderFromStorybook("tooltip--open-by-default");
+
+      cy.get('[aria-haspopup="true"]').trigger("mouseover");
+      cy.get('[role="tooltip"]').should("be.visible");
+      cy.isInViewport('[role="tooltip"]');
+    });
+    it("hides on outside click", () => {
+      cy.renderFromStorybook("tooltip--base");
+
+      cy.clickOutsideElement();
+      cy.get('[role="tooltip"]').should("be.visible");
+      cy.isNotInViewport('[role="tooltip"]');
+    });
+    it("hides content on hover", () => {
+      cy.renderFromStorybook("tooltip--open-by-default");
+      cy.get('[aria-haspopup="true"]').trigger("mouseover");
+      cy.get('[aria-haspopup="true"]').trigger("mouseout");
+      cy.wait(2000);
+      cy.isNotInViewport('[role="tooltip"]');
+    });
   });
 });

--- a/components-e2e/cypress/support/commands.js
+++ b/components-e2e/cypress/support/commands.js
@@ -35,3 +35,21 @@ Cypress.Commands.add("pressEscapeKey", () => {
 Cypress.Commands.add("clickOutsideElement", () => {
   cy.get("body").click();
 });
+
+/* VIEWPORT CHECKS: useful for checking if an element is in view, particularly useful since the "visible" check built into cypress checks the visibility according to the css propterty and will not catch elements that are visually moved off the screen but remain css visible for screenreaders or other purposes */
+
+Cypress.Commands.add("isInViewport", element => {
+  cy.get(element).then($el => {
+    const bottom = Cypress.$(cy.state("window")).height();
+    const rect = $el[0].getBoundingClientRect();
+
+    expect(rect.top).not.to.be.greaterThan(bottom);
+  });
+});
+Cypress.Commands.add("isNotInViewport", element => {
+  cy.get(element).then($el => {
+    const rect = $el[0].getBoundingClientRect();
+
+    expect(rect.top).to.be.lessThan(0 - rect.height);
+  });
+});

--- a/components/src/StoriesForTests/Tooltip.story.js
+++ b/components/src/StoriesForTests/Tooltip.story.js
@@ -1,11 +1,19 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { NDSProvider, Button, Tooltip } from "..";
+import { Button, Tooltip } from "..";
 
-storiesOf("StoriesForTests/Tooltip", module).add("Base", () => (
-  <NDSProvider>
-    <Tooltip placement="bottom" tooltip="I am a Tooltip!">
-      <Button>Hover me</Button>
-    </Tooltip>
-  </NDSProvider>
-));
+storiesOf("StoriesForTests/Tooltip", module)
+  .add("Base", () => (
+    <>
+      <Tooltip placement="bottom" tooltip="I am a Tooltip!">
+        <Button>Hover me</Button>
+      </Tooltip>
+    </>
+  ))
+  .add("Open by default", () => (
+    <>
+      <Tooltip tooltip="I am an open Tooltip!" defaultOpen>
+        <Button>Hover me</Button>
+      </Tooltip>
+    </>
+  ));

--- a/components/src/StoriesForTests/__snapshots__/Tooltip.story.storyshot
+++ b/components/src/StoriesForTests/__snapshots__/Tooltip.story.storyshot
@@ -388,1014 +388,1658 @@ exports[`Storyshots StoriesForTests/Tooltip Base 1`] = `
               }
             }
           >
-            <NDSProvider
-              theme={
-                Object {
-                  "borders": Array [],
-                  "breakpoints": Object {
-                    "extraLarge": "1920px",
-                    "extraSmall": "0px",
-                    "large": "1360px",
-                    "medium": "1024px",
-                    "small": "768px",
-                  },
-                  "colors": Object {
-                    "black": "#011e38",
-                    "blackBlue": "#122b47",
-                    "blue": "#216beb",
-                    "darkBlue": "#00438f",
-                    "darkGrey": "#434d59",
-                    "green": "#008059",
-                    "grey": "#c0c8d1",
-                    "lightBlue": "#e1ebfa",
-                    "lightGreen": "#e9f7f2",
-                    "lightGrey": "#e4e7eb",
-                    "lightRed": "#fae6ea",
-                    "lightYellow": "#fcf5e3",
-                    "red": "#cc1439",
-                    "white": "#ffffff",
-                    "whiteGrey": "#f0f2f5",
-                    "yellow": "#ffbb00",
-                  },
-                  "fontSizes": Object {
-                    "large": "20px",
-                    "larger": "26px",
-                    "largest": "46px",
-                    "medium": "16px",
-                    "small": "14px",
-                    "smaller": "12px",
-                  },
-                  "fontWeights": Object {
-                    "bold": "600",
-                    "light": "300",
-                    "medium": "500",
-                    "normal": "400",
-                  },
-                  "fonts": Object {
-                    "base": "'IBM Plex Sans', sans-serif",
-                    "mono": "'IBM Plex Mono', monospace",
-                  },
-                  "lineHeights": Object {
-                    "base": "1.5",
-                    "sectionTitle": "1.23076923",
-                    "smallTextBase": "1.71428571",
-                    "smallTextCompressed": "1.14285714",
-                    "smallerText": "1.33333333",
-                    "subsectionTitle": "1.2",
-                    "title": "1.04347826",
-                  },
-                  "radii": Object {
-                    "circle": "50%",
-                    "medium": "4px",
-                    "small": "2px",
-                  },
-                  "shadows": Object {
-                    "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                    "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                    "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                    "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                    "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                  },
-                  "space": Object {
-                    "half": "4px",
-                    "none": "0px",
-                    "x1": "8px",
-                    "x2": "16px",
-                    "x3": "24px",
-                    "x4": "32px",
-                    "x5": "40px",
-                    "x6": "48px",
-                    "x8": "64px",
-                  },
-                  "zIndex": Object {
-                    "content": 100,
-                    "overlay": 1000,
-                    "tabsBar": 210,
-                    "tabsScollIndicator": 200,
-                  },
-                }
-              }
+            <Component
+              placement="bottom"
+              tooltip="I am a Tooltip!"
             >
-              <GlobalStyleComponent />
-              <NDSProvider__GlobalStyles
-                theme={
-                  Object {
-                    "borders": Array [],
-                    "breakpoints": Object {
-                      "extraLarge": "1920px",
-                      "extraSmall": "0px",
-                      "large": "1360px",
-                      "medium": "1024px",
-                      "small": "768px",
-                    },
-                    "colors": Object {
-                      "black": "#011e38",
-                      "blackBlue": "#122b47",
-                      "blue": "#216beb",
-                      "darkBlue": "#00438f",
-                      "darkGrey": "#434d59",
-                      "green": "#008059",
-                      "grey": "#c0c8d1",
-                      "lightBlue": "#e1ebfa",
-                      "lightGreen": "#e9f7f2",
-                      "lightGrey": "#e4e7eb",
-                      "lightRed": "#fae6ea",
-                      "lightYellow": "#fcf5e3",
-                      "red": "#cc1439",
-                      "white": "#ffffff",
-                      "whiteGrey": "#f0f2f5",
-                      "yellow": "#ffbb00",
-                    },
-                    "fontSizes": Object {
-                      "large": "20px",
-                      "larger": "26px",
-                      "largest": "46px",
-                      "medium": "16px",
-                      "small": "14px",
-                      "smaller": "12px",
-                    },
-                    "fontWeights": Object {
-                      "bold": "600",
-                      "light": "300",
-                      "medium": "500",
-                      "normal": "400",
-                    },
-                    "fonts": Object {
-                      "base": "'IBM Plex Sans', sans-serif",
-                      "mono": "'IBM Plex Mono', monospace",
-                    },
-                    "lineHeights": Object {
-                      "base": "1.5",
-                      "sectionTitle": "1.23076923",
-                      "smallTextBase": "1.71428571",
-                      "smallTextCompressed": "1.14285714",
-                      "smallerText": "1.33333333",
-                      "subsectionTitle": "1.2",
-                      "title": "1.04347826",
-                    },
-                    "radii": Object {
-                      "circle": "50%",
-                      "medium": "4px",
-                      "small": "2px",
-                    },
-                    "shadows": Object {
-                      "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                      "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                      "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                      "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                      "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                    },
-                    "space": Object {
-                      "half": "4px",
-                      "none": "0px",
-                      "x1": "8px",
-                      "x2": "16px",
-                      "x3": "24px",
-                      "x4": "32px",
-                      "x5": "40px",
-                      "x6": "48px",
-                      "x8": "64px",
-                    },
-                    "zIndex": Object {
-                      "content": 100,
-                      "overlay": 1000,
-                      "tabsBar": 210,
-                      "tabsScollIndicator": 200,
-                    },
-                  }
-                }
-              >
-                <StyledComponent
-                  forwardedComponent={
-                    Object {
-                      "$$typeof": Symbol(react.forward_ref),
-                      "attrs": Array [],
-                      "componentStyle": ComponentStyle {
-                        "componentId": "NDSProvider__GlobalStyles-f28eoq-0",
-                        "isStatic": false,
-                        "lastClassName": "gWUgWA",
-                        "rules": Array [
-                          [Function],
-                        ],
-                      },
-                      "displayName": "NDSProvider__GlobalStyles",
-                      "foldedComponentIds": Array [],
-                      "render": [Function],
-                      "styledComponentId": "NDSProvider__GlobalStyles-f28eoq-0",
-                      "target": "div",
-                      "toString": [Function],
-                      "usesTheme": false,
-                      "warnTooManyClasses": [Function],
-                      "withComponent": [Function],
-                    }
-                  }
-                  forwardedRef={null}
-                  theme={
-                    Object {
-                      "borders": Array [],
-                      "breakpoints": Object {
-                        "extraLarge": "1920px",
-                        "extraSmall": "0px",
-                        "large": "1360px",
-                        "medium": "1024px",
-                        "small": "768px",
-                      },
-                      "colors": Object {
-                        "black": "#011e38",
-                        "blackBlue": "#122b47",
-                        "blue": "#216beb",
-                        "darkBlue": "#00438f",
-                        "darkGrey": "#434d59",
-                        "green": "#008059",
-                        "grey": "#c0c8d1",
-                        "lightBlue": "#e1ebfa",
-                        "lightGreen": "#e9f7f2",
-                        "lightGrey": "#e4e7eb",
-                        "lightRed": "#fae6ea",
-                        "lightYellow": "#fcf5e3",
-                        "red": "#cc1439",
-                        "white": "#ffffff",
-                        "whiteGrey": "#f0f2f5",
-                        "yellow": "#ffbb00",
-                      },
-                      "fontSizes": Object {
-                        "large": "20px",
-                        "larger": "26px",
-                        "largest": "46px",
-                        "medium": "16px",
-                        "small": "14px",
-                        "smaller": "12px",
-                      },
-                      "fontWeights": Object {
-                        "bold": "600",
-                        "light": "300",
-                        "medium": "500",
-                        "normal": "400",
-                      },
-                      "fonts": Object {
-                        "base": "'IBM Plex Sans', sans-serif",
-                        "mono": "'IBM Plex Mono', monospace",
-                      },
-                      "lineHeights": Object {
-                        "base": "1.5",
-                        "sectionTitle": "1.23076923",
-                        "smallTextBase": "1.71428571",
-                        "smallTextCompressed": "1.14285714",
-                        "smallerText": "1.33333333",
-                        "subsectionTitle": "1.2",
-                        "title": "1.04347826",
-                      },
-                      "radii": Object {
-                        "circle": "50%",
-                        "medium": "4px",
-                        "small": "2px",
-                      },
-                      "shadows": Object {
-                        "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                        "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                        "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                        "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                        "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                      },
-                      "space": Object {
-                        "half": "4px",
-                        "none": "0px",
-                        "x1": "8px",
-                        "x2": "16px",
-                        "x3": "24px",
-                        "x4": "32px",
-                        "x5": "40px",
-                        "x6": "48px",
-                        "x8": "64px",
-                      },
-                      "zIndex": Object {
-                        "content": 100,
-                        "overlay": 1000,
-                        "tabsBar": 210,
-                        "tabsScollIndicator": 200,
-                      },
-                    }
-                  }
+              <WithGeneratedId>
+                <MenuComponent
+                  defaultOpen={false}
+                  hideDelay="350"
+                  id="random-id-1"
+                  placement="bottom"
+                  showDelay="100"
+                  tooltip="I am a Tooltip!"
                 >
-                  <div
-                    className="NDSProvider__GlobalStyles-f28eoq-0 gWUgWA"
+                  <MenuState
+                    defaultOpen={false}
+                    hideDelay="350"
+                    showDelay="100"
                   >
-                    <ThemeProvider
-                      theme={
+                    <StatelessTooltip
+                      id="random-id-1"
+                      maxWidth="24em"
+                      menuState={
                         Object {
-                          "borders": Array [],
-                          "breakpoints": Object {
-                            "extraLarge": "1920px",
-                            "extraSmall": "0px",
-                            "large": "1360px",
-                            "medium": "1024px",
-                            "small": "768px",
-                          },
-                          "colors": Object {
-                            "black": "#011e38",
-                            "blackBlue": "#122b47",
-                            "blue": "#216beb",
-                            "darkBlue": "#00438f",
-                            "darkGrey": "#434d59",
-                            "green": "#008059",
-                            "grey": "#c0c8d1",
-                            "lightBlue": "#e1ebfa",
-                            "lightGreen": "#e9f7f2",
-                            "lightGrey": "#e4e7eb",
-                            "lightRed": "#fae6ea",
-                            "lightYellow": "#fcf5e3",
-                            "red": "#cc1439",
-                            "white": "#ffffff",
-                            "whiteGrey": "#f0f2f5",
-                            "yellow": "#ffbb00",
-                          },
-                          "fontSizes": Object {
-                            "large": "20px",
-                            "larger": "26px",
-                            "largest": "46px",
-                            "medium": "16px",
-                            "small": "14px",
-                            "smaller": "12px",
-                          },
-                          "fontWeights": Object {
-                            "bold": "600",
-                            "light": "300",
-                            "medium": "500",
-                            "normal": "400",
-                          },
-                          "fonts": Object {
-                            "base": "'IBM Plex Sans', sans-serif",
-                            "mono": "'IBM Plex Mono', monospace",
-                          },
-                          "lineHeights": Object {
-                            "base": "1.5",
-                            "sectionTitle": "1.23076923",
-                            "smallTextBase": "1.71428571",
-                            "smallTextCompressed": "1.14285714",
-                            "smallerText": "1.33333333",
-                            "subsectionTitle": "1.2",
-                            "title": "1.04347826",
-                          },
-                          "radii": Object {
-                            "circle": "50%",
-                            "medium": "4px",
-                            "small": "2px",
-                          },
-                          "shadows": Object {
-                            "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                            "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                            "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                            "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                            "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                          },
-                          "space": Object {
-                            "half": "4px",
-                            "none": "0px",
-                            "x1": "8px",
-                            "x2": "16px",
-                            "x3": "24px",
-                            "x4": "32px",
-                            "x5": "40px",
-                            "x6": "48px",
-                            "x8": "64px",
-                          },
-                          "zIndex": Object {
-                            "content": 100,
-                            "overlay": 1000,
-                            "tabsBar": 210,
-                            "tabsScollIndicator": 200,
-                          },
+                          "closeMenu": [Function],
+                          "handleMenuKeydown": [Function],
+                          "isOpen": false,
+                          "openMenu": [Function],
+                          "toggleMenu": [Function],
                         }
                       }
+                      placement="bottom"
+                      tooltip="I am a Tooltip!"
                     >
-                      <Component
-                        placement="bottom"
-                        tooltip="I am a Tooltip!"
-                      >
-                        <WithGeneratedId>
-                          <MenuComponent
-                            hideDelay="350"
-                            id="random-id-1"
-                            placement="bottom"
-                            showDelay="100"
-                            tooltip="I am a Tooltip!"
+                      <Manager>
+                        <Reference>
+                          <InnerReference
+                            setReferenceNode={[Function]}
                           >
-                            <MenuState
-                              defaultOpen={false}
-                              hideDelay="350"
-                              showDelay="100"
+                            <ForwardRef
+                              aria-describedby="random-id-1"
+                              aria-expanded={false}
+                              aria-haspopup={true}
+                              asLink={false}
+                              disabled={false}
+                              fullWidth={false}
+                              icon={null}
+                              iconSide="right"
+                              onBlur={[Function]}
+                              onFocus={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                              size="medium"
                             >
-                              <StatelessTooltip
-                                id="random-id-1"
-                                maxWidth="24em"
-                                menuState={
+                              <Button__WrapperButton
+                                aria-describedby="random-id-1"
+                                aria-expanded={false}
+                                aria-haspopup={true}
+                                disabled={false}
+                                fullWidth={false}
+                                onBlur={[Function]}
+                                onFocus={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                size="medium"
+                              >
+                                <StyledComponent
+                                  aria-describedby="random-id-1"
+                                  aria-expanded={false}
+                                  aria-haspopup={true}
+                                  disabled={false}
+                                  forwardedComponent={
+                                    Object {
+                                      "$$typeof": Symbol(react.forward_ref),
+                                      "attrs": Array [],
+                                      "componentStyle": ComponentStyle {
+                                        "componentId": "Button__WrapperButton-sc-1omxup2-0",
+                                        "isStatic": false,
+                                        "lastClassName": "idlBaC",
+                                        "rules": Array [
+                                          [Function],
+                                          [Function],
+                                          [Function],
+                                          [Function],
+                                        ],
+                                      },
+                                      "displayName": "Button__WrapperButton",
+                                      "foldedComponentIds": Array [],
+                                      "render": [Function],
+                                      "styledComponentId": "Button__WrapperButton-sc-1omxup2-0",
+                                      "target": "button",
+                                      "toString": [Function],
+                                      "usesTheme": false,
+                                      "warnTooManyClasses": [Function],
+                                      "withComponent": [Function],
+                                    }
+                                  }
+                                  forwardedRef={[Function]}
+                                  fullWidth={false}
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  size="medium"
+                                >
+                                  <button
+                                    aria-describedby="random-id-1"
+                                    aria-expanded={false}
+                                    aria-haspopup={true}
+                                    className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
+                                    disabled={false}
+                                    onBlur={[Function]}
+                                    onFocus={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                    size="medium"
+                                  >
+                                    Hover me
+                                  </button>
+                                </StyledComponent>
+                              </Button__WrapperButton>
+                            </ForwardRef>
+                          </InnerReference>
+                        </Reference>
+                        <Popper
+                          placement="bottom"
+                        >
+                          <InnerPopper
+                            eventsEnabled={true}
+                            placement="bottom"
+                            positionFixed={false}
+                            referenceElement={
+                              <button
+                                aria-describedby="random-id-1"
+                                aria-expanded="false"
+                                aria-haspopup="true"
+                                class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
+                              >
+                                Hover me
+                              </button>
+                            }
+                          >
+                            <Styled(Box)
+                              id="random-id-1"
+                              maxWidth="24em"
+                              onBlur={[Function]}
+                              onFocus={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                              open={false}
+                              position={
+                                Object {
+                                  "left": 0,
+                                  "opacity": 0,
+                                  "pointerEvents": "none",
+                                  "position": "absolute",
+                                  "top": 0,
+                                }
+                              }
+                              role="tooltip"
+                              theme={
+                                Object {
+                                  "borders": Array [],
+                                  "breakpoints": Object {
+                                    "extraLarge": "1920px",
+                                    "extraSmall": "0px",
+                                    "large": "1360px",
+                                    "medium": "1024px",
+                                    "small": "768px",
+                                  },
+                                  "colors": Object {
+                                    "black": "#011e38",
+                                    "blackBlue": "#122b47",
+                                    "blue": "#216beb",
+                                    "darkBlue": "#00438f",
+                                    "darkGrey": "#434d59",
+                                    "green": "#008059",
+                                    "grey": "#c0c8d1",
+                                    "lightBlue": "#e1ebfa",
+                                    "lightGreen": "#e9f7f2",
+                                    "lightGrey": "#e4e7eb",
+                                    "lightRed": "#fae6ea",
+                                    "lightYellow": "#fcf5e3",
+                                    "red": "#cc1439",
+                                    "white": "#ffffff",
+                                    "whiteGrey": "#f0f2f5",
+                                    "yellow": "#ffbb00",
+                                  },
+                                  "fontSizes": Object {
+                                    "large": "20px",
+                                    "larger": "26px",
+                                    "largest": "46px",
+                                    "medium": "16px",
+                                    "small": "14px",
+                                    "smaller": "12px",
+                                  },
+                                  "fontWeights": Object {
+                                    "bold": "600",
+                                    "light": "300",
+                                    "medium": "500",
+                                    "normal": "400",
+                                  },
+                                  "fonts": Object {
+                                    "base": "'IBM Plex Sans', sans-serif",
+                                    "mono": "'IBM Plex Mono', monospace",
+                                  },
+                                  "lineHeights": Object {
+                                    "base": "1.5",
+                                    "sectionTitle": "1.23076923",
+                                    "smallTextBase": "1.71428571",
+                                    "smallTextCompressed": "1.14285714",
+                                    "smallerText": "1.33333333",
+                                    "subsectionTitle": "1.2",
+                                    "title": "1.04347826",
+                                  },
+                                  "radii": Object {
+                                    "circle": "50%",
+                                    "medium": "4px",
+                                    "small": "2px",
+                                  },
+                                  "shadows": Object {
+                                    "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                    "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                    "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                    "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                    "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                  },
+                                  "space": Object {
+                                    "half": "4px",
+                                    "none": "0px",
+                                    "x1": "8px",
+                                    "x2": "16px",
+                                    "x3": "24px",
+                                    "x4": "32px",
+                                    "x5": "40px",
+                                    "x6": "48px",
+                                    "x8": "64px",
+                                  },
+                                  "zIndex": Object {
+                                    "content": 100,
+                                    "overlay": 1000,
+                                    "tabsBar": 210,
+                                    "tabsScollIndicator": 200,
+                                  },
+                                }
+                              }
+                            >
+                              <StyledComponent
+                                forwardedComponent={
                                   Object {
-                                    "closeMenu": [Function],
-                                    "handleMenuKeydown": [Function],
-                                    "isOpen": false,
-                                    "openMenu": [Function],
-                                    "toggleMenu": [Function],
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "_foldedDefaultProps": Object {
+                                      "theme": Object {
+                                        "borders": Array [],
+                                        "breakpoints": Object {
+                                          "extraLarge": "1920px",
+                                          "extraSmall": "0px",
+                                          "large": "1360px",
+                                          "medium": "1024px",
+                                          "small": "768px",
+                                        },
+                                        "colors": Object {
+                                          "black": "#011e38",
+                                          "blackBlue": "#122b47",
+                                          "blue": "#216beb",
+                                          "darkBlue": "#00438f",
+                                          "darkGrey": "#434d59",
+                                          "green": "#008059",
+                                          "grey": "#c0c8d1",
+                                          "lightBlue": "#e1ebfa",
+                                          "lightGreen": "#e9f7f2",
+                                          "lightGrey": "#e4e7eb",
+                                          "lightRed": "#fae6ea",
+                                          "lightYellow": "#fcf5e3",
+                                          "red": "#cc1439",
+                                          "white": "#ffffff",
+                                          "whiteGrey": "#f0f2f5",
+                                          "yellow": "#ffbb00",
+                                        },
+                                        "fontSizes": Object {
+                                          "large": "20px",
+                                          "larger": "26px",
+                                          "largest": "46px",
+                                          "medium": "16px",
+                                          "small": "14px",
+                                          "smaller": "12px",
+                                        },
+                                        "fontWeights": Object {
+                                          "bold": "600",
+                                          "light": "300",
+                                          "medium": "500",
+                                          "normal": "400",
+                                        },
+                                        "fonts": Object {
+                                          "base": "'IBM Plex Sans', sans-serif",
+                                          "mono": "'IBM Plex Mono', monospace",
+                                        },
+                                        "lineHeights": Object {
+                                          "base": "1.5",
+                                          "sectionTitle": "1.23076923",
+                                          "smallTextBase": "1.71428571",
+                                          "smallTextCompressed": "1.14285714",
+                                          "smallerText": "1.33333333",
+                                          "subsectionTitle": "1.2",
+                                          "title": "1.04347826",
+                                        },
+                                        "radii": Object {
+                                          "circle": "50%",
+                                          "medium": "4px",
+                                          "small": "2px",
+                                        },
+                                        "shadows": Object {
+                                          "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                          "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                          "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                          "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                          "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                        },
+                                        "space": Object {
+                                          "half": "4px",
+                                          "none": "0px",
+                                          "x1": "8px",
+                                          "x2": "16px",
+                                          "x3": "24px",
+                                          "x4": "32px",
+                                          "x5": "40px",
+                                          "x6": "48px",
+                                          "x8": "64px",
+                                        },
+                                        "zIndex": Object {
+                                          "content": 100,
+                                          "overlay": 1000,
+                                          "tabsBar": 210,
+                                          "tabsScollIndicator": 200,
+                                        },
+                                      },
+                                    },
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "sc-jWBwVP",
+                                      "isStatic": false,
+                                      "lastClassName": "hjigbL",
+                                      "rules": Array [
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        "color: #011e38;",
+                                        "display: flex;",
+                                        "flex-direction: column;",
+                                        "font-size: 14px;",
+                                        "background-color: #ffffff;",
+                                        "border-radius: 4px;",
+                                        "border: 1px solid #c0c8d1;",
+                                        "box-shadow: 0 2px 4px rgba(0, 0, 0, 0.18);",
+                                        "padding: 8px;",
+                                        "transition: opacity 0.3s;",
+                                        "z-index: 100;",
+                                        [Function],
+                                      ],
+                                    },
+                                    "displayName": "Styled(Box)",
+                                    "foldedComponentIds": Array [
+                                      "Box-sc-1qu1edy-0",
+                                    ],
+                                    "propTypes": Object {
+                                      "bg": [Function],
+                                      "border": [Function],
+                                      "borderBottom": [Function],
+                                      "borderLeft": [Function],
+                                      "borderRadius": [Function],
+                                      "borderRight": [Function],
+                                      "borderTop": [Function],
+                                      "boxShadow": [Function],
+                                      "color": [Function],
+                                      "display": [Function],
+                                      "flexGrow": [Function],
+                                      "height": [Function],
+                                      "m": [Function],
+                                      "maxHeight": [Function],
+                                      "maxWidth": [Function],
+                                      "mb": [Function],
+                                      "minHeight": [Function],
+                                      "minWidth": [Function],
+                                      "ml": [Function],
+                                      "mr": [Function],
+                                      "mt": [Function],
+                                      "mx": [Function],
+                                      "my": [Function],
+                                      "order": [Function],
+                                      "p": [Function],
+                                      "pb": [Function],
+                                      "pl": [Function],
+                                      "position": [Function],
+                                      "pr": [Function],
+                                      "pt": [Function],
+                                      "px": [Function],
+                                      "py": [Function],
+                                      "textAlign": [Function],
+                                      "width": [Function],
+                                    },
+                                    "render": [Function],
+                                    "styledComponentId": "sc-jWBwVP",
+                                    "target": "div",
+                                    "toString": [Function],
+                                    "usesTheme": false,
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
                                   }
                                 }
-                                placement="bottom"
-                                tooltip="I am a Tooltip!"
+                                forwardedRef={[Function]}
+                                id="random-id-1"
+                                maxWidth="24em"
+                                onBlur={[Function]}
+                                onFocus={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                open={false}
+                                position={
+                                  Object {
+                                    "left": 0,
+                                    "opacity": 0,
+                                    "pointerEvents": "none",
+                                    "position": "absolute",
+                                    "top": 0,
+                                  }
+                                }
+                                role="tooltip"
+                                theme={
+                                  Object {
+                                    "borders": Array [],
+                                    "breakpoints": Object {
+                                      "extraLarge": "1920px",
+                                      "extraSmall": "0px",
+                                      "large": "1360px",
+                                      "medium": "1024px",
+                                      "small": "768px",
+                                    },
+                                    "colors": Object {
+                                      "black": "#011e38",
+                                      "blackBlue": "#122b47",
+                                      "blue": "#216beb",
+                                      "darkBlue": "#00438f",
+                                      "darkGrey": "#434d59",
+                                      "green": "#008059",
+                                      "grey": "#c0c8d1",
+                                      "lightBlue": "#e1ebfa",
+                                      "lightGreen": "#e9f7f2",
+                                      "lightGrey": "#e4e7eb",
+                                      "lightRed": "#fae6ea",
+                                      "lightYellow": "#fcf5e3",
+                                      "red": "#cc1439",
+                                      "white": "#ffffff",
+                                      "whiteGrey": "#f0f2f5",
+                                      "yellow": "#ffbb00",
+                                    },
+                                    "fontSizes": Object {
+                                      "large": "20px",
+                                      "larger": "26px",
+                                      "largest": "46px",
+                                      "medium": "16px",
+                                      "small": "14px",
+                                      "smaller": "12px",
+                                    },
+                                    "fontWeights": Object {
+                                      "bold": "600",
+                                      "light": "300",
+                                      "medium": "500",
+                                      "normal": "400",
+                                    },
+                                    "fonts": Object {
+                                      "base": "'IBM Plex Sans', sans-serif",
+                                      "mono": "'IBM Plex Mono', monospace",
+                                    },
+                                    "lineHeights": Object {
+                                      "base": "1.5",
+                                      "sectionTitle": "1.23076923",
+                                      "smallTextBase": "1.71428571",
+                                      "smallTextCompressed": "1.14285714",
+                                      "smallerText": "1.33333333",
+                                      "subsectionTitle": "1.2",
+                                      "title": "1.04347826",
+                                    },
+                                    "radii": Object {
+                                      "circle": "50%",
+                                      "medium": "4px",
+                                      "small": "2px",
+                                    },
+                                    "shadows": Object {
+                                      "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                      "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                      "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                      "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                      "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                    },
+                                    "space": Object {
+                                      "half": "4px",
+                                      "none": "0px",
+                                      "x1": "8px",
+                                      "x2": "16px",
+                                      "x3": "24px",
+                                      "x4": "32px",
+                                      "x5": "40px",
+                                      "x6": "48px",
+                                      "x8": "64px",
+                                    },
+                                    "zIndex": Object {
+                                      "content": 100,
+                                      "overlay": 1000,
+                                      "tabsBar": 210,
+                                      "tabsScollIndicator": 200,
+                                    },
+                                  }
+                                }
                               >
-                                <Manager>
-                                  <Reference>
-                                    <InnerReference
-                                      setReferenceNode={[Function]}
-                                    >
-                                      <ForwardRef
-                                        aria-describedby="random-id-1"
-                                        aria-expanded={false}
-                                        aria-haspopup={true}
-                                        asLink={false}
-                                        disabled={false}
-                                        fullWidth={false}
-                                        icon={null}
-                                        iconSide="right"
-                                        onBlur={[Function]}
-                                        onFocus={[Function]}
-                                        onMouseEnter={[Function]}
-                                        onMouseLeave={[Function]}
-                                        size="medium"
-                                      >
-                                        <Button__WrapperButton
-                                          aria-describedby="random-id-1"
-                                          aria-expanded={false}
-                                          aria-haspopup={true}
-                                          disabled={false}
-                                          fullWidth={false}
-                                          onBlur={[Function]}
-                                          onFocus={[Function]}
-                                          onMouseEnter={[Function]}
-                                          onMouseLeave={[Function]}
-                                          size="medium"
-                                        >
-                                          <StyledComponent
-                                            aria-describedby="random-id-1"
-                                            aria-expanded={false}
-                                            aria-haspopup={true}
-                                            disabled={false}
-                                            forwardedComponent={
-                                              Object {
-                                                "$$typeof": Symbol(react.forward_ref),
-                                                "attrs": Array [],
-                                                "componentStyle": ComponentStyle {
-                                                  "componentId": "Button__WrapperButton-sc-1omxup2-0",
-                                                  "isStatic": false,
-                                                  "lastClassName": "idlBaC",
-                                                  "rules": Array [
-                                                    [Function],
-                                                    [Function],
-                                                    [Function],
-                                                    [Function],
-                                                  ],
-                                                },
-                                                "displayName": "Button__WrapperButton",
-                                                "foldedComponentIds": Array [],
-                                                "render": [Function],
-                                                "styledComponentId": "Button__WrapperButton-sc-1omxup2-0",
-                                                "target": "button",
-                                                "toString": [Function],
-                                                "usesTheme": false,
-                                                "warnTooManyClasses": [Function],
-                                                "withComponent": [Function],
-                                              }
-                                            }
-                                            forwardedRef={[Function]}
-                                            fullWidth={false}
-                                            onBlur={[Function]}
-                                            onFocus={[Function]}
-                                            onMouseEnter={[Function]}
-                                            onMouseLeave={[Function]}
-                                            size="medium"
-                                          >
-                                            <button
-                                              aria-describedby="random-id-1"
-                                              aria-expanded={false}
-                                              aria-haspopup={true}
-                                              className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
-                                              disabled={false}
-                                              onBlur={[Function]}
-                                              onFocus={[Function]}
-                                              onMouseEnter={[Function]}
-                                              onMouseLeave={[Function]}
-                                              size="medium"
-                                            >
-                                              Hover me
-                                            </button>
-                                          </StyledComponent>
-                                        </Button__WrapperButton>
-                                      </ForwardRef>
-                                    </InnerReference>
-                                  </Reference>
-                                  <Popper
+                                <div
+                                  className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
+                                  id="random-id-1"
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  open={false}
+                                  role="tooltip"
+                                >
+                                  I am a Tooltip!
+                                  <PopperArrow
+                                    backgroundColor="white"
+                                    borderColor="grey"
                                     placement="bottom"
+                                    style={Object {}}
                                   >
-                                    <InnerPopper
-                                      eventsEnabled={true}
-                                      placement="bottom"
-                                      positionFixed={false}
-                                      referenceElement={
-                                        <button
-                                          aria-describedby="random-id-1"
-                                          aria-expanded="false"
-                                          aria-haspopup="true"
-                                          class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
-                                        >
-                                          Hover me
-                                        </button>
+                                    <StyledComponent
+                                      backgroundColor="white"
+                                      borderColor="grey"
+                                      forwardedComponent={
+                                        Object {
+                                          "$$typeof": Symbol(react.forward_ref),
+                                          "_foldedDefaultProps": Object {
+                                            "backgroundColor": "white",
+                                            "borderColor": "grey",
+                                            "placement": "bottom",
+                                          },
+                                          "attrs": Array [],
+                                          "componentStyle": ComponentStyle {
+                                            "componentId": "PopperArrow-sc-1bcgj4w-0",
+                                            "isStatic": false,
+                                            "lastClassName": "bBzGzE",
+                                            "rules": Array [
+                                              "position: absolute;",
+                                              "height: 8px;",
+                                              "width: 8px;",
+                                              "margin: 12px;",
+                                              "&:before {",
+                                              "border-style: solid;",
+                                              "content: '';",
+                                              "display: block;",
+                                              "height: 0;",
+                                              "margin: auto;",
+                                              "position: absolute;",
+                                              "width: 0;",
+                                              "}",
+                                              "&:after {",
+                                              "border-style: solid;",
+                                              "content: '';",
+                                              "display: block;",
+                                              "height: 0;",
+                                              "margin: auto;",
+                                              "position: absolute;",
+                                              "width: 0;",
+                                              "}",
+                                              [Function],
+                                              [Function],
+                                            ],
+                                          },
+                                          "displayName": "PopperArrow",
+                                          "foldedComponentIds": Array [],
+                                          "propTypes": Object {
+                                            "backgroundColor": [Function],
+                                            "borderColor": [Function],
+                                            "placement": [Function],
+                                          },
+                                          "render": [Function],
+                                          "styledComponentId": "PopperArrow-sc-1bcgj4w-0",
+                                          "target": "div",
+                                          "toString": [Function],
+                                          "usesTheme": false,
+                                          "warnTooManyClasses": [Function],
+                                          "withComponent": [Function],
+                                        }
                                       }
+                                      forwardedRef={[Function]}
+                                      placement="bottom"
+                                      style={Object {}}
                                     >
-                                      <Styled(Box)
-                                        id="random-id-1"
-                                        maxWidth="24em"
-                                        onBlur={[Function]}
-                                        onFocus={[Function]}
-                                        onMouseEnter={[Function]}
-                                        onMouseLeave={[Function]}
-                                        open={false}
-                                        position={
-                                          Object {
-                                            "left": 0,
-                                            "opacity": 0,
-                                            "pointerEvents": "none",
-                                            "position": "absolute",
-                                            "top": 0,
-                                          }
+                                      <div
+                                        className="PopperArrow-sc-1bcgj4w-0 bBzGzE"
+                                        style={Object {}}
+                                      />
+                                    </StyledComponent>
+                                  </PopperArrow>
+                                </div>
+                              </StyledComponent>
+                            </Styled(Box)>
+                          </InnerPopper>
+                        </Popper>
+                      </Manager>
+                    </StatelessTooltip>
+                  </MenuState>
+                </MenuComponent>
+              </WithGeneratedId>
+            </Component>
+          </ThemeProvider>
+        </div>
+      </StyledComponent>
+    </NDSProvider__GlobalStyles>
+  </NDSProvider>
+</div>
+`;
+
+exports[`Storyshots StoriesForTests/Tooltip Open by default 1`] = `
+<div
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
+>
+  <NDSProvider
+    theme={
+      Object {
+        "borders": Array [],
+        "breakpoints": Object {
+          "extraLarge": "1920px",
+          "extraSmall": "0px",
+          "large": "1360px",
+          "medium": "1024px",
+          "small": "768px",
+        },
+        "colors": Object {
+          "black": "#011e38",
+          "blackBlue": "#122b47",
+          "blue": "#216beb",
+          "darkBlue": "#00438f",
+          "darkGrey": "#434d59",
+          "green": "#008059",
+          "grey": "#c0c8d1",
+          "lightBlue": "#e1ebfa",
+          "lightGreen": "#e9f7f2",
+          "lightGrey": "#e4e7eb",
+          "lightRed": "#fae6ea",
+          "lightYellow": "#fcf5e3",
+          "red": "#cc1439",
+          "white": "#ffffff",
+          "whiteGrey": "#f0f2f5",
+          "yellow": "#ffbb00",
+        },
+        "fontSizes": Object {
+          "large": "20px",
+          "larger": "26px",
+          "largest": "46px",
+          "medium": "16px",
+          "small": "14px",
+          "smaller": "12px",
+        },
+        "fontWeights": Object {
+          "bold": "600",
+          "light": "300",
+          "medium": "500",
+          "normal": "400",
+        },
+        "fonts": Object {
+          "base": "'IBM Plex Sans', sans-serif",
+          "mono": "'IBM Plex Mono', monospace",
+        },
+        "lineHeights": Object {
+          "base": "1.5",
+          "sectionTitle": "1.23076923",
+          "smallTextBase": "1.71428571",
+          "smallTextCompressed": "1.14285714",
+          "smallerText": "1.33333333",
+          "subsectionTitle": "1.2",
+          "title": "1.04347826",
+        },
+        "radii": Object {
+          "circle": "50%",
+          "medium": "4px",
+          "small": "2px",
+        },
+        "shadows": Object {
+          "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+          "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+          "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+          "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+          "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+        },
+        "space": Object {
+          "half": "4px",
+          "none": "0px",
+          "x1": "8px",
+          "x2": "16px",
+          "x3": "24px",
+          "x4": "32px",
+          "x5": "40px",
+          "x6": "48px",
+          "x8": "64px",
+        },
+        "zIndex": Object {
+          "content": 100,
+          "overlay": 1000,
+          "tabsBar": 210,
+          "tabsScollIndicator": 200,
+        },
+      }
+    }
+  >
+    <GlobalStyleComponent />
+    <NDSProvider__GlobalStyles
+      theme={
+        Object {
+          "borders": Array [],
+          "breakpoints": Object {
+            "extraLarge": "1920px",
+            "extraSmall": "0px",
+            "large": "1360px",
+            "medium": "1024px",
+            "small": "768px",
+          },
+          "colors": Object {
+            "black": "#011e38",
+            "blackBlue": "#122b47",
+            "blue": "#216beb",
+            "darkBlue": "#00438f",
+            "darkGrey": "#434d59",
+            "green": "#008059",
+            "grey": "#c0c8d1",
+            "lightBlue": "#e1ebfa",
+            "lightGreen": "#e9f7f2",
+            "lightGrey": "#e4e7eb",
+            "lightRed": "#fae6ea",
+            "lightYellow": "#fcf5e3",
+            "red": "#cc1439",
+            "white": "#ffffff",
+            "whiteGrey": "#f0f2f5",
+            "yellow": "#ffbb00",
+          },
+          "fontSizes": Object {
+            "large": "20px",
+            "larger": "26px",
+            "largest": "46px",
+            "medium": "16px",
+            "small": "14px",
+            "smaller": "12px",
+          },
+          "fontWeights": Object {
+            "bold": "600",
+            "light": "300",
+            "medium": "500",
+            "normal": "400",
+          },
+          "fonts": Object {
+            "base": "'IBM Plex Sans', sans-serif",
+            "mono": "'IBM Plex Mono', monospace",
+          },
+          "lineHeights": Object {
+            "base": "1.5",
+            "sectionTitle": "1.23076923",
+            "smallTextBase": "1.71428571",
+            "smallTextCompressed": "1.14285714",
+            "smallerText": "1.33333333",
+            "subsectionTitle": "1.2",
+            "title": "1.04347826",
+          },
+          "radii": Object {
+            "circle": "50%",
+            "medium": "4px",
+            "small": "2px",
+          },
+          "shadows": Object {
+            "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+            "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+            "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+            "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+            "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+          },
+          "space": Object {
+            "half": "4px",
+            "none": "0px",
+            "x1": "8px",
+            "x2": "16px",
+            "x3": "24px",
+            "x4": "32px",
+            "x5": "40px",
+            "x6": "48px",
+            "x8": "64px",
+          },
+          "zIndex": Object {
+            "content": 100,
+            "overlay": 1000,
+            "tabsBar": 210,
+            "tabsScollIndicator": 200,
+          },
+        }
+      }
+    >
+      <StyledComponent
+        forwardedComponent={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "attrs": Array [],
+            "componentStyle": ComponentStyle {
+              "componentId": "NDSProvider__GlobalStyles-f28eoq-0",
+              "isStatic": false,
+              "lastClassName": "gWUgWA",
+              "rules": Array [
+                [Function],
+              ],
+            },
+            "displayName": "NDSProvider__GlobalStyles",
+            "foldedComponentIds": Array [],
+            "render": [Function],
+            "styledComponentId": "NDSProvider__GlobalStyles-f28eoq-0",
+            "target": "div",
+            "toString": [Function],
+            "usesTheme": false,
+            "warnTooManyClasses": [Function],
+            "withComponent": [Function],
+          }
+        }
+        forwardedRef={null}
+        theme={
+          Object {
+            "borders": Array [],
+            "breakpoints": Object {
+              "extraLarge": "1920px",
+              "extraSmall": "0px",
+              "large": "1360px",
+              "medium": "1024px",
+              "small": "768px",
+            },
+            "colors": Object {
+              "black": "#011e38",
+              "blackBlue": "#122b47",
+              "blue": "#216beb",
+              "darkBlue": "#00438f",
+              "darkGrey": "#434d59",
+              "green": "#008059",
+              "grey": "#c0c8d1",
+              "lightBlue": "#e1ebfa",
+              "lightGreen": "#e9f7f2",
+              "lightGrey": "#e4e7eb",
+              "lightRed": "#fae6ea",
+              "lightYellow": "#fcf5e3",
+              "red": "#cc1439",
+              "white": "#ffffff",
+              "whiteGrey": "#f0f2f5",
+              "yellow": "#ffbb00",
+            },
+            "fontSizes": Object {
+              "large": "20px",
+              "larger": "26px",
+              "largest": "46px",
+              "medium": "16px",
+              "small": "14px",
+              "smaller": "12px",
+            },
+            "fontWeights": Object {
+              "bold": "600",
+              "light": "300",
+              "medium": "500",
+              "normal": "400",
+            },
+            "fonts": Object {
+              "base": "'IBM Plex Sans', sans-serif",
+              "mono": "'IBM Plex Mono', monospace",
+            },
+            "lineHeights": Object {
+              "base": "1.5",
+              "sectionTitle": "1.23076923",
+              "smallTextBase": "1.71428571",
+              "smallTextCompressed": "1.14285714",
+              "smallerText": "1.33333333",
+              "subsectionTitle": "1.2",
+              "title": "1.04347826",
+            },
+            "radii": Object {
+              "circle": "50%",
+              "medium": "4px",
+              "small": "2px",
+            },
+            "shadows": Object {
+              "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+              "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+              "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+              "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+              "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+            },
+            "space": Object {
+              "half": "4px",
+              "none": "0px",
+              "x1": "8px",
+              "x2": "16px",
+              "x3": "24px",
+              "x4": "32px",
+              "x5": "40px",
+              "x6": "48px",
+              "x8": "64px",
+            },
+            "zIndex": Object {
+              "content": 100,
+              "overlay": 1000,
+              "tabsBar": 210,
+              "tabsScollIndicator": 200,
+            },
+          }
+        }
+      >
+        <div
+          className="NDSProvider__GlobalStyles-f28eoq-0 gWUgWA"
+        >
+          <ThemeProvider
+            theme={
+              Object {
+                "borders": Array [],
+                "breakpoints": Object {
+                  "extraLarge": "1920px",
+                  "extraSmall": "0px",
+                  "large": "1360px",
+                  "medium": "1024px",
+                  "small": "768px",
+                },
+                "colors": Object {
+                  "black": "#011e38",
+                  "blackBlue": "#122b47",
+                  "blue": "#216beb",
+                  "darkBlue": "#00438f",
+                  "darkGrey": "#434d59",
+                  "green": "#008059",
+                  "grey": "#c0c8d1",
+                  "lightBlue": "#e1ebfa",
+                  "lightGreen": "#e9f7f2",
+                  "lightGrey": "#e4e7eb",
+                  "lightRed": "#fae6ea",
+                  "lightYellow": "#fcf5e3",
+                  "red": "#cc1439",
+                  "white": "#ffffff",
+                  "whiteGrey": "#f0f2f5",
+                  "yellow": "#ffbb00",
+                },
+                "fontSizes": Object {
+                  "large": "20px",
+                  "larger": "26px",
+                  "largest": "46px",
+                  "medium": "16px",
+                  "small": "14px",
+                  "smaller": "12px",
+                },
+                "fontWeights": Object {
+                  "bold": "600",
+                  "light": "300",
+                  "medium": "500",
+                  "normal": "400",
+                },
+                "fonts": Object {
+                  "base": "'IBM Plex Sans', sans-serif",
+                  "mono": "'IBM Plex Mono', monospace",
+                },
+                "lineHeights": Object {
+                  "base": "1.5",
+                  "sectionTitle": "1.23076923",
+                  "smallTextBase": "1.71428571",
+                  "smallTextCompressed": "1.14285714",
+                  "smallerText": "1.33333333",
+                  "subsectionTitle": "1.2",
+                  "title": "1.04347826",
+                },
+                "radii": Object {
+                  "circle": "50%",
+                  "medium": "4px",
+                  "small": "2px",
+                },
+                "shadows": Object {
+                  "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                  "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                  "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                  "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                  "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                },
+                "space": Object {
+                  "half": "4px",
+                  "none": "0px",
+                  "x1": "8px",
+                  "x2": "16px",
+                  "x3": "24px",
+                  "x4": "32px",
+                  "x5": "40px",
+                  "x6": "48px",
+                  "x8": "64px",
+                },
+                "zIndex": Object {
+                  "content": 100,
+                  "overlay": 1000,
+                  "tabsBar": 210,
+                  "tabsScollIndicator": 200,
+                },
+              }
+            }
+          >
+            <Component
+              defaultOpen={true}
+              tooltip="I am an open Tooltip!"
+            >
+              <WithGeneratedId>
+                <MenuComponent
+                  defaultOpen={true}
+                  hideDelay="350"
+                  id="random-id-2"
+                  showDelay="100"
+                  tooltip="I am an open Tooltip!"
+                >
+                  <MenuState
+                    defaultOpen={true}
+                    hideDelay="350"
+                    showDelay="100"
+                  >
+                    <StatelessTooltip
+                      id="random-id-2"
+                      maxWidth="24em"
+                      menuState={
+                        Object {
+                          "closeMenu": [Function],
+                          "handleMenuKeydown": [Function],
+                          "isOpen": true,
+                          "openMenu": [Function],
+                          "toggleMenu": [Function],
+                        }
+                      }
+                      placement="bottom"
+                      tooltip="I am an open Tooltip!"
+                    >
+                      <Manager>
+                        <Reference>
+                          <InnerReference
+                            setReferenceNode={[Function]}
+                          >
+                            <ForwardRef
+                              aria-describedby="random-id-2"
+                              aria-expanded={true}
+                              aria-haspopup={true}
+                              asLink={false}
+                              disabled={false}
+                              fullWidth={false}
+                              icon={null}
+                              iconSide="right"
+                              onBlur={[Function]}
+                              onFocus={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                              size="medium"
+                            >
+                              <Button__WrapperButton
+                                aria-describedby="random-id-2"
+                                aria-expanded={true}
+                                aria-haspopup={true}
+                                disabled={false}
+                                fullWidth={false}
+                                onBlur={[Function]}
+                                onFocus={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                size="medium"
+                              >
+                                <StyledComponent
+                                  aria-describedby="random-id-2"
+                                  aria-expanded={true}
+                                  aria-haspopup={true}
+                                  disabled={false}
+                                  forwardedComponent={
+                                    Object {
+                                      "$$typeof": Symbol(react.forward_ref),
+                                      "attrs": Array [],
+                                      "componentStyle": ComponentStyle {
+                                        "componentId": "Button__WrapperButton-sc-1omxup2-0",
+                                        "isStatic": false,
+                                        "lastClassName": "idlBaC",
+                                        "rules": Array [
+                                          [Function],
+                                          [Function],
+                                          [Function],
+                                          [Function],
+                                        ],
+                                      },
+                                      "displayName": "Button__WrapperButton",
+                                      "foldedComponentIds": Array [],
+                                      "render": [Function],
+                                      "styledComponentId": "Button__WrapperButton-sc-1omxup2-0",
+                                      "target": "button",
+                                      "toString": [Function],
+                                      "usesTheme": false,
+                                      "warnTooManyClasses": [Function],
+                                      "withComponent": [Function],
+                                    }
+                                  }
+                                  forwardedRef={[Function]}
+                                  fullWidth={false}
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  size="medium"
+                                >
+                                  <button
+                                    aria-describedby="random-id-2"
+                                    aria-expanded={true}
+                                    aria-haspopup={true}
+                                    className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
+                                    disabled={false}
+                                    onBlur={[Function]}
+                                    onFocus={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                    size="medium"
+                                  >
+                                    Hover me
+                                  </button>
+                                </StyledComponent>
+                              </Button__WrapperButton>
+                            </ForwardRef>
+                          </InnerReference>
+                        </Reference>
+                        <Popper
+                          placement="bottom"
+                        >
+                          <InnerPopper
+                            eventsEnabled={true}
+                            placement="bottom"
+                            positionFixed={false}
+                            referenceElement={
+                              <button
+                                aria-describedby="random-id-2"
+                                aria-expanded="true"
+                                aria-haspopup="true"
+                                class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
+                              >
+                                Hover me
+                              </button>
+                            }
+                          >
+                            <Styled(Box)
+                              id="random-id-2"
+                              maxWidth="24em"
+                              onBlur={[Function]}
+                              onFocus={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                              open={true}
+                              position={
+                                Object {
+                                  "left": 0,
+                                  "opacity": 0,
+                                  "pointerEvents": "none",
+                                  "position": "absolute",
+                                  "top": 0,
+                                }
+                              }
+                              role="tooltip"
+                              theme={
+                                Object {
+                                  "borders": Array [],
+                                  "breakpoints": Object {
+                                    "extraLarge": "1920px",
+                                    "extraSmall": "0px",
+                                    "large": "1360px",
+                                    "medium": "1024px",
+                                    "small": "768px",
+                                  },
+                                  "colors": Object {
+                                    "black": "#011e38",
+                                    "blackBlue": "#122b47",
+                                    "blue": "#216beb",
+                                    "darkBlue": "#00438f",
+                                    "darkGrey": "#434d59",
+                                    "green": "#008059",
+                                    "grey": "#c0c8d1",
+                                    "lightBlue": "#e1ebfa",
+                                    "lightGreen": "#e9f7f2",
+                                    "lightGrey": "#e4e7eb",
+                                    "lightRed": "#fae6ea",
+                                    "lightYellow": "#fcf5e3",
+                                    "red": "#cc1439",
+                                    "white": "#ffffff",
+                                    "whiteGrey": "#f0f2f5",
+                                    "yellow": "#ffbb00",
+                                  },
+                                  "fontSizes": Object {
+                                    "large": "20px",
+                                    "larger": "26px",
+                                    "largest": "46px",
+                                    "medium": "16px",
+                                    "small": "14px",
+                                    "smaller": "12px",
+                                  },
+                                  "fontWeights": Object {
+                                    "bold": "600",
+                                    "light": "300",
+                                    "medium": "500",
+                                    "normal": "400",
+                                  },
+                                  "fonts": Object {
+                                    "base": "'IBM Plex Sans', sans-serif",
+                                    "mono": "'IBM Plex Mono', monospace",
+                                  },
+                                  "lineHeights": Object {
+                                    "base": "1.5",
+                                    "sectionTitle": "1.23076923",
+                                    "smallTextBase": "1.71428571",
+                                    "smallTextCompressed": "1.14285714",
+                                    "smallerText": "1.33333333",
+                                    "subsectionTitle": "1.2",
+                                    "title": "1.04347826",
+                                  },
+                                  "radii": Object {
+                                    "circle": "50%",
+                                    "medium": "4px",
+                                    "small": "2px",
+                                  },
+                                  "shadows": Object {
+                                    "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                    "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                    "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                    "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                    "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                  },
+                                  "space": Object {
+                                    "half": "4px",
+                                    "none": "0px",
+                                    "x1": "8px",
+                                    "x2": "16px",
+                                    "x3": "24px",
+                                    "x4": "32px",
+                                    "x5": "40px",
+                                    "x6": "48px",
+                                    "x8": "64px",
+                                  },
+                                  "zIndex": Object {
+                                    "content": 100,
+                                    "overlay": 1000,
+                                    "tabsBar": 210,
+                                    "tabsScollIndicator": 200,
+                                  },
+                                }
+                              }
+                            >
+                              <StyledComponent
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "_foldedDefaultProps": Object {
+                                      "theme": Object {
+                                        "borders": Array [],
+                                        "breakpoints": Object {
+                                          "extraLarge": "1920px",
+                                          "extraSmall": "0px",
+                                          "large": "1360px",
+                                          "medium": "1024px",
+                                          "small": "768px",
+                                        },
+                                        "colors": Object {
+                                          "black": "#011e38",
+                                          "blackBlue": "#122b47",
+                                          "blue": "#216beb",
+                                          "darkBlue": "#00438f",
+                                          "darkGrey": "#434d59",
+                                          "green": "#008059",
+                                          "grey": "#c0c8d1",
+                                          "lightBlue": "#e1ebfa",
+                                          "lightGreen": "#e9f7f2",
+                                          "lightGrey": "#e4e7eb",
+                                          "lightRed": "#fae6ea",
+                                          "lightYellow": "#fcf5e3",
+                                          "red": "#cc1439",
+                                          "white": "#ffffff",
+                                          "whiteGrey": "#f0f2f5",
+                                          "yellow": "#ffbb00",
+                                        },
+                                        "fontSizes": Object {
+                                          "large": "20px",
+                                          "larger": "26px",
+                                          "largest": "46px",
+                                          "medium": "16px",
+                                          "small": "14px",
+                                          "smaller": "12px",
+                                        },
+                                        "fontWeights": Object {
+                                          "bold": "600",
+                                          "light": "300",
+                                          "medium": "500",
+                                          "normal": "400",
+                                        },
+                                        "fonts": Object {
+                                          "base": "'IBM Plex Sans', sans-serif",
+                                          "mono": "'IBM Plex Mono', monospace",
+                                        },
+                                        "lineHeights": Object {
+                                          "base": "1.5",
+                                          "sectionTitle": "1.23076923",
+                                          "smallTextBase": "1.71428571",
+                                          "smallTextCompressed": "1.14285714",
+                                          "smallerText": "1.33333333",
+                                          "subsectionTitle": "1.2",
+                                          "title": "1.04347826",
+                                        },
+                                        "radii": Object {
+                                          "circle": "50%",
+                                          "medium": "4px",
+                                          "small": "2px",
+                                        },
+                                        "shadows": Object {
+                                          "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                          "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                          "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                          "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                          "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                        },
+                                        "space": Object {
+                                          "half": "4px",
+                                          "none": "0px",
+                                          "x1": "8px",
+                                          "x2": "16px",
+                                          "x3": "24px",
+                                          "x4": "32px",
+                                          "x5": "40px",
+                                          "x6": "48px",
+                                          "x8": "64px",
+                                        },
+                                        "zIndex": Object {
+                                          "content": 100,
+                                          "overlay": 1000,
+                                          "tabsBar": 210,
+                                          "tabsScollIndicator": 200,
+                                        },
+                                      },
+                                    },
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "sc-jWBwVP",
+                                      "isStatic": false,
+                                      "lastClassName": "gCXFcy",
+                                      "rules": Array [
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        "color: #011e38;",
+                                        "display: flex;",
+                                        "flex-direction: column;",
+                                        "font-size: 14px;",
+                                        "background-color: #ffffff;",
+                                        "border-radius: 4px;",
+                                        "border: 1px solid #c0c8d1;",
+                                        "box-shadow: 0 2px 4px rgba(0, 0, 0, 0.18);",
+                                        "padding: 8px;",
+                                        "transition: opacity 0.3s;",
+                                        "z-index: 100;",
+                                        [Function],
+                                      ],
+                                    },
+                                    "displayName": "Styled(Box)",
+                                    "foldedComponentIds": Array [
+                                      "Box-sc-1qu1edy-0",
+                                    ],
+                                    "propTypes": Object {
+                                      "bg": [Function],
+                                      "border": [Function],
+                                      "borderBottom": [Function],
+                                      "borderLeft": [Function],
+                                      "borderRadius": [Function],
+                                      "borderRight": [Function],
+                                      "borderTop": [Function],
+                                      "boxShadow": [Function],
+                                      "color": [Function],
+                                      "display": [Function],
+                                      "flexGrow": [Function],
+                                      "height": [Function],
+                                      "m": [Function],
+                                      "maxHeight": [Function],
+                                      "maxWidth": [Function],
+                                      "mb": [Function],
+                                      "minHeight": [Function],
+                                      "minWidth": [Function],
+                                      "ml": [Function],
+                                      "mr": [Function],
+                                      "mt": [Function],
+                                      "mx": [Function],
+                                      "my": [Function],
+                                      "order": [Function],
+                                      "p": [Function],
+                                      "pb": [Function],
+                                      "pl": [Function],
+                                      "position": [Function],
+                                      "pr": [Function],
+                                      "pt": [Function],
+                                      "px": [Function],
+                                      "py": [Function],
+                                      "textAlign": [Function],
+                                      "width": [Function],
+                                    },
+                                    "render": [Function],
+                                    "styledComponentId": "sc-jWBwVP",
+                                    "target": "div",
+                                    "toString": [Function],
+                                    "usesTheme": false,
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={[Function]}
+                                id="random-id-2"
+                                maxWidth="24em"
+                                onBlur={[Function]}
+                                onFocus={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                open={true}
+                                position={
+                                  Object {
+                                    "left": 0,
+                                    "opacity": 0,
+                                    "pointerEvents": "none",
+                                    "position": "absolute",
+                                    "top": 0,
+                                  }
+                                }
+                                role="tooltip"
+                                theme={
+                                  Object {
+                                    "borders": Array [],
+                                    "breakpoints": Object {
+                                      "extraLarge": "1920px",
+                                      "extraSmall": "0px",
+                                      "large": "1360px",
+                                      "medium": "1024px",
+                                      "small": "768px",
+                                    },
+                                    "colors": Object {
+                                      "black": "#011e38",
+                                      "blackBlue": "#122b47",
+                                      "blue": "#216beb",
+                                      "darkBlue": "#00438f",
+                                      "darkGrey": "#434d59",
+                                      "green": "#008059",
+                                      "grey": "#c0c8d1",
+                                      "lightBlue": "#e1ebfa",
+                                      "lightGreen": "#e9f7f2",
+                                      "lightGrey": "#e4e7eb",
+                                      "lightRed": "#fae6ea",
+                                      "lightYellow": "#fcf5e3",
+                                      "red": "#cc1439",
+                                      "white": "#ffffff",
+                                      "whiteGrey": "#f0f2f5",
+                                      "yellow": "#ffbb00",
+                                    },
+                                    "fontSizes": Object {
+                                      "large": "20px",
+                                      "larger": "26px",
+                                      "largest": "46px",
+                                      "medium": "16px",
+                                      "small": "14px",
+                                      "smaller": "12px",
+                                    },
+                                    "fontWeights": Object {
+                                      "bold": "600",
+                                      "light": "300",
+                                      "medium": "500",
+                                      "normal": "400",
+                                    },
+                                    "fonts": Object {
+                                      "base": "'IBM Plex Sans', sans-serif",
+                                      "mono": "'IBM Plex Mono', monospace",
+                                    },
+                                    "lineHeights": Object {
+                                      "base": "1.5",
+                                      "sectionTitle": "1.23076923",
+                                      "smallTextBase": "1.71428571",
+                                      "smallTextCompressed": "1.14285714",
+                                      "smallerText": "1.33333333",
+                                      "subsectionTitle": "1.2",
+                                      "title": "1.04347826",
+                                    },
+                                    "radii": Object {
+                                      "circle": "50%",
+                                      "medium": "4px",
+                                      "small": "2px",
+                                    },
+                                    "shadows": Object {
+                                      "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                      "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                      "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                      "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                      "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                    },
+                                    "space": Object {
+                                      "half": "4px",
+                                      "none": "0px",
+                                      "x1": "8px",
+                                      "x2": "16px",
+                                      "x3": "24px",
+                                      "x4": "32px",
+                                      "x5": "40px",
+                                      "x6": "48px",
+                                      "x8": "64px",
+                                    },
+                                    "zIndex": Object {
+                                      "content": 100,
+                                      "overlay": 1000,
+                                      "tabsBar": 210,
+                                      "tabsScollIndicator": 200,
+                                    },
+                                  }
+                                }
+                              >
+                                <div
+                                  className="Box-sc-1qu1edy-0 sc-jWBwVP gCXFcy"
+                                  id="random-id-2"
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  open={true}
+                                  role="tooltip"
+                                >
+                                  I am an open Tooltip!
+                                  <PopperArrow
+                                    backgroundColor="white"
+                                    borderColor="grey"
+                                    placement="bottom"
+                                    style={Object {}}
+                                  >
+                                    <StyledComponent
+                                      backgroundColor="white"
+                                      borderColor="grey"
+                                      forwardedComponent={
+                                        Object {
+                                          "$$typeof": Symbol(react.forward_ref),
+                                          "_foldedDefaultProps": Object {
+                                            "backgroundColor": "white",
+                                            "borderColor": "grey",
+                                            "placement": "bottom",
+                                          },
+                                          "attrs": Array [],
+                                          "componentStyle": ComponentStyle {
+                                            "componentId": "PopperArrow-sc-1bcgj4w-0",
+                                            "isStatic": false,
+                                            "lastClassName": "bBzGzE",
+                                            "rules": Array [
+                                              "position: absolute;",
+                                              "height: 8px;",
+                                              "width: 8px;",
+                                              "margin: 12px;",
+                                              "&:before {",
+                                              "border-style: solid;",
+                                              "content: '';",
+                                              "display: block;",
+                                              "height: 0;",
+                                              "margin: auto;",
+                                              "position: absolute;",
+                                              "width: 0;",
+                                              "}",
+                                              "&:after {",
+                                              "border-style: solid;",
+                                              "content: '';",
+                                              "display: block;",
+                                              "height: 0;",
+                                              "margin: auto;",
+                                              "position: absolute;",
+                                              "width: 0;",
+                                              "}",
+                                              [Function],
+                                              [Function],
+                                            ],
+                                          },
+                                          "displayName": "PopperArrow",
+                                          "foldedComponentIds": Array [],
+                                          "propTypes": Object {
+                                            "backgroundColor": [Function],
+                                            "borderColor": [Function],
+                                            "placement": [Function],
+                                          },
+                                          "render": [Function],
+                                          "styledComponentId": "PopperArrow-sc-1bcgj4w-0",
+                                          "target": "div",
+                                          "toString": [Function],
+                                          "usesTheme": false,
+                                          "warnTooManyClasses": [Function],
+                                          "withComponent": [Function],
                                         }
-                                        role="tooltip"
-                                        theme={
-                                          Object {
-                                            "borders": Array [],
-                                            "breakpoints": Object {
-                                              "extraLarge": "1920px",
-                                              "extraSmall": "0px",
-                                              "large": "1360px",
-                                              "medium": "1024px",
-                                              "small": "768px",
-                                            },
-                                            "colors": Object {
-                                              "black": "#011e38",
-                                              "blackBlue": "#122b47",
-                                              "blue": "#216beb",
-                                              "darkBlue": "#00438f",
-                                              "darkGrey": "#434d59",
-                                              "green": "#008059",
-                                              "grey": "#c0c8d1",
-                                              "lightBlue": "#e1ebfa",
-                                              "lightGreen": "#e9f7f2",
-                                              "lightGrey": "#e4e7eb",
-                                              "lightRed": "#fae6ea",
-                                              "lightYellow": "#fcf5e3",
-                                              "red": "#cc1439",
-                                              "white": "#ffffff",
-                                              "whiteGrey": "#f0f2f5",
-                                              "yellow": "#ffbb00",
-                                            },
-                                            "fontSizes": Object {
-                                              "large": "20px",
-                                              "larger": "26px",
-                                              "largest": "46px",
-                                              "medium": "16px",
-                                              "small": "14px",
-                                              "smaller": "12px",
-                                            },
-                                            "fontWeights": Object {
-                                              "bold": "600",
-                                              "light": "300",
-                                              "medium": "500",
-                                              "normal": "400",
-                                            },
-                                            "fonts": Object {
-                                              "base": "'IBM Plex Sans', sans-serif",
-                                              "mono": "'IBM Plex Mono', monospace",
-                                            },
-                                            "lineHeights": Object {
-                                              "base": "1.5",
-                                              "sectionTitle": "1.23076923",
-                                              "smallTextBase": "1.71428571",
-                                              "smallTextCompressed": "1.14285714",
-                                              "smallerText": "1.33333333",
-                                              "subsectionTitle": "1.2",
-                                              "title": "1.04347826",
-                                            },
-                                            "radii": Object {
-                                              "circle": "50%",
-                                              "medium": "4px",
-                                              "small": "2px",
-                                            },
-                                            "shadows": Object {
-                                              "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                              "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                              "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                              "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                              "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                                            },
-                                            "space": Object {
-                                              "half": "4px",
-                                              "none": "0px",
-                                              "x1": "8px",
-                                              "x2": "16px",
-                                              "x3": "24px",
-                                              "x4": "32px",
-                                              "x5": "40px",
-                                              "x6": "48px",
-                                              "x8": "64px",
-                                            },
-                                            "zIndex": Object {
-                                              "content": 100,
-                                              "overlay": 1000,
-                                              "tabsBar": 210,
-                                              "tabsScollIndicator": 200,
-                                            },
-                                          }
-                                        }
-                                      >
-                                        <StyledComponent
-                                          forwardedComponent={
-                                            Object {
-                                              "$$typeof": Symbol(react.forward_ref),
-                                              "_foldedDefaultProps": Object {
-                                                "theme": Object {
-                                                  "borders": Array [],
-                                                  "breakpoints": Object {
-                                                    "extraLarge": "1920px",
-                                                    "extraSmall": "0px",
-                                                    "large": "1360px",
-                                                    "medium": "1024px",
-                                                    "small": "768px",
-                                                  },
-                                                  "colors": Object {
-                                                    "black": "#011e38",
-                                                    "blackBlue": "#122b47",
-                                                    "blue": "#216beb",
-                                                    "darkBlue": "#00438f",
-                                                    "darkGrey": "#434d59",
-                                                    "green": "#008059",
-                                                    "grey": "#c0c8d1",
-                                                    "lightBlue": "#e1ebfa",
-                                                    "lightGreen": "#e9f7f2",
-                                                    "lightGrey": "#e4e7eb",
-                                                    "lightRed": "#fae6ea",
-                                                    "lightYellow": "#fcf5e3",
-                                                    "red": "#cc1439",
-                                                    "white": "#ffffff",
-                                                    "whiteGrey": "#f0f2f5",
-                                                    "yellow": "#ffbb00",
-                                                  },
-                                                  "fontSizes": Object {
-                                                    "large": "20px",
-                                                    "larger": "26px",
-                                                    "largest": "46px",
-                                                    "medium": "16px",
-                                                    "small": "14px",
-                                                    "smaller": "12px",
-                                                  },
-                                                  "fontWeights": Object {
-                                                    "bold": "600",
-                                                    "light": "300",
-                                                    "medium": "500",
-                                                    "normal": "400",
-                                                  },
-                                                  "fonts": Object {
-                                                    "base": "'IBM Plex Sans', sans-serif",
-                                                    "mono": "'IBM Plex Mono', monospace",
-                                                  },
-                                                  "lineHeights": Object {
-                                                    "base": "1.5",
-                                                    "sectionTitle": "1.23076923",
-                                                    "smallTextBase": "1.71428571",
-                                                    "smallTextCompressed": "1.14285714",
-                                                    "smallerText": "1.33333333",
-                                                    "subsectionTitle": "1.2",
-                                                    "title": "1.04347826",
-                                                  },
-                                                  "radii": Object {
-                                                    "circle": "50%",
-                                                    "medium": "4px",
-                                                    "small": "2px",
-                                                  },
-                                                  "shadows": Object {
-                                                    "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                                    "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                                    "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                                    "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                                    "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                                                  },
-                                                  "space": Object {
-                                                    "half": "4px",
-                                                    "none": "0px",
-                                                    "x1": "8px",
-                                                    "x2": "16px",
-                                                    "x3": "24px",
-                                                    "x4": "32px",
-                                                    "x5": "40px",
-                                                    "x6": "48px",
-                                                    "x8": "64px",
-                                                  },
-                                                  "zIndex": Object {
-                                                    "content": 100,
-                                                    "overlay": 1000,
-                                                    "tabsBar": 210,
-                                                    "tabsScollIndicator": 200,
-                                                  },
-                                                },
-                                              },
-                                              "attrs": Array [],
-                                              "componentStyle": ComponentStyle {
-                                                "componentId": "sc-jWBwVP",
-                                                "isStatic": false,
-                                                "lastClassName": "hjigbL",
-                                                "rules": Array [
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  "color: #011e38;",
-                                                  "display: flex;",
-                                                  "flex-direction: column;",
-                                                  "font-size: 14px;",
-                                                  "background-color: #ffffff;",
-                                                  "border-radius: 4px;",
-                                                  "border: 1px solid #c0c8d1;",
-                                                  "box-shadow: 0 2px 4px rgba(0, 0, 0, 0.18);",
-                                                  "padding: 8px;",
-                                                  "transition: opacity 0.3s;",
-                                                  "z-index: 100;",
-                                                  [Function],
-                                                ],
-                                              },
-                                              "displayName": "Styled(Box)",
-                                              "foldedComponentIds": Array [
-                                                "Box-sc-1qu1edy-0",
-                                              ],
-                                              "propTypes": Object {
-                                                "bg": [Function],
-                                                "border": [Function],
-                                                "borderBottom": [Function],
-                                                "borderLeft": [Function],
-                                                "borderRadius": [Function],
-                                                "borderRight": [Function],
-                                                "borderTop": [Function],
-                                                "boxShadow": [Function],
-                                                "color": [Function],
-                                                "display": [Function],
-                                                "flexGrow": [Function],
-                                                "height": [Function],
-                                                "m": [Function],
-                                                "maxHeight": [Function],
-                                                "maxWidth": [Function],
-                                                "mb": [Function],
-                                                "minHeight": [Function],
-                                                "minWidth": [Function],
-                                                "ml": [Function],
-                                                "mr": [Function],
-                                                "mt": [Function],
-                                                "mx": [Function],
-                                                "my": [Function],
-                                                "order": [Function],
-                                                "p": [Function],
-                                                "pb": [Function],
-                                                "pl": [Function],
-                                                "position": [Function],
-                                                "pr": [Function],
-                                                "pt": [Function],
-                                                "px": [Function],
-                                                "py": [Function],
-                                                "textAlign": [Function],
-                                                "width": [Function],
-                                              },
-                                              "render": [Function],
-                                              "styledComponentId": "sc-jWBwVP",
-                                              "target": "div",
-                                              "toString": [Function],
-                                              "usesTheme": false,
-                                              "warnTooManyClasses": [Function],
-                                              "withComponent": [Function],
-                                            }
-                                          }
-                                          forwardedRef={[Function]}
-                                          id="random-id-1"
-                                          maxWidth="24em"
-                                          onBlur={[Function]}
-                                          onFocus={[Function]}
-                                          onMouseEnter={[Function]}
-                                          onMouseLeave={[Function]}
-                                          open={false}
-                                          position={
-                                            Object {
-                                              "left": 0,
-                                              "opacity": 0,
-                                              "pointerEvents": "none",
-                                              "position": "absolute",
-                                              "top": 0,
-                                            }
-                                          }
-                                          role="tooltip"
-                                          theme={
-                                            Object {
-                                              "borders": Array [],
-                                              "breakpoints": Object {
-                                                "extraLarge": "1920px",
-                                                "extraSmall": "0px",
-                                                "large": "1360px",
-                                                "medium": "1024px",
-                                                "small": "768px",
-                                              },
-                                              "colors": Object {
-                                                "black": "#011e38",
-                                                "blackBlue": "#122b47",
-                                                "blue": "#216beb",
-                                                "darkBlue": "#00438f",
-                                                "darkGrey": "#434d59",
-                                                "green": "#008059",
-                                                "grey": "#c0c8d1",
-                                                "lightBlue": "#e1ebfa",
-                                                "lightGreen": "#e9f7f2",
-                                                "lightGrey": "#e4e7eb",
-                                                "lightRed": "#fae6ea",
-                                                "lightYellow": "#fcf5e3",
-                                                "red": "#cc1439",
-                                                "white": "#ffffff",
-                                                "whiteGrey": "#f0f2f5",
-                                                "yellow": "#ffbb00",
-                                              },
-                                              "fontSizes": Object {
-                                                "large": "20px",
-                                                "larger": "26px",
-                                                "largest": "46px",
-                                                "medium": "16px",
-                                                "small": "14px",
-                                                "smaller": "12px",
-                                              },
-                                              "fontWeights": Object {
-                                                "bold": "600",
-                                                "light": "300",
-                                                "medium": "500",
-                                                "normal": "400",
-                                              },
-                                              "fonts": Object {
-                                                "base": "'IBM Plex Sans', sans-serif",
-                                                "mono": "'IBM Plex Mono', monospace",
-                                              },
-                                              "lineHeights": Object {
-                                                "base": "1.5",
-                                                "sectionTitle": "1.23076923",
-                                                "smallTextBase": "1.71428571",
-                                                "smallTextCompressed": "1.14285714",
-                                                "smallerText": "1.33333333",
-                                                "subsectionTitle": "1.2",
-                                                "title": "1.04347826",
-                                              },
-                                              "radii": Object {
-                                                "circle": "50%",
-                                                "medium": "4px",
-                                                "small": "2px",
-                                              },
-                                              "shadows": Object {
-                                                "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                                "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                                "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                                "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                                "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                                              },
-                                              "space": Object {
-                                                "half": "4px",
-                                                "none": "0px",
-                                                "x1": "8px",
-                                                "x2": "16px",
-                                                "x3": "24px",
-                                                "x4": "32px",
-                                                "x5": "40px",
-                                                "x6": "48px",
-                                                "x8": "64px",
-                                              },
-                                              "zIndex": Object {
-                                                "content": 100,
-                                                "overlay": 1000,
-                                                "tabsBar": 210,
-                                                "tabsScollIndicator": 200,
-                                              },
-                                            }
-                                          }
-                                        >
-                                          <div
-                                            className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
-                                            id="random-id-1"
-                                            onBlur={[Function]}
-                                            onFocus={[Function]}
-                                            onMouseEnter={[Function]}
-                                            onMouseLeave={[Function]}
-                                            open={false}
-                                            role="tooltip"
-                                          >
-                                            I am a Tooltip!
-                                            <PopperArrow
-                                              backgroundColor="white"
-                                              borderColor="grey"
-                                              placement="bottom"
-                                              style={Object {}}
-                                            >
-                                              <StyledComponent
-                                                backgroundColor="white"
-                                                borderColor="grey"
-                                                forwardedComponent={
-                                                  Object {
-                                                    "$$typeof": Symbol(react.forward_ref),
-                                                    "_foldedDefaultProps": Object {
-                                                      "backgroundColor": "white",
-                                                      "borderColor": "grey",
-                                                      "placement": "bottom",
-                                                    },
-                                                    "attrs": Array [],
-                                                    "componentStyle": ComponentStyle {
-                                                      "componentId": "PopperArrow-sc-1bcgj4w-0",
-                                                      "isStatic": false,
-                                                      "lastClassName": "bBzGzE",
-                                                      "rules": Array [
-                                                        "position: absolute;",
-                                                        "height: 8px;",
-                                                        "width: 8px;",
-                                                        "margin: 12px;",
-                                                        "&:before {",
-                                                        "border-style: solid;",
-                                                        "content: '';",
-                                                        "display: block;",
-                                                        "height: 0;",
-                                                        "margin: auto;",
-                                                        "position: absolute;",
-                                                        "width: 0;",
-                                                        "}",
-                                                        "&:after {",
-                                                        "border-style: solid;",
-                                                        "content: '';",
-                                                        "display: block;",
-                                                        "height: 0;",
-                                                        "margin: auto;",
-                                                        "position: absolute;",
-                                                        "width: 0;",
-                                                        "}",
-                                                        [Function],
-                                                        [Function],
-                                                      ],
-                                                    },
-                                                    "displayName": "PopperArrow",
-                                                    "foldedComponentIds": Array [],
-                                                    "propTypes": Object {
-                                                      "backgroundColor": [Function],
-                                                      "borderColor": [Function],
-                                                      "placement": [Function],
-                                                    },
-                                                    "render": [Function],
-                                                    "styledComponentId": "PopperArrow-sc-1bcgj4w-0",
-                                                    "target": "div",
-                                                    "toString": [Function],
-                                                    "usesTheme": false,
-                                                    "warnTooManyClasses": [Function],
-                                                    "withComponent": [Function],
-                                                  }
-                                                }
-                                                forwardedRef={[Function]}
-                                                placement="bottom"
-                                                style={Object {}}
-                                              >
-                                                <div
-                                                  className="PopperArrow-sc-1bcgj4w-0 bBzGzE"
-                                                  style={Object {}}
-                                                />
-                                              </StyledComponent>
-                                            </PopperArrow>
-                                          </div>
-                                        </StyledComponent>
-                                      </Styled(Box)>
-                                    </InnerPopper>
-                                  </Popper>
-                                </Manager>
-                              </StatelessTooltip>
-                            </MenuState>
-                          </MenuComponent>
-                        </WithGeneratedId>
-                      </Component>
-                    </ThemeProvider>
-                  </div>
-                </StyledComponent>
-              </NDSProvider__GlobalStyles>
-            </NDSProvider>
+                                      }
+                                      forwardedRef={[Function]}
+                                      placement="bottom"
+                                      style={Object {}}
+                                    >
+                                      <div
+                                        className="PopperArrow-sc-1bcgj4w-0 bBzGzE"
+                                        style={Object {}}
+                                      />
+                                    </StyledComponent>
+                                  </PopperArrow>
+                                </div>
+                              </StyledComponent>
+                            </Styled(Box)>
+                          </InnerPopper>
+                        </Popper>
+                        <DetectOutsideClick
+                          clickRef={
+                            Array [
+                              undefined,
+                              undefined,
+                            ]
+                          }
+                          onClick={[Function]}
+                        />
+                      </Manager>
+                    </StatelessTooltip>
+                  </MenuState>
+                </MenuComponent>
+              </WithGeneratedId>
+            </Component>
           </ThemeProvider>
         </div>
       </StyledComponent>

--- a/components/src/Tooltip/Tooltip.js
+++ b/components/src/Tooltip/Tooltip.js
@@ -181,12 +181,14 @@ const Tooltip = withMenuState(StatelessTooltip);
 
 Tooltip.propTypes = {
   showDelay: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  hideDelay: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  hideDelay: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  defaultOpen: PropTypes.boolean
 };
 
 Tooltip.defaultProps = {
   showDelay: "100",
-  hideDelay: "350"
+  hideDelay: "350",
+  defaultOpen: false
 };
 
 export default withGeneratedId(Tooltip);

--- a/components/src/Tooltip/Tooltip.js
+++ b/components/src/Tooltip/Tooltip.js
@@ -182,7 +182,7 @@ const Tooltip = withMenuState(StatelessTooltip);
 Tooltip.propTypes = {
   showDelay: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   hideDelay: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  defaultOpen: PropTypes.boolean
+  defaultOpen: PropTypes.bool
 };
 
 Tooltip.defaultProps = {

--- a/components/src/Tooltip/Tooltip.story.js
+++ b/components/src/Tooltip/Tooltip.story.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
 import { Button, Box, Link, Flex, Text, Tooltip } from "../index";
 
 storiesOf("Tooltip", module)
@@ -121,4 +122,9 @@ storiesOf("Tooltip", module)
         <Box bg="blue">Box</Box>
       </Tooltip>
     </>
+  ))
+  .add("open by default", () => (
+    <Tooltip placement="bottom" tooltip="Tooltip" defaultOpen>
+      <Button> Button </Button>
+    </Tooltip>
   ));

--- a/components/src/Tooltip/Tooltip.story.js
+++ b/components/src/Tooltip/Tooltip.story.js
@@ -16,6 +16,7 @@ storiesOf("Tooltip", module)
       <Tooltip
         placement="bottom"
         tooltip="I am a Tooltip! I have very long text, and my default max-width is 24em (based on 14px font-size), which is equal to 336px, or approximately 45 characters."
+        defaultOpen
       >
         <Button> Button </Button>
       </Tooltip>
@@ -27,6 +28,7 @@ storiesOf("Tooltip", module)
         placement="bottom"
         tooltip="I am a Tooltip! I have very long text, but I have a smaller maxWidth prop that causes me to wrap frequently."
         maxWidth="128px"
+        defaultOpen
       >
         <Button> Button </Button>
       </Tooltip>
@@ -35,46 +37,46 @@ storiesOf("Tooltip", module)
   .add("with placement", () => (
     <>
       <Flex my="x6" mx="x8" justifyContent="space-around">
-        <Tooltip placement="top-start" tooltip="top-start">
+        <Tooltip placement="top-start" tooltip="top-start" defaultOpen>
           <Button>Tooltip trigger</Button>
         </Tooltip>
-        <Tooltip placement="top" tooltip="top">
+        <Tooltip placement="top" tooltip="top" defaultOpen>
           <Button>Tooltip trigger</Button>
         </Tooltip>
-        <Tooltip placement="top-end" tooltip="top-end">
-          <Button>Tooltip trigger</Button>
-        </Tooltip>
-      </Flex>
-      <Flex my="x6" mx="x8" justifyContent="space-around">
-        <Tooltip placement="left-start" tooltip="left-start">
-          <Button>Tooltip trigger</Button>
-        </Tooltip>
-        <Tooltip placement="left" tooltip="left">
-          <Button>Tooltip trigger</Button>
-        </Tooltip>
-        <Tooltip placement="left-end" tooltip="left-end">
+        <Tooltip placement="top-end" tooltip="top-end" defaultOpen>
           <Button>Tooltip trigger</Button>
         </Tooltip>
       </Flex>
       <Flex my="x6" mx="x8" justifyContent="space-around">
-        <Tooltip placement="right-start" tooltip="right-start">
+        <Tooltip placement="left-start" tooltip="left-start" defaultOpen>
           <Button>Tooltip trigger</Button>
         </Tooltip>
-        <Tooltip placement="right" tooltip="right">
+        <Tooltip placement="left" tooltip="left" defaultOpen>
           <Button>Tooltip trigger</Button>
         </Tooltip>
-        <Tooltip placement="right-end" tooltip="right-end">
+        <Tooltip placement="left-end" tooltip="left-end" defaultOpen>
           <Button>Tooltip trigger</Button>
         </Tooltip>
       </Flex>
       <Flex my="x6" mx="x8" justifyContent="space-around">
-        <Tooltip placement="bottom-start" tooltip="bottom-start">
+        <Tooltip placement="right-start" tooltip="right-start" defaultOpen>
           <Button>Tooltip trigger</Button>
         </Tooltip>
-        <Tooltip placement="bottom" tooltip="bottom">
+        <Tooltip placement="right" tooltip="right" defaultOpen>
           <Button>Tooltip trigger</Button>
         </Tooltip>
-        <Tooltip placement="bottom-end" tooltip="bottom-end">
+        <Tooltip placement="right-end" tooltip="right-end" defaultOpen>
+          <Button>Tooltip trigger</Button>
+        </Tooltip>
+      </Flex>
+      <Flex my="x6" mx="x8" justifyContent="space-around">
+        <Tooltip placement="bottom-start" tooltip="bottom-start" defaultOpen>
+          <Button>Tooltip trigger</Button>
+        </Tooltip>
+        <Tooltip placement="bottom" tooltip="bottom" defaultOpen>
+          <Button>Tooltip trigger</Button>
+        </Tooltip>
+        <Tooltip placement="bottom-end" tooltip="bottom-end" defaultOpen>
           <Button>Tooltip trigger</Button>
         </Tooltip>
       </Flex>

--- a/components/src/Tooltip/Tooltip.story.js
+++ b/components/src/Tooltip/Tooltip.story.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { action } from "@storybook/addon-actions";
 import { Button, Box, Link, Flex, Text, Tooltip } from "../index";
 
 storiesOf("Tooltip", module)

--- a/components/src/Tooltip/__snapshots__/Tooltip.story.storyshot
+++ b/components/src/Tooltip/__snapshots__/Tooltip.story.storyshot
@@ -714,8 +714,9 @@ exports[`Storyshots Tooltip Tooltip 1`] = `
                   >
                     <WithGeneratedId>
                       <MenuComponent
+                        defaultOpen={false}
                         hideDelay="350"
-                        id="random-id-2"
+                        id="random-id-3"
                         placement="bottom"
                         showDelay="100"
                         tooltip="I am a Tooltip!"
@@ -726,7 +727,7 @@ exports[`Storyshots Tooltip Tooltip 1`] = `
                           showDelay="100"
                         >
                           <StatelessTooltip
-                            id="random-id-2"
+                            id="random-id-3"
                             maxWidth="24em"
                             menuState={
                               Object {
@@ -746,7 +747,7 @@ exports[`Storyshots Tooltip Tooltip 1`] = `
                                   setReferenceNode={[Function]}
                                 >
                                   <ForwardRef
-                                    aria-describedby="random-id-2"
+                                    aria-describedby="random-id-3"
                                     aria-expanded={false}
                                     aria-haspopup={true}
                                     asLink={false}
@@ -761,7 +762,7 @@ exports[`Storyshots Tooltip Tooltip 1`] = `
                                     size="medium"
                                   >
                                     <Button__WrapperButton
-                                      aria-describedby="random-id-2"
+                                      aria-describedby="random-id-3"
                                       aria-expanded={false}
                                       aria-haspopup={true}
                                       disabled={false}
@@ -773,7 +774,7 @@ exports[`Storyshots Tooltip Tooltip 1`] = `
                                       size="medium"
                                     >
                                       <StyledComponent
-                                        aria-describedby="random-id-2"
+                                        aria-describedby="random-id-3"
                                         aria-expanded={false}
                                         aria-haspopup={true}
                                         disabled={false}
@@ -812,7 +813,7 @@ exports[`Storyshots Tooltip Tooltip 1`] = `
                                         size="medium"
                                       >
                                         <button
-                                          aria-describedby="random-id-2"
+                                          aria-describedby="random-id-3"
                                           aria-expanded={false}
                                           aria-haspopup={true}
                                           className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
@@ -839,7 +840,7 @@ exports[`Storyshots Tooltip Tooltip 1`] = `
                                   positionFixed={false}
                                   referenceElement={
                                     <button
-                                      aria-describedby="random-id-2"
+                                      aria-describedby="random-id-3"
                                       aria-expanded="false"
                                       aria-haspopup="true"
                                       class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
@@ -849,7 +850,7 @@ exports[`Storyshots Tooltip Tooltip 1`] = `
                                   }
                                 >
                                   <Styled(Box)
-                                    id="random-id-2"
+                                    id="random-id-3"
                                     maxWidth="24em"
                                     onBlur={[Function]}
                                     onFocus={[Function]}
@@ -1130,7 +1131,7 @@ exports[`Storyshots Tooltip Tooltip 1`] = `
                                         }
                                       }
                                       forwardedRef={[Function]}
-                                      id="random-id-2"
+                                      id="random-id-3"
                                       maxWidth="24em"
                                       onBlur={[Function]}
                                       onFocus={[Function]}
@@ -1236,7 +1237,7 @@ exports[`Storyshots Tooltip Tooltip 1`] = `
                                     >
                                       <div
                                         className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
-                                        id="random-id-2"
+                                        id="random-id-3"
                                         onBlur={[Function]}
                                         onFocus={[Function]}
                                         onMouseEnter={[Function]}
@@ -1334,6 +1335,1036 @@ exports[`Storyshots Tooltip Tooltip 1`] = `
                 </div>
               </StyledComponent>
             </Styled(Box)>
+          </ThemeProvider>
+        </div>
+      </StyledComponent>
+    </NDSProvider__GlobalStyles>
+  </NDSProvider>
+</div>
+`;
+
+exports[`Storyshots Tooltip open by default 1`] = `
+<div
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
+>
+  <NDSProvider
+    theme={
+      Object {
+        "borders": Array [],
+        "breakpoints": Object {
+          "extraLarge": "1920px",
+          "extraSmall": "0px",
+          "large": "1360px",
+          "medium": "1024px",
+          "small": "768px",
+        },
+        "colors": Object {
+          "black": "#011e38",
+          "blackBlue": "#122b47",
+          "blue": "#216beb",
+          "darkBlue": "#00438f",
+          "darkGrey": "#434d59",
+          "green": "#008059",
+          "grey": "#c0c8d1",
+          "lightBlue": "#e1ebfa",
+          "lightGreen": "#e9f7f2",
+          "lightGrey": "#e4e7eb",
+          "lightRed": "#fae6ea",
+          "lightYellow": "#fcf5e3",
+          "red": "#cc1439",
+          "white": "#ffffff",
+          "whiteGrey": "#f0f2f5",
+          "yellow": "#ffbb00",
+        },
+        "fontSizes": Object {
+          "large": "20px",
+          "larger": "26px",
+          "largest": "46px",
+          "medium": "16px",
+          "small": "14px",
+          "smaller": "12px",
+        },
+        "fontWeights": Object {
+          "bold": "600",
+          "light": "300",
+          "medium": "500",
+          "normal": "400",
+        },
+        "fonts": Object {
+          "base": "'IBM Plex Sans', sans-serif",
+          "mono": "'IBM Plex Mono', monospace",
+        },
+        "lineHeights": Object {
+          "base": "1.5",
+          "sectionTitle": "1.23076923",
+          "smallTextBase": "1.71428571",
+          "smallTextCompressed": "1.14285714",
+          "smallerText": "1.33333333",
+          "subsectionTitle": "1.2",
+          "title": "1.04347826",
+        },
+        "radii": Object {
+          "circle": "50%",
+          "medium": "4px",
+          "small": "2px",
+        },
+        "shadows": Object {
+          "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+          "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+          "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+          "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+          "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+        },
+        "space": Object {
+          "half": "4px",
+          "none": "0px",
+          "x1": "8px",
+          "x2": "16px",
+          "x3": "24px",
+          "x4": "32px",
+          "x5": "40px",
+          "x6": "48px",
+          "x8": "64px",
+        },
+        "zIndex": Object {
+          "content": 100,
+          "overlay": 1000,
+          "tabsBar": 210,
+          "tabsScollIndicator": 200,
+        },
+      }
+    }
+  >
+    <GlobalStyleComponent />
+    <NDSProvider__GlobalStyles
+      theme={
+        Object {
+          "borders": Array [],
+          "breakpoints": Object {
+            "extraLarge": "1920px",
+            "extraSmall": "0px",
+            "large": "1360px",
+            "medium": "1024px",
+            "small": "768px",
+          },
+          "colors": Object {
+            "black": "#011e38",
+            "blackBlue": "#122b47",
+            "blue": "#216beb",
+            "darkBlue": "#00438f",
+            "darkGrey": "#434d59",
+            "green": "#008059",
+            "grey": "#c0c8d1",
+            "lightBlue": "#e1ebfa",
+            "lightGreen": "#e9f7f2",
+            "lightGrey": "#e4e7eb",
+            "lightRed": "#fae6ea",
+            "lightYellow": "#fcf5e3",
+            "red": "#cc1439",
+            "white": "#ffffff",
+            "whiteGrey": "#f0f2f5",
+            "yellow": "#ffbb00",
+          },
+          "fontSizes": Object {
+            "large": "20px",
+            "larger": "26px",
+            "largest": "46px",
+            "medium": "16px",
+            "small": "14px",
+            "smaller": "12px",
+          },
+          "fontWeights": Object {
+            "bold": "600",
+            "light": "300",
+            "medium": "500",
+            "normal": "400",
+          },
+          "fonts": Object {
+            "base": "'IBM Plex Sans', sans-serif",
+            "mono": "'IBM Plex Mono', monospace",
+          },
+          "lineHeights": Object {
+            "base": "1.5",
+            "sectionTitle": "1.23076923",
+            "smallTextBase": "1.71428571",
+            "smallTextCompressed": "1.14285714",
+            "smallerText": "1.33333333",
+            "subsectionTitle": "1.2",
+            "title": "1.04347826",
+          },
+          "radii": Object {
+            "circle": "50%",
+            "medium": "4px",
+            "small": "2px",
+          },
+          "shadows": Object {
+            "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+            "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+            "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+            "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+            "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+          },
+          "space": Object {
+            "half": "4px",
+            "none": "0px",
+            "x1": "8px",
+            "x2": "16px",
+            "x3": "24px",
+            "x4": "32px",
+            "x5": "40px",
+            "x6": "48px",
+            "x8": "64px",
+          },
+          "zIndex": Object {
+            "content": 100,
+            "overlay": 1000,
+            "tabsBar": 210,
+            "tabsScollIndicator": 200,
+          },
+        }
+      }
+    >
+      <StyledComponent
+        forwardedComponent={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "attrs": Array [],
+            "componentStyle": ComponentStyle {
+              "componentId": "NDSProvider__GlobalStyles-f28eoq-0",
+              "isStatic": false,
+              "lastClassName": "gWUgWA",
+              "rules": Array [
+                [Function],
+              ],
+            },
+            "displayName": "NDSProvider__GlobalStyles",
+            "foldedComponentIds": Array [],
+            "render": [Function],
+            "styledComponentId": "NDSProvider__GlobalStyles-f28eoq-0",
+            "target": "div",
+            "toString": [Function],
+            "usesTheme": false,
+            "warnTooManyClasses": [Function],
+            "withComponent": [Function],
+          }
+        }
+        forwardedRef={null}
+        theme={
+          Object {
+            "borders": Array [],
+            "breakpoints": Object {
+              "extraLarge": "1920px",
+              "extraSmall": "0px",
+              "large": "1360px",
+              "medium": "1024px",
+              "small": "768px",
+            },
+            "colors": Object {
+              "black": "#011e38",
+              "blackBlue": "#122b47",
+              "blue": "#216beb",
+              "darkBlue": "#00438f",
+              "darkGrey": "#434d59",
+              "green": "#008059",
+              "grey": "#c0c8d1",
+              "lightBlue": "#e1ebfa",
+              "lightGreen": "#e9f7f2",
+              "lightGrey": "#e4e7eb",
+              "lightRed": "#fae6ea",
+              "lightYellow": "#fcf5e3",
+              "red": "#cc1439",
+              "white": "#ffffff",
+              "whiteGrey": "#f0f2f5",
+              "yellow": "#ffbb00",
+            },
+            "fontSizes": Object {
+              "large": "20px",
+              "larger": "26px",
+              "largest": "46px",
+              "medium": "16px",
+              "small": "14px",
+              "smaller": "12px",
+            },
+            "fontWeights": Object {
+              "bold": "600",
+              "light": "300",
+              "medium": "500",
+              "normal": "400",
+            },
+            "fonts": Object {
+              "base": "'IBM Plex Sans', sans-serif",
+              "mono": "'IBM Plex Mono', monospace",
+            },
+            "lineHeights": Object {
+              "base": "1.5",
+              "sectionTitle": "1.23076923",
+              "smallTextBase": "1.71428571",
+              "smallTextCompressed": "1.14285714",
+              "smallerText": "1.33333333",
+              "subsectionTitle": "1.2",
+              "title": "1.04347826",
+            },
+            "radii": Object {
+              "circle": "50%",
+              "medium": "4px",
+              "small": "2px",
+            },
+            "shadows": Object {
+              "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+              "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+              "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+              "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+              "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+            },
+            "space": Object {
+              "half": "4px",
+              "none": "0px",
+              "x1": "8px",
+              "x2": "16px",
+              "x3": "24px",
+              "x4": "32px",
+              "x5": "40px",
+              "x6": "48px",
+              "x8": "64px",
+            },
+            "zIndex": Object {
+              "content": 100,
+              "overlay": 1000,
+              "tabsBar": 210,
+              "tabsScollIndicator": 200,
+            },
+          }
+        }
+      >
+        <div
+          className="NDSProvider__GlobalStyles-f28eoq-0 gWUgWA"
+        >
+          <ThemeProvider
+            theme={
+              Object {
+                "borders": Array [],
+                "breakpoints": Object {
+                  "extraLarge": "1920px",
+                  "extraSmall": "0px",
+                  "large": "1360px",
+                  "medium": "1024px",
+                  "small": "768px",
+                },
+                "colors": Object {
+                  "black": "#011e38",
+                  "blackBlue": "#122b47",
+                  "blue": "#216beb",
+                  "darkBlue": "#00438f",
+                  "darkGrey": "#434d59",
+                  "green": "#008059",
+                  "grey": "#c0c8d1",
+                  "lightBlue": "#e1ebfa",
+                  "lightGreen": "#e9f7f2",
+                  "lightGrey": "#e4e7eb",
+                  "lightRed": "#fae6ea",
+                  "lightYellow": "#fcf5e3",
+                  "red": "#cc1439",
+                  "white": "#ffffff",
+                  "whiteGrey": "#f0f2f5",
+                  "yellow": "#ffbb00",
+                },
+                "fontSizes": Object {
+                  "large": "20px",
+                  "larger": "26px",
+                  "largest": "46px",
+                  "medium": "16px",
+                  "small": "14px",
+                  "smaller": "12px",
+                },
+                "fontWeights": Object {
+                  "bold": "600",
+                  "light": "300",
+                  "medium": "500",
+                  "normal": "400",
+                },
+                "fonts": Object {
+                  "base": "'IBM Plex Sans', sans-serif",
+                  "mono": "'IBM Plex Mono', monospace",
+                },
+                "lineHeights": Object {
+                  "base": "1.5",
+                  "sectionTitle": "1.23076923",
+                  "smallTextBase": "1.71428571",
+                  "smallTextCompressed": "1.14285714",
+                  "smallerText": "1.33333333",
+                  "subsectionTitle": "1.2",
+                  "title": "1.04347826",
+                },
+                "radii": Object {
+                  "circle": "50%",
+                  "medium": "4px",
+                  "small": "2px",
+                },
+                "shadows": Object {
+                  "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                  "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                  "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                  "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                  "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                },
+                "space": Object {
+                  "half": "4px",
+                  "none": "0px",
+                  "x1": "8px",
+                  "x2": "16px",
+                  "x3": "24px",
+                  "x4": "32px",
+                  "x5": "40px",
+                  "x6": "48px",
+                  "x8": "64px",
+                },
+                "zIndex": Object {
+                  "content": 100,
+                  "overlay": 1000,
+                  "tabsBar": 210,
+                  "tabsScollIndicator": 200,
+                },
+              }
+            }
+          >
+            <Component
+              defaultOpen={true}
+              placement="bottom"
+              tooltip="Tooltip"
+            >
+              <WithGeneratedId>
+                <MenuComponent
+                  defaultOpen={true}
+                  hideDelay="350"
+                  id="random-id-27"
+                  placement="bottom"
+                  showDelay="100"
+                  tooltip="Tooltip"
+                >
+                  <MenuState
+                    defaultOpen={true}
+                    hideDelay="350"
+                    showDelay="100"
+                  >
+                    <StatelessTooltip
+                      id="random-id-27"
+                      maxWidth="24em"
+                      menuState={
+                        Object {
+                          "closeMenu": [Function],
+                          "handleMenuKeydown": [Function],
+                          "isOpen": true,
+                          "openMenu": [Function],
+                          "toggleMenu": [Function],
+                        }
+                      }
+                      placement="bottom"
+                      tooltip="Tooltip"
+                    >
+                      <Manager>
+                        <Reference>
+                          <InnerReference
+                            setReferenceNode={[Function]}
+                          >
+                            <ForwardRef
+                              aria-describedby="random-id-27"
+                              aria-expanded={true}
+                              aria-haspopup={true}
+                              asLink={false}
+                              disabled={false}
+                              fullWidth={false}
+                              icon={null}
+                              iconSide="right"
+                              onBlur={[Function]}
+                              onFocus={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                              size="medium"
+                            >
+                              <Button__WrapperButton
+                                aria-describedby="random-id-27"
+                                aria-expanded={true}
+                                aria-haspopup={true}
+                                disabled={false}
+                                fullWidth={false}
+                                onBlur={[Function]}
+                                onFocus={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                size="medium"
+                              >
+                                <StyledComponent
+                                  aria-describedby="random-id-27"
+                                  aria-expanded={true}
+                                  aria-haspopup={true}
+                                  disabled={false}
+                                  forwardedComponent={
+                                    Object {
+                                      "$$typeof": Symbol(react.forward_ref),
+                                      "attrs": Array [],
+                                      "componentStyle": ComponentStyle {
+                                        "componentId": "Button__WrapperButton-sc-1omxup2-0",
+                                        "isStatic": false,
+                                        "lastClassName": "idlBaC",
+                                        "rules": Array [
+                                          [Function],
+                                          [Function],
+                                          [Function],
+                                          [Function],
+                                        ],
+                                      },
+                                      "displayName": "Button__WrapperButton",
+                                      "foldedComponentIds": Array [],
+                                      "render": [Function],
+                                      "styledComponentId": "Button__WrapperButton-sc-1omxup2-0",
+                                      "target": "button",
+                                      "toString": [Function],
+                                      "usesTheme": false,
+                                      "warnTooManyClasses": [Function],
+                                      "withComponent": [Function],
+                                    }
+                                  }
+                                  forwardedRef={[Function]}
+                                  fullWidth={false}
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  size="medium"
+                                >
+                                  <button
+                                    aria-describedby="random-id-27"
+                                    aria-expanded={true}
+                                    aria-haspopup={true}
+                                    className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
+                                    disabled={false}
+                                    onBlur={[Function]}
+                                    onFocus={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                    size="medium"
+                                  >
+                                     Button 
+                                  </button>
+                                </StyledComponent>
+                              </Button__WrapperButton>
+                            </ForwardRef>
+                          </InnerReference>
+                        </Reference>
+                        <Popper
+                          placement="bottom"
+                        >
+                          <InnerPopper
+                            eventsEnabled={true}
+                            placement="bottom"
+                            positionFixed={false}
+                            referenceElement={
+                              <button
+                                aria-describedby="random-id-27"
+                                aria-expanded="true"
+                                aria-haspopup="true"
+                                class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
+                              >
+                                 Button 
+                              </button>
+                            }
+                          >
+                            <Styled(Box)
+                              id="random-id-27"
+                              maxWidth="24em"
+                              onBlur={[Function]}
+                              onFocus={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                              open={true}
+                              position={
+                                Object {
+                                  "left": 0,
+                                  "opacity": 0,
+                                  "pointerEvents": "none",
+                                  "position": "absolute",
+                                  "top": 0,
+                                }
+                              }
+                              role="tooltip"
+                              theme={
+                                Object {
+                                  "borders": Array [],
+                                  "breakpoints": Object {
+                                    "extraLarge": "1920px",
+                                    "extraSmall": "0px",
+                                    "large": "1360px",
+                                    "medium": "1024px",
+                                    "small": "768px",
+                                  },
+                                  "colors": Object {
+                                    "black": "#011e38",
+                                    "blackBlue": "#122b47",
+                                    "blue": "#216beb",
+                                    "darkBlue": "#00438f",
+                                    "darkGrey": "#434d59",
+                                    "green": "#008059",
+                                    "grey": "#c0c8d1",
+                                    "lightBlue": "#e1ebfa",
+                                    "lightGreen": "#e9f7f2",
+                                    "lightGrey": "#e4e7eb",
+                                    "lightRed": "#fae6ea",
+                                    "lightYellow": "#fcf5e3",
+                                    "red": "#cc1439",
+                                    "white": "#ffffff",
+                                    "whiteGrey": "#f0f2f5",
+                                    "yellow": "#ffbb00",
+                                  },
+                                  "fontSizes": Object {
+                                    "large": "20px",
+                                    "larger": "26px",
+                                    "largest": "46px",
+                                    "medium": "16px",
+                                    "small": "14px",
+                                    "smaller": "12px",
+                                  },
+                                  "fontWeights": Object {
+                                    "bold": "600",
+                                    "light": "300",
+                                    "medium": "500",
+                                    "normal": "400",
+                                  },
+                                  "fonts": Object {
+                                    "base": "'IBM Plex Sans', sans-serif",
+                                    "mono": "'IBM Plex Mono', monospace",
+                                  },
+                                  "lineHeights": Object {
+                                    "base": "1.5",
+                                    "sectionTitle": "1.23076923",
+                                    "smallTextBase": "1.71428571",
+                                    "smallTextCompressed": "1.14285714",
+                                    "smallerText": "1.33333333",
+                                    "subsectionTitle": "1.2",
+                                    "title": "1.04347826",
+                                  },
+                                  "radii": Object {
+                                    "circle": "50%",
+                                    "medium": "4px",
+                                    "small": "2px",
+                                  },
+                                  "shadows": Object {
+                                    "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                    "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                    "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                    "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                    "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                  },
+                                  "space": Object {
+                                    "half": "4px",
+                                    "none": "0px",
+                                    "x1": "8px",
+                                    "x2": "16px",
+                                    "x3": "24px",
+                                    "x4": "32px",
+                                    "x5": "40px",
+                                    "x6": "48px",
+                                    "x8": "64px",
+                                  },
+                                  "zIndex": Object {
+                                    "content": 100,
+                                    "overlay": 1000,
+                                    "tabsBar": 210,
+                                    "tabsScollIndicator": 200,
+                                  },
+                                }
+                              }
+                            >
+                              <StyledComponent
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "_foldedDefaultProps": Object {
+                                      "theme": Object {
+                                        "borders": Array [],
+                                        "breakpoints": Object {
+                                          "extraLarge": "1920px",
+                                          "extraSmall": "0px",
+                                          "large": "1360px",
+                                          "medium": "1024px",
+                                          "small": "768px",
+                                        },
+                                        "colors": Object {
+                                          "black": "#011e38",
+                                          "blackBlue": "#122b47",
+                                          "blue": "#216beb",
+                                          "darkBlue": "#00438f",
+                                          "darkGrey": "#434d59",
+                                          "green": "#008059",
+                                          "grey": "#c0c8d1",
+                                          "lightBlue": "#e1ebfa",
+                                          "lightGreen": "#e9f7f2",
+                                          "lightGrey": "#e4e7eb",
+                                          "lightRed": "#fae6ea",
+                                          "lightYellow": "#fcf5e3",
+                                          "red": "#cc1439",
+                                          "white": "#ffffff",
+                                          "whiteGrey": "#f0f2f5",
+                                          "yellow": "#ffbb00",
+                                        },
+                                        "fontSizes": Object {
+                                          "large": "20px",
+                                          "larger": "26px",
+                                          "largest": "46px",
+                                          "medium": "16px",
+                                          "small": "14px",
+                                          "smaller": "12px",
+                                        },
+                                        "fontWeights": Object {
+                                          "bold": "600",
+                                          "light": "300",
+                                          "medium": "500",
+                                          "normal": "400",
+                                        },
+                                        "fonts": Object {
+                                          "base": "'IBM Plex Sans', sans-serif",
+                                          "mono": "'IBM Plex Mono', monospace",
+                                        },
+                                        "lineHeights": Object {
+                                          "base": "1.5",
+                                          "sectionTitle": "1.23076923",
+                                          "smallTextBase": "1.71428571",
+                                          "smallTextCompressed": "1.14285714",
+                                          "smallerText": "1.33333333",
+                                          "subsectionTitle": "1.2",
+                                          "title": "1.04347826",
+                                        },
+                                        "radii": Object {
+                                          "circle": "50%",
+                                          "medium": "4px",
+                                          "small": "2px",
+                                        },
+                                        "shadows": Object {
+                                          "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                          "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                          "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                          "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                          "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                        },
+                                        "space": Object {
+                                          "half": "4px",
+                                          "none": "0px",
+                                          "x1": "8px",
+                                          "x2": "16px",
+                                          "x3": "24px",
+                                          "x4": "32px",
+                                          "x5": "40px",
+                                          "x6": "48px",
+                                          "x8": "64px",
+                                        },
+                                        "zIndex": Object {
+                                          "content": 100,
+                                          "overlay": 1000,
+                                          "tabsBar": 210,
+                                          "tabsScollIndicator": 200,
+                                        },
+                                      },
+                                    },
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "sc-jWBwVP",
+                                      "isStatic": false,
+                                      "lastClassName": "gCXFcy",
+                                      "rules": Array [
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        "color: #011e38;",
+                                        "display: flex;",
+                                        "flex-direction: column;",
+                                        "font-size: 14px;",
+                                        "background-color: #ffffff;",
+                                        "border-radius: 4px;",
+                                        "border: 1px solid #c0c8d1;",
+                                        "box-shadow: 0 2px 4px rgba(0, 0, 0, 0.18);",
+                                        "padding: 8px;",
+                                        "transition: opacity 0.3s;",
+                                        "z-index: 100;",
+                                        [Function],
+                                      ],
+                                    },
+                                    "displayName": "Styled(Box)",
+                                    "foldedComponentIds": Array [
+                                      "Box-sc-1qu1edy-0",
+                                    ],
+                                    "propTypes": Object {
+                                      "bg": [Function],
+                                      "border": [Function],
+                                      "borderBottom": [Function],
+                                      "borderLeft": [Function],
+                                      "borderRadius": [Function],
+                                      "borderRight": [Function],
+                                      "borderTop": [Function],
+                                      "boxShadow": [Function],
+                                      "color": [Function],
+                                      "display": [Function],
+                                      "flexGrow": [Function],
+                                      "height": [Function],
+                                      "m": [Function],
+                                      "maxHeight": [Function],
+                                      "maxWidth": [Function],
+                                      "mb": [Function],
+                                      "minHeight": [Function],
+                                      "minWidth": [Function],
+                                      "ml": [Function],
+                                      "mr": [Function],
+                                      "mt": [Function],
+                                      "mx": [Function],
+                                      "my": [Function],
+                                      "order": [Function],
+                                      "p": [Function],
+                                      "pb": [Function],
+                                      "pl": [Function],
+                                      "position": [Function],
+                                      "pr": [Function],
+                                      "pt": [Function],
+                                      "px": [Function],
+                                      "py": [Function],
+                                      "textAlign": [Function],
+                                      "width": [Function],
+                                    },
+                                    "render": [Function],
+                                    "styledComponentId": "sc-jWBwVP",
+                                    "target": "div",
+                                    "toString": [Function],
+                                    "usesTheme": false,
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={[Function]}
+                                id="random-id-27"
+                                maxWidth="24em"
+                                onBlur={[Function]}
+                                onFocus={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                open={true}
+                                position={
+                                  Object {
+                                    "left": 0,
+                                    "opacity": 0,
+                                    "pointerEvents": "none",
+                                    "position": "absolute",
+                                    "top": 0,
+                                  }
+                                }
+                                role="tooltip"
+                                theme={
+                                  Object {
+                                    "borders": Array [],
+                                    "breakpoints": Object {
+                                      "extraLarge": "1920px",
+                                      "extraSmall": "0px",
+                                      "large": "1360px",
+                                      "medium": "1024px",
+                                      "small": "768px",
+                                    },
+                                    "colors": Object {
+                                      "black": "#011e38",
+                                      "blackBlue": "#122b47",
+                                      "blue": "#216beb",
+                                      "darkBlue": "#00438f",
+                                      "darkGrey": "#434d59",
+                                      "green": "#008059",
+                                      "grey": "#c0c8d1",
+                                      "lightBlue": "#e1ebfa",
+                                      "lightGreen": "#e9f7f2",
+                                      "lightGrey": "#e4e7eb",
+                                      "lightRed": "#fae6ea",
+                                      "lightYellow": "#fcf5e3",
+                                      "red": "#cc1439",
+                                      "white": "#ffffff",
+                                      "whiteGrey": "#f0f2f5",
+                                      "yellow": "#ffbb00",
+                                    },
+                                    "fontSizes": Object {
+                                      "large": "20px",
+                                      "larger": "26px",
+                                      "largest": "46px",
+                                      "medium": "16px",
+                                      "small": "14px",
+                                      "smaller": "12px",
+                                    },
+                                    "fontWeights": Object {
+                                      "bold": "600",
+                                      "light": "300",
+                                      "medium": "500",
+                                      "normal": "400",
+                                    },
+                                    "fonts": Object {
+                                      "base": "'IBM Plex Sans', sans-serif",
+                                      "mono": "'IBM Plex Mono', monospace",
+                                    },
+                                    "lineHeights": Object {
+                                      "base": "1.5",
+                                      "sectionTitle": "1.23076923",
+                                      "smallTextBase": "1.71428571",
+                                      "smallTextCompressed": "1.14285714",
+                                      "smallerText": "1.33333333",
+                                      "subsectionTitle": "1.2",
+                                      "title": "1.04347826",
+                                    },
+                                    "radii": Object {
+                                      "circle": "50%",
+                                      "medium": "4px",
+                                      "small": "2px",
+                                    },
+                                    "shadows": Object {
+                                      "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                      "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                      "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                      "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                      "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                    },
+                                    "space": Object {
+                                      "half": "4px",
+                                      "none": "0px",
+                                      "x1": "8px",
+                                      "x2": "16px",
+                                      "x3": "24px",
+                                      "x4": "32px",
+                                      "x5": "40px",
+                                      "x6": "48px",
+                                      "x8": "64px",
+                                    },
+                                    "zIndex": Object {
+                                      "content": 100,
+                                      "overlay": 1000,
+                                      "tabsBar": 210,
+                                      "tabsScollIndicator": 200,
+                                    },
+                                  }
+                                }
+                              >
+                                <div
+                                  className="Box-sc-1qu1edy-0 sc-jWBwVP gCXFcy"
+                                  id="random-id-27"
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  open={true}
+                                  role="tooltip"
+                                >
+                                  Tooltip
+                                  <PopperArrow
+                                    backgroundColor="white"
+                                    borderColor="grey"
+                                    placement="bottom"
+                                    style={Object {}}
+                                  >
+                                    <StyledComponent
+                                      backgroundColor="white"
+                                      borderColor="grey"
+                                      forwardedComponent={
+                                        Object {
+                                          "$$typeof": Symbol(react.forward_ref),
+                                          "_foldedDefaultProps": Object {
+                                            "backgroundColor": "white",
+                                            "borderColor": "grey",
+                                            "placement": "bottom",
+                                          },
+                                          "attrs": Array [],
+                                          "componentStyle": ComponentStyle {
+                                            "componentId": "PopperArrow-sc-1bcgj4w-0",
+                                            "isStatic": false,
+                                            "lastClassName": "bBzGzE",
+                                            "rules": Array [
+                                              "position: absolute;",
+                                              "height: 8px;",
+                                              "width: 8px;",
+                                              "margin: 12px;",
+                                              "&:before {",
+                                              "border-style: solid;",
+                                              "content: '';",
+                                              "display: block;",
+                                              "height: 0;",
+                                              "margin: auto;",
+                                              "position: absolute;",
+                                              "width: 0;",
+                                              "}",
+                                              "&:after {",
+                                              "border-style: solid;",
+                                              "content: '';",
+                                              "display: block;",
+                                              "height: 0;",
+                                              "margin: auto;",
+                                              "position: absolute;",
+                                              "width: 0;",
+                                              "}",
+                                              [Function],
+                                              [Function],
+                                            ],
+                                          },
+                                          "displayName": "PopperArrow",
+                                          "foldedComponentIds": Array [],
+                                          "propTypes": Object {
+                                            "backgroundColor": [Function],
+                                            "borderColor": [Function],
+                                            "placement": [Function],
+                                          },
+                                          "render": [Function],
+                                          "styledComponentId": "PopperArrow-sc-1bcgj4w-0",
+                                          "target": "div",
+                                          "toString": [Function],
+                                          "usesTheme": false,
+                                          "warnTooManyClasses": [Function],
+                                          "withComponent": [Function],
+                                        }
+                                      }
+                                      forwardedRef={[Function]}
+                                      placement="bottom"
+                                      style={Object {}}
+                                    >
+                                      <div
+                                        className="PopperArrow-sc-1bcgj4w-0 bBzGzE"
+                                        style={Object {}}
+                                      />
+                                    </StyledComponent>
+                                  </PopperArrow>
+                                </div>
+                              </StyledComponent>
+                            </Styled(Box)>
+                          </InnerPopper>
+                        </Popper>
+                        <DetectOutsideClick
+                          clickRef={
+                            Array [
+                              undefined,
+                              undefined,
+                            ]
+                          }
+                          onClick={[Function]}
+                        />
+                      </Manager>
+                    </StatelessTooltip>
+                  </MenuState>
+                </MenuComponent>
+              </WithGeneratedId>
+            </Component>
           </ThemeProvider>
         </div>
       </StyledComponent>
@@ -1748,8 +2779,9 @@ exports[`Storyshots Tooltip with Button passed in 1`] = `
             >
               <WithGeneratedId>
                 <MenuComponent
+                  defaultOpen={false}
                   hideDelay="350"
-                  id="random-id-18"
+                  id="random-id-19"
                   placement="bottom"
                   showDelay="100"
                   tooltip={
@@ -1772,7 +2804,7 @@ exports[`Storyshots Tooltip with Button passed in 1`] = `
                     showDelay="100"
                   >
                     <StatelessTooltip
-                      id="random-id-18"
+                      id="random-id-19"
                       maxWidth="24em"
                       menuState={
                         Object {
@@ -1804,7 +2836,7 @@ exports[`Storyshots Tooltip with Button passed in 1`] = `
                             setReferenceNode={[Function]}
                           >
                             <ForwardRef
-                              aria-describedby="random-id-18"
+                              aria-describedby="random-id-19"
                               aria-expanded={false}
                               aria-haspopup={true}
                               asLink={false}
@@ -1819,7 +2851,7 @@ exports[`Storyshots Tooltip with Button passed in 1`] = `
                               size="medium"
                             >
                               <Button__WrapperButton
-                                aria-describedby="random-id-18"
+                                aria-describedby="random-id-19"
                                 aria-expanded={false}
                                 aria-haspopup={true}
                                 disabled={false}
@@ -1831,7 +2863,7 @@ exports[`Storyshots Tooltip with Button passed in 1`] = `
                                 size="medium"
                               >
                                 <StyledComponent
-                                  aria-describedby="random-id-18"
+                                  aria-describedby="random-id-19"
                                   aria-expanded={false}
                                   aria-haspopup={true}
                                   disabled={false}
@@ -1870,7 +2902,7 @@ exports[`Storyshots Tooltip with Button passed in 1`] = `
                                   size="medium"
                                 >
                                   <button
-                                    aria-describedby="random-id-18"
+                                    aria-describedby="random-id-19"
                                     aria-expanded={false}
                                     aria-haspopup={true}
                                     className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
@@ -1897,7 +2929,7 @@ exports[`Storyshots Tooltip with Button passed in 1`] = `
                             positionFixed={false}
                             referenceElement={
                               <button
-                                aria-describedby="random-id-18"
+                                aria-describedby="random-id-19"
                                 aria-expanded="false"
                                 aria-haspopup="true"
                                 class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
@@ -1907,7 +2939,7 @@ exports[`Storyshots Tooltip with Button passed in 1`] = `
                             }
                           >
                             <Styled(Box)
-                              id="random-id-18"
+                              id="random-id-19"
                               maxWidth="24em"
                               onBlur={[Function]}
                               onFocus={[Function]}
@@ -2188,7 +3220,7 @@ exports[`Storyshots Tooltip with Button passed in 1`] = `
                                   }
                                 }
                                 forwardedRef={[Function]}
-                                id="random-id-18"
+                                id="random-id-19"
                                 maxWidth="24em"
                                 onBlur={[Function]}
                                 onFocus={[Function]}
@@ -2294,7 +3326,7 @@ exports[`Storyshots Tooltip with Button passed in 1`] = `
                               >
                                 <div
                                   className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
-                                  id="random-id-18"
+                                  id="random-id-19"
                                   onBlur={[Function]}
                                   onFocus={[Function]}
                                   onMouseEnter={[Function]}
@@ -2944,8 +3976,9 @@ exports[`Storyshots Tooltip with Link passed in 1`] = `
             >
               <WithGeneratedId>
                 <MenuComponent
+                  defaultOpen={false}
                   hideDelay="350"
-                  id="random-id-17"
+                  id="random-id-18"
                   placement="bottom"
                   showDelay="100"
                   tooltip={
@@ -3051,7 +4084,7 @@ exports[`Storyshots Tooltip with Link passed in 1`] = `
                     showDelay="100"
                   >
                     <StatelessTooltip
-                      id="random-id-17"
+                      id="random-id-18"
                       maxWidth="24em"
                       menuState={
                         Object {
@@ -3166,7 +4199,7 @@ exports[`Storyshots Tooltip with Link passed in 1`] = `
                             setReferenceNode={[Function]}
                           >
                             <ForwardRef
-                              aria-describedby="random-id-17"
+                              aria-describedby="random-id-18"
                               aria-expanded={false}
                               aria-haspopup={true}
                               asLink={false}
@@ -3181,7 +4214,7 @@ exports[`Storyshots Tooltip with Link passed in 1`] = `
                               size="medium"
                             >
                               <Button__WrapperButton
-                                aria-describedby="random-id-17"
+                                aria-describedby="random-id-18"
                                 aria-expanded={false}
                                 aria-haspopup={true}
                                 disabled={false}
@@ -3193,7 +4226,7 @@ exports[`Storyshots Tooltip with Link passed in 1`] = `
                                 size="medium"
                               >
                                 <StyledComponent
-                                  aria-describedby="random-id-17"
+                                  aria-describedby="random-id-18"
                                   aria-expanded={false}
                                   aria-haspopup={true}
                                   disabled={false}
@@ -3232,7 +4265,7 @@ exports[`Storyshots Tooltip with Link passed in 1`] = `
                                   size="medium"
                                 >
                                   <button
-                                    aria-describedby="random-id-17"
+                                    aria-describedby="random-id-18"
                                     aria-expanded={false}
                                     aria-haspopup={true}
                                     className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
@@ -3259,7 +4292,7 @@ exports[`Storyshots Tooltip with Link passed in 1`] = `
                             positionFixed={false}
                             referenceElement={
                               <button
-                                aria-describedby="random-id-17"
+                                aria-describedby="random-id-18"
                                 aria-expanded="false"
                                 aria-haspopup="true"
                                 class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
@@ -3269,7 +4302,7 @@ exports[`Storyshots Tooltip with Link passed in 1`] = `
                             }
                           >
                             <Styled(Box)
-                              id="random-id-17"
+                              id="random-id-18"
                               maxWidth="24em"
                               onBlur={[Function]}
                               onFocus={[Function]}
@@ -3550,7 +4583,7 @@ exports[`Storyshots Tooltip with Link passed in 1`] = `
                                   }
                                 }
                                 forwardedRef={[Function]}
-                                id="random-id-17"
+                                id="random-id-18"
                                 maxWidth="24em"
                                 onBlur={[Function]}
                                 onFocus={[Function]}
@@ -3656,7 +4689,7 @@ exports[`Storyshots Tooltip with Link passed in 1`] = `
                               >
                                 <div
                                   className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
-                                  id="random-id-17"
+                                  id="random-id-18"
                                   onBlur={[Function]}
                                   onFocus={[Function]}
                                   onMouseEnter={[Function]}
@@ -4483,8 +5516,9 @@ exports[`Storyshots Tooltip with custom hideDelay 1`] = `
             >
               <WithGeneratedId>
                 <MenuComponent
+                  defaultOpen={false}
                   hideDelay="1000"
-                  id="random-id-20"
+                  id="random-id-21"
                   placement="bottom"
                   showDelay="100"
                   tooltip="Tooltip"
@@ -4495,7 +5529,7 @@ exports[`Storyshots Tooltip with custom hideDelay 1`] = `
                     showDelay="100"
                   >
                     <StatelessTooltip
-                      id="random-id-20"
+                      id="random-id-21"
                       maxWidth="24em"
                       menuState={
                         Object {
@@ -4515,7 +5549,7 @@ exports[`Storyshots Tooltip with custom hideDelay 1`] = `
                             setReferenceNode={[Function]}
                           >
                             <ForwardRef
-                              aria-describedby="random-id-20"
+                              aria-describedby="random-id-21"
                               aria-expanded={false}
                               aria-haspopup={true}
                               asLink={false}
@@ -4530,7 +5564,7 @@ exports[`Storyshots Tooltip with custom hideDelay 1`] = `
                               size="medium"
                             >
                               <Button__WrapperButton
-                                aria-describedby="random-id-20"
+                                aria-describedby="random-id-21"
                                 aria-expanded={false}
                                 aria-haspopup={true}
                                 disabled={false}
@@ -4542,7 +5576,7 @@ exports[`Storyshots Tooltip with custom hideDelay 1`] = `
                                 size="medium"
                               >
                                 <StyledComponent
-                                  aria-describedby="random-id-20"
+                                  aria-describedby="random-id-21"
                                   aria-expanded={false}
                                   aria-haspopup={true}
                                   disabled={false}
@@ -4581,7 +5615,7 @@ exports[`Storyshots Tooltip with custom hideDelay 1`] = `
                                   size="medium"
                                 >
                                   <button
-                                    aria-describedby="random-id-20"
+                                    aria-describedby="random-id-21"
                                     aria-expanded={false}
                                     aria-haspopup={true}
                                     className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
@@ -4608,7 +5642,7 @@ exports[`Storyshots Tooltip with custom hideDelay 1`] = `
                             positionFixed={false}
                             referenceElement={
                               <button
-                                aria-describedby="random-id-20"
+                                aria-describedby="random-id-21"
                                 aria-expanded="false"
                                 aria-haspopup="true"
                                 class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
@@ -4618,7 +5652,7 @@ exports[`Storyshots Tooltip with custom hideDelay 1`] = `
                             }
                           >
                             <Styled(Box)
-                              id="random-id-20"
+                              id="random-id-21"
                               maxWidth="24em"
                               onBlur={[Function]}
                               onFocus={[Function]}
@@ -4899,7 +5933,7 @@ exports[`Storyshots Tooltip with custom hideDelay 1`] = `
                                   }
                                 }
                                 forwardedRef={[Function]}
-                                id="random-id-20"
+                                id="random-id-21"
                                 maxWidth="24em"
                                 onBlur={[Function]}
                                 onFocus={[Function]}
@@ -5005,7 +6039,7 @@ exports[`Storyshots Tooltip with custom hideDelay 1`] = `
                               >
                                 <div
                                   className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
-                                  id="random-id-20"
+                                  id="random-id-21"
                                   onBlur={[Function]}
                                   onFocus={[Function]}
                                   onMouseEnter={[Function]}
@@ -5823,8 +6857,9 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                   >
                     <WithGeneratedId>
                       <MenuComponent
+                        defaultOpen={false}
                         hideDelay="350"
-                        id="random-id-4"
+                        id="random-id-5"
                         maxWidth="128px"
                         placement="bottom"
                         showDelay="100"
@@ -5836,7 +6871,7 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                           showDelay="100"
                         >
                           <StatelessTooltip
-                            id="random-id-4"
+                            id="random-id-5"
                             maxWidth="128px"
                             menuState={
                               Object {
@@ -5856,7 +6891,7 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                                   setReferenceNode={[Function]}
                                 >
                                   <ForwardRef
-                                    aria-describedby="random-id-4"
+                                    aria-describedby="random-id-5"
                                     aria-expanded={false}
                                     aria-haspopup={true}
                                     asLink={false}
@@ -5871,7 +6906,7 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                                     size="medium"
                                   >
                                     <Button__WrapperButton
-                                      aria-describedby="random-id-4"
+                                      aria-describedby="random-id-5"
                                       aria-expanded={false}
                                       aria-haspopup={true}
                                       disabled={false}
@@ -5883,7 +6918,7 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                                       size="medium"
                                     >
                                       <StyledComponent
-                                        aria-describedby="random-id-4"
+                                        aria-describedby="random-id-5"
                                         aria-expanded={false}
                                         aria-haspopup={true}
                                         disabled={false}
@@ -5922,7 +6957,7 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                                         size="medium"
                                       >
                                         <button
-                                          aria-describedby="random-id-4"
+                                          aria-describedby="random-id-5"
                                           aria-expanded={false}
                                           aria-haspopup={true}
                                           className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
@@ -5949,7 +6984,7 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                                   positionFixed={false}
                                   referenceElement={
                                     <button
-                                      aria-describedby="random-id-4"
+                                      aria-describedby="random-id-5"
                                       aria-expanded="false"
                                       aria-haspopup="true"
                                       class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
@@ -5959,7 +6994,7 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                                   }
                                 >
                                   <Styled(Box)
-                                    id="random-id-4"
+                                    id="random-id-5"
                                     maxWidth="128px"
                                     onBlur={[Function]}
                                     onFocus={[Function]}
@@ -6240,7 +7275,7 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                                         }
                                       }
                                       forwardedRef={[Function]}
-                                      id="random-id-4"
+                                      id="random-id-5"
                                       maxWidth="128px"
                                       onBlur={[Function]}
                                       onFocus={[Function]}
@@ -6346,7 +7381,7 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                                     >
                                       <div
                                         className="Box-sc-1qu1edy-0 sc-jWBwVP bghhYL"
-                                        id="random-id-4"
+                                        id="random-id-5"
                                         onBlur={[Function]}
                                         onFocus={[Function]}
                                         onMouseEnter={[Function]}
@@ -6847,8 +7882,9 @@ exports[`Storyshots Tooltip with custom showDelay 1`] = `
             >
               <WithGeneratedId>
                 <MenuComponent
+                  defaultOpen={false}
                   hideDelay="350"
-                  id="random-id-19"
+                  id="random-id-20"
                   placement="bottom"
                   showDelay="1000"
                   tooltip="Tooltip"
@@ -6859,7 +7895,7 @@ exports[`Storyshots Tooltip with custom showDelay 1`] = `
                     showDelay="1000"
                   >
                     <StatelessTooltip
-                      id="random-id-19"
+                      id="random-id-20"
                       maxWidth="24em"
                       menuState={
                         Object {
@@ -6879,7 +7915,7 @@ exports[`Storyshots Tooltip with custom showDelay 1`] = `
                             setReferenceNode={[Function]}
                           >
                             <ForwardRef
-                              aria-describedby="random-id-19"
+                              aria-describedby="random-id-20"
                               aria-expanded={false}
                               aria-haspopup={true}
                               asLink={false}
@@ -6894,7 +7930,7 @@ exports[`Storyshots Tooltip with custom showDelay 1`] = `
                               size="medium"
                             >
                               <Button__WrapperButton
-                                aria-describedby="random-id-19"
+                                aria-describedby="random-id-20"
                                 aria-expanded={false}
                                 aria-haspopup={true}
                                 disabled={false}
@@ -6906,7 +7942,7 @@ exports[`Storyshots Tooltip with custom showDelay 1`] = `
                                 size="medium"
                               >
                                 <StyledComponent
-                                  aria-describedby="random-id-19"
+                                  aria-describedby="random-id-20"
                                   aria-expanded={false}
                                   aria-haspopup={true}
                                   disabled={false}
@@ -6945,7 +7981,7 @@ exports[`Storyshots Tooltip with custom showDelay 1`] = `
                                   size="medium"
                                 >
                                   <button
-                                    aria-describedby="random-id-19"
+                                    aria-describedby="random-id-20"
                                     aria-expanded={false}
                                     aria-haspopup={true}
                                     className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
@@ -6972,7 +8008,7 @@ exports[`Storyshots Tooltip with custom showDelay 1`] = `
                             positionFixed={false}
                             referenceElement={
                               <button
-                                aria-describedby="random-id-19"
+                                aria-describedby="random-id-20"
                                 aria-expanded="false"
                                 aria-haspopup="true"
                                 class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
@@ -6982,7 +8018,7 @@ exports[`Storyshots Tooltip with custom showDelay 1`] = `
                             }
                           >
                             <Styled(Box)
-                              id="random-id-19"
+                              id="random-id-20"
                               maxWidth="24em"
                               onBlur={[Function]}
                               onFocus={[Function]}
@@ -7263,7 +8299,7 @@ exports[`Storyshots Tooltip with custom showDelay 1`] = `
                                   }
                                 }
                                 forwardedRef={[Function]}
-                                id="random-id-19"
+                                id="random-id-20"
                                 maxWidth="24em"
                                 onBlur={[Function]}
                                 onFocus={[Function]}
@@ -7369,7 +8405,7 @@ exports[`Storyshots Tooltip with custom showDelay 1`] = `
                               >
                                 <div
                                   className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
-                                  id="random-id-19"
+                                  id="random-id-20"
                                   onBlur={[Function]}
                                   onFocus={[Function]}
                                   onMouseEnter={[Function]}
@@ -7866,8 +8902,9 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
             >
               <WithGeneratedId>
                 <MenuComponent
+                  defaultOpen={false}
                   hideDelay="350"
-                  id="random-id-21"
+                  id="random-id-22"
                   placement="bottom"
                   showDelay="100"
                   tooltip="Tooltip"
@@ -7878,7 +8915,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                     showDelay="100"
                   >
                     <StatelessTooltip
-                      id="random-id-21"
+                      id="random-id-22"
                       maxWidth="24em"
                       menuState={
                         Object {
@@ -7898,7 +8935,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                             setReferenceNode={[Function]}
                           >
                             <ForwardRef
-                              aria-describedby="random-id-21"
+                              aria-describedby="random-id-22"
                               aria-expanded={false}
                               aria-haspopup={true}
                               asLink={false}
@@ -7913,7 +8950,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                               size="medium"
                             >
                               <Button__WrapperButton
-                                aria-describedby="random-id-21"
+                                aria-describedby="random-id-22"
                                 aria-expanded={false}
                                 aria-haspopup={true}
                                 disabled={false}
@@ -7925,7 +8962,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                                 size="medium"
                               >
                                 <StyledComponent
-                                  aria-describedby="random-id-21"
+                                  aria-describedby="random-id-22"
                                   aria-expanded={false}
                                   aria-haspopup={true}
                                   disabled={false}
@@ -7964,7 +9001,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                                   size="medium"
                                 >
                                   <button
-                                    aria-describedby="random-id-21"
+                                    aria-describedby="random-id-22"
                                     aria-expanded={false}
                                     aria-haspopup={true}
                                     className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
@@ -7991,906 +9028,13 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                             positionFixed={false}
                             referenceElement={
                               <button
-                                aria-describedby="random-id-21"
+                                aria-describedby="random-id-22"
                                 aria-expanded="false"
                                 aria-haspopup="true"
                                 class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
                               >
                                  Button 
                               </button>
-                            }
-                          >
-                            <Styled(Box)
-                              id="random-id-21"
-                              maxWidth="24em"
-                              onBlur={[Function]}
-                              onFocus={[Function]}
-                              onMouseEnter={[Function]}
-                              onMouseLeave={[Function]}
-                              open={false}
-                              position={
-                                Object {
-                                  "left": 0,
-                                  "opacity": 0,
-                                  "pointerEvents": "none",
-                                  "position": "absolute",
-                                  "top": 0,
-                                }
-                              }
-                              role="tooltip"
-                              theme={
-                                Object {
-                                  "borders": Array [],
-                                  "breakpoints": Object {
-                                    "extraLarge": "1920px",
-                                    "extraSmall": "0px",
-                                    "large": "1360px",
-                                    "medium": "1024px",
-                                    "small": "768px",
-                                  },
-                                  "colors": Object {
-                                    "black": "#011e38",
-                                    "blackBlue": "#122b47",
-                                    "blue": "#216beb",
-                                    "darkBlue": "#00438f",
-                                    "darkGrey": "#434d59",
-                                    "green": "#008059",
-                                    "grey": "#c0c8d1",
-                                    "lightBlue": "#e1ebfa",
-                                    "lightGreen": "#e9f7f2",
-                                    "lightGrey": "#e4e7eb",
-                                    "lightRed": "#fae6ea",
-                                    "lightYellow": "#fcf5e3",
-                                    "red": "#cc1439",
-                                    "white": "#ffffff",
-                                    "whiteGrey": "#f0f2f5",
-                                    "yellow": "#ffbb00",
-                                  },
-                                  "fontSizes": Object {
-                                    "large": "20px",
-                                    "larger": "26px",
-                                    "largest": "46px",
-                                    "medium": "16px",
-                                    "small": "14px",
-                                    "smaller": "12px",
-                                  },
-                                  "fontWeights": Object {
-                                    "bold": "600",
-                                    "light": "300",
-                                    "medium": "500",
-                                    "normal": "400",
-                                  },
-                                  "fonts": Object {
-                                    "base": "'IBM Plex Sans', sans-serif",
-                                    "mono": "'IBM Plex Mono', monospace",
-                                  },
-                                  "lineHeights": Object {
-                                    "base": "1.5",
-                                    "sectionTitle": "1.23076923",
-                                    "smallTextBase": "1.71428571",
-                                    "smallTextCompressed": "1.14285714",
-                                    "smallerText": "1.33333333",
-                                    "subsectionTitle": "1.2",
-                                    "title": "1.04347826",
-                                  },
-                                  "radii": Object {
-                                    "circle": "50%",
-                                    "medium": "4px",
-                                    "small": "2px",
-                                  },
-                                  "shadows": Object {
-                                    "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                    "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                    "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                    "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                    "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                                  },
-                                  "space": Object {
-                                    "half": "4px",
-                                    "none": "0px",
-                                    "x1": "8px",
-                                    "x2": "16px",
-                                    "x3": "24px",
-                                    "x4": "32px",
-                                    "x5": "40px",
-                                    "x6": "48px",
-                                    "x8": "64px",
-                                  },
-                                  "zIndex": Object {
-                                    "content": 100,
-                                    "overlay": 1000,
-                                    "tabsBar": 210,
-                                    "tabsScollIndicator": 200,
-                                  },
-                                }
-                              }
-                            >
-                              <StyledComponent
-                                forwardedComponent={
-                                  Object {
-                                    "$$typeof": Symbol(react.forward_ref),
-                                    "_foldedDefaultProps": Object {
-                                      "theme": Object {
-                                        "borders": Array [],
-                                        "breakpoints": Object {
-                                          "extraLarge": "1920px",
-                                          "extraSmall": "0px",
-                                          "large": "1360px",
-                                          "medium": "1024px",
-                                          "small": "768px",
-                                        },
-                                        "colors": Object {
-                                          "black": "#011e38",
-                                          "blackBlue": "#122b47",
-                                          "blue": "#216beb",
-                                          "darkBlue": "#00438f",
-                                          "darkGrey": "#434d59",
-                                          "green": "#008059",
-                                          "grey": "#c0c8d1",
-                                          "lightBlue": "#e1ebfa",
-                                          "lightGreen": "#e9f7f2",
-                                          "lightGrey": "#e4e7eb",
-                                          "lightRed": "#fae6ea",
-                                          "lightYellow": "#fcf5e3",
-                                          "red": "#cc1439",
-                                          "white": "#ffffff",
-                                          "whiteGrey": "#f0f2f5",
-                                          "yellow": "#ffbb00",
-                                        },
-                                        "fontSizes": Object {
-                                          "large": "20px",
-                                          "larger": "26px",
-                                          "largest": "46px",
-                                          "medium": "16px",
-                                          "small": "14px",
-                                          "smaller": "12px",
-                                        },
-                                        "fontWeights": Object {
-                                          "bold": "600",
-                                          "light": "300",
-                                          "medium": "500",
-                                          "normal": "400",
-                                        },
-                                        "fonts": Object {
-                                          "base": "'IBM Plex Sans', sans-serif",
-                                          "mono": "'IBM Plex Mono', monospace",
-                                        },
-                                        "lineHeights": Object {
-                                          "base": "1.5",
-                                          "sectionTitle": "1.23076923",
-                                          "smallTextBase": "1.71428571",
-                                          "smallTextCompressed": "1.14285714",
-                                          "smallerText": "1.33333333",
-                                          "subsectionTitle": "1.2",
-                                          "title": "1.04347826",
-                                        },
-                                        "radii": Object {
-                                          "circle": "50%",
-                                          "medium": "4px",
-                                          "small": "2px",
-                                        },
-                                        "shadows": Object {
-                                          "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                          "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                          "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                          "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                          "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                                        },
-                                        "space": Object {
-                                          "half": "4px",
-                                          "none": "0px",
-                                          "x1": "8px",
-                                          "x2": "16px",
-                                          "x3": "24px",
-                                          "x4": "32px",
-                                          "x5": "40px",
-                                          "x6": "48px",
-                                          "x8": "64px",
-                                        },
-                                        "zIndex": Object {
-                                          "content": 100,
-                                          "overlay": 1000,
-                                          "tabsBar": 210,
-                                          "tabsScollIndicator": 200,
-                                        },
-                                      },
-                                    },
-                                    "attrs": Array [],
-                                    "componentStyle": ComponentStyle {
-                                      "componentId": "sc-jWBwVP",
-                                      "isStatic": false,
-                                      "lastClassName": "hjigbL",
-                                      "rules": Array [
-                                        [Function],
-                                        [Function],
-                                        [Function],
-                                        [Function],
-                                        [Function],
-                                        [Function],
-                                        [Function],
-                                        [Function],
-                                        [Function],
-                                        [Function],
-                                        [Function],
-                                        [Function],
-                                        [Function],
-                                        [Function],
-                                        [Function],
-                                        [Function],
-                                        [Function],
-                                        "color: #011e38;",
-                                        "display: flex;",
-                                        "flex-direction: column;",
-                                        "font-size: 14px;",
-                                        "background-color: #ffffff;",
-                                        "border-radius: 4px;",
-                                        "border: 1px solid #c0c8d1;",
-                                        "box-shadow: 0 2px 4px rgba(0, 0, 0, 0.18);",
-                                        "padding: 8px;",
-                                        "transition: opacity 0.3s;",
-                                        "z-index: 100;",
-                                        [Function],
-                                      ],
-                                    },
-                                    "displayName": "Styled(Box)",
-                                    "foldedComponentIds": Array [
-                                      "Box-sc-1qu1edy-0",
-                                    ],
-                                    "propTypes": Object {
-                                      "bg": [Function],
-                                      "border": [Function],
-                                      "borderBottom": [Function],
-                                      "borderLeft": [Function],
-                                      "borderRadius": [Function],
-                                      "borderRight": [Function],
-                                      "borderTop": [Function],
-                                      "boxShadow": [Function],
-                                      "color": [Function],
-                                      "display": [Function],
-                                      "flexGrow": [Function],
-                                      "height": [Function],
-                                      "m": [Function],
-                                      "maxHeight": [Function],
-                                      "maxWidth": [Function],
-                                      "mb": [Function],
-                                      "minHeight": [Function],
-                                      "minWidth": [Function],
-                                      "ml": [Function],
-                                      "mr": [Function],
-                                      "mt": [Function],
-                                      "mx": [Function],
-                                      "my": [Function],
-                                      "order": [Function],
-                                      "p": [Function],
-                                      "pb": [Function],
-                                      "pl": [Function],
-                                      "position": [Function],
-                                      "pr": [Function],
-                                      "pt": [Function],
-                                      "px": [Function],
-                                      "py": [Function],
-                                      "textAlign": [Function],
-                                      "width": [Function],
-                                    },
-                                    "render": [Function],
-                                    "styledComponentId": "sc-jWBwVP",
-                                    "target": "div",
-                                    "toString": [Function],
-                                    "usesTheme": false,
-                                    "warnTooManyClasses": [Function],
-                                    "withComponent": [Function],
-                                  }
-                                }
-                                forwardedRef={[Function]}
-                                id="random-id-21"
-                                maxWidth="24em"
-                                onBlur={[Function]}
-                                onFocus={[Function]}
-                                onMouseEnter={[Function]}
-                                onMouseLeave={[Function]}
-                                open={false}
-                                position={
-                                  Object {
-                                    "left": 0,
-                                    "opacity": 0,
-                                    "pointerEvents": "none",
-                                    "position": "absolute",
-                                    "top": 0,
-                                  }
-                                }
-                                role="tooltip"
-                                theme={
-                                  Object {
-                                    "borders": Array [],
-                                    "breakpoints": Object {
-                                      "extraLarge": "1920px",
-                                      "extraSmall": "0px",
-                                      "large": "1360px",
-                                      "medium": "1024px",
-                                      "small": "768px",
-                                    },
-                                    "colors": Object {
-                                      "black": "#011e38",
-                                      "blackBlue": "#122b47",
-                                      "blue": "#216beb",
-                                      "darkBlue": "#00438f",
-                                      "darkGrey": "#434d59",
-                                      "green": "#008059",
-                                      "grey": "#c0c8d1",
-                                      "lightBlue": "#e1ebfa",
-                                      "lightGreen": "#e9f7f2",
-                                      "lightGrey": "#e4e7eb",
-                                      "lightRed": "#fae6ea",
-                                      "lightYellow": "#fcf5e3",
-                                      "red": "#cc1439",
-                                      "white": "#ffffff",
-                                      "whiteGrey": "#f0f2f5",
-                                      "yellow": "#ffbb00",
-                                    },
-                                    "fontSizes": Object {
-                                      "large": "20px",
-                                      "larger": "26px",
-                                      "largest": "46px",
-                                      "medium": "16px",
-                                      "small": "14px",
-                                      "smaller": "12px",
-                                    },
-                                    "fontWeights": Object {
-                                      "bold": "600",
-                                      "light": "300",
-                                      "medium": "500",
-                                      "normal": "400",
-                                    },
-                                    "fonts": Object {
-                                      "base": "'IBM Plex Sans', sans-serif",
-                                      "mono": "'IBM Plex Mono', monospace",
-                                    },
-                                    "lineHeights": Object {
-                                      "base": "1.5",
-                                      "sectionTitle": "1.23076923",
-                                      "smallTextBase": "1.71428571",
-                                      "smallTextCompressed": "1.14285714",
-                                      "smallerText": "1.33333333",
-                                      "subsectionTitle": "1.2",
-                                      "title": "1.04347826",
-                                    },
-                                    "radii": Object {
-                                      "circle": "50%",
-                                      "medium": "4px",
-                                      "small": "2px",
-                                    },
-                                    "shadows": Object {
-                                      "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                      "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                      "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                      "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                      "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                                    },
-                                    "space": Object {
-                                      "half": "4px",
-                                      "none": "0px",
-                                      "x1": "8px",
-                                      "x2": "16px",
-                                      "x3": "24px",
-                                      "x4": "32px",
-                                      "x5": "40px",
-                                      "x6": "48px",
-                                      "x8": "64px",
-                                    },
-                                    "zIndex": Object {
-                                      "content": 100,
-                                      "overlay": 1000,
-                                      "tabsBar": 210,
-                                      "tabsScollIndicator": 200,
-                                    },
-                                  }
-                                }
-                              >
-                                <div
-                                  className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
-                                  id="random-id-21"
-                                  onBlur={[Function]}
-                                  onFocus={[Function]}
-                                  onMouseEnter={[Function]}
-                                  onMouseLeave={[Function]}
-                                  open={false}
-                                  role="tooltip"
-                                >
-                                  Tooltip
-                                  <PopperArrow
-                                    backgroundColor="white"
-                                    borderColor="grey"
-                                    placement="bottom"
-                                    style={Object {}}
-                                  >
-                                    <StyledComponent
-                                      backgroundColor="white"
-                                      borderColor="grey"
-                                      forwardedComponent={
-                                        Object {
-                                          "$$typeof": Symbol(react.forward_ref),
-                                          "_foldedDefaultProps": Object {
-                                            "backgroundColor": "white",
-                                            "borderColor": "grey",
-                                            "placement": "bottom",
-                                          },
-                                          "attrs": Array [],
-                                          "componentStyle": ComponentStyle {
-                                            "componentId": "PopperArrow-sc-1bcgj4w-0",
-                                            "isStatic": false,
-                                            "lastClassName": "bBzGzE",
-                                            "rules": Array [
-                                              "position: absolute;",
-                                              "height: 8px;",
-                                              "width: 8px;",
-                                              "margin: 12px;",
-                                              "&:before {",
-                                              "border-style: solid;",
-                                              "content: '';",
-                                              "display: block;",
-                                              "height: 0;",
-                                              "margin: auto;",
-                                              "position: absolute;",
-                                              "width: 0;",
-                                              "}",
-                                              "&:after {",
-                                              "border-style: solid;",
-                                              "content: '';",
-                                              "display: block;",
-                                              "height: 0;",
-                                              "margin: auto;",
-                                              "position: absolute;",
-                                              "width: 0;",
-                                              "}",
-                                              [Function],
-                                              [Function],
-                                            ],
-                                          },
-                                          "displayName": "PopperArrow",
-                                          "foldedComponentIds": Array [],
-                                          "propTypes": Object {
-                                            "backgroundColor": [Function],
-                                            "borderColor": [Function],
-                                            "placement": [Function],
-                                          },
-                                          "render": [Function],
-                                          "styledComponentId": "PopperArrow-sc-1bcgj4w-0",
-                                          "target": "div",
-                                          "toString": [Function],
-                                          "usesTheme": false,
-                                          "warnTooManyClasses": [Function],
-                                          "withComponent": [Function],
-                                        }
-                                      }
-                                      forwardedRef={[Function]}
-                                      placement="bottom"
-                                      style={Object {}}
-                                    >
-                                      <div
-                                        className="PopperArrow-sc-1bcgj4w-0 bBzGzE"
-                                        style={Object {}}
-                                      />
-                                    </StyledComponent>
-                                  </PopperArrow>
-                                </div>
-                              </StyledComponent>
-                            </Styled(Box)>
-                          </InnerPopper>
-                        </Popper>
-                      </Manager>
-                    </StatelessTooltip>
-                  </MenuState>
-                </MenuComponent>
-              </WithGeneratedId>
-            </Component>
-            <Component
-              placement="bottom"
-              tooltip="Tooltip"
-            >
-              <WithGeneratedId>
-                <MenuComponent
-                  hideDelay="350"
-                  id="random-id-22"
-                  placement="bottom"
-                  showDelay="100"
-                  tooltip="Tooltip"
-                >
-                  <MenuState
-                    defaultOpen={false}
-                    hideDelay="350"
-                    showDelay="100"
-                  >
-                    <StatelessTooltip
-                      id="random-id-22"
-                      maxWidth="24em"
-                      menuState={
-                        Object {
-                          "closeMenu": [Function],
-                          "handleMenuKeydown": [Function],
-                          "isOpen": false,
-                          "openMenu": [Function],
-                          "toggleMenu": [Function],
-                        }
-                      }
-                      placement="bottom"
-                      tooltip="Tooltip"
-                    >
-                      <Manager>
-                        <Reference>
-                          <InnerReference
-                            setReferenceNode={[Function]}
-                          >
-                            <Link
-                              aria-describedby="random-id-22"
-                              aria-expanded={false}
-                              aria-haspopup={true}
-                              color="blue"
-                              href="/"
-                              onBlur={[Function]}
-                              onFocus={[Function]}
-                              onMouseEnter={[Function]}
-                              onMouseLeave={[Function]}
-                              p={0}
-                              theme={
-                                Object {
-                                  "borders": Array [],
-                                  "breakpoints": Object {
-                                    "extraLarge": "1920px",
-                                    "extraSmall": "0px",
-                                    "large": "1360px",
-                                    "medium": "1024px",
-                                    "small": "768px",
-                                  },
-                                  "colors": Object {
-                                    "black": "#011e38",
-                                    "blackBlue": "#122b47",
-                                    "blue": "#216beb",
-                                    "darkBlue": "#00438f",
-                                    "darkGrey": "#434d59",
-                                    "green": "#008059",
-                                    "grey": "#c0c8d1",
-                                    "lightBlue": "#e1ebfa",
-                                    "lightGreen": "#e9f7f2",
-                                    "lightGrey": "#e4e7eb",
-                                    "lightRed": "#fae6ea",
-                                    "lightYellow": "#fcf5e3",
-                                    "red": "#cc1439",
-                                    "white": "#ffffff",
-                                    "whiteGrey": "#f0f2f5",
-                                    "yellow": "#ffbb00",
-                                  },
-                                  "fontSizes": Object {
-                                    "large": "20px",
-                                    "larger": "26px",
-                                    "largest": "46px",
-                                    "medium": "16px",
-                                    "small": "14px",
-                                    "smaller": "12px",
-                                  },
-                                  "fontWeights": Object {
-                                    "bold": "600",
-                                    "light": "300",
-                                    "medium": "500",
-                                    "normal": "400",
-                                  },
-                                  "fonts": Object {
-                                    "base": "'IBM Plex Sans', sans-serif",
-                                    "mono": "'IBM Plex Mono', monospace",
-                                  },
-                                  "lineHeights": Object {
-                                    "base": "1.5",
-                                    "sectionTitle": "1.23076923",
-                                    "smallTextBase": "1.71428571",
-                                    "smallTextCompressed": "1.14285714",
-                                    "smallerText": "1.33333333",
-                                    "subsectionTitle": "1.2",
-                                    "title": "1.04347826",
-                                  },
-                                  "radii": Object {
-                                    "circle": "50%",
-                                    "medium": "4px",
-                                    "small": "2px",
-                                  },
-                                  "shadows": Object {
-                                    "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                    "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                    "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                    "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                    "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                                  },
-                                  "space": Object {
-                                    "half": "4px",
-                                    "none": "0px",
-                                    "x1": "8px",
-                                    "x2": "16px",
-                                    "x3": "24px",
-                                    "x4": "32px",
-                                    "x5": "40px",
-                                    "x6": "48px",
-                                    "x8": "64px",
-                                  },
-                                  "zIndex": Object {
-                                    "content": 100,
-                                    "overlay": 1000,
-                                    "tabsBar": 210,
-                                    "tabsScollIndicator": 200,
-                                  },
-                                }
-                              }
-                              underline={true}
-                            >
-                              <StyledComponent
-                                aria-describedby="random-id-22"
-                                aria-expanded={false}
-                                aria-haspopup={true}
-                                color="blue"
-                                forwardedComponent={
-                                  Object {
-                                    "$$typeof": Symbol(react.forward_ref),
-                                    "_foldedDefaultProps": Object {
-                                      "className": undefined,
-                                      "color": "blue",
-                                      "p": 0,
-                                      "theme": Object {
-                                        "borders": Array [],
-                                        "breakpoints": Object {
-                                          "extraLarge": "1920px",
-                                          "extraSmall": "0px",
-                                          "large": "1360px",
-                                          "medium": "1024px",
-                                          "small": "768px",
-                                        },
-                                        "colors": Object {
-                                          "black": "#011e38",
-                                          "blackBlue": "#122b47",
-                                          "blue": "#216beb",
-                                          "darkBlue": "#00438f",
-                                          "darkGrey": "#434d59",
-                                          "green": "#008059",
-                                          "grey": "#c0c8d1",
-                                          "lightBlue": "#e1ebfa",
-                                          "lightGreen": "#e9f7f2",
-                                          "lightGrey": "#e4e7eb",
-                                          "lightRed": "#fae6ea",
-                                          "lightYellow": "#fcf5e3",
-                                          "red": "#cc1439",
-                                          "white": "#ffffff",
-                                          "whiteGrey": "#f0f2f5",
-                                          "yellow": "#ffbb00",
-                                        },
-                                        "fontSizes": Object {
-                                          "large": "20px",
-                                          "larger": "26px",
-                                          "largest": "46px",
-                                          "medium": "16px",
-                                          "small": "14px",
-                                          "smaller": "12px",
-                                        },
-                                        "fontWeights": Object {
-                                          "bold": "600",
-                                          "light": "300",
-                                          "medium": "500",
-                                          "normal": "400",
-                                        },
-                                        "fonts": Object {
-                                          "base": "'IBM Plex Sans', sans-serif",
-                                          "mono": "'IBM Plex Mono', monospace",
-                                        },
-                                        "lineHeights": Object {
-                                          "base": "1.5",
-                                          "sectionTitle": "1.23076923",
-                                          "smallTextBase": "1.71428571",
-                                          "smallTextCompressed": "1.14285714",
-                                          "smallerText": "1.33333333",
-                                          "subsectionTitle": "1.2",
-                                          "title": "1.04347826",
-                                        },
-                                        "radii": Object {
-                                          "circle": "50%",
-                                          "medium": "4px",
-                                          "small": "2px",
-                                        },
-                                        "shadows": Object {
-                                          "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                          "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                          "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                          "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                          "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                                        },
-                                        "space": Object {
-                                          "half": "4px",
-                                          "none": "0px",
-                                          "x1": "8px",
-                                          "x2": "16px",
-                                          "x3": "24px",
-                                          "x4": "32px",
-                                          "x5": "40px",
-                                          "x6": "48px",
-                                          "x8": "64px",
-                                        },
-                                        "zIndex": Object {
-                                          "content": 100,
-                                          "overlay": 1000,
-                                          "tabsBar": 210,
-                                          "tabsScollIndicator": 200,
-                                        },
-                                      },
-                                      "underline": true,
-                                    },
-                                    "attrs": Array [],
-                                    "componentStyle": ComponentStyle {
-                                      "componentId": "Link-sc-1lpx3d0-0",
-                                      "isStatic": false,
-                                      "lastClassName": "cRusvg",
-                                      "rules": Array [
-                                        [Function],
-                                        [Function],
-                                        [Function],
-                                      ],
-                                    },
-                                    "displayName": "Link",
-                                    "foldedComponentIds": Array [],
-                                    "propTypes": Object {
-                                      "bg": [Function],
-                                      "className": [Function],
-                                      "color": [Function],
-                                      "hover": [Function],
-                                      "m": [Function],
-                                      "mb": [Function],
-                                      "ml": [Function],
-                                      "mr": [Function],
-                                      "mt": [Function],
-                                      "mx": [Function],
-                                      "my": [Function],
-                                      "p": [Function],
-                                      "pb": [Function],
-                                      "pl": [Function],
-                                      "pr": [Function],
-                                      "pt": [Function],
-                                      "px": [Function],
-                                      "py": [Function],
-                                      "underline": [Function],
-                                    },
-                                    "render": [Function],
-                                    "styledComponentId": "Link-sc-1lpx3d0-0",
-                                    "target": "a",
-                                    "toString": [Function],
-                                    "usesTheme": false,
-                                    "warnTooManyClasses": [Function],
-                                    "withComponent": [Function],
-                                  }
-                                }
-                                forwardedRef={[Function]}
-                                href="/"
-                                onBlur={[Function]}
-                                onFocus={[Function]}
-                                onMouseEnter={[Function]}
-                                onMouseLeave={[Function]}
-                                p={0}
-                                theme={
-                                  Object {
-                                    "borders": Array [],
-                                    "breakpoints": Object {
-                                      "extraLarge": "1920px",
-                                      "extraSmall": "0px",
-                                      "large": "1360px",
-                                      "medium": "1024px",
-                                      "small": "768px",
-                                    },
-                                    "colors": Object {
-                                      "black": "#011e38",
-                                      "blackBlue": "#122b47",
-                                      "blue": "#216beb",
-                                      "darkBlue": "#00438f",
-                                      "darkGrey": "#434d59",
-                                      "green": "#008059",
-                                      "grey": "#c0c8d1",
-                                      "lightBlue": "#e1ebfa",
-                                      "lightGreen": "#e9f7f2",
-                                      "lightGrey": "#e4e7eb",
-                                      "lightRed": "#fae6ea",
-                                      "lightYellow": "#fcf5e3",
-                                      "red": "#cc1439",
-                                      "white": "#ffffff",
-                                      "whiteGrey": "#f0f2f5",
-                                      "yellow": "#ffbb00",
-                                    },
-                                    "fontSizes": Object {
-                                      "large": "20px",
-                                      "larger": "26px",
-                                      "largest": "46px",
-                                      "medium": "16px",
-                                      "small": "14px",
-                                      "smaller": "12px",
-                                    },
-                                    "fontWeights": Object {
-                                      "bold": "600",
-                                      "light": "300",
-                                      "medium": "500",
-                                      "normal": "400",
-                                    },
-                                    "fonts": Object {
-                                      "base": "'IBM Plex Sans', sans-serif",
-                                      "mono": "'IBM Plex Mono', monospace",
-                                    },
-                                    "lineHeights": Object {
-                                      "base": "1.5",
-                                      "sectionTitle": "1.23076923",
-                                      "smallTextBase": "1.71428571",
-                                      "smallTextCompressed": "1.14285714",
-                                      "smallerText": "1.33333333",
-                                      "subsectionTitle": "1.2",
-                                      "title": "1.04347826",
-                                    },
-                                    "radii": Object {
-                                      "circle": "50%",
-                                      "medium": "4px",
-                                      "small": "2px",
-                                    },
-                                    "shadows": Object {
-                                      "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                      "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                      "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                      "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                      "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                                    },
-                                    "space": Object {
-                                      "half": "4px",
-                                      "none": "0px",
-                                      "x1": "8px",
-                                      "x2": "16px",
-                                      "x3": "24px",
-                                      "x4": "32px",
-                                      "x5": "40px",
-                                      "x6": "48px",
-                                      "x8": "64px",
-                                    },
-                                    "zIndex": Object {
-                                      "content": 100,
-                                      "overlay": 1000,
-                                      "tabsBar": 210,
-                                      "tabsScollIndicator": 200,
-                                    },
-                                  }
-                                }
-                                underline={true}
-                              >
-                                <a
-                                  aria-describedby="random-id-22"
-                                  aria-expanded={false}
-                                  aria-haspopup={true}
-                                  className="Link-sc-1lpx3d0-0 cRusvg"
-                                  color="blue"
-                                  href="/"
-                                  onBlur={[Function]}
-                                  onFocus={[Function]}
-                                  onMouseEnter={[Function]}
-                                  onMouseLeave={[Function]}
-                                >
-                                   Link 
-                                </a>
-                              </StyledComponent>
-                            </Link>
-                          </InnerReference>
-                        </Reference>
-                        <Popper
-                          placement="bottom"
-                        >
-                          <InnerPopper
-                            eventsEnabled={true}
-                            placement="bottom"
-                            positionFixed={false}
-                            referenceElement={
-                              <a
-                                aria-describedby="random-id-22"
-                                aria-expanded="false"
-                                aria-haspopup="true"
-                                class="Link-sc-1lpx3d0-0 cRusvg"
-                                color="blue"
-                                href="/"
-                              >
-                                 Link 
-                              </a>
                             }
                           >
                             <Styled(Box)
@@ -9382,6 +9526,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
             >
               <WithGeneratedId>
                 <MenuComponent
+                  defaultOpen={false}
                   hideDelay="350"
                   id="random-id-23"
                   placement="bottom"
@@ -9413,69 +9558,240 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                           <InnerReference
                             setReferenceNode={[Function]}
                           >
-                            <styled.p
+                            <Link
                               aria-describedby="random-id-23"
                               aria-expanded={false}
                               aria-haspopup={true}
-                              bg="blue"
-                              color="currentColor"
-                              disabled={false}
-                              fontSize="16px"
-                              inline={true}
-                              lineHeight="1.5"
-                              m={0}
-                              mr="x2"
+                              color="blue"
+                              href="/"
                               onBlur={[Function]}
                               onFocus={[Function]}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
+                              p={0}
+                              theme={
+                                Object {
+                                  "borders": Array [],
+                                  "breakpoints": Object {
+                                    "extraLarge": "1920px",
+                                    "extraSmall": "0px",
+                                    "large": "1360px",
+                                    "medium": "1024px",
+                                    "small": "768px",
+                                  },
+                                  "colors": Object {
+                                    "black": "#011e38",
+                                    "blackBlue": "#122b47",
+                                    "blue": "#216beb",
+                                    "darkBlue": "#00438f",
+                                    "darkGrey": "#434d59",
+                                    "green": "#008059",
+                                    "grey": "#c0c8d1",
+                                    "lightBlue": "#e1ebfa",
+                                    "lightGreen": "#e9f7f2",
+                                    "lightGrey": "#e4e7eb",
+                                    "lightRed": "#fae6ea",
+                                    "lightYellow": "#fcf5e3",
+                                    "red": "#cc1439",
+                                    "white": "#ffffff",
+                                    "whiteGrey": "#f0f2f5",
+                                    "yellow": "#ffbb00",
+                                  },
+                                  "fontSizes": Object {
+                                    "large": "20px",
+                                    "larger": "26px",
+                                    "largest": "46px",
+                                    "medium": "16px",
+                                    "small": "14px",
+                                    "smaller": "12px",
+                                  },
+                                  "fontWeights": Object {
+                                    "bold": "600",
+                                    "light": "300",
+                                    "medium": "500",
+                                    "normal": "400",
+                                  },
+                                  "fonts": Object {
+                                    "base": "'IBM Plex Sans', sans-serif",
+                                    "mono": "'IBM Plex Mono', monospace",
+                                  },
+                                  "lineHeights": Object {
+                                    "base": "1.5",
+                                    "sectionTitle": "1.23076923",
+                                    "smallTextBase": "1.71428571",
+                                    "smallTextCompressed": "1.14285714",
+                                    "smallerText": "1.33333333",
+                                    "subsectionTitle": "1.2",
+                                    "title": "1.04347826",
+                                  },
+                                  "radii": Object {
+                                    "circle": "50%",
+                                    "medium": "4px",
+                                    "small": "2px",
+                                  },
+                                  "shadows": Object {
+                                    "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                    "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                    "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                    "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                    "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                  },
+                                  "space": Object {
+                                    "half": "4px",
+                                    "none": "0px",
+                                    "x1": "8px",
+                                    "x2": "16px",
+                                    "x3": "24px",
+                                    "x4": "32px",
+                                    "x5": "40px",
+                                    "x6": "48px",
+                                    "x8": "64px",
+                                  },
+                                  "zIndex": Object {
+                                    "content": 100,
+                                    "overlay": 1000,
+                                    "tabsBar": 210,
+                                    "tabsScollIndicator": 200,
+                                  },
+                                }
+                              }
+                              underline={true}
                             >
                               <StyledComponent
                                 aria-describedby="random-id-23"
                                 aria-expanded={false}
                                 aria-haspopup={true}
-                                bg="blue"
-                                color="currentColor"
-                                disabled={false}
-                                fontSize="16px"
+                                color="blue"
                                 forwardedComponent={
                                   Object {
                                     "$$typeof": Symbol(react.forward_ref),
                                     "_foldedDefaultProps": Object {
-                                      "color": "currentColor",
-                                      "disabled": false,
-                                      "fontSize": "16px",
-                                      "inline": false,
-                                      "lineHeight": "1.5",
-                                      "m": 0,
+                                      "className": undefined,
+                                      "color": "blue",
+                                      "p": 0,
+                                      "theme": Object {
+                                        "borders": Array [],
+                                        "breakpoints": Object {
+                                          "extraLarge": "1920px",
+                                          "extraSmall": "0px",
+                                          "large": "1360px",
+                                          "medium": "1024px",
+                                          "small": "768px",
+                                        },
+                                        "colors": Object {
+                                          "black": "#011e38",
+                                          "blackBlue": "#122b47",
+                                          "blue": "#216beb",
+                                          "darkBlue": "#00438f",
+                                          "darkGrey": "#434d59",
+                                          "green": "#008059",
+                                          "grey": "#c0c8d1",
+                                          "lightBlue": "#e1ebfa",
+                                          "lightGreen": "#e9f7f2",
+                                          "lightGrey": "#e4e7eb",
+                                          "lightRed": "#fae6ea",
+                                          "lightYellow": "#fcf5e3",
+                                          "red": "#cc1439",
+                                          "white": "#ffffff",
+                                          "whiteGrey": "#f0f2f5",
+                                          "yellow": "#ffbb00",
+                                        },
+                                        "fontSizes": Object {
+                                          "large": "20px",
+                                          "larger": "26px",
+                                          "largest": "46px",
+                                          "medium": "16px",
+                                          "small": "14px",
+                                          "smaller": "12px",
+                                        },
+                                        "fontWeights": Object {
+                                          "bold": "600",
+                                          "light": "300",
+                                          "medium": "500",
+                                          "normal": "400",
+                                        },
+                                        "fonts": Object {
+                                          "base": "'IBM Plex Sans', sans-serif",
+                                          "mono": "'IBM Plex Mono', monospace",
+                                        },
+                                        "lineHeights": Object {
+                                          "base": "1.5",
+                                          "sectionTitle": "1.23076923",
+                                          "smallTextBase": "1.71428571",
+                                          "smallTextCompressed": "1.14285714",
+                                          "smallerText": "1.33333333",
+                                          "subsectionTitle": "1.2",
+                                          "title": "1.04347826",
+                                        },
+                                        "radii": Object {
+                                          "circle": "50%",
+                                          "medium": "4px",
+                                          "small": "2px",
+                                        },
+                                        "shadows": Object {
+                                          "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                          "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                          "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                          "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                          "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                        },
+                                        "space": Object {
+                                          "half": "4px",
+                                          "none": "0px",
+                                          "x1": "8px",
+                                          "x2": "16px",
+                                          "x3": "24px",
+                                          "x4": "32px",
+                                          "x5": "40px",
+                                          "x6": "48px",
+                                          "x8": "64px",
+                                        },
+                                        "zIndex": Object {
+                                          "content": 100,
+                                          "overlay": 1000,
+                                          "tabsBar": 210,
+                                          "tabsScollIndicator": 200,
+                                        },
+                                      },
+                                      "underline": true,
                                     },
-                                    "attrs": Array [
-                                      [Function],
-                                    ],
+                                    "attrs": Array [],
                                     "componentStyle": ComponentStyle {
-                                      "componentId": "sc-bxivhb",
+                                      "componentId": "Link-sc-1lpx3d0-0",
                                       "isStatic": false,
-                                      "lastClassName": "pAxHO",
+                                      "lastClassName": "cRusvg",
                                       "rules": Array [
-                                        [Function],
-                                        [Function],
-                                        [Function],
-                                        [Function],
-                                        [Function],
                                         [Function],
                                         [Function],
                                         [Function],
                                       ],
                                     },
-                                    "displayName": "styled.p",
+                                    "displayName": "Link",
                                     "foldedComponentIds": Array [],
                                     "propTypes": Object {
-                                      "disabled": [Function],
-                                      "inline": [Function],
+                                      "bg": [Function],
+                                      "className": [Function],
+                                      "color": [Function],
+                                      "hover": [Function],
+                                      "m": [Function],
+                                      "mb": [Function],
+                                      "ml": [Function],
+                                      "mr": [Function],
+                                      "mt": [Function],
+                                      "mx": [Function],
+                                      "my": [Function],
+                                      "p": [Function],
+                                      "pb": [Function],
+                                      "pl": [Function],
+                                      "pr": [Function],
+                                      "pt": [Function],
+                                      "px": [Function],
+                                      "py": [Function],
+                                      "underline": [Function],
                                     },
                                     "render": [Function],
-                                    "styledComponentId": "sc-bxivhb",
-                                    "target": "p",
+                                    "styledComponentId": "Link-sc-1lpx3d0-0",
+                                    "target": "a",
                                     "toString": [Function],
                                     "usesTheme": false,
                                     "warnTooManyClasses": [Function],
@@ -9483,32 +9799,116 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                                   }
                                 }
                                 forwardedRef={[Function]}
-                                inline={true}
-                                lineHeight="1.5"
-                                m={0}
-                                mr="x2"
+                                href="/"
                                 onBlur={[Function]}
                                 onFocus={[Function]}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
+                                p={0}
+                                theme={
+                                  Object {
+                                    "borders": Array [],
+                                    "breakpoints": Object {
+                                      "extraLarge": "1920px",
+                                      "extraSmall": "0px",
+                                      "large": "1360px",
+                                      "medium": "1024px",
+                                      "small": "768px",
+                                    },
+                                    "colors": Object {
+                                      "black": "#011e38",
+                                      "blackBlue": "#122b47",
+                                      "blue": "#216beb",
+                                      "darkBlue": "#00438f",
+                                      "darkGrey": "#434d59",
+                                      "green": "#008059",
+                                      "grey": "#c0c8d1",
+                                      "lightBlue": "#e1ebfa",
+                                      "lightGreen": "#e9f7f2",
+                                      "lightGrey": "#e4e7eb",
+                                      "lightRed": "#fae6ea",
+                                      "lightYellow": "#fcf5e3",
+                                      "red": "#cc1439",
+                                      "white": "#ffffff",
+                                      "whiteGrey": "#f0f2f5",
+                                      "yellow": "#ffbb00",
+                                    },
+                                    "fontSizes": Object {
+                                      "large": "20px",
+                                      "larger": "26px",
+                                      "largest": "46px",
+                                      "medium": "16px",
+                                      "small": "14px",
+                                      "smaller": "12px",
+                                    },
+                                    "fontWeights": Object {
+                                      "bold": "600",
+                                      "light": "300",
+                                      "medium": "500",
+                                      "normal": "400",
+                                    },
+                                    "fonts": Object {
+                                      "base": "'IBM Plex Sans', sans-serif",
+                                      "mono": "'IBM Plex Mono', monospace",
+                                    },
+                                    "lineHeights": Object {
+                                      "base": "1.5",
+                                      "sectionTitle": "1.23076923",
+                                      "smallTextBase": "1.71428571",
+                                      "smallTextCompressed": "1.14285714",
+                                      "smallerText": "1.33333333",
+                                      "subsectionTitle": "1.2",
+                                      "title": "1.04347826",
+                                    },
+                                    "radii": Object {
+                                      "circle": "50%",
+                                      "medium": "4px",
+                                      "small": "2px",
+                                    },
+                                    "shadows": Object {
+                                      "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                      "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                      "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                      "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                      "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                    },
+                                    "space": Object {
+                                      "half": "4px",
+                                      "none": "0px",
+                                      "x1": "8px",
+                                      "x2": "16px",
+                                      "x3": "24px",
+                                      "x4": "32px",
+                                      "x5": "40px",
+                                      "x6": "48px",
+                                      "x8": "64px",
+                                    },
+                                    "zIndex": Object {
+                                      "content": 100,
+                                      "overlay": 1000,
+                                      "tabsBar": 210,
+                                      "tabsScollIndicator": 200,
+                                    },
+                                  }
+                                }
+                                underline={true}
                               >
-                                <span
+                                <a
                                   aria-describedby="random-id-23"
                                   aria-expanded={false}
                                   aria-haspopup={true}
-                                  className="sc-bxivhb pAxHO"
-                                  color="currentColor"
-                                  disabled={false}
-                                  fontSize="16px"
+                                  className="Link-sc-1lpx3d0-0 cRusvg"
+                                  color="blue"
+                                  href="/"
                                   onBlur={[Function]}
                                   onFocus={[Function]}
                                   onMouseEnter={[Function]}
                                   onMouseLeave={[Function]}
                                 >
-                                  Inline Text
-                                </span>
+                                   Link 
+                                </a>
                               </StyledComponent>
-                            </styled.p>
+                            </Link>
                           </InnerReference>
                         </Reference>
                         <Popper
@@ -9519,16 +9919,16 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                             placement="bottom"
                             positionFixed={false}
                             referenceElement={
-                              <span
+                              <a
                                 aria-describedby="random-id-23"
                                 aria-expanded="false"
                                 aria-haspopup="true"
-                                class="sc-bxivhb pAxHO"
-                                color="currentColor"
-                                font-size="16px"
+                                class="Link-sc-1lpx3d0-0 cRusvg"
+                                color="blue"
+                                href="/"
                               >
-                                Inline Text
-                              </span>
+                                 Link 
+                              </a>
                             }
                           >
                             <Styled(Box)
@@ -10020,6 +10420,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
             >
               <WithGeneratedId>
                 <MenuComponent
+                  defaultOpen={false}
                   hideDelay="350"
                   id="random-id-24"
                   placement="bottom"
@@ -10051,212 +10452,50 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                           <InnerReference
                             setReferenceNode={[Function]}
                           >
-                            <Box
+                            <styled.p
                               aria-describedby="random-id-24"
                               aria-expanded={false}
                               aria-haspopup={true}
                               bg="blue"
+                              color="currentColor"
+                              disabled={false}
+                              fontSize="16px"
+                              inline={true}
+                              lineHeight="1.5"
+                              m={0}
+                              mr="x2"
                               onBlur={[Function]}
                               onFocus={[Function]}
                               onMouseEnter={[Function]}
                               onMouseLeave={[Function]}
-                              theme={
-                                Object {
-                                  "borders": Array [],
-                                  "breakpoints": Object {
-                                    "extraLarge": "1920px",
-                                    "extraSmall": "0px",
-                                    "large": "1360px",
-                                    "medium": "1024px",
-                                    "small": "768px",
-                                  },
-                                  "colors": Object {
-                                    "black": "#011e38",
-                                    "blackBlue": "#122b47",
-                                    "blue": "#216beb",
-                                    "darkBlue": "#00438f",
-                                    "darkGrey": "#434d59",
-                                    "green": "#008059",
-                                    "grey": "#c0c8d1",
-                                    "lightBlue": "#e1ebfa",
-                                    "lightGreen": "#e9f7f2",
-                                    "lightGrey": "#e4e7eb",
-                                    "lightRed": "#fae6ea",
-                                    "lightYellow": "#fcf5e3",
-                                    "red": "#cc1439",
-                                    "white": "#ffffff",
-                                    "whiteGrey": "#f0f2f5",
-                                    "yellow": "#ffbb00",
-                                  },
-                                  "fontSizes": Object {
-                                    "large": "20px",
-                                    "larger": "26px",
-                                    "largest": "46px",
-                                    "medium": "16px",
-                                    "small": "14px",
-                                    "smaller": "12px",
-                                  },
-                                  "fontWeights": Object {
-                                    "bold": "600",
-                                    "light": "300",
-                                    "medium": "500",
-                                    "normal": "400",
-                                  },
-                                  "fonts": Object {
-                                    "base": "'IBM Plex Sans', sans-serif",
-                                    "mono": "'IBM Plex Mono', monospace",
-                                  },
-                                  "lineHeights": Object {
-                                    "base": "1.5",
-                                    "sectionTitle": "1.23076923",
-                                    "smallTextBase": "1.71428571",
-                                    "smallTextCompressed": "1.14285714",
-                                    "smallerText": "1.33333333",
-                                    "subsectionTitle": "1.2",
-                                    "title": "1.04347826",
-                                  },
-                                  "radii": Object {
-                                    "circle": "50%",
-                                    "medium": "4px",
-                                    "small": "2px",
-                                  },
-                                  "shadows": Object {
-                                    "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                    "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                    "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                    "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                    "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                                  },
-                                  "space": Object {
-                                    "half": "4px",
-                                    "none": "0px",
-                                    "x1": "8px",
-                                    "x2": "16px",
-                                    "x3": "24px",
-                                    "x4": "32px",
-                                    "x5": "40px",
-                                    "x6": "48px",
-                                    "x8": "64px",
-                                  },
-                                  "zIndex": Object {
-                                    "content": 100,
-                                    "overlay": 1000,
-                                    "tabsBar": 210,
-                                    "tabsScollIndicator": 200,
-                                  },
-                                }
-                              }
-                              width="200px"
                             >
                               <StyledComponent
                                 aria-describedby="random-id-24"
                                 aria-expanded={false}
                                 aria-haspopup={true}
                                 bg="blue"
+                                color="currentColor"
+                                disabled={false}
+                                fontSize="16px"
                                 forwardedComponent={
                                   Object {
                                     "$$typeof": Symbol(react.forward_ref),
                                     "_foldedDefaultProps": Object {
-                                      "theme": Object {
-                                        "borders": Array [],
-                                        "breakpoints": Object {
-                                          "extraLarge": "1920px",
-                                          "extraSmall": "0px",
-                                          "large": "1360px",
-                                          "medium": "1024px",
-                                          "small": "768px",
-                                        },
-                                        "colors": Object {
-                                          "black": "#011e38",
-                                          "blackBlue": "#122b47",
-                                          "blue": "#216beb",
-                                          "darkBlue": "#00438f",
-                                          "darkGrey": "#434d59",
-                                          "green": "#008059",
-                                          "grey": "#c0c8d1",
-                                          "lightBlue": "#e1ebfa",
-                                          "lightGreen": "#e9f7f2",
-                                          "lightGrey": "#e4e7eb",
-                                          "lightRed": "#fae6ea",
-                                          "lightYellow": "#fcf5e3",
-                                          "red": "#cc1439",
-                                          "white": "#ffffff",
-                                          "whiteGrey": "#f0f2f5",
-                                          "yellow": "#ffbb00",
-                                        },
-                                        "fontSizes": Object {
-                                          "large": "20px",
-                                          "larger": "26px",
-                                          "largest": "46px",
-                                          "medium": "16px",
-                                          "small": "14px",
-                                          "smaller": "12px",
-                                        },
-                                        "fontWeights": Object {
-                                          "bold": "600",
-                                          "light": "300",
-                                          "medium": "500",
-                                          "normal": "400",
-                                        },
-                                        "fonts": Object {
-                                          "base": "'IBM Plex Sans', sans-serif",
-                                          "mono": "'IBM Plex Mono', monospace",
-                                        },
-                                        "lineHeights": Object {
-                                          "base": "1.5",
-                                          "sectionTitle": "1.23076923",
-                                          "smallTextBase": "1.71428571",
-                                          "smallTextCompressed": "1.14285714",
-                                          "smallerText": "1.33333333",
-                                          "subsectionTitle": "1.2",
-                                          "title": "1.04347826",
-                                        },
-                                        "radii": Object {
-                                          "circle": "50%",
-                                          "medium": "4px",
-                                          "small": "2px",
-                                        },
-                                        "shadows": Object {
-                                          "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                          "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                          "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                          "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                          "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                                        },
-                                        "space": Object {
-                                          "half": "4px",
-                                          "none": "0px",
-                                          "x1": "8px",
-                                          "x2": "16px",
-                                          "x3": "24px",
-                                          "x4": "32px",
-                                          "x5": "40px",
-                                          "x6": "48px",
-                                          "x8": "64px",
-                                        },
-                                        "zIndex": Object {
-                                          "content": 100,
-                                          "overlay": 1000,
-                                          "tabsBar": 210,
-                                          "tabsScollIndicator": 200,
-                                        },
-                                      },
+                                      "color": "currentColor",
+                                      "disabled": false,
+                                      "fontSize": "16px",
+                                      "inline": false,
+                                      "lineHeight": "1.5",
+                                      "m": 0,
                                     },
-                                    "attrs": Array [],
+                                    "attrs": Array [
+                                      [Function],
+                                    ],
                                     "componentStyle": ComponentStyle {
-                                      "componentId": "Box-sc-1qu1edy-0",
+                                      "componentId": "sc-bxivhb",
                                       "isStatic": false,
-                                      "lastClassName": "kElHLN",
+                                      "lastClassName": "pAxHO",
                                       "rules": Array [
-                                        [Function],
-                                        [Function],
-                                        [Function],
-                                        [Function],
-                                        [Function],
-                                        [Function],
-                                        [Function],
-                                        [Function],
-                                        [Function],
                                         [Function],
                                         [Function],
                                         [Function],
@@ -10267,47 +10506,15 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                                         [Function],
                                       ],
                                     },
-                                    "displayName": "Box",
+                                    "displayName": "styled.p",
                                     "foldedComponentIds": Array [],
                                     "propTypes": Object {
-                                      "bg": [Function],
-                                      "border": [Function],
-                                      "borderBottom": [Function],
-                                      "borderLeft": [Function],
-                                      "borderRadius": [Function],
-                                      "borderRight": [Function],
-                                      "borderTop": [Function],
-                                      "boxShadow": [Function],
-                                      "color": [Function],
-                                      "display": [Function],
-                                      "flexGrow": [Function],
-                                      "height": [Function],
-                                      "m": [Function],
-                                      "maxHeight": [Function],
-                                      "maxWidth": [Function],
-                                      "mb": [Function],
-                                      "minHeight": [Function],
-                                      "minWidth": [Function],
-                                      "ml": [Function],
-                                      "mr": [Function],
-                                      "mt": [Function],
-                                      "mx": [Function],
-                                      "my": [Function],
-                                      "order": [Function],
-                                      "p": [Function],
-                                      "pb": [Function],
-                                      "pl": [Function],
-                                      "position": [Function],
-                                      "pr": [Function],
-                                      "pt": [Function],
-                                      "px": [Function],
-                                      "py": [Function],
-                                      "textAlign": [Function],
-                                      "width": [Function],
+                                      "disabled": [Function],
+                                      "inline": [Function],
                                     },
                                     "render": [Function],
-                                    "styledComponentId": "Box-sc-1qu1edy-0",
-                                    "target": "div",
+                                    "styledComponentId": "sc-bxivhb",
+                                    "target": "p",
                                     "toString": [Function],
                                     "usesTheme": false,
                                     "warnTooManyClasses": [Function],
@@ -10315,113 +10522,32 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                                   }
                                 }
                                 forwardedRef={[Function]}
+                                inline={true}
+                                lineHeight="1.5"
+                                m={0}
+                                mr="x2"
                                 onBlur={[Function]}
                                 onFocus={[Function]}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
-                                theme={
-                                  Object {
-                                    "borders": Array [],
-                                    "breakpoints": Object {
-                                      "extraLarge": "1920px",
-                                      "extraSmall": "0px",
-                                      "large": "1360px",
-                                      "medium": "1024px",
-                                      "small": "768px",
-                                    },
-                                    "colors": Object {
-                                      "black": "#011e38",
-                                      "blackBlue": "#122b47",
-                                      "blue": "#216beb",
-                                      "darkBlue": "#00438f",
-                                      "darkGrey": "#434d59",
-                                      "green": "#008059",
-                                      "grey": "#c0c8d1",
-                                      "lightBlue": "#e1ebfa",
-                                      "lightGreen": "#e9f7f2",
-                                      "lightGrey": "#e4e7eb",
-                                      "lightRed": "#fae6ea",
-                                      "lightYellow": "#fcf5e3",
-                                      "red": "#cc1439",
-                                      "white": "#ffffff",
-                                      "whiteGrey": "#f0f2f5",
-                                      "yellow": "#ffbb00",
-                                    },
-                                    "fontSizes": Object {
-                                      "large": "20px",
-                                      "larger": "26px",
-                                      "largest": "46px",
-                                      "medium": "16px",
-                                      "small": "14px",
-                                      "smaller": "12px",
-                                    },
-                                    "fontWeights": Object {
-                                      "bold": "600",
-                                      "light": "300",
-                                      "medium": "500",
-                                      "normal": "400",
-                                    },
-                                    "fonts": Object {
-                                      "base": "'IBM Plex Sans', sans-serif",
-                                      "mono": "'IBM Plex Mono', monospace",
-                                    },
-                                    "lineHeights": Object {
-                                      "base": "1.5",
-                                      "sectionTitle": "1.23076923",
-                                      "smallTextBase": "1.71428571",
-                                      "smallTextCompressed": "1.14285714",
-                                      "smallerText": "1.33333333",
-                                      "subsectionTitle": "1.2",
-                                      "title": "1.04347826",
-                                    },
-                                    "radii": Object {
-                                      "circle": "50%",
-                                      "medium": "4px",
-                                      "small": "2px",
-                                    },
-                                    "shadows": Object {
-                                      "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                      "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                      "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                      "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                      "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                                    },
-                                    "space": Object {
-                                      "half": "4px",
-                                      "none": "0px",
-                                      "x1": "8px",
-                                      "x2": "16px",
-                                      "x3": "24px",
-                                      "x4": "32px",
-                                      "x5": "40px",
-                                      "x6": "48px",
-                                      "x8": "64px",
-                                    },
-                                    "zIndex": Object {
-                                      "content": 100,
-                                      "overlay": 1000,
-                                      "tabsBar": 210,
-                                      "tabsScollIndicator": 200,
-                                    },
-                                  }
-                                }
-                                width="200px"
                               >
-                                <div
+                                <span
                                   aria-describedby="random-id-24"
                                   aria-expanded={false}
                                   aria-haspopup={true}
-                                  className="Box-sc-1qu1edy-0 mCCAC"
+                                  className="sc-bxivhb pAxHO"
+                                  color="currentColor"
+                                  disabled={false}
+                                  fontSize="16px"
                                   onBlur={[Function]}
                                   onFocus={[Function]}
                                   onMouseEnter={[Function]}
                                   onMouseLeave={[Function]}
-                                  width="200px"
                                 >
-                                  Box width 200px
-                                </div>
+                                  Inline Text
+                                </span>
                               </StyledComponent>
-                            </Box>
+                            </styled.p>
                           </InnerReference>
                         </Reference>
                         <Popper
@@ -10432,15 +10558,16 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                             placement="bottom"
                             positionFixed={false}
                             referenceElement={
-                              <div
+                              <span
                                 aria-describedby="random-id-24"
                                 aria-expanded="false"
                                 aria-haspopup="true"
-                                class="Box-sc-1qu1edy-0 mCCAC"
-                                width="200px"
+                                class="sc-bxivhb pAxHO"
+                                color="currentColor"
+                                font-size="16px"
                               >
-                                Box width 200px
-                              </div>
+                                Inline Text
+                              </span>
                             }
                           >
                             <Styled(Box)
@@ -10932,6 +11059,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
             >
               <WithGeneratedId>
                 <MenuComponent
+                  defaultOpen={false}
                   hideDelay="350"
                   id="random-id-25"
                   placement="bottom"
@@ -11058,6 +11186,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                                   },
                                 }
                               }
+                              width="200px"
                             >
                               <StyledComponent
                                 aria-describedby="random-id-25"
@@ -11316,18 +11445,20 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                                     },
                                   }
                                 }
+                                width="200px"
                               >
                                 <div
                                   aria-describedby="random-id-25"
                                   aria-expanded={false}
                                   aria-haspopup={true}
-                                  className="Box-sc-1qu1edy-0 kElHLN"
+                                  className="Box-sc-1qu1edy-0 mCCAC"
                                   onBlur={[Function]}
                                   onFocus={[Function]}
                                   onMouseEnter={[Function]}
                                   onMouseLeave={[Function]}
+                                  width="200px"
                                 >
-                                  Box
+                                  Box width 200px
                                 </div>
                               </StyledComponent>
                             </Box>
@@ -11345,9 +11476,10 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                                 aria-describedby="random-id-25"
                                 aria-expanded="false"
                                 aria-haspopup="true"
-                                class="Box-sc-1qu1edy-0 kElHLN"
+                                class="Box-sc-1qu1edy-0 mCCAC"
+                                width="200px"
                               >
-                                Box
+                                Box width 200px
                               </div>
                             }
                           >
@@ -11740,6 +11872,915 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                                 <div
                                   className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
                                   id="random-id-25"
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                  open={false}
+                                  role="tooltip"
+                                >
+                                  Tooltip
+                                  <PopperArrow
+                                    backgroundColor="white"
+                                    borderColor="grey"
+                                    placement="bottom"
+                                    style={Object {}}
+                                  >
+                                    <StyledComponent
+                                      backgroundColor="white"
+                                      borderColor="grey"
+                                      forwardedComponent={
+                                        Object {
+                                          "$$typeof": Symbol(react.forward_ref),
+                                          "_foldedDefaultProps": Object {
+                                            "backgroundColor": "white",
+                                            "borderColor": "grey",
+                                            "placement": "bottom",
+                                          },
+                                          "attrs": Array [],
+                                          "componentStyle": ComponentStyle {
+                                            "componentId": "PopperArrow-sc-1bcgj4w-0",
+                                            "isStatic": false,
+                                            "lastClassName": "bBzGzE",
+                                            "rules": Array [
+                                              "position: absolute;",
+                                              "height: 8px;",
+                                              "width: 8px;",
+                                              "margin: 12px;",
+                                              "&:before {",
+                                              "border-style: solid;",
+                                              "content: '';",
+                                              "display: block;",
+                                              "height: 0;",
+                                              "margin: auto;",
+                                              "position: absolute;",
+                                              "width: 0;",
+                                              "}",
+                                              "&:after {",
+                                              "border-style: solid;",
+                                              "content: '';",
+                                              "display: block;",
+                                              "height: 0;",
+                                              "margin: auto;",
+                                              "position: absolute;",
+                                              "width: 0;",
+                                              "}",
+                                              [Function],
+                                              [Function],
+                                            ],
+                                          },
+                                          "displayName": "PopperArrow",
+                                          "foldedComponentIds": Array [],
+                                          "propTypes": Object {
+                                            "backgroundColor": [Function],
+                                            "borderColor": [Function],
+                                            "placement": [Function],
+                                          },
+                                          "render": [Function],
+                                          "styledComponentId": "PopperArrow-sc-1bcgj4w-0",
+                                          "target": "div",
+                                          "toString": [Function],
+                                          "usesTheme": false,
+                                          "warnTooManyClasses": [Function],
+                                          "withComponent": [Function],
+                                        }
+                                      }
+                                      forwardedRef={[Function]}
+                                      placement="bottom"
+                                      style={Object {}}
+                                    >
+                                      <div
+                                        className="PopperArrow-sc-1bcgj4w-0 bBzGzE"
+                                        style={Object {}}
+                                      />
+                                    </StyledComponent>
+                                  </PopperArrow>
+                                </div>
+                              </StyledComponent>
+                            </Styled(Box)>
+                          </InnerPopper>
+                        </Popper>
+                      </Manager>
+                    </StatelessTooltip>
+                  </MenuState>
+                </MenuComponent>
+              </WithGeneratedId>
+            </Component>
+            <Component
+              placement="bottom"
+              tooltip="Tooltip"
+            >
+              <WithGeneratedId>
+                <MenuComponent
+                  defaultOpen={false}
+                  hideDelay="350"
+                  id="random-id-26"
+                  placement="bottom"
+                  showDelay="100"
+                  tooltip="Tooltip"
+                >
+                  <MenuState
+                    defaultOpen={false}
+                    hideDelay="350"
+                    showDelay="100"
+                  >
+                    <StatelessTooltip
+                      id="random-id-26"
+                      maxWidth="24em"
+                      menuState={
+                        Object {
+                          "closeMenu": [Function],
+                          "handleMenuKeydown": [Function],
+                          "isOpen": false,
+                          "openMenu": [Function],
+                          "toggleMenu": [Function],
+                        }
+                      }
+                      placement="bottom"
+                      tooltip="Tooltip"
+                    >
+                      <Manager>
+                        <Reference>
+                          <InnerReference
+                            setReferenceNode={[Function]}
+                          >
+                            <Box
+                              aria-describedby="random-id-26"
+                              aria-expanded={false}
+                              aria-haspopup={true}
+                              bg="blue"
+                              onBlur={[Function]}
+                              onFocus={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                              theme={
+                                Object {
+                                  "borders": Array [],
+                                  "breakpoints": Object {
+                                    "extraLarge": "1920px",
+                                    "extraSmall": "0px",
+                                    "large": "1360px",
+                                    "medium": "1024px",
+                                    "small": "768px",
+                                  },
+                                  "colors": Object {
+                                    "black": "#011e38",
+                                    "blackBlue": "#122b47",
+                                    "blue": "#216beb",
+                                    "darkBlue": "#00438f",
+                                    "darkGrey": "#434d59",
+                                    "green": "#008059",
+                                    "grey": "#c0c8d1",
+                                    "lightBlue": "#e1ebfa",
+                                    "lightGreen": "#e9f7f2",
+                                    "lightGrey": "#e4e7eb",
+                                    "lightRed": "#fae6ea",
+                                    "lightYellow": "#fcf5e3",
+                                    "red": "#cc1439",
+                                    "white": "#ffffff",
+                                    "whiteGrey": "#f0f2f5",
+                                    "yellow": "#ffbb00",
+                                  },
+                                  "fontSizes": Object {
+                                    "large": "20px",
+                                    "larger": "26px",
+                                    "largest": "46px",
+                                    "medium": "16px",
+                                    "small": "14px",
+                                    "smaller": "12px",
+                                  },
+                                  "fontWeights": Object {
+                                    "bold": "600",
+                                    "light": "300",
+                                    "medium": "500",
+                                    "normal": "400",
+                                  },
+                                  "fonts": Object {
+                                    "base": "'IBM Plex Sans', sans-serif",
+                                    "mono": "'IBM Plex Mono', monospace",
+                                  },
+                                  "lineHeights": Object {
+                                    "base": "1.5",
+                                    "sectionTitle": "1.23076923",
+                                    "smallTextBase": "1.71428571",
+                                    "smallTextCompressed": "1.14285714",
+                                    "smallerText": "1.33333333",
+                                    "subsectionTitle": "1.2",
+                                    "title": "1.04347826",
+                                  },
+                                  "radii": Object {
+                                    "circle": "50%",
+                                    "medium": "4px",
+                                    "small": "2px",
+                                  },
+                                  "shadows": Object {
+                                    "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                    "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                    "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                    "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                    "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                  },
+                                  "space": Object {
+                                    "half": "4px",
+                                    "none": "0px",
+                                    "x1": "8px",
+                                    "x2": "16px",
+                                    "x3": "24px",
+                                    "x4": "32px",
+                                    "x5": "40px",
+                                    "x6": "48px",
+                                    "x8": "64px",
+                                  },
+                                  "zIndex": Object {
+                                    "content": 100,
+                                    "overlay": 1000,
+                                    "tabsBar": 210,
+                                    "tabsScollIndicator": 200,
+                                  },
+                                }
+                              }
+                            >
+                              <StyledComponent
+                                aria-describedby="random-id-26"
+                                aria-expanded={false}
+                                aria-haspopup={true}
+                                bg="blue"
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "_foldedDefaultProps": Object {
+                                      "theme": Object {
+                                        "borders": Array [],
+                                        "breakpoints": Object {
+                                          "extraLarge": "1920px",
+                                          "extraSmall": "0px",
+                                          "large": "1360px",
+                                          "medium": "1024px",
+                                          "small": "768px",
+                                        },
+                                        "colors": Object {
+                                          "black": "#011e38",
+                                          "blackBlue": "#122b47",
+                                          "blue": "#216beb",
+                                          "darkBlue": "#00438f",
+                                          "darkGrey": "#434d59",
+                                          "green": "#008059",
+                                          "grey": "#c0c8d1",
+                                          "lightBlue": "#e1ebfa",
+                                          "lightGreen": "#e9f7f2",
+                                          "lightGrey": "#e4e7eb",
+                                          "lightRed": "#fae6ea",
+                                          "lightYellow": "#fcf5e3",
+                                          "red": "#cc1439",
+                                          "white": "#ffffff",
+                                          "whiteGrey": "#f0f2f5",
+                                          "yellow": "#ffbb00",
+                                        },
+                                        "fontSizes": Object {
+                                          "large": "20px",
+                                          "larger": "26px",
+                                          "largest": "46px",
+                                          "medium": "16px",
+                                          "small": "14px",
+                                          "smaller": "12px",
+                                        },
+                                        "fontWeights": Object {
+                                          "bold": "600",
+                                          "light": "300",
+                                          "medium": "500",
+                                          "normal": "400",
+                                        },
+                                        "fonts": Object {
+                                          "base": "'IBM Plex Sans', sans-serif",
+                                          "mono": "'IBM Plex Mono', monospace",
+                                        },
+                                        "lineHeights": Object {
+                                          "base": "1.5",
+                                          "sectionTitle": "1.23076923",
+                                          "smallTextBase": "1.71428571",
+                                          "smallTextCompressed": "1.14285714",
+                                          "smallerText": "1.33333333",
+                                          "subsectionTitle": "1.2",
+                                          "title": "1.04347826",
+                                        },
+                                        "radii": Object {
+                                          "circle": "50%",
+                                          "medium": "4px",
+                                          "small": "2px",
+                                        },
+                                        "shadows": Object {
+                                          "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                          "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                          "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                          "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                          "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                        },
+                                        "space": Object {
+                                          "half": "4px",
+                                          "none": "0px",
+                                          "x1": "8px",
+                                          "x2": "16px",
+                                          "x3": "24px",
+                                          "x4": "32px",
+                                          "x5": "40px",
+                                          "x6": "48px",
+                                          "x8": "64px",
+                                        },
+                                        "zIndex": Object {
+                                          "content": 100,
+                                          "overlay": 1000,
+                                          "tabsBar": 210,
+                                          "tabsScollIndicator": 200,
+                                        },
+                                      },
+                                    },
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "Box-sc-1qu1edy-0",
+                                      "isStatic": false,
+                                      "lastClassName": "kElHLN",
+                                      "rules": Array [
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                      ],
+                                    },
+                                    "displayName": "Box",
+                                    "foldedComponentIds": Array [],
+                                    "propTypes": Object {
+                                      "bg": [Function],
+                                      "border": [Function],
+                                      "borderBottom": [Function],
+                                      "borderLeft": [Function],
+                                      "borderRadius": [Function],
+                                      "borderRight": [Function],
+                                      "borderTop": [Function],
+                                      "boxShadow": [Function],
+                                      "color": [Function],
+                                      "display": [Function],
+                                      "flexGrow": [Function],
+                                      "height": [Function],
+                                      "m": [Function],
+                                      "maxHeight": [Function],
+                                      "maxWidth": [Function],
+                                      "mb": [Function],
+                                      "minHeight": [Function],
+                                      "minWidth": [Function],
+                                      "ml": [Function],
+                                      "mr": [Function],
+                                      "mt": [Function],
+                                      "mx": [Function],
+                                      "my": [Function],
+                                      "order": [Function],
+                                      "p": [Function],
+                                      "pb": [Function],
+                                      "pl": [Function],
+                                      "position": [Function],
+                                      "pr": [Function],
+                                      "pt": [Function],
+                                      "px": [Function],
+                                      "py": [Function],
+                                      "textAlign": [Function],
+                                      "width": [Function],
+                                    },
+                                    "render": [Function],
+                                    "styledComponentId": "Box-sc-1qu1edy-0",
+                                    "target": "div",
+                                    "toString": [Function],
+                                    "usesTheme": false,
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={[Function]}
+                                onBlur={[Function]}
+                                onFocus={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                theme={
+                                  Object {
+                                    "borders": Array [],
+                                    "breakpoints": Object {
+                                      "extraLarge": "1920px",
+                                      "extraSmall": "0px",
+                                      "large": "1360px",
+                                      "medium": "1024px",
+                                      "small": "768px",
+                                    },
+                                    "colors": Object {
+                                      "black": "#011e38",
+                                      "blackBlue": "#122b47",
+                                      "blue": "#216beb",
+                                      "darkBlue": "#00438f",
+                                      "darkGrey": "#434d59",
+                                      "green": "#008059",
+                                      "grey": "#c0c8d1",
+                                      "lightBlue": "#e1ebfa",
+                                      "lightGreen": "#e9f7f2",
+                                      "lightGrey": "#e4e7eb",
+                                      "lightRed": "#fae6ea",
+                                      "lightYellow": "#fcf5e3",
+                                      "red": "#cc1439",
+                                      "white": "#ffffff",
+                                      "whiteGrey": "#f0f2f5",
+                                      "yellow": "#ffbb00",
+                                    },
+                                    "fontSizes": Object {
+                                      "large": "20px",
+                                      "larger": "26px",
+                                      "largest": "46px",
+                                      "medium": "16px",
+                                      "small": "14px",
+                                      "smaller": "12px",
+                                    },
+                                    "fontWeights": Object {
+                                      "bold": "600",
+                                      "light": "300",
+                                      "medium": "500",
+                                      "normal": "400",
+                                    },
+                                    "fonts": Object {
+                                      "base": "'IBM Plex Sans', sans-serif",
+                                      "mono": "'IBM Plex Mono', monospace",
+                                    },
+                                    "lineHeights": Object {
+                                      "base": "1.5",
+                                      "sectionTitle": "1.23076923",
+                                      "smallTextBase": "1.71428571",
+                                      "smallTextCompressed": "1.14285714",
+                                      "smallerText": "1.33333333",
+                                      "subsectionTitle": "1.2",
+                                      "title": "1.04347826",
+                                    },
+                                    "radii": Object {
+                                      "circle": "50%",
+                                      "medium": "4px",
+                                      "small": "2px",
+                                    },
+                                    "shadows": Object {
+                                      "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                      "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                      "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                      "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                      "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                    },
+                                    "space": Object {
+                                      "half": "4px",
+                                      "none": "0px",
+                                      "x1": "8px",
+                                      "x2": "16px",
+                                      "x3": "24px",
+                                      "x4": "32px",
+                                      "x5": "40px",
+                                      "x6": "48px",
+                                      "x8": "64px",
+                                    },
+                                    "zIndex": Object {
+                                      "content": 100,
+                                      "overlay": 1000,
+                                      "tabsBar": 210,
+                                      "tabsScollIndicator": 200,
+                                    },
+                                  }
+                                }
+                              >
+                                <div
+                                  aria-describedby="random-id-26"
+                                  aria-expanded={false}
+                                  aria-haspopup={true}
+                                  className="Box-sc-1qu1edy-0 kElHLN"
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  Box
+                                </div>
+                              </StyledComponent>
+                            </Box>
+                          </InnerReference>
+                        </Reference>
+                        <Popper
+                          placement="bottom"
+                        >
+                          <InnerPopper
+                            eventsEnabled={true}
+                            placement="bottom"
+                            positionFixed={false}
+                            referenceElement={
+                              <div
+                                aria-describedby="random-id-26"
+                                aria-expanded="false"
+                                aria-haspopup="true"
+                                class="Box-sc-1qu1edy-0 kElHLN"
+                              >
+                                Box
+                              </div>
+                            }
+                          >
+                            <Styled(Box)
+                              id="random-id-26"
+                              maxWidth="24em"
+                              onBlur={[Function]}
+                              onFocus={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                              open={false}
+                              position={
+                                Object {
+                                  "left": 0,
+                                  "opacity": 0,
+                                  "pointerEvents": "none",
+                                  "position": "absolute",
+                                  "top": 0,
+                                }
+                              }
+                              role="tooltip"
+                              theme={
+                                Object {
+                                  "borders": Array [],
+                                  "breakpoints": Object {
+                                    "extraLarge": "1920px",
+                                    "extraSmall": "0px",
+                                    "large": "1360px",
+                                    "medium": "1024px",
+                                    "small": "768px",
+                                  },
+                                  "colors": Object {
+                                    "black": "#011e38",
+                                    "blackBlue": "#122b47",
+                                    "blue": "#216beb",
+                                    "darkBlue": "#00438f",
+                                    "darkGrey": "#434d59",
+                                    "green": "#008059",
+                                    "grey": "#c0c8d1",
+                                    "lightBlue": "#e1ebfa",
+                                    "lightGreen": "#e9f7f2",
+                                    "lightGrey": "#e4e7eb",
+                                    "lightRed": "#fae6ea",
+                                    "lightYellow": "#fcf5e3",
+                                    "red": "#cc1439",
+                                    "white": "#ffffff",
+                                    "whiteGrey": "#f0f2f5",
+                                    "yellow": "#ffbb00",
+                                  },
+                                  "fontSizes": Object {
+                                    "large": "20px",
+                                    "larger": "26px",
+                                    "largest": "46px",
+                                    "medium": "16px",
+                                    "small": "14px",
+                                    "smaller": "12px",
+                                  },
+                                  "fontWeights": Object {
+                                    "bold": "600",
+                                    "light": "300",
+                                    "medium": "500",
+                                    "normal": "400",
+                                  },
+                                  "fonts": Object {
+                                    "base": "'IBM Plex Sans', sans-serif",
+                                    "mono": "'IBM Plex Mono', monospace",
+                                  },
+                                  "lineHeights": Object {
+                                    "base": "1.5",
+                                    "sectionTitle": "1.23076923",
+                                    "smallTextBase": "1.71428571",
+                                    "smallTextCompressed": "1.14285714",
+                                    "smallerText": "1.33333333",
+                                    "subsectionTitle": "1.2",
+                                    "title": "1.04347826",
+                                  },
+                                  "radii": Object {
+                                    "circle": "50%",
+                                    "medium": "4px",
+                                    "small": "2px",
+                                  },
+                                  "shadows": Object {
+                                    "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                    "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                    "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                    "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                    "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                  },
+                                  "space": Object {
+                                    "half": "4px",
+                                    "none": "0px",
+                                    "x1": "8px",
+                                    "x2": "16px",
+                                    "x3": "24px",
+                                    "x4": "32px",
+                                    "x5": "40px",
+                                    "x6": "48px",
+                                    "x8": "64px",
+                                  },
+                                  "zIndex": Object {
+                                    "content": 100,
+                                    "overlay": 1000,
+                                    "tabsBar": 210,
+                                    "tabsScollIndicator": 200,
+                                  },
+                                }
+                              }
+                            >
+                              <StyledComponent
+                                forwardedComponent={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "_foldedDefaultProps": Object {
+                                      "theme": Object {
+                                        "borders": Array [],
+                                        "breakpoints": Object {
+                                          "extraLarge": "1920px",
+                                          "extraSmall": "0px",
+                                          "large": "1360px",
+                                          "medium": "1024px",
+                                          "small": "768px",
+                                        },
+                                        "colors": Object {
+                                          "black": "#011e38",
+                                          "blackBlue": "#122b47",
+                                          "blue": "#216beb",
+                                          "darkBlue": "#00438f",
+                                          "darkGrey": "#434d59",
+                                          "green": "#008059",
+                                          "grey": "#c0c8d1",
+                                          "lightBlue": "#e1ebfa",
+                                          "lightGreen": "#e9f7f2",
+                                          "lightGrey": "#e4e7eb",
+                                          "lightRed": "#fae6ea",
+                                          "lightYellow": "#fcf5e3",
+                                          "red": "#cc1439",
+                                          "white": "#ffffff",
+                                          "whiteGrey": "#f0f2f5",
+                                          "yellow": "#ffbb00",
+                                        },
+                                        "fontSizes": Object {
+                                          "large": "20px",
+                                          "larger": "26px",
+                                          "largest": "46px",
+                                          "medium": "16px",
+                                          "small": "14px",
+                                          "smaller": "12px",
+                                        },
+                                        "fontWeights": Object {
+                                          "bold": "600",
+                                          "light": "300",
+                                          "medium": "500",
+                                          "normal": "400",
+                                        },
+                                        "fonts": Object {
+                                          "base": "'IBM Plex Sans', sans-serif",
+                                          "mono": "'IBM Plex Mono', monospace",
+                                        },
+                                        "lineHeights": Object {
+                                          "base": "1.5",
+                                          "sectionTitle": "1.23076923",
+                                          "smallTextBase": "1.71428571",
+                                          "smallTextCompressed": "1.14285714",
+                                          "smallerText": "1.33333333",
+                                          "subsectionTitle": "1.2",
+                                          "title": "1.04347826",
+                                        },
+                                        "radii": Object {
+                                          "circle": "50%",
+                                          "medium": "4px",
+                                          "small": "2px",
+                                        },
+                                        "shadows": Object {
+                                          "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                          "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                          "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                          "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                          "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                        },
+                                        "space": Object {
+                                          "half": "4px",
+                                          "none": "0px",
+                                          "x1": "8px",
+                                          "x2": "16px",
+                                          "x3": "24px",
+                                          "x4": "32px",
+                                          "x5": "40px",
+                                          "x6": "48px",
+                                          "x8": "64px",
+                                        },
+                                        "zIndex": Object {
+                                          "content": 100,
+                                          "overlay": 1000,
+                                          "tabsBar": 210,
+                                          "tabsScollIndicator": 200,
+                                        },
+                                      },
+                                    },
+                                    "attrs": Array [],
+                                    "componentStyle": ComponentStyle {
+                                      "componentId": "sc-jWBwVP",
+                                      "isStatic": false,
+                                      "lastClassName": "hjigbL",
+                                      "rules": Array [
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        [Function],
+                                        "color: #011e38;",
+                                        "display: flex;",
+                                        "flex-direction: column;",
+                                        "font-size: 14px;",
+                                        "background-color: #ffffff;",
+                                        "border-radius: 4px;",
+                                        "border: 1px solid #c0c8d1;",
+                                        "box-shadow: 0 2px 4px rgba(0, 0, 0, 0.18);",
+                                        "padding: 8px;",
+                                        "transition: opacity 0.3s;",
+                                        "z-index: 100;",
+                                        [Function],
+                                      ],
+                                    },
+                                    "displayName": "Styled(Box)",
+                                    "foldedComponentIds": Array [
+                                      "Box-sc-1qu1edy-0",
+                                    ],
+                                    "propTypes": Object {
+                                      "bg": [Function],
+                                      "border": [Function],
+                                      "borderBottom": [Function],
+                                      "borderLeft": [Function],
+                                      "borderRadius": [Function],
+                                      "borderRight": [Function],
+                                      "borderTop": [Function],
+                                      "boxShadow": [Function],
+                                      "color": [Function],
+                                      "display": [Function],
+                                      "flexGrow": [Function],
+                                      "height": [Function],
+                                      "m": [Function],
+                                      "maxHeight": [Function],
+                                      "maxWidth": [Function],
+                                      "mb": [Function],
+                                      "minHeight": [Function],
+                                      "minWidth": [Function],
+                                      "ml": [Function],
+                                      "mr": [Function],
+                                      "mt": [Function],
+                                      "mx": [Function],
+                                      "my": [Function],
+                                      "order": [Function],
+                                      "p": [Function],
+                                      "pb": [Function],
+                                      "pl": [Function],
+                                      "position": [Function],
+                                      "pr": [Function],
+                                      "pt": [Function],
+                                      "px": [Function],
+                                      "py": [Function],
+                                      "textAlign": [Function],
+                                      "width": [Function],
+                                    },
+                                    "render": [Function],
+                                    "styledComponentId": "sc-jWBwVP",
+                                    "target": "div",
+                                    "toString": [Function],
+                                    "usesTheme": false,
+                                    "warnTooManyClasses": [Function],
+                                    "withComponent": [Function],
+                                  }
+                                }
+                                forwardedRef={[Function]}
+                                id="random-id-26"
+                                maxWidth="24em"
+                                onBlur={[Function]}
+                                onFocus={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                open={false}
+                                position={
+                                  Object {
+                                    "left": 0,
+                                    "opacity": 0,
+                                    "pointerEvents": "none",
+                                    "position": "absolute",
+                                    "top": 0,
+                                  }
+                                }
+                                role="tooltip"
+                                theme={
+                                  Object {
+                                    "borders": Array [],
+                                    "breakpoints": Object {
+                                      "extraLarge": "1920px",
+                                      "extraSmall": "0px",
+                                      "large": "1360px",
+                                      "medium": "1024px",
+                                      "small": "768px",
+                                    },
+                                    "colors": Object {
+                                      "black": "#011e38",
+                                      "blackBlue": "#122b47",
+                                      "blue": "#216beb",
+                                      "darkBlue": "#00438f",
+                                      "darkGrey": "#434d59",
+                                      "green": "#008059",
+                                      "grey": "#c0c8d1",
+                                      "lightBlue": "#e1ebfa",
+                                      "lightGreen": "#e9f7f2",
+                                      "lightGrey": "#e4e7eb",
+                                      "lightRed": "#fae6ea",
+                                      "lightYellow": "#fcf5e3",
+                                      "red": "#cc1439",
+                                      "white": "#ffffff",
+                                      "whiteGrey": "#f0f2f5",
+                                      "yellow": "#ffbb00",
+                                    },
+                                    "fontSizes": Object {
+                                      "large": "20px",
+                                      "larger": "26px",
+                                      "largest": "46px",
+                                      "medium": "16px",
+                                      "small": "14px",
+                                      "smaller": "12px",
+                                    },
+                                    "fontWeights": Object {
+                                      "bold": "600",
+                                      "light": "300",
+                                      "medium": "500",
+                                      "normal": "400",
+                                    },
+                                    "fonts": Object {
+                                      "base": "'IBM Plex Sans', sans-serif",
+                                      "mono": "'IBM Plex Mono', monospace",
+                                    },
+                                    "lineHeights": Object {
+                                      "base": "1.5",
+                                      "sectionTitle": "1.23076923",
+                                      "smallTextBase": "1.71428571",
+                                      "smallTextCompressed": "1.14285714",
+                                      "smallerText": "1.33333333",
+                                      "subsectionTitle": "1.2",
+                                      "title": "1.04347826",
+                                    },
+                                    "radii": Object {
+                                      "circle": "50%",
+                                      "medium": "4px",
+                                      "small": "2px",
+                                    },
+                                    "shadows": Object {
+                                      "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                      "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                      "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                      "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                      "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                    },
+                                    "space": Object {
+                                      "half": "4px",
+                                      "none": "0px",
+                                      "x1": "8px",
+                                      "x2": "16px",
+                                      "x3": "24px",
+                                      "x4": "32px",
+                                      "x5": "40px",
+                                      "x6": "48px",
+                                      "x8": "64px",
+                                    },
+                                    "zIndex": Object {
+                                      "content": 100,
+                                      "overlay": 1000,
+                                      "tabsBar": 210,
+                                      "tabsScollIndicator": 200,
+                                    },
+                                  }
+                                }
+                              >
+                                <div
+                                  className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
+                                  id="random-id-26"
                                   onBlur={[Function]}
                                   onFocus={[Function]}
                                   onMouseEnter={[Function]}
@@ -12560,634 +13601,12 @@ exports[`Storyshots Tooltip with placement 1`] = `
                   >
                     <WithGeneratedId>
                       <MenuComponent
+                        defaultOpen={false}
                         hideDelay="350"
-                        id="random-id-5"
+                        id="random-id-6"
                         placement="top-start"
                         showDelay="100"
                         tooltip="top-start"
-                      >
-                        <MenuState
-                          defaultOpen={false}
-                          hideDelay="350"
-                          showDelay="100"
-                        >
-                          <StatelessTooltip
-                            id="random-id-5"
-                            maxWidth="24em"
-                            menuState={
-                              Object {
-                                "closeMenu": [Function],
-                                "handleMenuKeydown": [Function],
-                                "isOpen": false,
-                                "openMenu": [Function],
-                                "toggleMenu": [Function],
-                              }
-                            }
-                            placement="top-start"
-                            tooltip="top-start"
-                          >
-                            <Manager>
-                              <Reference>
-                                <InnerReference
-                                  setReferenceNode={[Function]}
-                                >
-                                  <ForwardRef
-                                    aria-describedby="random-id-5"
-                                    aria-expanded={false}
-                                    aria-haspopup={true}
-                                    asLink={false}
-                                    disabled={false}
-                                    fullWidth={false}
-                                    icon={null}
-                                    iconSide="right"
-                                    onBlur={[Function]}
-                                    onFocus={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    size="medium"
-                                  >
-                                    <Button__WrapperButton
-                                      aria-describedby="random-id-5"
-                                      aria-expanded={false}
-                                      aria-haspopup={true}
-                                      disabled={false}
-                                      fullWidth={false}
-                                      onBlur={[Function]}
-                                      onFocus={[Function]}
-                                      onMouseEnter={[Function]}
-                                      onMouseLeave={[Function]}
-                                      size="medium"
-                                    >
-                                      <StyledComponent
-                                        aria-describedby="random-id-5"
-                                        aria-expanded={false}
-                                        aria-haspopup={true}
-                                        disabled={false}
-                                        forwardedComponent={
-                                          Object {
-                                            "$$typeof": Symbol(react.forward_ref),
-                                            "attrs": Array [],
-                                            "componentStyle": ComponentStyle {
-                                              "componentId": "Button__WrapperButton-sc-1omxup2-0",
-                                              "isStatic": false,
-                                              "lastClassName": "idlBaC",
-                                              "rules": Array [
-                                                [Function],
-                                                [Function],
-                                                [Function],
-                                                [Function],
-                                              ],
-                                            },
-                                            "displayName": "Button__WrapperButton",
-                                            "foldedComponentIds": Array [],
-                                            "render": [Function],
-                                            "styledComponentId": "Button__WrapperButton-sc-1omxup2-0",
-                                            "target": "button",
-                                            "toString": [Function],
-                                            "usesTheme": false,
-                                            "warnTooManyClasses": [Function],
-                                            "withComponent": [Function],
-                                          }
-                                        }
-                                        forwardedRef={[Function]}
-                                        fullWidth={false}
-                                        onBlur={[Function]}
-                                        onFocus={[Function]}
-                                        onMouseEnter={[Function]}
-                                        onMouseLeave={[Function]}
-                                        size="medium"
-                                      >
-                                        <button
-                                          aria-describedby="random-id-5"
-                                          aria-expanded={false}
-                                          aria-haspopup={true}
-                                          className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
-                                          disabled={false}
-                                          onBlur={[Function]}
-                                          onFocus={[Function]}
-                                          onMouseEnter={[Function]}
-                                          onMouseLeave={[Function]}
-                                          size="medium"
-                                        >
-                                          Tooltip trigger
-                                        </button>
-                                      </StyledComponent>
-                                    </Button__WrapperButton>
-                                  </ForwardRef>
-                                </InnerReference>
-                              </Reference>
-                              <Popper
-                                placement="top-start"
-                              >
-                                <InnerPopper
-                                  eventsEnabled={true}
-                                  placement="top-start"
-                                  positionFixed={false}
-                                  referenceElement={
-                                    <button
-                                      aria-describedby="random-id-5"
-                                      aria-expanded="false"
-                                      aria-haspopup="true"
-                                      class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
-                                    >
-                                      Tooltip trigger
-                                    </button>
-                                  }
-                                >
-                                  <Styled(Box)
-                                    id="random-id-5"
-                                    maxWidth="24em"
-                                    onBlur={[Function]}
-                                    onFocus={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    open={false}
-                                    position={
-                                      Object {
-                                        "left": 0,
-                                        "opacity": 0,
-                                        "pointerEvents": "none",
-                                        "position": "absolute",
-                                        "top": 0,
-                                      }
-                                    }
-                                    role="tooltip"
-                                    theme={
-                                      Object {
-                                        "borders": Array [],
-                                        "breakpoints": Object {
-                                          "extraLarge": "1920px",
-                                          "extraSmall": "0px",
-                                          "large": "1360px",
-                                          "medium": "1024px",
-                                          "small": "768px",
-                                        },
-                                        "colors": Object {
-                                          "black": "#011e38",
-                                          "blackBlue": "#122b47",
-                                          "blue": "#216beb",
-                                          "darkBlue": "#00438f",
-                                          "darkGrey": "#434d59",
-                                          "green": "#008059",
-                                          "grey": "#c0c8d1",
-                                          "lightBlue": "#e1ebfa",
-                                          "lightGreen": "#e9f7f2",
-                                          "lightGrey": "#e4e7eb",
-                                          "lightRed": "#fae6ea",
-                                          "lightYellow": "#fcf5e3",
-                                          "red": "#cc1439",
-                                          "white": "#ffffff",
-                                          "whiteGrey": "#f0f2f5",
-                                          "yellow": "#ffbb00",
-                                        },
-                                        "fontSizes": Object {
-                                          "large": "20px",
-                                          "larger": "26px",
-                                          "largest": "46px",
-                                          "medium": "16px",
-                                          "small": "14px",
-                                          "smaller": "12px",
-                                        },
-                                        "fontWeights": Object {
-                                          "bold": "600",
-                                          "light": "300",
-                                          "medium": "500",
-                                          "normal": "400",
-                                        },
-                                        "fonts": Object {
-                                          "base": "'IBM Plex Sans', sans-serif",
-                                          "mono": "'IBM Plex Mono', monospace",
-                                        },
-                                        "lineHeights": Object {
-                                          "base": "1.5",
-                                          "sectionTitle": "1.23076923",
-                                          "smallTextBase": "1.71428571",
-                                          "smallTextCompressed": "1.14285714",
-                                          "smallerText": "1.33333333",
-                                          "subsectionTitle": "1.2",
-                                          "title": "1.04347826",
-                                        },
-                                        "radii": Object {
-                                          "circle": "50%",
-                                          "medium": "4px",
-                                          "small": "2px",
-                                        },
-                                        "shadows": Object {
-                                          "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                          "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                          "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                          "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                          "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                                        },
-                                        "space": Object {
-                                          "half": "4px",
-                                          "none": "0px",
-                                          "x1": "8px",
-                                          "x2": "16px",
-                                          "x3": "24px",
-                                          "x4": "32px",
-                                          "x5": "40px",
-                                          "x6": "48px",
-                                          "x8": "64px",
-                                        },
-                                        "zIndex": Object {
-                                          "content": 100,
-                                          "overlay": 1000,
-                                          "tabsBar": 210,
-                                          "tabsScollIndicator": 200,
-                                        },
-                                      }
-                                    }
-                                  >
-                                    <StyledComponent
-                                      forwardedComponent={
-                                        Object {
-                                          "$$typeof": Symbol(react.forward_ref),
-                                          "_foldedDefaultProps": Object {
-                                            "theme": Object {
-                                              "borders": Array [],
-                                              "breakpoints": Object {
-                                                "extraLarge": "1920px",
-                                                "extraSmall": "0px",
-                                                "large": "1360px",
-                                                "medium": "1024px",
-                                                "small": "768px",
-                                              },
-                                              "colors": Object {
-                                                "black": "#011e38",
-                                                "blackBlue": "#122b47",
-                                                "blue": "#216beb",
-                                                "darkBlue": "#00438f",
-                                                "darkGrey": "#434d59",
-                                                "green": "#008059",
-                                                "grey": "#c0c8d1",
-                                                "lightBlue": "#e1ebfa",
-                                                "lightGreen": "#e9f7f2",
-                                                "lightGrey": "#e4e7eb",
-                                                "lightRed": "#fae6ea",
-                                                "lightYellow": "#fcf5e3",
-                                                "red": "#cc1439",
-                                                "white": "#ffffff",
-                                                "whiteGrey": "#f0f2f5",
-                                                "yellow": "#ffbb00",
-                                              },
-                                              "fontSizes": Object {
-                                                "large": "20px",
-                                                "larger": "26px",
-                                                "largest": "46px",
-                                                "medium": "16px",
-                                                "small": "14px",
-                                                "smaller": "12px",
-                                              },
-                                              "fontWeights": Object {
-                                                "bold": "600",
-                                                "light": "300",
-                                                "medium": "500",
-                                                "normal": "400",
-                                              },
-                                              "fonts": Object {
-                                                "base": "'IBM Plex Sans', sans-serif",
-                                                "mono": "'IBM Plex Mono', monospace",
-                                              },
-                                              "lineHeights": Object {
-                                                "base": "1.5",
-                                                "sectionTitle": "1.23076923",
-                                                "smallTextBase": "1.71428571",
-                                                "smallTextCompressed": "1.14285714",
-                                                "smallerText": "1.33333333",
-                                                "subsectionTitle": "1.2",
-                                                "title": "1.04347826",
-                                              },
-                                              "radii": Object {
-                                                "circle": "50%",
-                                                "medium": "4px",
-                                                "small": "2px",
-                                              },
-                                              "shadows": Object {
-                                                "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                                "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                                "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                                "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                                "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                                              },
-                                              "space": Object {
-                                                "half": "4px",
-                                                "none": "0px",
-                                                "x1": "8px",
-                                                "x2": "16px",
-                                                "x3": "24px",
-                                                "x4": "32px",
-                                                "x5": "40px",
-                                                "x6": "48px",
-                                                "x8": "64px",
-                                              },
-                                              "zIndex": Object {
-                                                "content": 100,
-                                                "overlay": 1000,
-                                                "tabsBar": 210,
-                                                "tabsScollIndicator": 200,
-                                              },
-                                            },
-                                          },
-                                          "attrs": Array [],
-                                          "componentStyle": ComponentStyle {
-                                            "componentId": "sc-jWBwVP",
-                                            "isStatic": false,
-                                            "lastClassName": "hjigbL",
-                                            "rules": Array [
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              "color: #011e38;",
-                                              "display: flex;",
-                                              "flex-direction: column;",
-                                              "font-size: 14px;",
-                                              "background-color: #ffffff;",
-                                              "border-radius: 4px;",
-                                              "border: 1px solid #c0c8d1;",
-                                              "box-shadow: 0 2px 4px rgba(0, 0, 0, 0.18);",
-                                              "padding: 8px;",
-                                              "transition: opacity 0.3s;",
-                                              "z-index: 100;",
-                                              [Function],
-                                            ],
-                                          },
-                                          "displayName": "Styled(Box)",
-                                          "foldedComponentIds": Array [
-                                            "Box-sc-1qu1edy-0",
-                                          ],
-                                          "propTypes": Object {
-                                            "bg": [Function],
-                                            "border": [Function],
-                                            "borderBottom": [Function],
-                                            "borderLeft": [Function],
-                                            "borderRadius": [Function],
-                                            "borderRight": [Function],
-                                            "borderTop": [Function],
-                                            "boxShadow": [Function],
-                                            "color": [Function],
-                                            "display": [Function],
-                                            "flexGrow": [Function],
-                                            "height": [Function],
-                                            "m": [Function],
-                                            "maxHeight": [Function],
-                                            "maxWidth": [Function],
-                                            "mb": [Function],
-                                            "minHeight": [Function],
-                                            "minWidth": [Function],
-                                            "ml": [Function],
-                                            "mr": [Function],
-                                            "mt": [Function],
-                                            "mx": [Function],
-                                            "my": [Function],
-                                            "order": [Function],
-                                            "p": [Function],
-                                            "pb": [Function],
-                                            "pl": [Function],
-                                            "position": [Function],
-                                            "pr": [Function],
-                                            "pt": [Function],
-                                            "px": [Function],
-                                            "py": [Function],
-                                            "textAlign": [Function],
-                                            "width": [Function],
-                                          },
-                                          "render": [Function],
-                                          "styledComponentId": "sc-jWBwVP",
-                                          "target": "div",
-                                          "toString": [Function],
-                                          "usesTheme": false,
-                                          "warnTooManyClasses": [Function],
-                                          "withComponent": [Function],
-                                        }
-                                      }
-                                      forwardedRef={[Function]}
-                                      id="random-id-5"
-                                      maxWidth="24em"
-                                      onBlur={[Function]}
-                                      onFocus={[Function]}
-                                      onMouseEnter={[Function]}
-                                      onMouseLeave={[Function]}
-                                      open={false}
-                                      position={
-                                        Object {
-                                          "left": 0,
-                                          "opacity": 0,
-                                          "pointerEvents": "none",
-                                          "position": "absolute",
-                                          "top": 0,
-                                        }
-                                      }
-                                      role="tooltip"
-                                      theme={
-                                        Object {
-                                          "borders": Array [],
-                                          "breakpoints": Object {
-                                            "extraLarge": "1920px",
-                                            "extraSmall": "0px",
-                                            "large": "1360px",
-                                            "medium": "1024px",
-                                            "small": "768px",
-                                          },
-                                          "colors": Object {
-                                            "black": "#011e38",
-                                            "blackBlue": "#122b47",
-                                            "blue": "#216beb",
-                                            "darkBlue": "#00438f",
-                                            "darkGrey": "#434d59",
-                                            "green": "#008059",
-                                            "grey": "#c0c8d1",
-                                            "lightBlue": "#e1ebfa",
-                                            "lightGreen": "#e9f7f2",
-                                            "lightGrey": "#e4e7eb",
-                                            "lightRed": "#fae6ea",
-                                            "lightYellow": "#fcf5e3",
-                                            "red": "#cc1439",
-                                            "white": "#ffffff",
-                                            "whiteGrey": "#f0f2f5",
-                                            "yellow": "#ffbb00",
-                                          },
-                                          "fontSizes": Object {
-                                            "large": "20px",
-                                            "larger": "26px",
-                                            "largest": "46px",
-                                            "medium": "16px",
-                                            "small": "14px",
-                                            "smaller": "12px",
-                                          },
-                                          "fontWeights": Object {
-                                            "bold": "600",
-                                            "light": "300",
-                                            "medium": "500",
-                                            "normal": "400",
-                                          },
-                                          "fonts": Object {
-                                            "base": "'IBM Plex Sans', sans-serif",
-                                            "mono": "'IBM Plex Mono', monospace",
-                                          },
-                                          "lineHeights": Object {
-                                            "base": "1.5",
-                                            "sectionTitle": "1.23076923",
-                                            "smallTextBase": "1.71428571",
-                                            "smallTextCompressed": "1.14285714",
-                                            "smallerText": "1.33333333",
-                                            "subsectionTitle": "1.2",
-                                            "title": "1.04347826",
-                                          },
-                                          "radii": Object {
-                                            "circle": "50%",
-                                            "medium": "4px",
-                                            "small": "2px",
-                                          },
-                                          "shadows": Object {
-                                            "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                            "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                            "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                            "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                            "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                                          },
-                                          "space": Object {
-                                            "half": "4px",
-                                            "none": "0px",
-                                            "x1": "8px",
-                                            "x2": "16px",
-                                            "x3": "24px",
-                                            "x4": "32px",
-                                            "x5": "40px",
-                                            "x6": "48px",
-                                            "x8": "64px",
-                                          },
-                                          "zIndex": Object {
-                                            "content": 100,
-                                            "overlay": 1000,
-                                            "tabsBar": 210,
-                                            "tabsScollIndicator": 200,
-                                          },
-                                        }
-                                      }
-                                    >
-                                      <div
-                                        className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
-                                        id="random-id-5"
-                                        onBlur={[Function]}
-                                        onFocus={[Function]}
-                                        onMouseEnter={[Function]}
-                                        onMouseLeave={[Function]}
-                                        open={false}
-                                        role="tooltip"
-                                      >
-                                        top-start
-                                        <PopperArrow
-                                          backgroundColor="white"
-                                          borderColor="grey"
-                                          placement="bottom"
-                                          style={Object {}}
-                                        >
-                                          <StyledComponent
-                                            backgroundColor="white"
-                                            borderColor="grey"
-                                            forwardedComponent={
-                                              Object {
-                                                "$$typeof": Symbol(react.forward_ref),
-                                                "_foldedDefaultProps": Object {
-                                                  "backgroundColor": "white",
-                                                  "borderColor": "grey",
-                                                  "placement": "bottom",
-                                                },
-                                                "attrs": Array [],
-                                                "componentStyle": ComponentStyle {
-                                                  "componentId": "PopperArrow-sc-1bcgj4w-0",
-                                                  "isStatic": false,
-                                                  "lastClassName": "bBzGzE",
-                                                  "rules": Array [
-                                                    "position: absolute;",
-                                                    "height: 8px;",
-                                                    "width: 8px;",
-                                                    "margin: 12px;",
-                                                    "&:before {",
-                                                    "border-style: solid;",
-                                                    "content: '';",
-                                                    "display: block;",
-                                                    "height: 0;",
-                                                    "margin: auto;",
-                                                    "position: absolute;",
-                                                    "width: 0;",
-                                                    "}",
-                                                    "&:after {",
-                                                    "border-style: solid;",
-                                                    "content: '';",
-                                                    "display: block;",
-                                                    "height: 0;",
-                                                    "margin: auto;",
-                                                    "position: absolute;",
-                                                    "width: 0;",
-                                                    "}",
-                                                    [Function],
-                                                    [Function],
-                                                  ],
-                                                },
-                                                "displayName": "PopperArrow",
-                                                "foldedComponentIds": Array [],
-                                                "propTypes": Object {
-                                                  "backgroundColor": [Function],
-                                                  "borderColor": [Function],
-                                                  "placement": [Function],
-                                                },
-                                                "render": [Function],
-                                                "styledComponentId": "PopperArrow-sc-1bcgj4w-0",
-                                                "target": "div",
-                                                "toString": [Function],
-                                                "usesTheme": false,
-                                                "warnTooManyClasses": [Function],
-                                                "withComponent": [Function],
-                                              }
-                                            }
-                                            forwardedRef={[Function]}
-                                            placement="bottom"
-                                            style={Object {}}
-                                          >
-                                            <div
-                                              className="PopperArrow-sc-1bcgj4w-0 bBzGzE"
-                                              style={Object {}}
-                                            />
-                                          </StyledComponent>
-                                        </PopperArrow>
-                                      </div>
-                                    </StyledComponent>
-                                  </Styled(Box)>
-                                </InnerPopper>
-                              </Popper>
-                            </Manager>
-                          </StatelessTooltip>
-                        </MenuState>
-                      </MenuComponent>
-                    </WithGeneratedId>
-                  </Component>
-                  <Component
-                    placement="top"
-                    tooltip="top"
-                  >
-                    <WithGeneratedId>
-                      <MenuComponent
-                        hideDelay="350"
-                        id="random-id-6"
-                        placement="top"
-                        showDelay="100"
-                        tooltip="top"
                       >
                         <MenuState
                           defaultOpen={false}
@@ -13206,8 +13625,8 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                 "toggleMenu": [Function],
                               }
                             }
-                            placement="top"
-                            tooltip="top"
+                            placement="top-start"
+                            tooltip="top-start"
                           >
                             <Manager>
                               <Reference>
@@ -13300,11 +13719,11 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                 </InnerReference>
                               </Reference>
                               <Popper
-                                placement="top"
+                                placement="top-start"
                               >
                                 <InnerPopper
                                   eventsEnabled={true}
-                                  placement="top"
+                                  placement="top-start"
                                   positionFixed={false}
                                   referenceElement={
                                     <button
@@ -13713,7 +14132,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                         open={false}
                                         role="tooltip"
                                       >
-                                        top
+                                        top-start
                                         <PopperArrow
                                           backgroundColor="white"
                                           borderColor="grey"
@@ -13801,16 +14220,17 @@ exports[`Storyshots Tooltip with placement 1`] = `
                     </WithGeneratedId>
                   </Component>
                   <Component
-                    placement="top-end"
-                    tooltip="top-end"
+                    placement="top"
+                    tooltip="top"
                   >
                     <WithGeneratedId>
                       <MenuComponent
+                        defaultOpen={false}
                         hideDelay="350"
                         id="random-id-7"
-                        placement="top-end"
+                        placement="top"
                         showDelay="100"
-                        tooltip="top-end"
+                        tooltip="top"
                       >
                         <MenuState
                           defaultOpen={false}
@@ -13829,8 +14249,8 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                 "toggleMenu": [Function],
                               }
                             }
-                            placement="top-end"
-                            tooltip="top-end"
+                            placement="top"
+                            tooltip="top"
                           >
                             <Manager>
                               <Reference>
@@ -13923,11 +14343,11 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                 </InnerReference>
                               </Reference>
                               <Popper
-                                placement="top-end"
+                                placement="top"
                               >
                                 <InnerPopper
                                   eventsEnabled={true}
-                                  placement="top-end"
+                                  placement="top"
                                   positionFixed={false}
                                   referenceElement={
                                     <button
@@ -14329,6 +14749,630 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       <div
                                         className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
                                         id="random-id-7"
+                                        onBlur={[Function]}
+                                        onFocus={[Function]}
+                                        onMouseEnter={[Function]}
+                                        onMouseLeave={[Function]}
+                                        open={false}
+                                        role="tooltip"
+                                      >
+                                        top
+                                        <PopperArrow
+                                          backgroundColor="white"
+                                          borderColor="grey"
+                                          placement="bottom"
+                                          style={Object {}}
+                                        >
+                                          <StyledComponent
+                                            backgroundColor="white"
+                                            borderColor="grey"
+                                            forwardedComponent={
+                                              Object {
+                                                "$$typeof": Symbol(react.forward_ref),
+                                                "_foldedDefaultProps": Object {
+                                                  "backgroundColor": "white",
+                                                  "borderColor": "grey",
+                                                  "placement": "bottom",
+                                                },
+                                                "attrs": Array [],
+                                                "componentStyle": ComponentStyle {
+                                                  "componentId": "PopperArrow-sc-1bcgj4w-0",
+                                                  "isStatic": false,
+                                                  "lastClassName": "bBzGzE",
+                                                  "rules": Array [
+                                                    "position: absolute;",
+                                                    "height: 8px;",
+                                                    "width: 8px;",
+                                                    "margin: 12px;",
+                                                    "&:before {",
+                                                    "border-style: solid;",
+                                                    "content: '';",
+                                                    "display: block;",
+                                                    "height: 0;",
+                                                    "margin: auto;",
+                                                    "position: absolute;",
+                                                    "width: 0;",
+                                                    "}",
+                                                    "&:after {",
+                                                    "border-style: solid;",
+                                                    "content: '';",
+                                                    "display: block;",
+                                                    "height: 0;",
+                                                    "margin: auto;",
+                                                    "position: absolute;",
+                                                    "width: 0;",
+                                                    "}",
+                                                    [Function],
+                                                    [Function],
+                                                  ],
+                                                },
+                                                "displayName": "PopperArrow",
+                                                "foldedComponentIds": Array [],
+                                                "propTypes": Object {
+                                                  "backgroundColor": [Function],
+                                                  "borderColor": [Function],
+                                                  "placement": [Function],
+                                                },
+                                                "render": [Function],
+                                                "styledComponentId": "PopperArrow-sc-1bcgj4w-0",
+                                                "target": "div",
+                                                "toString": [Function],
+                                                "usesTheme": false,
+                                                "warnTooManyClasses": [Function],
+                                                "withComponent": [Function],
+                                              }
+                                            }
+                                            forwardedRef={[Function]}
+                                            placement="bottom"
+                                            style={Object {}}
+                                          >
+                                            <div
+                                              className="PopperArrow-sc-1bcgj4w-0 bBzGzE"
+                                              style={Object {}}
+                                            />
+                                          </StyledComponent>
+                                        </PopperArrow>
+                                      </div>
+                                    </StyledComponent>
+                                  </Styled(Box)>
+                                </InnerPopper>
+                              </Popper>
+                            </Manager>
+                          </StatelessTooltip>
+                        </MenuState>
+                      </MenuComponent>
+                    </WithGeneratedId>
+                  </Component>
+                  <Component
+                    placement="top-end"
+                    tooltip="top-end"
+                  >
+                    <WithGeneratedId>
+                      <MenuComponent
+                        defaultOpen={false}
+                        hideDelay="350"
+                        id="random-id-8"
+                        placement="top-end"
+                        showDelay="100"
+                        tooltip="top-end"
+                      >
+                        <MenuState
+                          defaultOpen={false}
+                          hideDelay="350"
+                          showDelay="100"
+                        >
+                          <StatelessTooltip
+                            id="random-id-8"
+                            maxWidth="24em"
+                            menuState={
+                              Object {
+                                "closeMenu": [Function],
+                                "handleMenuKeydown": [Function],
+                                "isOpen": false,
+                                "openMenu": [Function],
+                                "toggleMenu": [Function],
+                              }
+                            }
+                            placement="top-end"
+                            tooltip="top-end"
+                          >
+                            <Manager>
+                              <Reference>
+                                <InnerReference
+                                  setReferenceNode={[Function]}
+                                >
+                                  <ForwardRef
+                                    aria-describedby="random-id-8"
+                                    aria-expanded={false}
+                                    aria-haspopup={true}
+                                    asLink={false}
+                                    disabled={false}
+                                    fullWidth={false}
+                                    icon={null}
+                                    iconSide="right"
+                                    onBlur={[Function]}
+                                    onFocus={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                    size="medium"
+                                  >
+                                    <Button__WrapperButton
+                                      aria-describedby="random-id-8"
+                                      aria-expanded={false}
+                                      aria-haspopup={true}
+                                      disabled={false}
+                                      fullWidth={false}
+                                      onBlur={[Function]}
+                                      onFocus={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                      size="medium"
+                                    >
+                                      <StyledComponent
+                                        aria-describedby="random-id-8"
+                                        aria-expanded={false}
+                                        aria-haspopup={true}
+                                        disabled={false}
+                                        forwardedComponent={
+                                          Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "attrs": Array [],
+                                            "componentStyle": ComponentStyle {
+                                              "componentId": "Button__WrapperButton-sc-1omxup2-0",
+                                              "isStatic": false,
+                                              "lastClassName": "idlBaC",
+                                              "rules": Array [
+                                                [Function],
+                                                [Function],
+                                                [Function],
+                                                [Function],
+                                              ],
+                                            },
+                                            "displayName": "Button__WrapperButton",
+                                            "foldedComponentIds": Array [],
+                                            "render": [Function],
+                                            "styledComponentId": "Button__WrapperButton-sc-1omxup2-0",
+                                            "target": "button",
+                                            "toString": [Function],
+                                            "usesTheme": false,
+                                            "warnTooManyClasses": [Function],
+                                            "withComponent": [Function],
+                                          }
+                                        }
+                                        forwardedRef={[Function]}
+                                        fullWidth={false}
+                                        onBlur={[Function]}
+                                        onFocus={[Function]}
+                                        onMouseEnter={[Function]}
+                                        onMouseLeave={[Function]}
+                                        size="medium"
+                                      >
+                                        <button
+                                          aria-describedby="random-id-8"
+                                          aria-expanded={false}
+                                          aria-haspopup={true}
+                                          className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
+                                          disabled={false}
+                                          onBlur={[Function]}
+                                          onFocus={[Function]}
+                                          onMouseEnter={[Function]}
+                                          onMouseLeave={[Function]}
+                                          size="medium"
+                                        >
+                                          Tooltip trigger
+                                        </button>
+                                      </StyledComponent>
+                                    </Button__WrapperButton>
+                                  </ForwardRef>
+                                </InnerReference>
+                              </Reference>
+                              <Popper
+                                placement="top-end"
+                              >
+                                <InnerPopper
+                                  eventsEnabled={true}
+                                  placement="top-end"
+                                  positionFixed={false}
+                                  referenceElement={
+                                    <button
+                                      aria-describedby="random-id-8"
+                                      aria-expanded="false"
+                                      aria-haspopup="true"
+                                      class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
+                                    >
+                                      Tooltip trigger
+                                    </button>
+                                  }
+                                >
+                                  <Styled(Box)
+                                    id="random-id-8"
+                                    maxWidth="24em"
+                                    onBlur={[Function]}
+                                    onFocus={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                    open={false}
+                                    position={
+                                      Object {
+                                        "left": 0,
+                                        "opacity": 0,
+                                        "pointerEvents": "none",
+                                        "position": "absolute",
+                                        "top": 0,
+                                      }
+                                    }
+                                    role="tooltip"
+                                    theme={
+                                      Object {
+                                        "borders": Array [],
+                                        "breakpoints": Object {
+                                          "extraLarge": "1920px",
+                                          "extraSmall": "0px",
+                                          "large": "1360px",
+                                          "medium": "1024px",
+                                          "small": "768px",
+                                        },
+                                        "colors": Object {
+                                          "black": "#011e38",
+                                          "blackBlue": "#122b47",
+                                          "blue": "#216beb",
+                                          "darkBlue": "#00438f",
+                                          "darkGrey": "#434d59",
+                                          "green": "#008059",
+                                          "grey": "#c0c8d1",
+                                          "lightBlue": "#e1ebfa",
+                                          "lightGreen": "#e9f7f2",
+                                          "lightGrey": "#e4e7eb",
+                                          "lightRed": "#fae6ea",
+                                          "lightYellow": "#fcf5e3",
+                                          "red": "#cc1439",
+                                          "white": "#ffffff",
+                                          "whiteGrey": "#f0f2f5",
+                                          "yellow": "#ffbb00",
+                                        },
+                                        "fontSizes": Object {
+                                          "large": "20px",
+                                          "larger": "26px",
+                                          "largest": "46px",
+                                          "medium": "16px",
+                                          "small": "14px",
+                                          "smaller": "12px",
+                                        },
+                                        "fontWeights": Object {
+                                          "bold": "600",
+                                          "light": "300",
+                                          "medium": "500",
+                                          "normal": "400",
+                                        },
+                                        "fonts": Object {
+                                          "base": "'IBM Plex Sans', sans-serif",
+                                          "mono": "'IBM Plex Mono', monospace",
+                                        },
+                                        "lineHeights": Object {
+                                          "base": "1.5",
+                                          "sectionTitle": "1.23076923",
+                                          "smallTextBase": "1.71428571",
+                                          "smallTextCompressed": "1.14285714",
+                                          "smallerText": "1.33333333",
+                                          "subsectionTitle": "1.2",
+                                          "title": "1.04347826",
+                                        },
+                                        "radii": Object {
+                                          "circle": "50%",
+                                          "medium": "4px",
+                                          "small": "2px",
+                                        },
+                                        "shadows": Object {
+                                          "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                          "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                          "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                          "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                          "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                        },
+                                        "space": Object {
+                                          "half": "4px",
+                                          "none": "0px",
+                                          "x1": "8px",
+                                          "x2": "16px",
+                                          "x3": "24px",
+                                          "x4": "32px",
+                                          "x5": "40px",
+                                          "x6": "48px",
+                                          "x8": "64px",
+                                        },
+                                        "zIndex": Object {
+                                          "content": 100,
+                                          "overlay": 1000,
+                                          "tabsBar": 210,
+                                          "tabsScollIndicator": 200,
+                                        },
+                                      }
+                                    }
+                                  >
+                                    <StyledComponent
+                                      forwardedComponent={
+                                        Object {
+                                          "$$typeof": Symbol(react.forward_ref),
+                                          "_foldedDefaultProps": Object {
+                                            "theme": Object {
+                                              "borders": Array [],
+                                              "breakpoints": Object {
+                                                "extraLarge": "1920px",
+                                                "extraSmall": "0px",
+                                                "large": "1360px",
+                                                "medium": "1024px",
+                                                "small": "768px",
+                                              },
+                                              "colors": Object {
+                                                "black": "#011e38",
+                                                "blackBlue": "#122b47",
+                                                "blue": "#216beb",
+                                                "darkBlue": "#00438f",
+                                                "darkGrey": "#434d59",
+                                                "green": "#008059",
+                                                "grey": "#c0c8d1",
+                                                "lightBlue": "#e1ebfa",
+                                                "lightGreen": "#e9f7f2",
+                                                "lightGrey": "#e4e7eb",
+                                                "lightRed": "#fae6ea",
+                                                "lightYellow": "#fcf5e3",
+                                                "red": "#cc1439",
+                                                "white": "#ffffff",
+                                                "whiteGrey": "#f0f2f5",
+                                                "yellow": "#ffbb00",
+                                              },
+                                              "fontSizes": Object {
+                                                "large": "20px",
+                                                "larger": "26px",
+                                                "largest": "46px",
+                                                "medium": "16px",
+                                                "small": "14px",
+                                                "smaller": "12px",
+                                              },
+                                              "fontWeights": Object {
+                                                "bold": "600",
+                                                "light": "300",
+                                                "medium": "500",
+                                                "normal": "400",
+                                              },
+                                              "fonts": Object {
+                                                "base": "'IBM Plex Sans', sans-serif",
+                                                "mono": "'IBM Plex Mono', monospace",
+                                              },
+                                              "lineHeights": Object {
+                                                "base": "1.5",
+                                                "sectionTitle": "1.23076923",
+                                                "smallTextBase": "1.71428571",
+                                                "smallTextCompressed": "1.14285714",
+                                                "smallerText": "1.33333333",
+                                                "subsectionTitle": "1.2",
+                                                "title": "1.04347826",
+                                              },
+                                              "radii": Object {
+                                                "circle": "50%",
+                                                "medium": "4px",
+                                                "small": "2px",
+                                              },
+                                              "shadows": Object {
+                                                "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                                "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                                "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                                "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                                "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                              },
+                                              "space": Object {
+                                                "half": "4px",
+                                                "none": "0px",
+                                                "x1": "8px",
+                                                "x2": "16px",
+                                                "x3": "24px",
+                                                "x4": "32px",
+                                                "x5": "40px",
+                                                "x6": "48px",
+                                                "x8": "64px",
+                                              },
+                                              "zIndex": Object {
+                                                "content": 100,
+                                                "overlay": 1000,
+                                                "tabsBar": 210,
+                                                "tabsScollIndicator": 200,
+                                              },
+                                            },
+                                          },
+                                          "attrs": Array [],
+                                          "componentStyle": ComponentStyle {
+                                            "componentId": "sc-jWBwVP",
+                                            "isStatic": false,
+                                            "lastClassName": "hjigbL",
+                                            "rules": Array [
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              "color: #011e38;",
+                                              "display: flex;",
+                                              "flex-direction: column;",
+                                              "font-size: 14px;",
+                                              "background-color: #ffffff;",
+                                              "border-radius: 4px;",
+                                              "border: 1px solid #c0c8d1;",
+                                              "box-shadow: 0 2px 4px rgba(0, 0, 0, 0.18);",
+                                              "padding: 8px;",
+                                              "transition: opacity 0.3s;",
+                                              "z-index: 100;",
+                                              [Function],
+                                            ],
+                                          },
+                                          "displayName": "Styled(Box)",
+                                          "foldedComponentIds": Array [
+                                            "Box-sc-1qu1edy-0",
+                                          ],
+                                          "propTypes": Object {
+                                            "bg": [Function],
+                                            "border": [Function],
+                                            "borderBottom": [Function],
+                                            "borderLeft": [Function],
+                                            "borderRadius": [Function],
+                                            "borderRight": [Function],
+                                            "borderTop": [Function],
+                                            "boxShadow": [Function],
+                                            "color": [Function],
+                                            "display": [Function],
+                                            "flexGrow": [Function],
+                                            "height": [Function],
+                                            "m": [Function],
+                                            "maxHeight": [Function],
+                                            "maxWidth": [Function],
+                                            "mb": [Function],
+                                            "minHeight": [Function],
+                                            "minWidth": [Function],
+                                            "ml": [Function],
+                                            "mr": [Function],
+                                            "mt": [Function],
+                                            "mx": [Function],
+                                            "my": [Function],
+                                            "order": [Function],
+                                            "p": [Function],
+                                            "pb": [Function],
+                                            "pl": [Function],
+                                            "position": [Function],
+                                            "pr": [Function],
+                                            "pt": [Function],
+                                            "px": [Function],
+                                            "py": [Function],
+                                            "textAlign": [Function],
+                                            "width": [Function],
+                                          },
+                                          "render": [Function],
+                                          "styledComponentId": "sc-jWBwVP",
+                                          "target": "div",
+                                          "toString": [Function],
+                                          "usesTheme": false,
+                                          "warnTooManyClasses": [Function],
+                                          "withComponent": [Function],
+                                        }
+                                      }
+                                      forwardedRef={[Function]}
+                                      id="random-id-8"
+                                      maxWidth="24em"
+                                      onBlur={[Function]}
+                                      onFocus={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                      open={false}
+                                      position={
+                                        Object {
+                                          "left": 0,
+                                          "opacity": 0,
+                                          "pointerEvents": "none",
+                                          "position": "absolute",
+                                          "top": 0,
+                                        }
+                                      }
+                                      role="tooltip"
+                                      theme={
+                                        Object {
+                                          "borders": Array [],
+                                          "breakpoints": Object {
+                                            "extraLarge": "1920px",
+                                            "extraSmall": "0px",
+                                            "large": "1360px",
+                                            "medium": "1024px",
+                                            "small": "768px",
+                                          },
+                                          "colors": Object {
+                                            "black": "#011e38",
+                                            "blackBlue": "#122b47",
+                                            "blue": "#216beb",
+                                            "darkBlue": "#00438f",
+                                            "darkGrey": "#434d59",
+                                            "green": "#008059",
+                                            "grey": "#c0c8d1",
+                                            "lightBlue": "#e1ebfa",
+                                            "lightGreen": "#e9f7f2",
+                                            "lightGrey": "#e4e7eb",
+                                            "lightRed": "#fae6ea",
+                                            "lightYellow": "#fcf5e3",
+                                            "red": "#cc1439",
+                                            "white": "#ffffff",
+                                            "whiteGrey": "#f0f2f5",
+                                            "yellow": "#ffbb00",
+                                          },
+                                          "fontSizes": Object {
+                                            "large": "20px",
+                                            "larger": "26px",
+                                            "largest": "46px",
+                                            "medium": "16px",
+                                            "small": "14px",
+                                            "smaller": "12px",
+                                          },
+                                          "fontWeights": Object {
+                                            "bold": "600",
+                                            "light": "300",
+                                            "medium": "500",
+                                            "normal": "400",
+                                          },
+                                          "fonts": Object {
+                                            "base": "'IBM Plex Sans', sans-serif",
+                                            "mono": "'IBM Plex Mono', monospace",
+                                          },
+                                          "lineHeights": Object {
+                                            "base": "1.5",
+                                            "sectionTitle": "1.23076923",
+                                            "smallTextBase": "1.71428571",
+                                            "smallTextCompressed": "1.14285714",
+                                            "smallerText": "1.33333333",
+                                            "subsectionTitle": "1.2",
+                                            "title": "1.04347826",
+                                          },
+                                          "radii": Object {
+                                            "circle": "50%",
+                                            "medium": "4px",
+                                            "small": "2px",
+                                          },
+                                          "shadows": Object {
+                                            "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                            "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                            "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                            "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                            "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                          },
+                                          "space": Object {
+                                            "half": "4px",
+                                            "none": "0px",
+                                            "x1": "8px",
+                                            "x2": "16px",
+                                            "x3": "24px",
+                                            "x4": "32px",
+                                            "x5": "40px",
+                                            "x6": "48px",
+                                            "x8": "64px",
+                                          },
+                                          "zIndex": Object {
+                                            "content": 100,
+                                            "overlay": 1000,
+                                            "tabsBar": 210,
+                                            "tabsScollIndicator": 200,
+                                          },
+                                        }
+                                      }
+                                    >
+                                      <div
+                                        className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
+                                        id="random-id-8"
                                         onBlur={[Function]}
                                         onFocus={[Function]}
                                         onMouseEnter={[Function]}
@@ -14756,634 +15800,12 @@ exports[`Storyshots Tooltip with placement 1`] = `
                   >
                     <WithGeneratedId>
                       <MenuComponent
+                        defaultOpen={false}
                         hideDelay="350"
-                        id="random-id-8"
+                        id="random-id-9"
                         placement="left-start"
                         showDelay="100"
                         tooltip="left-start"
-                      >
-                        <MenuState
-                          defaultOpen={false}
-                          hideDelay="350"
-                          showDelay="100"
-                        >
-                          <StatelessTooltip
-                            id="random-id-8"
-                            maxWidth="24em"
-                            menuState={
-                              Object {
-                                "closeMenu": [Function],
-                                "handleMenuKeydown": [Function],
-                                "isOpen": false,
-                                "openMenu": [Function],
-                                "toggleMenu": [Function],
-                              }
-                            }
-                            placement="left-start"
-                            tooltip="left-start"
-                          >
-                            <Manager>
-                              <Reference>
-                                <InnerReference
-                                  setReferenceNode={[Function]}
-                                >
-                                  <ForwardRef
-                                    aria-describedby="random-id-8"
-                                    aria-expanded={false}
-                                    aria-haspopup={true}
-                                    asLink={false}
-                                    disabled={false}
-                                    fullWidth={false}
-                                    icon={null}
-                                    iconSide="right"
-                                    onBlur={[Function]}
-                                    onFocus={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    size="medium"
-                                  >
-                                    <Button__WrapperButton
-                                      aria-describedby="random-id-8"
-                                      aria-expanded={false}
-                                      aria-haspopup={true}
-                                      disabled={false}
-                                      fullWidth={false}
-                                      onBlur={[Function]}
-                                      onFocus={[Function]}
-                                      onMouseEnter={[Function]}
-                                      onMouseLeave={[Function]}
-                                      size="medium"
-                                    >
-                                      <StyledComponent
-                                        aria-describedby="random-id-8"
-                                        aria-expanded={false}
-                                        aria-haspopup={true}
-                                        disabled={false}
-                                        forwardedComponent={
-                                          Object {
-                                            "$$typeof": Symbol(react.forward_ref),
-                                            "attrs": Array [],
-                                            "componentStyle": ComponentStyle {
-                                              "componentId": "Button__WrapperButton-sc-1omxup2-0",
-                                              "isStatic": false,
-                                              "lastClassName": "idlBaC",
-                                              "rules": Array [
-                                                [Function],
-                                                [Function],
-                                                [Function],
-                                                [Function],
-                                              ],
-                                            },
-                                            "displayName": "Button__WrapperButton",
-                                            "foldedComponentIds": Array [],
-                                            "render": [Function],
-                                            "styledComponentId": "Button__WrapperButton-sc-1omxup2-0",
-                                            "target": "button",
-                                            "toString": [Function],
-                                            "usesTheme": false,
-                                            "warnTooManyClasses": [Function],
-                                            "withComponent": [Function],
-                                          }
-                                        }
-                                        forwardedRef={[Function]}
-                                        fullWidth={false}
-                                        onBlur={[Function]}
-                                        onFocus={[Function]}
-                                        onMouseEnter={[Function]}
-                                        onMouseLeave={[Function]}
-                                        size="medium"
-                                      >
-                                        <button
-                                          aria-describedby="random-id-8"
-                                          aria-expanded={false}
-                                          aria-haspopup={true}
-                                          className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
-                                          disabled={false}
-                                          onBlur={[Function]}
-                                          onFocus={[Function]}
-                                          onMouseEnter={[Function]}
-                                          onMouseLeave={[Function]}
-                                          size="medium"
-                                        >
-                                          Tooltip trigger
-                                        </button>
-                                      </StyledComponent>
-                                    </Button__WrapperButton>
-                                  </ForwardRef>
-                                </InnerReference>
-                              </Reference>
-                              <Popper
-                                placement="left-start"
-                              >
-                                <InnerPopper
-                                  eventsEnabled={true}
-                                  placement="left-start"
-                                  positionFixed={false}
-                                  referenceElement={
-                                    <button
-                                      aria-describedby="random-id-8"
-                                      aria-expanded="false"
-                                      aria-haspopup="true"
-                                      class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
-                                    >
-                                      Tooltip trigger
-                                    </button>
-                                  }
-                                >
-                                  <Styled(Box)
-                                    id="random-id-8"
-                                    maxWidth="24em"
-                                    onBlur={[Function]}
-                                    onFocus={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    open={false}
-                                    position={
-                                      Object {
-                                        "left": 0,
-                                        "opacity": 0,
-                                        "pointerEvents": "none",
-                                        "position": "absolute",
-                                        "top": 0,
-                                      }
-                                    }
-                                    role="tooltip"
-                                    theme={
-                                      Object {
-                                        "borders": Array [],
-                                        "breakpoints": Object {
-                                          "extraLarge": "1920px",
-                                          "extraSmall": "0px",
-                                          "large": "1360px",
-                                          "medium": "1024px",
-                                          "small": "768px",
-                                        },
-                                        "colors": Object {
-                                          "black": "#011e38",
-                                          "blackBlue": "#122b47",
-                                          "blue": "#216beb",
-                                          "darkBlue": "#00438f",
-                                          "darkGrey": "#434d59",
-                                          "green": "#008059",
-                                          "grey": "#c0c8d1",
-                                          "lightBlue": "#e1ebfa",
-                                          "lightGreen": "#e9f7f2",
-                                          "lightGrey": "#e4e7eb",
-                                          "lightRed": "#fae6ea",
-                                          "lightYellow": "#fcf5e3",
-                                          "red": "#cc1439",
-                                          "white": "#ffffff",
-                                          "whiteGrey": "#f0f2f5",
-                                          "yellow": "#ffbb00",
-                                        },
-                                        "fontSizes": Object {
-                                          "large": "20px",
-                                          "larger": "26px",
-                                          "largest": "46px",
-                                          "medium": "16px",
-                                          "small": "14px",
-                                          "smaller": "12px",
-                                        },
-                                        "fontWeights": Object {
-                                          "bold": "600",
-                                          "light": "300",
-                                          "medium": "500",
-                                          "normal": "400",
-                                        },
-                                        "fonts": Object {
-                                          "base": "'IBM Plex Sans', sans-serif",
-                                          "mono": "'IBM Plex Mono', monospace",
-                                        },
-                                        "lineHeights": Object {
-                                          "base": "1.5",
-                                          "sectionTitle": "1.23076923",
-                                          "smallTextBase": "1.71428571",
-                                          "smallTextCompressed": "1.14285714",
-                                          "smallerText": "1.33333333",
-                                          "subsectionTitle": "1.2",
-                                          "title": "1.04347826",
-                                        },
-                                        "radii": Object {
-                                          "circle": "50%",
-                                          "medium": "4px",
-                                          "small": "2px",
-                                        },
-                                        "shadows": Object {
-                                          "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                          "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                          "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                          "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                          "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                                        },
-                                        "space": Object {
-                                          "half": "4px",
-                                          "none": "0px",
-                                          "x1": "8px",
-                                          "x2": "16px",
-                                          "x3": "24px",
-                                          "x4": "32px",
-                                          "x5": "40px",
-                                          "x6": "48px",
-                                          "x8": "64px",
-                                        },
-                                        "zIndex": Object {
-                                          "content": 100,
-                                          "overlay": 1000,
-                                          "tabsBar": 210,
-                                          "tabsScollIndicator": 200,
-                                        },
-                                      }
-                                    }
-                                  >
-                                    <StyledComponent
-                                      forwardedComponent={
-                                        Object {
-                                          "$$typeof": Symbol(react.forward_ref),
-                                          "_foldedDefaultProps": Object {
-                                            "theme": Object {
-                                              "borders": Array [],
-                                              "breakpoints": Object {
-                                                "extraLarge": "1920px",
-                                                "extraSmall": "0px",
-                                                "large": "1360px",
-                                                "medium": "1024px",
-                                                "small": "768px",
-                                              },
-                                              "colors": Object {
-                                                "black": "#011e38",
-                                                "blackBlue": "#122b47",
-                                                "blue": "#216beb",
-                                                "darkBlue": "#00438f",
-                                                "darkGrey": "#434d59",
-                                                "green": "#008059",
-                                                "grey": "#c0c8d1",
-                                                "lightBlue": "#e1ebfa",
-                                                "lightGreen": "#e9f7f2",
-                                                "lightGrey": "#e4e7eb",
-                                                "lightRed": "#fae6ea",
-                                                "lightYellow": "#fcf5e3",
-                                                "red": "#cc1439",
-                                                "white": "#ffffff",
-                                                "whiteGrey": "#f0f2f5",
-                                                "yellow": "#ffbb00",
-                                              },
-                                              "fontSizes": Object {
-                                                "large": "20px",
-                                                "larger": "26px",
-                                                "largest": "46px",
-                                                "medium": "16px",
-                                                "small": "14px",
-                                                "smaller": "12px",
-                                              },
-                                              "fontWeights": Object {
-                                                "bold": "600",
-                                                "light": "300",
-                                                "medium": "500",
-                                                "normal": "400",
-                                              },
-                                              "fonts": Object {
-                                                "base": "'IBM Plex Sans', sans-serif",
-                                                "mono": "'IBM Plex Mono', monospace",
-                                              },
-                                              "lineHeights": Object {
-                                                "base": "1.5",
-                                                "sectionTitle": "1.23076923",
-                                                "smallTextBase": "1.71428571",
-                                                "smallTextCompressed": "1.14285714",
-                                                "smallerText": "1.33333333",
-                                                "subsectionTitle": "1.2",
-                                                "title": "1.04347826",
-                                              },
-                                              "radii": Object {
-                                                "circle": "50%",
-                                                "medium": "4px",
-                                                "small": "2px",
-                                              },
-                                              "shadows": Object {
-                                                "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                                "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                                "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                                "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                                "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                                              },
-                                              "space": Object {
-                                                "half": "4px",
-                                                "none": "0px",
-                                                "x1": "8px",
-                                                "x2": "16px",
-                                                "x3": "24px",
-                                                "x4": "32px",
-                                                "x5": "40px",
-                                                "x6": "48px",
-                                                "x8": "64px",
-                                              },
-                                              "zIndex": Object {
-                                                "content": 100,
-                                                "overlay": 1000,
-                                                "tabsBar": 210,
-                                                "tabsScollIndicator": 200,
-                                              },
-                                            },
-                                          },
-                                          "attrs": Array [],
-                                          "componentStyle": ComponentStyle {
-                                            "componentId": "sc-jWBwVP",
-                                            "isStatic": false,
-                                            "lastClassName": "hjigbL",
-                                            "rules": Array [
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              "color: #011e38;",
-                                              "display: flex;",
-                                              "flex-direction: column;",
-                                              "font-size: 14px;",
-                                              "background-color: #ffffff;",
-                                              "border-radius: 4px;",
-                                              "border: 1px solid #c0c8d1;",
-                                              "box-shadow: 0 2px 4px rgba(0, 0, 0, 0.18);",
-                                              "padding: 8px;",
-                                              "transition: opacity 0.3s;",
-                                              "z-index: 100;",
-                                              [Function],
-                                            ],
-                                          },
-                                          "displayName": "Styled(Box)",
-                                          "foldedComponentIds": Array [
-                                            "Box-sc-1qu1edy-0",
-                                          ],
-                                          "propTypes": Object {
-                                            "bg": [Function],
-                                            "border": [Function],
-                                            "borderBottom": [Function],
-                                            "borderLeft": [Function],
-                                            "borderRadius": [Function],
-                                            "borderRight": [Function],
-                                            "borderTop": [Function],
-                                            "boxShadow": [Function],
-                                            "color": [Function],
-                                            "display": [Function],
-                                            "flexGrow": [Function],
-                                            "height": [Function],
-                                            "m": [Function],
-                                            "maxHeight": [Function],
-                                            "maxWidth": [Function],
-                                            "mb": [Function],
-                                            "minHeight": [Function],
-                                            "minWidth": [Function],
-                                            "ml": [Function],
-                                            "mr": [Function],
-                                            "mt": [Function],
-                                            "mx": [Function],
-                                            "my": [Function],
-                                            "order": [Function],
-                                            "p": [Function],
-                                            "pb": [Function],
-                                            "pl": [Function],
-                                            "position": [Function],
-                                            "pr": [Function],
-                                            "pt": [Function],
-                                            "px": [Function],
-                                            "py": [Function],
-                                            "textAlign": [Function],
-                                            "width": [Function],
-                                          },
-                                          "render": [Function],
-                                          "styledComponentId": "sc-jWBwVP",
-                                          "target": "div",
-                                          "toString": [Function],
-                                          "usesTheme": false,
-                                          "warnTooManyClasses": [Function],
-                                          "withComponent": [Function],
-                                        }
-                                      }
-                                      forwardedRef={[Function]}
-                                      id="random-id-8"
-                                      maxWidth="24em"
-                                      onBlur={[Function]}
-                                      onFocus={[Function]}
-                                      onMouseEnter={[Function]}
-                                      onMouseLeave={[Function]}
-                                      open={false}
-                                      position={
-                                        Object {
-                                          "left": 0,
-                                          "opacity": 0,
-                                          "pointerEvents": "none",
-                                          "position": "absolute",
-                                          "top": 0,
-                                        }
-                                      }
-                                      role="tooltip"
-                                      theme={
-                                        Object {
-                                          "borders": Array [],
-                                          "breakpoints": Object {
-                                            "extraLarge": "1920px",
-                                            "extraSmall": "0px",
-                                            "large": "1360px",
-                                            "medium": "1024px",
-                                            "small": "768px",
-                                          },
-                                          "colors": Object {
-                                            "black": "#011e38",
-                                            "blackBlue": "#122b47",
-                                            "blue": "#216beb",
-                                            "darkBlue": "#00438f",
-                                            "darkGrey": "#434d59",
-                                            "green": "#008059",
-                                            "grey": "#c0c8d1",
-                                            "lightBlue": "#e1ebfa",
-                                            "lightGreen": "#e9f7f2",
-                                            "lightGrey": "#e4e7eb",
-                                            "lightRed": "#fae6ea",
-                                            "lightYellow": "#fcf5e3",
-                                            "red": "#cc1439",
-                                            "white": "#ffffff",
-                                            "whiteGrey": "#f0f2f5",
-                                            "yellow": "#ffbb00",
-                                          },
-                                          "fontSizes": Object {
-                                            "large": "20px",
-                                            "larger": "26px",
-                                            "largest": "46px",
-                                            "medium": "16px",
-                                            "small": "14px",
-                                            "smaller": "12px",
-                                          },
-                                          "fontWeights": Object {
-                                            "bold": "600",
-                                            "light": "300",
-                                            "medium": "500",
-                                            "normal": "400",
-                                          },
-                                          "fonts": Object {
-                                            "base": "'IBM Plex Sans', sans-serif",
-                                            "mono": "'IBM Plex Mono', monospace",
-                                          },
-                                          "lineHeights": Object {
-                                            "base": "1.5",
-                                            "sectionTitle": "1.23076923",
-                                            "smallTextBase": "1.71428571",
-                                            "smallTextCompressed": "1.14285714",
-                                            "smallerText": "1.33333333",
-                                            "subsectionTitle": "1.2",
-                                            "title": "1.04347826",
-                                          },
-                                          "radii": Object {
-                                            "circle": "50%",
-                                            "medium": "4px",
-                                            "small": "2px",
-                                          },
-                                          "shadows": Object {
-                                            "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                            "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                            "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                            "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                            "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                                          },
-                                          "space": Object {
-                                            "half": "4px",
-                                            "none": "0px",
-                                            "x1": "8px",
-                                            "x2": "16px",
-                                            "x3": "24px",
-                                            "x4": "32px",
-                                            "x5": "40px",
-                                            "x6": "48px",
-                                            "x8": "64px",
-                                          },
-                                          "zIndex": Object {
-                                            "content": 100,
-                                            "overlay": 1000,
-                                            "tabsBar": 210,
-                                            "tabsScollIndicator": 200,
-                                          },
-                                        }
-                                      }
-                                    >
-                                      <div
-                                        className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
-                                        id="random-id-8"
-                                        onBlur={[Function]}
-                                        onFocus={[Function]}
-                                        onMouseEnter={[Function]}
-                                        onMouseLeave={[Function]}
-                                        open={false}
-                                        role="tooltip"
-                                      >
-                                        left-start
-                                        <PopperArrow
-                                          backgroundColor="white"
-                                          borderColor="grey"
-                                          placement="bottom"
-                                          style={Object {}}
-                                        >
-                                          <StyledComponent
-                                            backgroundColor="white"
-                                            borderColor="grey"
-                                            forwardedComponent={
-                                              Object {
-                                                "$$typeof": Symbol(react.forward_ref),
-                                                "_foldedDefaultProps": Object {
-                                                  "backgroundColor": "white",
-                                                  "borderColor": "grey",
-                                                  "placement": "bottom",
-                                                },
-                                                "attrs": Array [],
-                                                "componentStyle": ComponentStyle {
-                                                  "componentId": "PopperArrow-sc-1bcgj4w-0",
-                                                  "isStatic": false,
-                                                  "lastClassName": "bBzGzE",
-                                                  "rules": Array [
-                                                    "position: absolute;",
-                                                    "height: 8px;",
-                                                    "width: 8px;",
-                                                    "margin: 12px;",
-                                                    "&:before {",
-                                                    "border-style: solid;",
-                                                    "content: '';",
-                                                    "display: block;",
-                                                    "height: 0;",
-                                                    "margin: auto;",
-                                                    "position: absolute;",
-                                                    "width: 0;",
-                                                    "}",
-                                                    "&:after {",
-                                                    "border-style: solid;",
-                                                    "content: '';",
-                                                    "display: block;",
-                                                    "height: 0;",
-                                                    "margin: auto;",
-                                                    "position: absolute;",
-                                                    "width: 0;",
-                                                    "}",
-                                                    [Function],
-                                                    [Function],
-                                                  ],
-                                                },
-                                                "displayName": "PopperArrow",
-                                                "foldedComponentIds": Array [],
-                                                "propTypes": Object {
-                                                  "backgroundColor": [Function],
-                                                  "borderColor": [Function],
-                                                  "placement": [Function],
-                                                },
-                                                "render": [Function],
-                                                "styledComponentId": "PopperArrow-sc-1bcgj4w-0",
-                                                "target": "div",
-                                                "toString": [Function],
-                                                "usesTheme": false,
-                                                "warnTooManyClasses": [Function],
-                                                "withComponent": [Function],
-                                              }
-                                            }
-                                            forwardedRef={[Function]}
-                                            placement="bottom"
-                                            style={Object {}}
-                                          >
-                                            <div
-                                              className="PopperArrow-sc-1bcgj4w-0 bBzGzE"
-                                              style={Object {}}
-                                            />
-                                          </StyledComponent>
-                                        </PopperArrow>
-                                      </div>
-                                    </StyledComponent>
-                                  </Styled(Box)>
-                                </InnerPopper>
-                              </Popper>
-                            </Manager>
-                          </StatelessTooltip>
-                        </MenuState>
-                      </MenuComponent>
-                    </WithGeneratedId>
-                  </Component>
-                  <Component
-                    placement="left"
-                    tooltip="left"
-                  >
-                    <WithGeneratedId>
-                      <MenuComponent
-                        hideDelay="350"
-                        id="random-id-9"
-                        placement="left"
-                        showDelay="100"
-                        tooltip="left"
                       >
                         <MenuState
                           defaultOpen={false}
@@ -15402,8 +15824,8 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                 "toggleMenu": [Function],
                               }
                             }
-                            placement="left"
-                            tooltip="left"
+                            placement="left-start"
+                            tooltip="left-start"
                           >
                             <Manager>
                               <Reference>
@@ -15496,11 +15918,11 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                 </InnerReference>
                               </Reference>
                               <Popper
-                                placement="left"
+                                placement="left-start"
                               >
                                 <InnerPopper
                                   eventsEnabled={true}
-                                  placement="left"
+                                  placement="left-start"
                                   positionFixed={false}
                                   referenceElement={
                                     <button
@@ -15909,7 +16331,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                         open={false}
                                         role="tooltip"
                                       >
-                                        left
+                                        left-start
                                         <PopperArrow
                                           backgroundColor="white"
                                           borderColor="grey"
@@ -15997,16 +16419,17 @@ exports[`Storyshots Tooltip with placement 1`] = `
                     </WithGeneratedId>
                   </Component>
                   <Component
-                    placement="left-end"
-                    tooltip="left-end"
+                    placement="left"
+                    tooltip="left"
                   >
                     <WithGeneratedId>
                       <MenuComponent
+                        defaultOpen={false}
                         hideDelay="350"
                         id="random-id-10"
-                        placement="left-end"
+                        placement="left"
                         showDelay="100"
-                        tooltip="left-end"
+                        tooltip="left"
                       >
                         <MenuState
                           defaultOpen={false}
@@ -16025,8 +16448,8 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                 "toggleMenu": [Function],
                               }
                             }
-                            placement="left-end"
-                            tooltip="left-end"
+                            placement="left"
+                            tooltip="left"
                           >
                             <Manager>
                               <Reference>
@@ -16119,11 +16542,11 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                 </InnerReference>
                               </Reference>
                               <Popper
-                                placement="left-end"
+                                placement="left"
                               >
                                 <InnerPopper
                                   eventsEnabled={true}
-                                  placement="left-end"
+                                  placement="left"
                                   positionFixed={false}
                                   referenceElement={
                                     <button
@@ -16525,6 +16948,630 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       <div
                                         className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
                                         id="random-id-10"
+                                        onBlur={[Function]}
+                                        onFocus={[Function]}
+                                        onMouseEnter={[Function]}
+                                        onMouseLeave={[Function]}
+                                        open={false}
+                                        role="tooltip"
+                                      >
+                                        left
+                                        <PopperArrow
+                                          backgroundColor="white"
+                                          borderColor="grey"
+                                          placement="bottom"
+                                          style={Object {}}
+                                        >
+                                          <StyledComponent
+                                            backgroundColor="white"
+                                            borderColor="grey"
+                                            forwardedComponent={
+                                              Object {
+                                                "$$typeof": Symbol(react.forward_ref),
+                                                "_foldedDefaultProps": Object {
+                                                  "backgroundColor": "white",
+                                                  "borderColor": "grey",
+                                                  "placement": "bottom",
+                                                },
+                                                "attrs": Array [],
+                                                "componentStyle": ComponentStyle {
+                                                  "componentId": "PopperArrow-sc-1bcgj4w-0",
+                                                  "isStatic": false,
+                                                  "lastClassName": "bBzGzE",
+                                                  "rules": Array [
+                                                    "position: absolute;",
+                                                    "height: 8px;",
+                                                    "width: 8px;",
+                                                    "margin: 12px;",
+                                                    "&:before {",
+                                                    "border-style: solid;",
+                                                    "content: '';",
+                                                    "display: block;",
+                                                    "height: 0;",
+                                                    "margin: auto;",
+                                                    "position: absolute;",
+                                                    "width: 0;",
+                                                    "}",
+                                                    "&:after {",
+                                                    "border-style: solid;",
+                                                    "content: '';",
+                                                    "display: block;",
+                                                    "height: 0;",
+                                                    "margin: auto;",
+                                                    "position: absolute;",
+                                                    "width: 0;",
+                                                    "}",
+                                                    [Function],
+                                                    [Function],
+                                                  ],
+                                                },
+                                                "displayName": "PopperArrow",
+                                                "foldedComponentIds": Array [],
+                                                "propTypes": Object {
+                                                  "backgroundColor": [Function],
+                                                  "borderColor": [Function],
+                                                  "placement": [Function],
+                                                },
+                                                "render": [Function],
+                                                "styledComponentId": "PopperArrow-sc-1bcgj4w-0",
+                                                "target": "div",
+                                                "toString": [Function],
+                                                "usesTheme": false,
+                                                "warnTooManyClasses": [Function],
+                                                "withComponent": [Function],
+                                              }
+                                            }
+                                            forwardedRef={[Function]}
+                                            placement="bottom"
+                                            style={Object {}}
+                                          >
+                                            <div
+                                              className="PopperArrow-sc-1bcgj4w-0 bBzGzE"
+                                              style={Object {}}
+                                            />
+                                          </StyledComponent>
+                                        </PopperArrow>
+                                      </div>
+                                    </StyledComponent>
+                                  </Styled(Box)>
+                                </InnerPopper>
+                              </Popper>
+                            </Manager>
+                          </StatelessTooltip>
+                        </MenuState>
+                      </MenuComponent>
+                    </WithGeneratedId>
+                  </Component>
+                  <Component
+                    placement="left-end"
+                    tooltip="left-end"
+                  >
+                    <WithGeneratedId>
+                      <MenuComponent
+                        defaultOpen={false}
+                        hideDelay="350"
+                        id="random-id-11"
+                        placement="left-end"
+                        showDelay="100"
+                        tooltip="left-end"
+                      >
+                        <MenuState
+                          defaultOpen={false}
+                          hideDelay="350"
+                          showDelay="100"
+                        >
+                          <StatelessTooltip
+                            id="random-id-11"
+                            maxWidth="24em"
+                            menuState={
+                              Object {
+                                "closeMenu": [Function],
+                                "handleMenuKeydown": [Function],
+                                "isOpen": false,
+                                "openMenu": [Function],
+                                "toggleMenu": [Function],
+                              }
+                            }
+                            placement="left-end"
+                            tooltip="left-end"
+                          >
+                            <Manager>
+                              <Reference>
+                                <InnerReference
+                                  setReferenceNode={[Function]}
+                                >
+                                  <ForwardRef
+                                    aria-describedby="random-id-11"
+                                    aria-expanded={false}
+                                    aria-haspopup={true}
+                                    asLink={false}
+                                    disabled={false}
+                                    fullWidth={false}
+                                    icon={null}
+                                    iconSide="right"
+                                    onBlur={[Function]}
+                                    onFocus={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                    size="medium"
+                                  >
+                                    <Button__WrapperButton
+                                      aria-describedby="random-id-11"
+                                      aria-expanded={false}
+                                      aria-haspopup={true}
+                                      disabled={false}
+                                      fullWidth={false}
+                                      onBlur={[Function]}
+                                      onFocus={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                      size="medium"
+                                    >
+                                      <StyledComponent
+                                        aria-describedby="random-id-11"
+                                        aria-expanded={false}
+                                        aria-haspopup={true}
+                                        disabled={false}
+                                        forwardedComponent={
+                                          Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "attrs": Array [],
+                                            "componentStyle": ComponentStyle {
+                                              "componentId": "Button__WrapperButton-sc-1omxup2-0",
+                                              "isStatic": false,
+                                              "lastClassName": "idlBaC",
+                                              "rules": Array [
+                                                [Function],
+                                                [Function],
+                                                [Function],
+                                                [Function],
+                                              ],
+                                            },
+                                            "displayName": "Button__WrapperButton",
+                                            "foldedComponentIds": Array [],
+                                            "render": [Function],
+                                            "styledComponentId": "Button__WrapperButton-sc-1omxup2-0",
+                                            "target": "button",
+                                            "toString": [Function],
+                                            "usesTheme": false,
+                                            "warnTooManyClasses": [Function],
+                                            "withComponent": [Function],
+                                          }
+                                        }
+                                        forwardedRef={[Function]}
+                                        fullWidth={false}
+                                        onBlur={[Function]}
+                                        onFocus={[Function]}
+                                        onMouseEnter={[Function]}
+                                        onMouseLeave={[Function]}
+                                        size="medium"
+                                      >
+                                        <button
+                                          aria-describedby="random-id-11"
+                                          aria-expanded={false}
+                                          aria-haspopup={true}
+                                          className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
+                                          disabled={false}
+                                          onBlur={[Function]}
+                                          onFocus={[Function]}
+                                          onMouseEnter={[Function]}
+                                          onMouseLeave={[Function]}
+                                          size="medium"
+                                        >
+                                          Tooltip trigger
+                                        </button>
+                                      </StyledComponent>
+                                    </Button__WrapperButton>
+                                  </ForwardRef>
+                                </InnerReference>
+                              </Reference>
+                              <Popper
+                                placement="left-end"
+                              >
+                                <InnerPopper
+                                  eventsEnabled={true}
+                                  placement="left-end"
+                                  positionFixed={false}
+                                  referenceElement={
+                                    <button
+                                      aria-describedby="random-id-11"
+                                      aria-expanded="false"
+                                      aria-haspopup="true"
+                                      class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
+                                    >
+                                      Tooltip trigger
+                                    </button>
+                                  }
+                                >
+                                  <Styled(Box)
+                                    id="random-id-11"
+                                    maxWidth="24em"
+                                    onBlur={[Function]}
+                                    onFocus={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                    open={false}
+                                    position={
+                                      Object {
+                                        "left": 0,
+                                        "opacity": 0,
+                                        "pointerEvents": "none",
+                                        "position": "absolute",
+                                        "top": 0,
+                                      }
+                                    }
+                                    role="tooltip"
+                                    theme={
+                                      Object {
+                                        "borders": Array [],
+                                        "breakpoints": Object {
+                                          "extraLarge": "1920px",
+                                          "extraSmall": "0px",
+                                          "large": "1360px",
+                                          "medium": "1024px",
+                                          "small": "768px",
+                                        },
+                                        "colors": Object {
+                                          "black": "#011e38",
+                                          "blackBlue": "#122b47",
+                                          "blue": "#216beb",
+                                          "darkBlue": "#00438f",
+                                          "darkGrey": "#434d59",
+                                          "green": "#008059",
+                                          "grey": "#c0c8d1",
+                                          "lightBlue": "#e1ebfa",
+                                          "lightGreen": "#e9f7f2",
+                                          "lightGrey": "#e4e7eb",
+                                          "lightRed": "#fae6ea",
+                                          "lightYellow": "#fcf5e3",
+                                          "red": "#cc1439",
+                                          "white": "#ffffff",
+                                          "whiteGrey": "#f0f2f5",
+                                          "yellow": "#ffbb00",
+                                        },
+                                        "fontSizes": Object {
+                                          "large": "20px",
+                                          "larger": "26px",
+                                          "largest": "46px",
+                                          "medium": "16px",
+                                          "small": "14px",
+                                          "smaller": "12px",
+                                        },
+                                        "fontWeights": Object {
+                                          "bold": "600",
+                                          "light": "300",
+                                          "medium": "500",
+                                          "normal": "400",
+                                        },
+                                        "fonts": Object {
+                                          "base": "'IBM Plex Sans', sans-serif",
+                                          "mono": "'IBM Plex Mono', monospace",
+                                        },
+                                        "lineHeights": Object {
+                                          "base": "1.5",
+                                          "sectionTitle": "1.23076923",
+                                          "smallTextBase": "1.71428571",
+                                          "smallTextCompressed": "1.14285714",
+                                          "smallerText": "1.33333333",
+                                          "subsectionTitle": "1.2",
+                                          "title": "1.04347826",
+                                        },
+                                        "radii": Object {
+                                          "circle": "50%",
+                                          "medium": "4px",
+                                          "small": "2px",
+                                        },
+                                        "shadows": Object {
+                                          "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                          "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                          "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                          "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                          "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                        },
+                                        "space": Object {
+                                          "half": "4px",
+                                          "none": "0px",
+                                          "x1": "8px",
+                                          "x2": "16px",
+                                          "x3": "24px",
+                                          "x4": "32px",
+                                          "x5": "40px",
+                                          "x6": "48px",
+                                          "x8": "64px",
+                                        },
+                                        "zIndex": Object {
+                                          "content": 100,
+                                          "overlay": 1000,
+                                          "tabsBar": 210,
+                                          "tabsScollIndicator": 200,
+                                        },
+                                      }
+                                    }
+                                  >
+                                    <StyledComponent
+                                      forwardedComponent={
+                                        Object {
+                                          "$$typeof": Symbol(react.forward_ref),
+                                          "_foldedDefaultProps": Object {
+                                            "theme": Object {
+                                              "borders": Array [],
+                                              "breakpoints": Object {
+                                                "extraLarge": "1920px",
+                                                "extraSmall": "0px",
+                                                "large": "1360px",
+                                                "medium": "1024px",
+                                                "small": "768px",
+                                              },
+                                              "colors": Object {
+                                                "black": "#011e38",
+                                                "blackBlue": "#122b47",
+                                                "blue": "#216beb",
+                                                "darkBlue": "#00438f",
+                                                "darkGrey": "#434d59",
+                                                "green": "#008059",
+                                                "grey": "#c0c8d1",
+                                                "lightBlue": "#e1ebfa",
+                                                "lightGreen": "#e9f7f2",
+                                                "lightGrey": "#e4e7eb",
+                                                "lightRed": "#fae6ea",
+                                                "lightYellow": "#fcf5e3",
+                                                "red": "#cc1439",
+                                                "white": "#ffffff",
+                                                "whiteGrey": "#f0f2f5",
+                                                "yellow": "#ffbb00",
+                                              },
+                                              "fontSizes": Object {
+                                                "large": "20px",
+                                                "larger": "26px",
+                                                "largest": "46px",
+                                                "medium": "16px",
+                                                "small": "14px",
+                                                "smaller": "12px",
+                                              },
+                                              "fontWeights": Object {
+                                                "bold": "600",
+                                                "light": "300",
+                                                "medium": "500",
+                                                "normal": "400",
+                                              },
+                                              "fonts": Object {
+                                                "base": "'IBM Plex Sans', sans-serif",
+                                                "mono": "'IBM Plex Mono', monospace",
+                                              },
+                                              "lineHeights": Object {
+                                                "base": "1.5",
+                                                "sectionTitle": "1.23076923",
+                                                "smallTextBase": "1.71428571",
+                                                "smallTextCompressed": "1.14285714",
+                                                "smallerText": "1.33333333",
+                                                "subsectionTitle": "1.2",
+                                                "title": "1.04347826",
+                                              },
+                                              "radii": Object {
+                                                "circle": "50%",
+                                                "medium": "4px",
+                                                "small": "2px",
+                                              },
+                                              "shadows": Object {
+                                                "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                                "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                                "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                                "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                                "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                              },
+                                              "space": Object {
+                                                "half": "4px",
+                                                "none": "0px",
+                                                "x1": "8px",
+                                                "x2": "16px",
+                                                "x3": "24px",
+                                                "x4": "32px",
+                                                "x5": "40px",
+                                                "x6": "48px",
+                                                "x8": "64px",
+                                              },
+                                              "zIndex": Object {
+                                                "content": 100,
+                                                "overlay": 1000,
+                                                "tabsBar": 210,
+                                                "tabsScollIndicator": 200,
+                                              },
+                                            },
+                                          },
+                                          "attrs": Array [],
+                                          "componentStyle": ComponentStyle {
+                                            "componentId": "sc-jWBwVP",
+                                            "isStatic": false,
+                                            "lastClassName": "hjigbL",
+                                            "rules": Array [
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              "color: #011e38;",
+                                              "display: flex;",
+                                              "flex-direction: column;",
+                                              "font-size: 14px;",
+                                              "background-color: #ffffff;",
+                                              "border-radius: 4px;",
+                                              "border: 1px solid #c0c8d1;",
+                                              "box-shadow: 0 2px 4px rgba(0, 0, 0, 0.18);",
+                                              "padding: 8px;",
+                                              "transition: opacity 0.3s;",
+                                              "z-index: 100;",
+                                              [Function],
+                                            ],
+                                          },
+                                          "displayName": "Styled(Box)",
+                                          "foldedComponentIds": Array [
+                                            "Box-sc-1qu1edy-0",
+                                          ],
+                                          "propTypes": Object {
+                                            "bg": [Function],
+                                            "border": [Function],
+                                            "borderBottom": [Function],
+                                            "borderLeft": [Function],
+                                            "borderRadius": [Function],
+                                            "borderRight": [Function],
+                                            "borderTop": [Function],
+                                            "boxShadow": [Function],
+                                            "color": [Function],
+                                            "display": [Function],
+                                            "flexGrow": [Function],
+                                            "height": [Function],
+                                            "m": [Function],
+                                            "maxHeight": [Function],
+                                            "maxWidth": [Function],
+                                            "mb": [Function],
+                                            "minHeight": [Function],
+                                            "minWidth": [Function],
+                                            "ml": [Function],
+                                            "mr": [Function],
+                                            "mt": [Function],
+                                            "mx": [Function],
+                                            "my": [Function],
+                                            "order": [Function],
+                                            "p": [Function],
+                                            "pb": [Function],
+                                            "pl": [Function],
+                                            "position": [Function],
+                                            "pr": [Function],
+                                            "pt": [Function],
+                                            "px": [Function],
+                                            "py": [Function],
+                                            "textAlign": [Function],
+                                            "width": [Function],
+                                          },
+                                          "render": [Function],
+                                          "styledComponentId": "sc-jWBwVP",
+                                          "target": "div",
+                                          "toString": [Function],
+                                          "usesTheme": false,
+                                          "warnTooManyClasses": [Function],
+                                          "withComponent": [Function],
+                                        }
+                                      }
+                                      forwardedRef={[Function]}
+                                      id="random-id-11"
+                                      maxWidth="24em"
+                                      onBlur={[Function]}
+                                      onFocus={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                      open={false}
+                                      position={
+                                        Object {
+                                          "left": 0,
+                                          "opacity": 0,
+                                          "pointerEvents": "none",
+                                          "position": "absolute",
+                                          "top": 0,
+                                        }
+                                      }
+                                      role="tooltip"
+                                      theme={
+                                        Object {
+                                          "borders": Array [],
+                                          "breakpoints": Object {
+                                            "extraLarge": "1920px",
+                                            "extraSmall": "0px",
+                                            "large": "1360px",
+                                            "medium": "1024px",
+                                            "small": "768px",
+                                          },
+                                          "colors": Object {
+                                            "black": "#011e38",
+                                            "blackBlue": "#122b47",
+                                            "blue": "#216beb",
+                                            "darkBlue": "#00438f",
+                                            "darkGrey": "#434d59",
+                                            "green": "#008059",
+                                            "grey": "#c0c8d1",
+                                            "lightBlue": "#e1ebfa",
+                                            "lightGreen": "#e9f7f2",
+                                            "lightGrey": "#e4e7eb",
+                                            "lightRed": "#fae6ea",
+                                            "lightYellow": "#fcf5e3",
+                                            "red": "#cc1439",
+                                            "white": "#ffffff",
+                                            "whiteGrey": "#f0f2f5",
+                                            "yellow": "#ffbb00",
+                                          },
+                                          "fontSizes": Object {
+                                            "large": "20px",
+                                            "larger": "26px",
+                                            "largest": "46px",
+                                            "medium": "16px",
+                                            "small": "14px",
+                                            "smaller": "12px",
+                                          },
+                                          "fontWeights": Object {
+                                            "bold": "600",
+                                            "light": "300",
+                                            "medium": "500",
+                                            "normal": "400",
+                                          },
+                                          "fonts": Object {
+                                            "base": "'IBM Plex Sans', sans-serif",
+                                            "mono": "'IBM Plex Mono', monospace",
+                                          },
+                                          "lineHeights": Object {
+                                            "base": "1.5",
+                                            "sectionTitle": "1.23076923",
+                                            "smallTextBase": "1.71428571",
+                                            "smallTextCompressed": "1.14285714",
+                                            "smallerText": "1.33333333",
+                                            "subsectionTitle": "1.2",
+                                            "title": "1.04347826",
+                                          },
+                                          "radii": Object {
+                                            "circle": "50%",
+                                            "medium": "4px",
+                                            "small": "2px",
+                                          },
+                                          "shadows": Object {
+                                            "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                            "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                            "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                            "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                            "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                          },
+                                          "space": Object {
+                                            "half": "4px",
+                                            "none": "0px",
+                                            "x1": "8px",
+                                            "x2": "16px",
+                                            "x3": "24px",
+                                            "x4": "32px",
+                                            "x5": "40px",
+                                            "x6": "48px",
+                                            "x8": "64px",
+                                          },
+                                          "zIndex": Object {
+                                            "content": 100,
+                                            "overlay": 1000,
+                                            "tabsBar": 210,
+                                            "tabsScollIndicator": 200,
+                                          },
+                                        }
+                                      }
+                                    >
+                                      <div
+                                        className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
+                                        id="random-id-11"
                                         onBlur={[Function]}
                                         onFocus={[Function]}
                                         onMouseEnter={[Function]}
@@ -16952,634 +17999,12 @@ exports[`Storyshots Tooltip with placement 1`] = `
                   >
                     <WithGeneratedId>
                       <MenuComponent
+                        defaultOpen={false}
                         hideDelay="350"
-                        id="random-id-11"
+                        id="random-id-12"
                         placement="right-start"
                         showDelay="100"
                         tooltip="right-start"
-                      >
-                        <MenuState
-                          defaultOpen={false}
-                          hideDelay="350"
-                          showDelay="100"
-                        >
-                          <StatelessTooltip
-                            id="random-id-11"
-                            maxWidth="24em"
-                            menuState={
-                              Object {
-                                "closeMenu": [Function],
-                                "handleMenuKeydown": [Function],
-                                "isOpen": false,
-                                "openMenu": [Function],
-                                "toggleMenu": [Function],
-                              }
-                            }
-                            placement="right-start"
-                            tooltip="right-start"
-                          >
-                            <Manager>
-                              <Reference>
-                                <InnerReference
-                                  setReferenceNode={[Function]}
-                                >
-                                  <ForwardRef
-                                    aria-describedby="random-id-11"
-                                    aria-expanded={false}
-                                    aria-haspopup={true}
-                                    asLink={false}
-                                    disabled={false}
-                                    fullWidth={false}
-                                    icon={null}
-                                    iconSide="right"
-                                    onBlur={[Function]}
-                                    onFocus={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    size="medium"
-                                  >
-                                    <Button__WrapperButton
-                                      aria-describedby="random-id-11"
-                                      aria-expanded={false}
-                                      aria-haspopup={true}
-                                      disabled={false}
-                                      fullWidth={false}
-                                      onBlur={[Function]}
-                                      onFocus={[Function]}
-                                      onMouseEnter={[Function]}
-                                      onMouseLeave={[Function]}
-                                      size="medium"
-                                    >
-                                      <StyledComponent
-                                        aria-describedby="random-id-11"
-                                        aria-expanded={false}
-                                        aria-haspopup={true}
-                                        disabled={false}
-                                        forwardedComponent={
-                                          Object {
-                                            "$$typeof": Symbol(react.forward_ref),
-                                            "attrs": Array [],
-                                            "componentStyle": ComponentStyle {
-                                              "componentId": "Button__WrapperButton-sc-1omxup2-0",
-                                              "isStatic": false,
-                                              "lastClassName": "idlBaC",
-                                              "rules": Array [
-                                                [Function],
-                                                [Function],
-                                                [Function],
-                                                [Function],
-                                              ],
-                                            },
-                                            "displayName": "Button__WrapperButton",
-                                            "foldedComponentIds": Array [],
-                                            "render": [Function],
-                                            "styledComponentId": "Button__WrapperButton-sc-1omxup2-0",
-                                            "target": "button",
-                                            "toString": [Function],
-                                            "usesTheme": false,
-                                            "warnTooManyClasses": [Function],
-                                            "withComponent": [Function],
-                                          }
-                                        }
-                                        forwardedRef={[Function]}
-                                        fullWidth={false}
-                                        onBlur={[Function]}
-                                        onFocus={[Function]}
-                                        onMouseEnter={[Function]}
-                                        onMouseLeave={[Function]}
-                                        size="medium"
-                                      >
-                                        <button
-                                          aria-describedby="random-id-11"
-                                          aria-expanded={false}
-                                          aria-haspopup={true}
-                                          className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
-                                          disabled={false}
-                                          onBlur={[Function]}
-                                          onFocus={[Function]}
-                                          onMouseEnter={[Function]}
-                                          onMouseLeave={[Function]}
-                                          size="medium"
-                                        >
-                                          Tooltip trigger
-                                        </button>
-                                      </StyledComponent>
-                                    </Button__WrapperButton>
-                                  </ForwardRef>
-                                </InnerReference>
-                              </Reference>
-                              <Popper
-                                placement="right-start"
-                              >
-                                <InnerPopper
-                                  eventsEnabled={true}
-                                  placement="right-start"
-                                  positionFixed={false}
-                                  referenceElement={
-                                    <button
-                                      aria-describedby="random-id-11"
-                                      aria-expanded="false"
-                                      aria-haspopup="true"
-                                      class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
-                                    >
-                                      Tooltip trigger
-                                    </button>
-                                  }
-                                >
-                                  <Styled(Box)
-                                    id="random-id-11"
-                                    maxWidth="24em"
-                                    onBlur={[Function]}
-                                    onFocus={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    open={false}
-                                    position={
-                                      Object {
-                                        "left": 0,
-                                        "opacity": 0,
-                                        "pointerEvents": "none",
-                                        "position": "absolute",
-                                        "top": 0,
-                                      }
-                                    }
-                                    role="tooltip"
-                                    theme={
-                                      Object {
-                                        "borders": Array [],
-                                        "breakpoints": Object {
-                                          "extraLarge": "1920px",
-                                          "extraSmall": "0px",
-                                          "large": "1360px",
-                                          "medium": "1024px",
-                                          "small": "768px",
-                                        },
-                                        "colors": Object {
-                                          "black": "#011e38",
-                                          "blackBlue": "#122b47",
-                                          "blue": "#216beb",
-                                          "darkBlue": "#00438f",
-                                          "darkGrey": "#434d59",
-                                          "green": "#008059",
-                                          "grey": "#c0c8d1",
-                                          "lightBlue": "#e1ebfa",
-                                          "lightGreen": "#e9f7f2",
-                                          "lightGrey": "#e4e7eb",
-                                          "lightRed": "#fae6ea",
-                                          "lightYellow": "#fcf5e3",
-                                          "red": "#cc1439",
-                                          "white": "#ffffff",
-                                          "whiteGrey": "#f0f2f5",
-                                          "yellow": "#ffbb00",
-                                        },
-                                        "fontSizes": Object {
-                                          "large": "20px",
-                                          "larger": "26px",
-                                          "largest": "46px",
-                                          "medium": "16px",
-                                          "small": "14px",
-                                          "smaller": "12px",
-                                        },
-                                        "fontWeights": Object {
-                                          "bold": "600",
-                                          "light": "300",
-                                          "medium": "500",
-                                          "normal": "400",
-                                        },
-                                        "fonts": Object {
-                                          "base": "'IBM Plex Sans', sans-serif",
-                                          "mono": "'IBM Plex Mono', monospace",
-                                        },
-                                        "lineHeights": Object {
-                                          "base": "1.5",
-                                          "sectionTitle": "1.23076923",
-                                          "smallTextBase": "1.71428571",
-                                          "smallTextCompressed": "1.14285714",
-                                          "smallerText": "1.33333333",
-                                          "subsectionTitle": "1.2",
-                                          "title": "1.04347826",
-                                        },
-                                        "radii": Object {
-                                          "circle": "50%",
-                                          "medium": "4px",
-                                          "small": "2px",
-                                        },
-                                        "shadows": Object {
-                                          "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                          "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                          "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                          "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                          "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                                        },
-                                        "space": Object {
-                                          "half": "4px",
-                                          "none": "0px",
-                                          "x1": "8px",
-                                          "x2": "16px",
-                                          "x3": "24px",
-                                          "x4": "32px",
-                                          "x5": "40px",
-                                          "x6": "48px",
-                                          "x8": "64px",
-                                        },
-                                        "zIndex": Object {
-                                          "content": 100,
-                                          "overlay": 1000,
-                                          "tabsBar": 210,
-                                          "tabsScollIndicator": 200,
-                                        },
-                                      }
-                                    }
-                                  >
-                                    <StyledComponent
-                                      forwardedComponent={
-                                        Object {
-                                          "$$typeof": Symbol(react.forward_ref),
-                                          "_foldedDefaultProps": Object {
-                                            "theme": Object {
-                                              "borders": Array [],
-                                              "breakpoints": Object {
-                                                "extraLarge": "1920px",
-                                                "extraSmall": "0px",
-                                                "large": "1360px",
-                                                "medium": "1024px",
-                                                "small": "768px",
-                                              },
-                                              "colors": Object {
-                                                "black": "#011e38",
-                                                "blackBlue": "#122b47",
-                                                "blue": "#216beb",
-                                                "darkBlue": "#00438f",
-                                                "darkGrey": "#434d59",
-                                                "green": "#008059",
-                                                "grey": "#c0c8d1",
-                                                "lightBlue": "#e1ebfa",
-                                                "lightGreen": "#e9f7f2",
-                                                "lightGrey": "#e4e7eb",
-                                                "lightRed": "#fae6ea",
-                                                "lightYellow": "#fcf5e3",
-                                                "red": "#cc1439",
-                                                "white": "#ffffff",
-                                                "whiteGrey": "#f0f2f5",
-                                                "yellow": "#ffbb00",
-                                              },
-                                              "fontSizes": Object {
-                                                "large": "20px",
-                                                "larger": "26px",
-                                                "largest": "46px",
-                                                "medium": "16px",
-                                                "small": "14px",
-                                                "smaller": "12px",
-                                              },
-                                              "fontWeights": Object {
-                                                "bold": "600",
-                                                "light": "300",
-                                                "medium": "500",
-                                                "normal": "400",
-                                              },
-                                              "fonts": Object {
-                                                "base": "'IBM Plex Sans', sans-serif",
-                                                "mono": "'IBM Plex Mono', monospace",
-                                              },
-                                              "lineHeights": Object {
-                                                "base": "1.5",
-                                                "sectionTitle": "1.23076923",
-                                                "smallTextBase": "1.71428571",
-                                                "smallTextCompressed": "1.14285714",
-                                                "smallerText": "1.33333333",
-                                                "subsectionTitle": "1.2",
-                                                "title": "1.04347826",
-                                              },
-                                              "radii": Object {
-                                                "circle": "50%",
-                                                "medium": "4px",
-                                                "small": "2px",
-                                              },
-                                              "shadows": Object {
-                                                "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                                "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                                "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                                "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                                "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                                              },
-                                              "space": Object {
-                                                "half": "4px",
-                                                "none": "0px",
-                                                "x1": "8px",
-                                                "x2": "16px",
-                                                "x3": "24px",
-                                                "x4": "32px",
-                                                "x5": "40px",
-                                                "x6": "48px",
-                                                "x8": "64px",
-                                              },
-                                              "zIndex": Object {
-                                                "content": 100,
-                                                "overlay": 1000,
-                                                "tabsBar": 210,
-                                                "tabsScollIndicator": 200,
-                                              },
-                                            },
-                                          },
-                                          "attrs": Array [],
-                                          "componentStyle": ComponentStyle {
-                                            "componentId": "sc-jWBwVP",
-                                            "isStatic": false,
-                                            "lastClassName": "hjigbL",
-                                            "rules": Array [
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              "color: #011e38;",
-                                              "display: flex;",
-                                              "flex-direction: column;",
-                                              "font-size: 14px;",
-                                              "background-color: #ffffff;",
-                                              "border-radius: 4px;",
-                                              "border: 1px solid #c0c8d1;",
-                                              "box-shadow: 0 2px 4px rgba(0, 0, 0, 0.18);",
-                                              "padding: 8px;",
-                                              "transition: opacity 0.3s;",
-                                              "z-index: 100;",
-                                              [Function],
-                                            ],
-                                          },
-                                          "displayName": "Styled(Box)",
-                                          "foldedComponentIds": Array [
-                                            "Box-sc-1qu1edy-0",
-                                          ],
-                                          "propTypes": Object {
-                                            "bg": [Function],
-                                            "border": [Function],
-                                            "borderBottom": [Function],
-                                            "borderLeft": [Function],
-                                            "borderRadius": [Function],
-                                            "borderRight": [Function],
-                                            "borderTop": [Function],
-                                            "boxShadow": [Function],
-                                            "color": [Function],
-                                            "display": [Function],
-                                            "flexGrow": [Function],
-                                            "height": [Function],
-                                            "m": [Function],
-                                            "maxHeight": [Function],
-                                            "maxWidth": [Function],
-                                            "mb": [Function],
-                                            "minHeight": [Function],
-                                            "minWidth": [Function],
-                                            "ml": [Function],
-                                            "mr": [Function],
-                                            "mt": [Function],
-                                            "mx": [Function],
-                                            "my": [Function],
-                                            "order": [Function],
-                                            "p": [Function],
-                                            "pb": [Function],
-                                            "pl": [Function],
-                                            "position": [Function],
-                                            "pr": [Function],
-                                            "pt": [Function],
-                                            "px": [Function],
-                                            "py": [Function],
-                                            "textAlign": [Function],
-                                            "width": [Function],
-                                          },
-                                          "render": [Function],
-                                          "styledComponentId": "sc-jWBwVP",
-                                          "target": "div",
-                                          "toString": [Function],
-                                          "usesTheme": false,
-                                          "warnTooManyClasses": [Function],
-                                          "withComponent": [Function],
-                                        }
-                                      }
-                                      forwardedRef={[Function]}
-                                      id="random-id-11"
-                                      maxWidth="24em"
-                                      onBlur={[Function]}
-                                      onFocus={[Function]}
-                                      onMouseEnter={[Function]}
-                                      onMouseLeave={[Function]}
-                                      open={false}
-                                      position={
-                                        Object {
-                                          "left": 0,
-                                          "opacity": 0,
-                                          "pointerEvents": "none",
-                                          "position": "absolute",
-                                          "top": 0,
-                                        }
-                                      }
-                                      role="tooltip"
-                                      theme={
-                                        Object {
-                                          "borders": Array [],
-                                          "breakpoints": Object {
-                                            "extraLarge": "1920px",
-                                            "extraSmall": "0px",
-                                            "large": "1360px",
-                                            "medium": "1024px",
-                                            "small": "768px",
-                                          },
-                                          "colors": Object {
-                                            "black": "#011e38",
-                                            "blackBlue": "#122b47",
-                                            "blue": "#216beb",
-                                            "darkBlue": "#00438f",
-                                            "darkGrey": "#434d59",
-                                            "green": "#008059",
-                                            "grey": "#c0c8d1",
-                                            "lightBlue": "#e1ebfa",
-                                            "lightGreen": "#e9f7f2",
-                                            "lightGrey": "#e4e7eb",
-                                            "lightRed": "#fae6ea",
-                                            "lightYellow": "#fcf5e3",
-                                            "red": "#cc1439",
-                                            "white": "#ffffff",
-                                            "whiteGrey": "#f0f2f5",
-                                            "yellow": "#ffbb00",
-                                          },
-                                          "fontSizes": Object {
-                                            "large": "20px",
-                                            "larger": "26px",
-                                            "largest": "46px",
-                                            "medium": "16px",
-                                            "small": "14px",
-                                            "smaller": "12px",
-                                          },
-                                          "fontWeights": Object {
-                                            "bold": "600",
-                                            "light": "300",
-                                            "medium": "500",
-                                            "normal": "400",
-                                          },
-                                          "fonts": Object {
-                                            "base": "'IBM Plex Sans', sans-serif",
-                                            "mono": "'IBM Plex Mono', monospace",
-                                          },
-                                          "lineHeights": Object {
-                                            "base": "1.5",
-                                            "sectionTitle": "1.23076923",
-                                            "smallTextBase": "1.71428571",
-                                            "smallTextCompressed": "1.14285714",
-                                            "smallerText": "1.33333333",
-                                            "subsectionTitle": "1.2",
-                                            "title": "1.04347826",
-                                          },
-                                          "radii": Object {
-                                            "circle": "50%",
-                                            "medium": "4px",
-                                            "small": "2px",
-                                          },
-                                          "shadows": Object {
-                                            "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                            "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                            "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                            "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                            "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                                          },
-                                          "space": Object {
-                                            "half": "4px",
-                                            "none": "0px",
-                                            "x1": "8px",
-                                            "x2": "16px",
-                                            "x3": "24px",
-                                            "x4": "32px",
-                                            "x5": "40px",
-                                            "x6": "48px",
-                                            "x8": "64px",
-                                          },
-                                          "zIndex": Object {
-                                            "content": 100,
-                                            "overlay": 1000,
-                                            "tabsBar": 210,
-                                            "tabsScollIndicator": 200,
-                                          },
-                                        }
-                                      }
-                                    >
-                                      <div
-                                        className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
-                                        id="random-id-11"
-                                        onBlur={[Function]}
-                                        onFocus={[Function]}
-                                        onMouseEnter={[Function]}
-                                        onMouseLeave={[Function]}
-                                        open={false}
-                                        role="tooltip"
-                                      >
-                                        right-start
-                                        <PopperArrow
-                                          backgroundColor="white"
-                                          borderColor="grey"
-                                          placement="bottom"
-                                          style={Object {}}
-                                        >
-                                          <StyledComponent
-                                            backgroundColor="white"
-                                            borderColor="grey"
-                                            forwardedComponent={
-                                              Object {
-                                                "$$typeof": Symbol(react.forward_ref),
-                                                "_foldedDefaultProps": Object {
-                                                  "backgroundColor": "white",
-                                                  "borderColor": "grey",
-                                                  "placement": "bottom",
-                                                },
-                                                "attrs": Array [],
-                                                "componentStyle": ComponentStyle {
-                                                  "componentId": "PopperArrow-sc-1bcgj4w-0",
-                                                  "isStatic": false,
-                                                  "lastClassName": "bBzGzE",
-                                                  "rules": Array [
-                                                    "position: absolute;",
-                                                    "height: 8px;",
-                                                    "width: 8px;",
-                                                    "margin: 12px;",
-                                                    "&:before {",
-                                                    "border-style: solid;",
-                                                    "content: '';",
-                                                    "display: block;",
-                                                    "height: 0;",
-                                                    "margin: auto;",
-                                                    "position: absolute;",
-                                                    "width: 0;",
-                                                    "}",
-                                                    "&:after {",
-                                                    "border-style: solid;",
-                                                    "content: '';",
-                                                    "display: block;",
-                                                    "height: 0;",
-                                                    "margin: auto;",
-                                                    "position: absolute;",
-                                                    "width: 0;",
-                                                    "}",
-                                                    [Function],
-                                                    [Function],
-                                                  ],
-                                                },
-                                                "displayName": "PopperArrow",
-                                                "foldedComponentIds": Array [],
-                                                "propTypes": Object {
-                                                  "backgroundColor": [Function],
-                                                  "borderColor": [Function],
-                                                  "placement": [Function],
-                                                },
-                                                "render": [Function],
-                                                "styledComponentId": "PopperArrow-sc-1bcgj4w-0",
-                                                "target": "div",
-                                                "toString": [Function],
-                                                "usesTheme": false,
-                                                "warnTooManyClasses": [Function],
-                                                "withComponent": [Function],
-                                              }
-                                            }
-                                            forwardedRef={[Function]}
-                                            placement="bottom"
-                                            style={Object {}}
-                                          >
-                                            <div
-                                              className="PopperArrow-sc-1bcgj4w-0 bBzGzE"
-                                              style={Object {}}
-                                            />
-                                          </StyledComponent>
-                                        </PopperArrow>
-                                      </div>
-                                    </StyledComponent>
-                                  </Styled(Box)>
-                                </InnerPopper>
-                              </Popper>
-                            </Manager>
-                          </StatelessTooltip>
-                        </MenuState>
-                      </MenuComponent>
-                    </WithGeneratedId>
-                  </Component>
-                  <Component
-                    placement="right"
-                    tooltip="right"
-                  >
-                    <WithGeneratedId>
-                      <MenuComponent
-                        hideDelay="350"
-                        id="random-id-12"
-                        placement="right"
-                        showDelay="100"
-                        tooltip="right"
                       >
                         <MenuState
                           defaultOpen={false}
@@ -17598,8 +18023,8 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                 "toggleMenu": [Function],
                               }
                             }
-                            placement="right"
-                            tooltip="right"
+                            placement="right-start"
+                            tooltip="right-start"
                           >
                             <Manager>
                               <Reference>
@@ -17692,11 +18117,11 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                 </InnerReference>
                               </Reference>
                               <Popper
-                                placement="right"
+                                placement="right-start"
                               >
                                 <InnerPopper
                                   eventsEnabled={true}
-                                  placement="right"
+                                  placement="right-start"
                                   positionFixed={false}
                                   referenceElement={
                                     <button
@@ -18105,7 +18530,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                         open={false}
                                         role="tooltip"
                                       >
-                                        right
+                                        right-start
                                         <PopperArrow
                                           backgroundColor="white"
                                           borderColor="grey"
@@ -18193,16 +18618,17 @@ exports[`Storyshots Tooltip with placement 1`] = `
                     </WithGeneratedId>
                   </Component>
                   <Component
-                    placement="right-end"
-                    tooltip="right-end"
+                    placement="right"
+                    tooltip="right"
                   >
                     <WithGeneratedId>
                       <MenuComponent
+                        defaultOpen={false}
                         hideDelay="350"
                         id="random-id-13"
-                        placement="right-end"
+                        placement="right"
                         showDelay="100"
-                        tooltip="right-end"
+                        tooltip="right"
                       >
                         <MenuState
                           defaultOpen={false}
@@ -18221,8 +18647,8 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                 "toggleMenu": [Function],
                               }
                             }
-                            placement="right-end"
-                            tooltip="right-end"
+                            placement="right"
+                            tooltip="right"
                           >
                             <Manager>
                               <Reference>
@@ -18315,11 +18741,11 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                 </InnerReference>
                               </Reference>
                               <Popper
-                                placement="right-end"
+                                placement="right"
                               >
                                 <InnerPopper
                                   eventsEnabled={true}
-                                  placement="right-end"
+                                  placement="right"
                                   positionFixed={false}
                                   referenceElement={
                                     <button
@@ -18721,6 +19147,630 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       <div
                                         className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
                                         id="random-id-13"
+                                        onBlur={[Function]}
+                                        onFocus={[Function]}
+                                        onMouseEnter={[Function]}
+                                        onMouseLeave={[Function]}
+                                        open={false}
+                                        role="tooltip"
+                                      >
+                                        right
+                                        <PopperArrow
+                                          backgroundColor="white"
+                                          borderColor="grey"
+                                          placement="bottom"
+                                          style={Object {}}
+                                        >
+                                          <StyledComponent
+                                            backgroundColor="white"
+                                            borderColor="grey"
+                                            forwardedComponent={
+                                              Object {
+                                                "$$typeof": Symbol(react.forward_ref),
+                                                "_foldedDefaultProps": Object {
+                                                  "backgroundColor": "white",
+                                                  "borderColor": "grey",
+                                                  "placement": "bottom",
+                                                },
+                                                "attrs": Array [],
+                                                "componentStyle": ComponentStyle {
+                                                  "componentId": "PopperArrow-sc-1bcgj4w-0",
+                                                  "isStatic": false,
+                                                  "lastClassName": "bBzGzE",
+                                                  "rules": Array [
+                                                    "position: absolute;",
+                                                    "height: 8px;",
+                                                    "width: 8px;",
+                                                    "margin: 12px;",
+                                                    "&:before {",
+                                                    "border-style: solid;",
+                                                    "content: '';",
+                                                    "display: block;",
+                                                    "height: 0;",
+                                                    "margin: auto;",
+                                                    "position: absolute;",
+                                                    "width: 0;",
+                                                    "}",
+                                                    "&:after {",
+                                                    "border-style: solid;",
+                                                    "content: '';",
+                                                    "display: block;",
+                                                    "height: 0;",
+                                                    "margin: auto;",
+                                                    "position: absolute;",
+                                                    "width: 0;",
+                                                    "}",
+                                                    [Function],
+                                                    [Function],
+                                                  ],
+                                                },
+                                                "displayName": "PopperArrow",
+                                                "foldedComponentIds": Array [],
+                                                "propTypes": Object {
+                                                  "backgroundColor": [Function],
+                                                  "borderColor": [Function],
+                                                  "placement": [Function],
+                                                },
+                                                "render": [Function],
+                                                "styledComponentId": "PopperArrow-sc-1bcgj4w-0",
+                                                "target": "div",
+                                                "toString": [Function],
+                                                "usesTheme": false,
+                                                "warnTooManyClasses": [Function],
+                                                "withComponent": [Function],
+                                              }
+                                            }
+                                            forwardedRef={[Function]}
+                                            placement="bottom"
+                                            style={Object {}}
+                                          >
+                                            <div
+                                              className="PopperArrow-sc-1bcgj4w-0 bBzGzE"
+                                              style={Object {}}
+                                            />
+                                          </StyledComponent>
+                                        </PopperArrow>
+                                      </div>
+                                    </StyledComponent>
+                                  </Styled(Box)>
+                                </InnerPopper>
+                              </Popper>
+                            </Manager>
+                          </StatelessTooltip>
+                        </MenuState>
+                      </MenuComponent>
+                    </WithGeneratedId>
+                  </Component>
+                  <Component
+                    placement="right-end"
+                    tooltip="right-end"
+                  >
+                    <WithGeneratedId>
+                      <MenuComponent
+                        defaultOpen={false}
+                        hideDelay="350"
+                        id="random-id-14"
+                        placement="right-end"
+                        showDelay="100"
+                        tooltip="right-end"
+                      >
+                        <MenuState
+                          defaultOpen={false}
+                          hideDelay="350"
+                          showDelay="100"
+                        >
+                          <StatelessTooltip
+                            id="random-id-14"
+                            maxWidth="24em"
+                            menuState={
+                              Object {
+                                "closeMenu": [Function],
+                                "handleMenuKeydown": [Function],
+                                "isOpen": false,
+                                "openMenu": [Function],
+                                "toggleMenu": [Function],
+                              }
+                            }
+                            placement="right-end"
+                            tooltip="right-end"
+                          >
+                            <Manager>
+                              <Reference>
+                                <InnerReference
+                                  setReferenceNode={[Function]}
+                                >
+                                  <ForwardRef
+                                    aria-describedby="random-id-14"
+                                    aria-expanded={false}
+                                    aria-haspopup={true}
+                                    asLink={false}
+                                    disabled={false}
+                                    fullWidth={false}
+                                    icon={null}
+                                    iconSide="right"
+                                    onBlur={[Function]}
+                                    onFocus={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                    size="medium"
+                                  >
+                                    <Button__WrapperButton
+                                      aria-describedby="random-id-14"
+                                      aria-expanded={false}
+                                      aria-haspopup={true}
+                                      disabled={false}
+                                      fullWidth={false}
+                                      onBlur={[Function]}
+                                      onFocus={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                      size="medium"
+                                    >
+                                      <StyledComponent
+                                        aria-describedby="random-id-14"
+                                        aria-expanded={false}
+                                        aria-haspopup={true}
+                                        disabled={false}
+                                        forwardedComponent={
+                                          Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "attrs": Array [],
+                                            "componentStyle": ComponentStyle {
+                                              "componentId": "Button__WrapperButton-sc-1omxup2-0",
+                                              "isStatic": false,
+                                              "lastClassName": "idlBaC",
+                                              "rules": Array [
+                                                [Function],
+                                                [Function],
+                                                [Function],
+                                                [Function],
+                                              ],
+                                            },
+                                            "displayName": "Button__WrapperButton",
+                                            "foldedComponentIds": Array [],
+                                            "render": [Function],
+                                            "styledComponentId": "Button__WrapperButton-sc-1omxup2-0",
+                                            "target": "button",
+                                            "toString": [Function],
+                                            "usesTheme": false,
+                                            "warnTooManyClasses": [Function],
+                                            "withComponent": [Function],
+                                          }
+                                        }
+                                        forwardedRef={[Function]}
+                                        fullWidth={false}
+                                        onBlur={[Function]}
+                                        onFocus={[Function]}
+                                        onMouseEnter={[Function]}
+                                        onMouseLeave={[Function]}
+                                        size="medium"
+                                      >
+                                        <button
+                                          aria-describedby="random-id-14"
+                                          aria-expanded={false}
+                                          aria-haspopup={true}
+                                          className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
+                                          disabled={false}
+                                          onBlur={[Function]}
+                                          onFocus={[Function]}
+                                          onMouseEnter={[Function]}
+                                          onMouseLeave={[Function]}
+                                          size="medium"
+                                        >
+                                          Tooltip trigger
+                                        </button>
+                                      </StyledComponent>
+                                    </Button__WrapperButton>
+                                  </ForwardRef>
+                                </InnerReference>
+                              </Reference>
+                              <Popper
+                                placement="right-end"
+                              >
+                                <InnerPopper
+                                  eventsEnabled={true}
+                                  placement="right-end"
+                                  positionFixed={false}
+                                  referenceElement={
+                                    <button
+                                      aria-describedby="random-id-14"
+                                      aria-expanded="false"
+                                      aria-haspopup="true"
+                                      class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
+                                    >
+                                      Tooltip trigger
+                                    </button>
+                                  }
+                                >
+                                  <Styled(Box)
+                                    id="random-id-14"
+                                    maxWidth="24em"
+                                    onBlur={[Function]}
+                                    onFocus={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                    open={false}
+                                    position={
+                                      Object {
+                                        "left": 0,
+                                        "opacity": 0,
+                                        "pointerEvents": "none",
+                                        "position": "absolute",
+                                        "top": 0,
+                                      }
+                                    }
+                                    role="tooltip"
+                                    theme={
+                                      Object {
+                                        "borders": Array [],
+                                        "breakpoints": Object {
+                                          "extraLarge": "1920px",
+                                          "extraSmall": "0px",
+                                          "large": "1360px",
+                                          "medium": "1024px",
+                                          "small": "768px",
+                                        },
+                                        "colors": Object {
+                                          "black": "#011e38",
+                                          "blackBlue": "#122b47",
+                                          "blue": "#216beb",
+                                          "darkBlue": "#00438f",
+                                          "darkGrey": "#434d59",
+                                          "green": "#008059",
+                                          "grey": "#c0c8d1",
+                                          "lightBlue": "#e1ebfa",
+                                          "lightGreen": "#e9f7f2",
+                                          "lightGrey": "#e4e7eb",
+                                          "lightRed": "#fae6ea",
+                                          "lightYellow": "#fcf5e3",
+                                          "red": "#cc1439",
+                                          "white": "#ffffff",
+                                          "whiteGrey": "#f0f2f5",
+                                          "yellow": "#ffbb00",
+                                        },
+                                        "fontSizes": Object {
+                                          "large": "20px",
+                                          "larger": "26px",
+                                          "largest": "46px",
+                                          "medium": "16px",
+                                          "small": "14px",
+                                          "smaller": "12px",
+                                        },
+                                        "fontWeights": Object {
+                                          "bold": "600",
+                                          "light": "300",
+                                          "medium": "500",
+                                          "normal": "400",
+                                        },
+                                        "fonts": Object {
+                                          "base": "'IBM Plex Sans', sans-serif",
+                                          "mono": "'IBM Plex Mono', monospace",
+                                        },
+                                        "lineHeights": Object {
+                                          "base": "1.5",
+                                          "sectionTitle": "1.23076923",
+                                          "smallTextBase": "1.71428571",
+                                          "smallTextCompressed": "1.14285714",
+                                          "smallerText": "1.33333333",
+                                          "subsectionTitle": "1.2",
+                                          "title": "1.04347826",
+                                        },
+                                        "radii": Object {
+                                          "circle": "50%",
+                                          "medium": "4px",
+                                          "small": "2px",
+                                        },
+                                        "shadows": Object {
+                                          "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                          "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                          "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                          "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                          "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                        },
+                                        "space": Object {
+                                          "half": "4px",
+                                          "none": "0px",
+                                          "x1": "8px",
+                                          "x2": "16px",
+                                          "x3": "24px",
+                                          "x4": "32px",
+                                          "x5": "40px",
+                                          "x6": "48px",
+                                          "x8": "64px",
+                                        },
+                                        "zIndex": Object {
+                                          "content": 100,
+                                          "overlay": 1000,
+                                          "tabsBar": 210,
+                                          "tabsScollIndicator": 200,
+                                        },
+                                      }
+                                    }
+                                  >
+                                    <StyledComponent
+                                      forwardedComponent={
+                                        Object {
+                                          "$$typeof": Symbol(react.forward_ref),
+                                          "_foldedDefaultProps": Object {
+                                            "theme": Object {
+                                              "borders": Array [],
+                                              "breakpoints": Object {
+                                                "extraLarge": "1920px",
+                                                "extraSmall": "0px",
+                                                "large": "1360px",
+                                                "medium": "1024px",
+                                                "small": "768px",
+                                              },
+                                              "colors": Object {
+                                                "black": "#011e38",
+                                                "blackBlue": "#122b47",
+                                                "blue": "#216beb",
+                                                "darkBlue": "#00438f",
+                                                "darkGrey": "#434d59",
+                                                "green": "#008059",
+                                                "grey": "#c0c8d1",
+                                                "lightBlue": "#e1ebfa",
+                                                "lightGreen": "#e9f7f2",
+                                                "lightGrey": "#e4e7eb",
+                                                "lightRed": "#fae6ea",
+                                                "lightYellow": "#fcf5e3",
+                                                "red": "#cc1439",
+                                                "white": "#ffffff",
+                                                "whiteGrey": "#f0f2f5",
+                                                "yellow": "#ffbb00",
+                                              },
+                                              "fontSizes": Object {
+                                                "large": "20px",
+                                                "larger": "26px",
+                                                "largest": "46px",
+                                                "medium": "16px",
+                                                "small": "14px",
+                                                "smaller": "12px",
+                                              },
+                                              "fontWeights": Object {
+                                                "bold": "600",
+                                                "light": "300",
+                                                "medium": "500",
+                                                "normal": "400",
+                                              },
+                                              "fonts": Object {
+                                                "base": "'IBM Plex Sans', sans-serif",
+                                                "mono": "'IBM Plex Mono', monospace",
+                                              },
+                                              "lineHeights": Object {
+                                                "base": "1.5",
+                                                "sectionTitle": "1.23076923",
+                                                "smallTextBase": "1.71428571",
+                                                "smallTextCompressed": "1.14285714",
+                                                "smallerText": "1.33333333",
+                                                "subsectionTitle": "1.2",
+                                                "title": "1.04347826",
+                                              },
+                                              "radii": Object {
+                                                "circle": "50%",
+                                                "medium": "4px",
+                                                "small": "2px",
+                                              },
+                                              "shadows": Object {
+                                                "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                                "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                                "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                                "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                                "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                              },
+                                              "space": Object {
+                                                "half": "4px",
+                                                "none": "0px",
+                                                "x1": "8px",
+                                                "x2": "16px",
+                                                "x3": "24px",
+                                                "x4": "32px",
+                                                "x5": "40px",
+                                                "x6": "48px",
+                                                "x8": "64px",
+                                              },
+                                              "zIndex": Object {
+                                                "content": 100,
+                                                "overlay": 1000,
+                                                "tabsBar": 210,
+                                                "tabsScollIndicator": 200,
+                                              },
+                                            },
+                                          },
+                                          "attrs": Array [],
+                                          "componentStyle": ComponentStyle {
+                                            "componentId": "sc-jWBwVP",
+                                            "isStatic": false,
+                                            "lastClassName": "hjigbL",
+                                            "rules": Array [
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              "color: #011e38;",
+                                              "display: flex;",
+                                              "flex-direction: column;",
+                                              "font-size: 14px;",
+                                              "background-color: #ffffff;",
+                                              "border-radius: 4px;",
+                                              "border: 1px solid #c0c8d1;",
+                                              "box-shadow: 0 2px 4px rgba(0, 0, 0, 0.18);",
+                                              "padding: 8px;",
+                                              "transition: opacity 0.3s;",
+                                              "z-index: 100;",
+                                              [Function],
+                                            ],
+                                          },
+                                          "displayName": "Styled(Box)",
+                                          "foldedComponentIds": Array [
+                                            "Box-sc-1qu1edy-0",
+                                          ],
+                                          "propTypes": Object {
+                                            "bg": [Function],
+                                            "border": [Function],
+                                            "borderBottom": [Function],
+                                            "borderLeft": [Function],
+                                            "borderRadius": [Function],
+                                            "borderRight": [Function],
+                                            "borderTop": [Function],
+                                            "boxShadow": [Function],
+                                            "color": [Function],
+                                            "display": [Function],
+                                            "flexGrow": [Function],
+                                            "height": [Function],
+                                            "m": [Function],
+                                            "maxHeight": [Function],
+                                            "maxWidth": [Function],
+                                            "mb": [Function],
+                                            "minHeight": [Function],
+                                            "minWidth": [Function],
+                                            "ml": [Function],
+                                            "mr": [Function],
+                                            "mt": [Function],
+                                            "mx": [Function],
+                                            "my": [Function],
+                                            "order": [Function],
+                                            "p": [Function],
+                                            "pb": [Function],
+                                            "pl": [Function],
+                                            "position": [Function],
+                                            "pr": [Function],
+                                            "pt": [Function],
+                                            "px": [Function],
+                                            "py": [Function],
+                                            "textAlign": [Function],
+                                            "width": [Function],
+                                          },
+                                          "render": [Function],
+                                          "styledComponentId": "sc-jWBwVP",
+                                          "target": "div",
+                                          "toString": [Function],
+                                          "usesTheme": false,
+                                          "warnTooManyClasses": [Function],
+                                          "withComponent": [Function],
+                                        }
+                                      }
+                                      forwardedRef={[Function]}
+                                      id="random-id-14"
+                                      maxWidth="24em"
+                                      onBlur={[Function]}
+                                      onFocus={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                      open={false}
+                                      position={
+                                        Object {
+                                          "left": 0,
+                                          "opacity": 0,
+                                          "pointerEvents": "none",
+                                          "position": "absolute",
+                                          "top": 0,
+                                        }
+                                      }
+                                      role="tooltip"
+                                      theme={
+                                        Object {
+                                          "borders": Array [],
+                                          "breakpoints": Object {
+                                            "extraLarge": "1920px",
+                                            "extraSmall": "0px",
+                                            "large": "1360px",
+                                            "medium": "1024px",
+                                            "small": "768px",
+                                          },
+                                          "colors": Object {
+                                            "black": "#011e38",
+                                            "blackBlue": "#122b47",
+                                            "blue": "#216beb",
+                                            "darkBlue": "#00438f",
+                                            "darkGrey": "#434d59",
+                                            "green": "#008059",
+                                            "grey": "#c0c8d1",
+                                            "lightBlue": "#e1ebfa",
+                                            "lightGreen": "#e9f7f2",
+                                            "lightGrey": "#e4e7eb",
+                                            "lightRed": "#fae6ea",
+                                            "lightYellow": "#fcf5e3",
+                                            "red": "#cc1439",
+                                            "white": "#ffffff",
+                                            "whiteGrey": "#f0f2f5",
+                                            "yellow": "#ffbb00",
+                                          },
+                                          "fontSizes": Object {
+                                            "large": "20px",
+                                            "larger": "26px",
+                                            "largest": "46px",
+                                            "medium": "16px",
+                                            "small": "14px",
+                                            "smaller": "12px",
+                                          },
+                                          "fontWeights": Object {
+                                            "bold": "600",
+                                            "light": "300",
+                                            "medium": "500",
+                                            "normal": "400",
+                                          },
+                                          "fonts": Object {
+                                            "base": "'IBM Plex Sans', sans-serif",
+                                            "mono": "'IBM Plex Mono', monospace",
+                                          },
+                                          "lineHeights": Object {
+                                            "base": "1.5",
+                                            "sectionTitle": "1.23076923",
+                                            "smallTextBase": "1.71428571",
+                                            "smallTextCompressed": "1.14285714",
+                                            "smallerText": "1.33333333",
+                                            "subsectionTitle": "1.2",
+                                            "title": "1.04347826",
+                                          },
+                                          "radii": Object {
+                                            "circle": "50%",
+                                            "medium": "4px",
+                                            "small": "2px",
+                                          },
+                                          "shadows": Object {
+                                            "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                            "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                            "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                            "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                            "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                          },
+                                          "space": Object {
+                                            "half": "4px",
+                                            "none": "0px",
+                                            "x1": "8px",
+                                            "x2": "16px",
+                                            "x3": "24px",
+                                            "x4": "32px",
+                                            "x5": "40px",
+                                            "x6": "48px",
+                                            "x8": "64px",
+                                          },
+                                          "zIndex": Object {
+                                            "content": 100,
+                                            "overlay": 1000,
+                                            "tabsBar": 210,
+                                            "tabsScollIndicator": 200,
+                                          },
+                                        }
+                                      }
+                                    >
+                                      <div
+                                        className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
+                                        id="random-id-14"
                                         onBlur={[Function]}
                                         onFocus={[Function]}
                                         onMouseEnter={[Function]}
@@ -19148,634 +20198,12 @@ exports[`Storyshots Tooltip with placement 1`] = `
                   >
                     <WithGeneratedId>
                       <MenuComponent
+                        defaultOpen={false}
                         hideDelay="350"
-                        id="random-id-14"
+                        id="random-id-15"
                         placement="bottom-start"
                         showDelay="100"
                         tooltip="bottom-start"
-                      >
-                        <MenuState
-                          defaultOpen={false}
-                          hideDelay="350"
-                          showDelay="100"
-                        >
-                          <StatelessTooltip
-                            id="random-id-14"
-                            maxWidth="24em"
-                            menuState={
-                              Object {
-                                "closeMenu": [Function],
-                                "handleMenuKeydown": [Function],
-                                "isOpen": false,
-                                "openMenu": [Function],
-                                "toggleMenu": [Function],
-                              }
-                            }
-                            placement="bottom-start"
-                            tooltip="bottom-start"
-                          >
-                            <Manager>
-                              <Reference>
-                                <InnerReference
-                                  setReferenceNode={[Function]}
-                                >
-                                  <ForwardRef
-                                    aria-describedby="random-id-14"
-                                    aria-expanded={false}
-                                    aria-haspopup={true}
-                                    asLink={false}
-                                    disabled={false}
-                                    fullWidth={false}
-                                    icon={null}
-                                    iconSide="right"
-                                    onBlur={[Function]}
-                                    onFocus={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    size="medium"
-                                  >
-                                    <Button__WrapperButton
-                                      aria-describedby="random-id-14"
-                                      aria-expanded={false}
-                                      aria-haspopup={true}
-                                      disabled={false}
-                                      fullWidth={false}
-                                      onBlur={[Function]}
-                                      onFocus={[Function]}
-                                      onMouseEnter={[Function]}
-                                      onMouseLeave={[Function]}
-                                      size="medium"
-                                    >
-                                      <StyledComponent
-                                        aria-describedby="random-id-14"
-                                        aria-expanded={false}
-                                        aria-haspopup={true}
-                                        disabled={false}
-                                        forwardedComponent={
-                                          Object {
-                                            "$$typeof": Symbol(react.forward_ref),
-                                            "attrs": Array [],
-                                            "componentStyle": ComponentStyle {
-                                              "componentId": "Button__WrapperButton-sc-1omxup2-0",
-                                              "isStatic": false,
-                                              "lastClassName": "idlBaC",
-                                              "rules": Array [
-                                                [Function],
-                                                [Function],
-                                                [Function],
-                                                [Function],
-                                              ],
-                                            },
-                                            "displayName": "Button__WrapperButton",
-                                            "foldedComponentIds": Array [],
-                                            "render": [Function],
-                                            "styledComponentId": "Button__WrapperButton-sc-1omxup2-0",
-                                            "target": "button",
-                                            "toString": [Function],
-                                            "usesTheme": false,
-                                            "warnTooManyClasses": [Function],
-                                            "withComponent": [Function],
-                                          }
-                                        }
-                                        forwardedRef={[Function]}
-                                        fullWidth={false}
-                                        onBlur={[Function]}
-                                        onFocus={[Function]}
-                                        onMouseEnter={[Function]}
-                                        onMouseLeave={[Function]}
-                                        size="medium"
-                                      >
-                                        <button
-                                          aria-describedby="random-id-14"
-                                          aria-expanded={false}
-                                          aria-haspopup={true}
-                                          className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
-                                          disabled={false}
-                                          onBlur={[Function]}
-                                          onFocus={[Function]}
-                                          onMouseEnter={[Function]}
-                                          onMouseLeave={[Function]}
-                                          size="medium"
-                                        >
-                                          Tooltip trigger
-                                        </button>
-                                      </StyledComponent>
-                                    </Button__WrapperButton>
-                                  </ForwardRef>
-                                </InnerReference>
-                              </Reference>
-                              <Popper
-                                placement="bottom-start"
-                              >
-                                <InnerPopper
-                                  eventsEnabled={true}
-                                  placement="bottom-start"
-                                  positionFixed={false}
-                                  referenceElement={
-                                    <button
-                                      aria-describedby="random-id-14"
-                                      aria-expanded="false"
-                                      aria-haspopup="true"
-                                      class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
-                                    >
-                                      Tooltip trigger
-                                    </button>
-                                  }
-                                >
-                                  <Styled(Box)
-                                    id="random-id-14"
-                                    maxWidth="24em"
-                                    onBlur={[Function]}
-                                    onFocus={[Function]}
-                                    onMouseEnter={[Function]}
-                                    onMouseLeave={[Function]}
-                                    open={false}
-                                    position={
-                                      Object {
-                                        "left": 0,
-                                        "opacity": 0,
-                                        "pointerEvents": "none",
-                                        "position": "absolute",
-                                        "top": 0,
-                                      }
-                                    }
-                                    role="tooltip"
-                                    theme={
-                                      Object {
-                                        "borders": Array [],
-                                        "breakpoints": Object {
-                                          "extraLarge": "1920px",
-                                          "extraSmall": "0px",
-                                          "large": "1360px",
-                                          "medium": "1024px",
-                                          "small": "768px",
-                                        },
-                                        "colors": Object {
-                                          "black": "#011e38",
-                                          "blackBlue": "#122b47",
-                                          "blue": "#216beb",
-                                          "darkBlue": "#00438f",
-                                          "darkGrey": "#434d59",
-                                          "green": "#008059",
-                                          "grey": "#c0c8d1",
-                                          "lightBlue": "#e1ebfa",
-                                          "lightGreen": "#e9f7f2",
-                                          "lightGrey": "#e4e7eb",
-                                          "lightRed": "#fae6ea",
-                                          "lightYellow": "#fcf5e3",
-                                          "red": "#cc1439",
-                                          "white": "#ffffff",
-                                          "whiteGrey": "#f0f2f5",
-                                          "yellow": "#ffbb00",
-                                        },
-                                        "fontSizes": Object {
-                                          "large": "20px",
-                                          "larger": "26px",
-                                          "largest": "46px",
-                                          "medium": "16px",
-                                          "small": "14px",
-                                          "smaller": "12px",
-                                        },
-                                        "fontWeights": Object {
-                                          "bold": "600",
-                                          "light": "300",
-                                          "medium": "500",
-                                          "normal": "400",
-                                        },
-                                        "fonts": Object {
-                                          "base": "'IBM Plex Sans', sans-serif",
-                                          "mono": "'IBM Plex Mono', monospace",
-                                        },
-                                        "lineHeights": Object {
-                                          "base": "1.5",
-                                          "sectionTitle": "1.23076923",
-                                          "smallTextBase": "1.71428571",
-                                          "smallTextCompressed": "1.14285714",
-                                          "smallerText": "1.33333333",
-                                          "subsectionTitle": "1.2",
-                                          "title": "1.04347826",
-                                        },
-                                        "radii": Object {
-                                          "circle": "50%",
-                                          "medium": "4px",
-                                          "small": "2px",
-                                        },
-                                        "shadows": Object {
-                                          "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                          "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                          "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                          "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                          "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                                        },
-                                        "space": Object {
-                                          "half": "4px",
-                                          "none": "0px",
-                                          "x1": "8px",
-                                          "x2": "16px",
-                                          "x3": "24px",
-                                          "x4": "32px",
-                                          "x5": "40px",
-                                          "x6": "48px",
-                                          "x8": "64px",
-                                        },
-                                        "zIndex": Object {
-                                          "content": 100,
-                                          "overlay": 1000,
-                                          "tabsBar": 210,
-                                          "tabsScollIndicator": 200,
-                                        },
-                                      }
-                                    }
-                                  >
-                                    <StyledComponent
-                                      forwardedComponent={
-                                        Object {
-                                          "$$typeof": Symbol(react.forward_ref),
-                                          "_foldedDefaultProps": Object {
-                                            "theme": Object {
-                                              "borders": Array [],
-                                              "breakpoints": Object {
-                                                "extraLarge": "1920px",
-                                                "extraSmall": "0px",
-                                                "large": "1360px",
-                                                "medium": "1024px",
-                                                "small": "768px",
-                                              },
-                                              "colors": Object {
-                                                "black": "#011e38",
-                                                "blackBlue": "#122b47",
-                                                "blue": "#216beb",
-                                                "darkBlue": "#00438f",
-                                                "darkGrey": "#434d59",
-                                                "green": "#008059",
-                                                "grey": "#c0c8d1",
-                                                "lightBlue": "#e1ebfa",
-                                                "lightGreen": "#e9f7f2",
-                                                "lightGrey": "#e4e7eb",
-                                                "lightRed": "#fae6ea",
-                                                "lightYellow": "#fcf5e3",
-                                                "red": "#cc1439",
-                                                "white": "#ffffff",
-                                                "whiteGrey": "#f0f2f5",
-                                                "yellow": "#ffbb00",
-                                              },
-                                              "fontSizes": Object {
-                                                "large": "20px",
-                                                "larger": "26px",
-                                                "largest": "46px",
-                                                "medium": "16px",
-                                                "small": "14px",
-                                                "smaller": "12px",
-                                              },
-                                              "fontWeights": Object {
-                                                "bold": "600",
-                                                "light": "300",
-                                                "medium": "500",
-                                                "normal": "400",
-                                              },
-                                              "fonts": Object {
-                                                "base": "'IBM Plex Sans', sans-serif",
-                                                "mono": "'IBM Plex Mono', monospace",
-                                              },
-                                              "lineHeights": Object {
-                                                "base": "1.5",
-                                                "sectionTitle": "1.23076923",
-                                                "smallTextBase": "1.71428571",
-                                                "smallTextCompressed": "1.14285714",
-                                                "smallerText": "1.33333333",
-                                                "subsectionTitle": "1.2",
-                                                "title": "1.04347826",
-                                              },
-                                              "radii": Object {
-                                                "circle": "50%",
-                                                "medium": "4px",
-                                                "small": "2px",
-                                              },
-                                              "shadows": Object {
-                                                "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                                "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                                "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                                "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                                "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                                              },
-                                              "space": Object {
-                                                "half": "4px",
-                                                "none": "0px",
-                                                "x1": "8px",
-                                                "x2": "16px",
-                                                "x3": "24px",
-                                                "x4": "32px",
-                                                "x5": "40px",
-                                                "x6": "48px",
-                                                "x8": "64px",
-                                              },
-                                              "zIndex": Object {
-                                                "content": 100,
-                                                "overlay": 1000,
-                                                "tabsBar": 210,
-                                                "tabsScollIndicator": 200,
-                                              },
-                                            },
-                                          },
-                                          "attrs": Array [],
-                                          "componentStyle": ComponentStyle {
-                                            "componentId": "sc-jWBwVP",
-                                            "isStatic": false,
-                                            "lastClassName": "hjigbL",
-                                            "rules": Array [
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              [Function],
-                                              "color: #011e38;",
-                                              "display: flex;",
-                                              "flex-direction: column;",
-                                              "font-size: 14px;",
-                                              "background-color: #ffffff;",
-                                              "border-radius: 4px;",
-                                              "border: 1px solid #c0c8d1;",
-                                              "box-shadow: 0 2px 4px rgba(0, 0, 0, 0.18);",
-                                              "padding: 8px;",
-                                              "transition: opacity 0.3s;",
-                                              "z-index: 100;",
-                                              [Function],
-                                            ],
-                                          },
-                                          "displayName": "Styled(Box)",
-                                          "foldedComponentIds": Array [
-                                            "Box-sc-1qu1edy-0",
-                                          ],
-                                          "propTypes": Object {
-                                            "bg": [Function],
-                                            "border": [Function],
-                                            "borderBottom": [Function],
-                                            "borderLeft": [Function],
-                                            "borderRadius": [Function],
-                                            "borderRight": [Function],
-                                            "borderTop": [Function],
-                                            "boxShadow": [Function],
-                                            "color": [Function],
-                                            "display": [Function],
-                                            "flexGrow": [Function],
-                                            "height": [Function],
-                                            "m": [Function],
-                                            "maxHeight": [Function],
-                                            "maxWidth": [Function],
-                                            "mb": [Function],
-                                            "minHeight": [Function],
-                                            "minWidth": [Function],
-                                            "ml": [Function],
-                                            "mr": [Function],
-                                            "mt": [Function],
-                                            "mx": [Function],
-                                            "my": [Function],
-                                            "order": [Function],
-                                            "p": [Function],
-                                            "pb": [Function],
-                                            "pl": [Function],
-                                            "position": [Function],
-                                            "pr": [Function],
-                                            "pt": [Function],
-                                            "px": [Function],
-                                            "py": [Function],
-                                            "textAlign": [Function],
-                                            "width": [Function],
-                                          },
-                                          "render": [Function],
-                                          "styledComponentId": "sc-jWBwVP",
-                                          "target": "div",
-                                          "toString": [Function],
-                                          "usesTheme": false,
-                                          "warnTooManyClasses": [Function],
-                                          "withComponent": [Function],
-                                        }
-                                      }
-                                      forwardedRef={[Function]}
-                                      id="random-id-14"
-                                      maxWidth="24em"
-                                      onBlur={[Function]}
-                                      onFocus={[Function]}
-                                      onMouseEnter={[Function]}
-                                      onMouseLeave={[Function]}
-                                      open={false}
-                                      position={
-                                        Object {
-                                          "left": 0,
-                                          "opacity": 0,
-                                          "pointerEvents": "none",
-                                          "position": "absolute",
-                                          "top": 0,
-                                        }
-                                      }
-                                      role="tooltip"
-                                      theme={
-                                        Object {
-                                          "borders": Array [],
-                                          "breakpoints": Object {
-                                            "extraLarge": "1920px",
-                                            "extraSmall": "0px",
-                                            "large": "1360px",
-                                            "medium": "1024px",
-                                            "small": "768px",
-                                          },
-                                          "colors": Object {
-                                            "black": "#011e38",
-                                            "blackBlue": "#122b47",
-                                            "blue": "#216beb",
-                                            "darkBlue": "#00438f",
-                                            "darkGrey": "#434d59",
-                                            "green": "#008059",
-                                            "grey": "#c0c8d1",
-                                            "lightBlue": "#e1ebfa",
-                                            "lightGreen": "#e9f7f2",
-                                            "lightGrey": "#e4e7eb",
-                                            "lightRed": "#fae6ea",
-                                            "lightYellow": "#fcf5e3",
-                                            "red": "#cc1439",
-                                            "white": "#ffffff",
-                                            "whiteGrey": "#f0f2f5",
-                                            "yellow": "#ffbb00",
-                                          },
-                                          "fontSizes": Object {
-                                            "large": "20px",
-                                            "larger": "26px",
-                                            "largest": "46px",
-                                            "medium": "16px",
-                                            "small": "14px",
-                                            "smaller": "12px",
-                                          },
-                                          "fontWeights": Object {
-                                            "bold": "600",
-                                            "light": "300",
-                                            "medium": "500",
-                                            "normal": "400",
-                                          },
-                                          "fonts": Object {
-                                            "base": "'IBM Plex Sans', sans-serif",
-                                            "mono": "'IBM Plex Mono', monospace",
-                                          },
-                                          "lineHeights": Object {
-                                            "base": "1.5",
-                                            "sectionTitle": "1.23076923",
-                                            "smallTextBase": "1.71428571",
-                                            "smallTextCompressed": "1.14285714",
-                                            "smallerText": "1.33333333",
-                                            "subsectionTitle": "1.2",
-                                            "title": "1.04347826",
-                                          },
-                                          "radii": Object {
-                                            "circle": "50%",
-                                            "medium": "4px",
-                                            "small": "2px",
-                                          },
-                                          "shadows": Object {
-                                            "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                            "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                            "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                            "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                            "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                                          },
-                                          "space": Object {
-                                            "half": "4px",
-                                            "none": "0px",
-                                            "x1": "8px",
-                                            "x2": "16px",
-                                            "x3": "24px",
-                                            "x4": "32px",
-                                            "x5": "40px",
-                                            "x6": "48px",
-                                            "x8": "64px",
-                                          },
-                                          "zIndex": Object {
-                                            "content": 100,
-                                            "overlay": 1000,
-                                            "tabsBar": 210,
-                                            "tabsScollIndicator": 200,
-                                          },
-                                        }
-                                      }
-                                    >
-                                      <div
-                                        className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
-                                        id="random-id-14"
-                                        onBlur={[Function]}
-                                        onFocus={[Function]}
-                                        onMouseEnter={[Function]}
-                                        onMouseLeave={[Function]}
-                                        open={false}
-                                        role="tooltip"
-                                      >
-                                        bottom-start
-                                        <PopperArrow
-                                          backgroundColor="white"
-                                          borderColor="grey"
-                                          placement="bottom"
-                                          style={Object {}}
-                                        >
-                                          <StyledComponent
-                                            backgroundColor="white"
-                                            borderColor="grey"
-                                            forwardedComponent={
-                                              Object {
-                                                "$$typeof": Symbol(react.forward_ref),
-                                                "_foldedDefaultProps": Object {
-                                                  "backgroundColor": "white",
-                                                  "borderColor": "grey",
-                                                  "placement": "bottom",
-                                                },
-                                                "attrs": Array [],
-                                                "componentStyle": ComponentStyle {
-                                                  "componentId": "PopperArrow-sc-1bcgj4w-0",
-                                                  "isStatic": false,
-                                                  "lastClassName": "bBzGzE",
-                                                  "rules": Array [
-                                                    "position: absolute;",
-                                                    "height: 8px;",
-                                                    "width: 8px;",
-                                                    "margin: 12px;",
-                                                    "&:before {",
-                                                    "border-style: solid;",
-                                                    "content: '';",
-                                                    "display: block;",
-                                                    "height: 0;",
-                                                    "margin: auto;",
-                                                    "position: absolute;",
-                                                    "width: 0;",
-                                                    "}",
-                                                    "&:after {",
-                                                    "border-style: solid;",
-                                                    "content: '';",
-                                                    "display: block;",
-                                                    "height: 0;",
-                                                    "margin: auto;",
-                                                    "position: absolute;",
-                                                    "width: 0;",
-                                                    "}",
-                                                    [Function],
-                                                    [Function],
-                                                  ],
-                                                },
-                                                "displayName": "PopperArrow",
-                                                "foldedComponentIds": Array [],
-                                                "propTypes": Object {
-                                                  "backgroundColor": [Function],
-                                                  "borderColor": [Function],
-                                                  "placement": [Function],
-                                                },
-                                                "render": [Function],
-                                                "styledComponentId": "PopperArrow-sc-1bcgj4w-0",
-                                                "target": "div",
-                                                "toString": [Function],
-                                                "usesTheme": false,
-                                                "warnTooManyClasses": [Function],
-                                                "withComponent": [Function],
-                                              }
-                                            }
-                                            forwardedRef={[Function]}
-                                            placement="bottom"
-                                            style={Object {}}
-                                          >
-                                            <div
-                                              className="PopperArrow-sc-1bcgj4w-0 bBzGzE"
-                                              style={Object {}}
-                                            />
-                                          </StyledComponent>
-                                        </PopperArrow>
-                                      </div>
-                                    </StyledComponent>
-                                  </Styled(Box)>
-                                </InnerPopper>
-                              </Popper>
-                            </Manager>
-                          </StatelessTooltip>
-                        </MenuState>
-                      </MenuComponent>
-                    </WithGeneratedId>
-                  </Component>
-                  <Component
-                    placement="bottom"
-                    tooltip="bottom"
-                  >
-                    <WithGeneratedId>
-                      <MenuComponent
-                        hideDelay="350"
-                        id="random-id-15"
-                        placement="bottom"
-                        showDelay="100"
-                        tooltip="bottom"
                       >
                         <MenuState
                           defaultOpen={false}
@@ -19794,8 +20222,8 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                 "toggleMenu": [Function],
                               }
                             }
-                            placement="bottom"
-                            tooltip="bottom"
+                            placement="bottom-start"
+                            tooltip="bottom-start"
                           >
                             <Manager>
                               <Reference>
@@ -19888,11 +20316,11 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                 </InnerReference>
                               </Reference>
                               <Popper
-                                placement="bottom"
+                                placement="bottom-start"
                               >
                                 <InnerPopper
                                   eventsEnabled={true}
-                                  placement="bottom"
+                                  placement="bottom-start"
                                   positionFixed={false}
                                   referenceElement={
                                     <button
@@ -20301,7 +20729,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                         open={false}
                                         role="tooltip"
                                       >
-                                        bottom
+                                        bottom-start
                                         <PopperArrow
                                           backgroundColor="white"
                                           borderColor="grey"
@@ -20389,16 +20817,17 @@ exports[`Storyshots Tooltip with placement 1`] = `
                     </WithGeneratedId>
                   </Component>
                   <Component
-                    placement="bottom-end"
-                    tooltip="bottom-end"
+                    placement="bottom"
+                    tooltip="bottom"
                   >
                     <WithGeneratedId>
                       <MenuComponent
+                        defaultOpen={false}
                         hideDelay="350"
                         id="random-id-16"
-                        placement="bottom-end"
+                        placement="bottom"
                         showDelay="100"
-                        tooltip="bottom-end"
+                        tooltip="bottom"
                       >
                         <MenuState
                           defaultOpen={false}
@@ -20417,8 +20846,8 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                 "toggleMenu": [Function],
                               }
                             }
-                            placement="bottom-end"
-                            tooltip="bottom-end"
+                            placement="bottom"
+                            tooltip="bottom"
                           >
                             <Manager>
                               <Reference>
@@ -20511,11 +20940,11 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                 </InnerReference>
                               </Reference>
                               <Popper
-                                placement="bottom-end"
+                                placement="bottom"
                               >
                                 <InnerPopper
                                   eventsEnabled={true}
-                                  placement="bottom-end"
+                                  placement="bottom"
                                   positionFixed={false}
                                   referenceElement={
                                     <button
@@ -20917,6 +21346,630 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       <div
                                         className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
                                         id="random-id-16"
+                                        onBlur={[Function]}
+                                        onFocus={[Function]}
+                                        onMouseEnter={[Function]}
+                                        onMouseLeave={[Function]}
+                                        open={false}
+                                        role="tooltip"
+                                      >
+                                        bottom
+                                        <PopperArrow
+                                          backgroundColor="white"
+                                          borderColor="grey"
+                                          placement="bottom"
+                                          style={Object {}}
+                                        >
+                                          <StyledComponent
+                                            backgroundColor="white"
+                                            borderColor="grey"
+                                            forwardedComponent={
+                                              Object {
+                                                "$$typeof": Symbol(react.forward_ref),
+                                                "_foldedDefaultProps": Object {
+                                                  "backgroundColor": "white",
+                                                  "borderColor": "grey",
+                                                  "placement": "bottom",
+                                                },
+                                                "attrs": Array [],
+                                                "componentStyle": ComponentStyle {
+                                                  "componentId": "PopperArrow-sc-1bcgj4w-0",
+                                                  "isStatic": false,
+                                                  "lastClassName": "bBzGzE",
+                                                  "rules": Array [
+                                                    "position: absolute;",
+                                                    "height: 8px;",
+                                                    "width: 8px;",
+                                                    "margin: 12px;",
+                                                    "&:before {",
+                                                    "border-style: solid;",
+                                                    "content: '';",
+                                                    "display: block;",
+                                                    "height: 0;",
+                                                    "margin: auto;",
+                                                    "position: absolute;",
+                                                    "width: 0;",
+                                                    "}",
+                                                    "&:after {",
+                                                    "border-style: solid;",
+                                                    "content: '';",
+                                                    "display: block;",
+                                                    "height: 0;",
+                                                    "margin: auto;",
+                                                    "position: absolute;",
+                                                    "width: 0;",
+                                                    "}",
+                                                    [Function],
+                                                    [Function],
+                                                  ],
+                                                },
+                                                "displayName": "PopperArrow",
+                                                "foldedComponentIds": Array [],
+                                                "propTypes": Object {
+                                                  "backgroundColor": [Function],
+                                                  "borderColor": [Function],
+                                                  "placement": [Function],
+                                                },
+                                                "render": [Function],
+                                                "styledComponentId": "PopperArrow-sc-1bcgj4w-0",
+                                                "target": "div",
+                                                "toString": [Function],
+                                                "usesTheme": false,
+                                                "warnTooManyClasses": [Function],
+                                                "withComponent": [Function],
+                                              }
+                                            }
+                                            forwardedRef={[Function]}
+                                            placement="bottom"
+                                            style={Object {}}
+                                          >
+                                            <div
+                                              className="PopperArrow-sc-1bcgj4w-0 bBzGzE"
+                                              style={Object {}}
+                                            />
+                                          </StyledComponent>
+                                        </PopperArrow>
+                                      </div>
+                                    </StyledComponent>
+                                  </Styled(Box)>
+                                </InnerPopper>
+                              </Popper>
+                            </Manager>
+                          </StatelessTooltip>
+                        </MenuState>
+                      </MenuComponent>
+                    </WithGeneratedId>
+                  </Component>
+                  <Component
+                    placement="bottom-end"
+                    tooltip="bottom-end"
+                  >
+                    <WithGeneratedId>
+                      <MenuComponent
+                        defaultOpen={false}
+                        hideDelay="350"
+                        id="random-id-17"
+                        placement="bottom-end"
+                        showDelay="100"
+                        tooltip="bottom-end"
+                      >
+                        <MenuState
+                          defaultOpen={false}
+                          hideDelay="350"
+                          showDelay="100"
+                        >
+                          <StatelessTooltip
+                            id="random-id-17"
+                            maxWidth="24em"
+                            menuState={
+                              Object {
+                                "closeMenu": [Function],
+                                "handleMenuKeydown": [Function],
+                                "isOpen": false,
+                                "openMenu": [Function],
+                                "toggleMenu": [Function],
+                              }
+                            }
+                            placement="bottom-end"
+                            tooltip="bottom-end"
+                          >
+                            <Manager>
+                              <Reference>
+                                <InnerReference
+                                  setReferenceNode={[Function]}
+                                >
+                                  <ForwardRef
+                                    aria-describedby="random-id-17"
+                                    aria-expanded={false}
+                                    aria-haspopup={true}
+                                    asLink={false}
+                                    disabled={false}
+                                    fullWidth={false}
+                                    icon={null}
+                                    iconSide="right"
+                                    onBlur={[Function]}
+                                    onFocus={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                    size="medium"
+                                  >
+                                    <Button__WrapperButton
+                                      aria-describedby="random-id-17"
+                                      aria-expanded={false}
+                                      aria-haspopup={true}
+                                      disabled={false}
+                                      fullWidth={false}
+                                      onBlur={[Function]}
+                                      onFocus={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                      size="medium"
+                                    >
+                                      <StyledComponent
+                                        aria-describedby="random-id-17"
+                                        aria-expanded={false}
+                                        aria-haspopup={true}
+                                        disabled={false}
+                                        forwardedComponent={
+                                          Object {
+                                            "$$typeof": Symbol(react.forward_ref),
+                                            "attrs": Array [],
+                                            "componentStyle": ComponentStyle {
+                                              "componentId": "Button__WrapperButton-sc-1omxup2-0",
+                                              "isStatic": false,
+                                              "lastClassName": "idlBaC",
+                                              "rules": Array [
+                                                [Function],
+                                                [Function],
+                                                [Function],
+                                                [Function],
+                                              ],
+                                            },
+                                            "displayName": "Button__WrapperButton",
+                                            "foldedComponentIds": Array [],
+                                            "render": [Function],
+                                            "styledComponentId": "Button__WrapperButton-sc-1omxup2-0",
+                                            "target": "button",
+                                            "toString": [Function],
+                                            "usesTheme": false,
+                                            "warnTooManyClasses": [Function],
+                                            "withComponent": [Function],
+                                          }
+                                        }
+                                        forwardedRef={[Function]}
+                                        fullWidth={false}
+                                        onBlur={[Function]}
+                                        onFocus={[Function]}
+                                        onMouseEnter={[Function]}
+                                        onMouseLeave={[Function]}
+                                        size="medium"
+                                      >
+                                        <button
+                                          aria-describedby="random-id-17"
+                                          aria-expanded={false}
+                                          aria-haspopup={true}
+                                          className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
+                                          disabled={false}
+                                          onBlur={[Function]}
+                                          onFocus={[Function]}
+                                          onMouseEnter={[Function]}
+                                          onMouseLeave={[Function]}
+                                          size="medium"
+                                        >
+                                          Tooltip trigger
+                                        </button>
+                                      </StyledComponent>
+                                    </Button__WrapperButton>
+                                  </ForwardRef>
+                                </InnerReference>
+                              </Reference>
+                              <Popper
+                                placement="bottom-end"
+                              >
+                                <InnerPopper
+                                  eventsEnabled={true}
+                                  placement="bottom-end"
+                                  positionFixed={false}
+                                  referenceElement={
+                                    <button
+                                      aria-describedby="random-id-17"
+                                      aria-expanded="false"
+                                      aria-haspopup="true"
+                                      class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
+                                    >
+                                      Tooltip trigger
+                                    </button>
+                                  }
+                                >
+                                  <Styled(Box)
+                                    id="random-id-17"
+                                    maxWidth="24em"
+                                    onBlur={[Function]}
+                                    onFocus={[Function]}
+                                    onMouseEnter={[Function]}
+                                    onMouseLeave={[Function]}
+                                    open={false}
+                                    position={
+                                      Object {
+                                        "left": 0,
+                                        "opacity": 0,
+                                        "pointerEvents": "none",
+                                        "position": "absolute",
+                                        "top": 0,
+                                      }
+                                    }
+                                    role="tooltip"
+                                    theme={
+                                      Object {
+                                        "borders": Array [],
+                                        "breakpoints": Object {
+                                          "extraLarge": "1920px",
+                                          "extraSmall": "0px",
+                                          "large": "1360px",
+                                          "medium": "1024px",
+                                          "small": "768px",
+                                        },
+                                        "colors": Object {
+                                          "black": "#011e38",
+                                          "blackBlue": "#122b47",
+                                          "blue": "#216beb",
+                                          "darkBlue": "#00438f",
+                                          "darkGrey": "#434d59",
+                                          "green": "#008059",
+                                          "grey": "#c0c8d1",
+                                          "lightBlue": "#e1ebfa",
+                                          "lightGreen": "#e9f7f2",
+                                          "lightGrey": "#e4e7eb",
+                                          "lightRed": "#fae6ea",
+                                          "lightYellow": "#fcf5e3",
+                                          "red": "#cc1439",
+                                          "white": "#ffffff",
+                                          "whiteGrey": "#f0f2f5",
+                                          "yellow": "#ffbb00",
+                                        },
+                                        "fontSizes": Object {
+                                          "large": "20px",
+                                          "larger": "26px",
+                                          "largest": "46px",
+                                          "medium": "16px",
+                                          "small": "14px",
+                                          "smaller": "12px",
+                                        },
+                                        "fontWeights": Object {
+                                          "bold": "600",
+                                          "light": "300",
+                                          "medium": "500",
+                                          "normal": "400",
+                                        },
+                                        "fonts": Object {
+                                          "base": "'IBM Plex Sans', sans-serif",
+                                          "mono": "'IBM Plex Mono', monospace",
+                                        },
+                                        "lineHeights": Object {
+                                          "base": "1.5",
+                                          "sectionTitle": "1.23076923",
+                                          "smallTextBase": "1.71428571",
+                                          "smallTextCompressed": "1.14285714",
+                                          "smallerText": "1.33333333",
+                                          "subsectionTitle": "1.2",
+                                          "title": "1.04347826",
+                                        },
+                                        "radii": Object {
+                                          "circle": "50%",
+                                          "medium": "4px",
+                                          "small": "2px",
+                                        },
+                                        "shadows": Object {
+                                          "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                          "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                          "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                          "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                          "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                        },
+                                        "space": Object {
+                                          "half": "4px",
+                                          "none": "0px",
+                                          "x1": "8px",
+                                          "x2": "16px",
+                                          "x3": "24px",
+                                          "x4": "32px",
+                                          "x5": "40px",
+                                          "x6": "48px",
+                                          "x8": "64px",
+                                        },
+                                        "zIndex": Object {
+                                          "content": 100,
+                                          "overlay": 1000,
+                                          "tabsBar": 210,
+                                          "tabsScollIndicator": 200,
+                                        },
+                                      }
+                                    }
+                                  >
+                                    <StyledComponent
+                                      forwardedComponent={
+                                        Object {
+                                          "$$typeof": Symbol(react.forward_ref),
+                                          "_foldedDefaultProps": Object {
+                                            "theme": Object {
+                                              "borders": Array [],
+                                              "breakpoints": Object {
+                                                "extraLarge": "1920px",
+                                                "extraSmall": "0px",
+                                                "large": "1360px",
+                                                "medium": "1024px",
+                                                "small": "768px",
+                                              },
+                                              "colors": Object {
+                                                "black": "#011e38",
+                                                "blackBlue": "#122b47",
+                                                "blue": "#216beb",
+                                                "darkBlue": "#00438f",
+                                                "darkGrey": "#434d59",
+                                                "green": "#008059",
+                                                "grey": "#c0c8d1",
+                                                "lightBlue": "#e1ebfa",
+                                                "lightGreen": "#e9f7f2",
+                                                "lightGrey": "#e4e7eb",
+                                                "lightRed": "#fae6ea",
+                                                "lightYellow": "#fcf5e3",
+                                                "red": "#cc1439",
+                                                "white": "#ffffff",
+                                                "whiteGrey": "#f0f2f5",
+                                                "yellow": "#ffbb00",
+                                              },
+                                              "fontSizes": Object {
+                                                "large": "20px",
+                                                "larger": "26px",
+                                                "largest": "46px",
+                                                "medium": "16px",
+                                                "small": "14px",
+                                                "smaller": "12px",
+                                              },
+                                              "fontWeights": Object {
+                                                "bold": "600",
+                                                "light": "300",
+                                                "medium": "500",
+                                                "normal": "400",
+                                              },
+                                              "fonts": Object {
+                                                "base": "'IBM Plex Sans', sans-serif",
+                                                "mono": "'IBM Plex Mono', monospace",
+                                              },
+                                              "lineHeights": Object {
+                                                "base": "1.5",
+                                                "sectionTitle": "1.23076923",
+                                                "smallTextBase": "1.71428571",
+                                                "smallTextCompressed": "1.14285714",
+                                                "smallerText": "1.33333333",
+                                                "subsectionTitle": "1.2",
+                                                "title": "1.04347826",
+                                              },
+                                              "radii": Object {
+                                                "circle": "50%",
+                                                "medium": "4px",
+                                                "small": "2px",
+                                              },
+                                              "shadows": Object {
+                                                "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                                "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                                "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                                "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                                "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                              },
+                                              "space": Object {
+                                                "half": "4px",
+                                                "none": "0px",
+                                                "x1": "8px",
+                                                "x2": "16px",
+                                                "x3": "24px",
+                                                "x4": "32px",
+                                                "x5": "40px",
+                                                "x6": "48px",
+                                                "x8": "64px",
+                                              },
+                                              "zIndex": Object {
+                                                "content": 100,
+                                                "overlay": 1000,
+                                                "tabsBar": 210,
+                                                "tabsScollIndicator": 200,
+                                              },
+                                            },
+                                          },
+                                          "attrs": Array [],
+                                          "componentStyle": ComponentStyle {
+                                            "componentId": "sc-jWBwVP",
+                                            "isStatic": false,
+                                            "lastClassName": "hjigbL",
+                                            "rules": Array [
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              [Function],
+                                              "color: #011e38;",
+                                              "display: flex;",
+                                              "flex-direction: column;",
+                                              "font-size: 14px;",
+                                              "background-color: #ffffff;",
+                                              "border-radius: 4px;",
+                                              "border: 1px solid #c0c8d1;",
+                                              "box-shadow: 0 2px 4px rgba(0, 0, 0, 0.18);",
+                                              "padding: 8px;",
+                                              "transition: opacity 0.3s;",
+                                              "z-index: 100;",
+                                              [Function],
+                                            ],
+                                          },
+                                          "displayName": "Styled(Box)",
+                                          "foldedComponentIds": Array [
+                                            "Box-sc-1qu1edy-0",
+                                          ],
+                                          "propTypes": Object {
+                                            "bg": [Function],
+                                            "border": [Function],
+                                            "borderBottom": [Function],
+                                            "borderLeft": [Function],
+                                            "borderRadius": [Function],
+                                            "borderRight": [Function],
+                                            "borderTop": [Function],
+                                            "boxShadow": [Function],
+                                            "color": [Function],
+                                            "display": [Function],
+                                            "flexGrow": [Function],
+                                            "height": [Function],
+                                            "m": [Function],
+                                            "maxHeight": [Function],
+                                            "maxWidth": [Function],
+                                            "mb": [Function],
+                                            "minHeight": [Function],
+                                            "minWidth": [Function],
+                                            "ml": [Function],
+                                            "mr": [Function],
+                                            "mt": [Function],
+                                            "mx": [Function],
+                                            "my": [Function],
+                                            "order": [Function],
+                                            "p": [Function],
+                                            "pb": [Function],
+                                            "pl": [Function],
+                                            "position": [Function],
+                                            "pr": [Function],
+                                            "pt": [Function],
+                                            "px": [Function],
+                                            "py": [Function],
+                                            "textAlign": [Function],
+                                            "width": [Function],
+                                          },
+                                          "render": [Function],
+                                          "styledComponentId": "sc-jWBwVP",
+                                          "target": "div",
+                                          "toString": [Function],
+                                          "usesTheme": false,
+                                          "warnTooManyClasses": [Function],
+                                          "withComponent": [Function],
+                                        }
+                                      }
+                                      forwardedRef={[Function]}
+                                      id="random-id-17"
+                                      maxWidth="24em"
+                                      onBlur={[Function]}
+                                      onFocus={[Function]}
+                                      onMouseEnter={[Function]}
+                                      onMouseLeave={[Function]}
+                                      open={false}
+                                      position={
+                                        Object {
+                                          "left": 0,
+                                          "opacity": 0,
+                                          "pointerEvents": "none",
+                                          "position": "absolute",
+                                          "top": 0,
+                                        }
+                                      }
+                                      role="tooltip"
+                                      theme={
+                                        Object {
+                                          "borders": Array [],
+                                          "breakpoints": Object {
+                                            "extraLarge": "1920px",
+                                            "extraSmall": "0px",
+                                            "large": "1360px",
+                                            "medium": "1024px",
+                                            "small": "768px",
+                                          },
+                                          "colors": Object {
+                                            "black": "#011e38",
+                                            "blackBlue": "#122b47",
+                                            "blue": "#216beb",
+                                            "darkBlue": "#00438f",
+                                            "darkGrey": "#434d59",
+                                            "green": "#008059",
+                                            "grey": "#c0c8d1",
+                                            "lightBlue": "#e1ebfa",
+                                            "lightGreen": "#e9f7f2",
+                                            "lightGrey": "#e4e7eb",
+                                            "lightRed": "#fae6ea",
+                                            "lightYellow": "#fcf5e3",
+                                            "red": "#cc1439",
+                                            "white": "#ffffff",
+                                            "whiteGrey": "#f0f2f5",
+                                            "yellow": "#ffbb00",
+                                          },
+                                          "fontSizes": Object {
+                                            "large": "20px",
+                                            "larger": "26px",
+                                            "largest": "46px",
+                                            "medium": "16px",
+                                            "small": "14px",
+                                            "smaller": "12px",
+                                          },
+                                          "fontWeights": Object {
+                                            "bold": "600",
+                                            "light": "300",
+                                            "medium": "500",
+                                            "normal": "400",
+                                          },
+                                          "fonts": Object {
+                                            "base": "'IBM Plex Sans', sans-serif",
+                                            "mono": "'IBM Plex Mono', monospace",
+                                          },
+                                          "lineHeights": Object {
+                                            "base": "1.5",
+                                            "sectionTitle": "1.23076923",
+                                            "smallTextBase": "1.71428571",
+                                            "smallTextCompressed": "1.14285714",
+                                            "smallerText": "1.33333333",
+                                            "subsectionTitle": "1.2",
+                                            "title": "1.04347826",
+                                          },
+                                          "radii": Object {
+                                            "circle": "50%",
+                                            "medium": "4px",
+                                            "small": "2px",
+                                          },
+                                          "shadows": Object {
+                                            "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                            "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                            "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                            "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                            "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                          },
+                                          "space": Object {
+                                            "half": "4px",
+                                            "none": "0px",
+                                            "x1": "8px",
+                                            "x2": "16px",
+                                            "x3": "24px",
+                                            "x4": "32px",
+                                            "x5": "40px",
+                                            "x6": "48px",
+                                            "x8": "64px",
+                                          },
+                                          "zIndex": Object {
+                                            "content": 100,
+                                            "overlay": 1000,
+                                            "tabsBar": 210,
+                                            "tabsScollIndicator": 200,
+                                          },
+                                        }
+                                      }
+                                    >
+                                      <div
+                                        className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
+                                        id="random-id-17"
                                         onBlur={[Function]}
                                         onFocus={[Function]}
                                         onMouseEnter={[Function]}
@@ -21736,8 +22789,9 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                   >
                     <WithGeneratedId>
                       <MenuComponent
+                        defaultOpen={false}
                         hideDelay="350"
-                        id="random-id-3"
+                        id="random-id-4"
                         placement="bottom"
                         showDelay="100"
                         tooltip="I am a Tooltip! I have very long text, and my default max-width is 24em (based on 14px font-size), which is equal to 336px, or approximately 45 characters."
@@ -21748,7 +22802,7 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                           showDelay="100"
                         >
                           <StatelessTooltip
-                            id="random-id-3"
+                            id="random-id-4"
                             maxWidth="24em"
                             menuState={
                               Object {
@@ -21768,7 +22822,7 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                                   setReferenceNode={[Function]}
                                 >
                                   <ForwardRef
-                                    aria-describedby="random-id-3"
+                                    aria-describedby="random-id-4"
                                     aria-expanded={false}
                                     aria-haspopup={true}
                                     asLink={false}
@@ -21783,7 +22837,7 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                                     size="medium"
                                   >
                                     <Button__WrapperButton
-                                      aria-describedby="random-id-3"
+                                      aria-describedby="random-id-4"
                                       aria-expanded={false}
                                       aria-haspopup={true}
                                       disabled={false}
@@ -21795,7 +22849,7 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                                       size="medium"
                                     >
                                       <StyledComponent
-                                        aria-describedby="random-id-3"
+                                        aria-describedby="random-id-4"
                                         aria-expanded={false}
                                         aria-haspopup={true}
                                         disabled={false}
@@ -21834,7 +22888,7 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                                         size="medium"
                                       >
                                         <button
-                                          aria-describedby="random-id-3"
+                                          aria-describedby="random-id-4"
                                           aria-expanded={false}
                                           aria-haspopup={true}
                                           className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
@@ -21861,7 +22915,7 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                                   positionFixed={false}
                                   referenceElement={
                                     <button
-                                      aria-describedby="random-id-3"
+                                      aria-describedby="random-id-4"
                                       aria-expanded="false"
                                       aria-haspopup="true"
                                       class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
@@ -21871,7 +22925,7 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                                   }
                                 >
                                   <Styled(Box)
-                                    id="random-id-3"
+                                    id="random-id-4"
                                     maxWidth="24em"
                                     onBlur={[Function]}
                                     onFocus={[Function]}
@@ -22152,7 +23206,7 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                                         }
                                       }
                                       forwardedRef={[Function]}
-                                      id="random-id-3"
+                                      id="random-id-4"
                                       maxWidth="24em"
                                       onBlur={[Function]}
                                       onFocus={[Function]}
@@ -22258,7 +23312,7 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                                     >
                                       <div
                                         className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
-                                        id="random-id-3"
+                                        id="random-id-4"
                                         onBlur={[Function]}
                                         onFocus={[Function]}
                                         onMouseEnter={[Function]}

--- a/components/src/Tooltip/__snapshots__/Tooltip.story.storyshot
+++ b/components/src/Tooltip/__snapshots__/Tooltip.story.storyshot
@@ -6851,13 +6851,14 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                   className="Box-sc-1qu1edy-0 sc-bdVaJa jAdjeH"
                 >
                   <Component
+                    defaultOpen={true}
                     maxWidth="128px"
                     placement="bottom"
                     tooltip="I am a Tooltip! I have very long text, but I have a smaller maxWidth prop that causes me to wrap frequently."
                   >
                     <WithGeneratedId>
                       <MenuComponent
-                        defaultOpen={false}
+                        defaultOpen={true}
                         hideDelay="350"
                         id="random-id-5"
                         maxWidth="128px"
@@ -6866,7 +6867,7 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                         tooltip="I am a Tooltip! I have very long text, but I have a smaller maxWidth prop that causes me to wrap frequently."
                       >
                         <MenuState
-                          defaultOpen={false}
+                          defaultOpen={true}
                           hideDelay="350"
                           showDelay="100"
                         >
@@ -6877,7 +6878,7 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                               Object {
                                 "closeMenu": [Function],
                                 "handleMenuKeydown": [Function],
-                                "isOpen": false,
+                                "isOpen": true,
                                 "openMenu": [Function],
                                 "toggleMenu": [Function],
                               }
@@ -6892,7 +6893,7 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                                 >
                                   <ForwardRef
                                     aria-describedby="random-id-5"
-                                    aria-expanded={false}
+                                    aria-expanded={true}
                                     aria-haspopup={true}
                                     asLink={false}
                                     disabled={false}
@@ -6907,7 +6908,7 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                                   >
                                     <Button__WrapperButton
                                       aria-describedby="random-id-5"
-                                      aria-expanded={false}
+                                      aria-expanded={true}
                                       aria-haspopup={true}
                                       disabled={false}
                                       fullWidth={false}
@@ -6919,7 +6920,7 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                                     >
                                       <StyledComponent
                                         aria-describedby="random-id-5"
-                                        aria-expanded={false}
+                                        aria-expanded={true}
                                         aria-haspopup={true}
                                         disabled={false}
                                         forwardedComponent={
@@ -6958,7 +6959,7 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                                       >
                                         <button
                                           aria-describedby="random-id-5"
-                                          aria-expanded={false}
+                                          aria-expanded={true}
                                           aria-haspopup={true}
                                           className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
                                           disabled={false}
@@ -6985,7 +6986,7 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                                   referenceElement={
                                     <button
                                       aria-describedby="random-id-5"
-                                      aria-expanded="false"
+                                      aria-expanded="true"
                                       aria-haspopup="true"
                                       class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
                                     >
@@ -7000,7 +7001,7 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                                     onFocus={[Function]}
                                     onMouseEnter={[Function]}
                                     onMouseLeave={[Function]}
-                                    open={false}
+                                    open={true}
                                     position={
                                       Object {
                                         "left": 0,
@@ -7192,7 +7193,7 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "sc-jWBwVP",
                                             "isStatic": false,
-                                            "lastClassName": "bghhYL",
+                                            "lastClassName": "SFncy",
                                             "rules": Array [
                                               [Function],
                                               [Function],
@@ -7281,7 +7282,7 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                                       onFocus={[Function]}
                                       onMouseEnter={[Function]}
                                       onMouseLeave={[Function]}
-                                      open={false}
+                                      open={true}
                                       position={
                                         Object {
                                           "left": 0,
@@ -7380,13 +7381,13 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                                       }
                                     >
                                       <div
-                                        className="Box-sc-1qu1edy-0 sc-jWBwVP bghhYL"
+                                        className="Box-sc-1qu1edy-0 sc-jWBwVP SFncy"
                                         id="random-id-5"
                                         onBlur={[Function]}
                                         onFocus={[Function]}
                                         onMouseEnter={[Function]}
                                         onMouseLeave={[Function]}
-                                        open={false}
+                                        open={true}
                                         role="tooltip"
                                       >
                                         I am a Tooltip! I have very long text, but I have a smaller maxWidth prop that causes me to wrap frequently.
@@ -7470,6 +7471,15 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                                   </Styled(Box)>
                                 </InnerPopper>
                               </Popper>
+                              <DetectOutsideClick
+                                clickRef={
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                  ]
+                                }
+                                onClick={[Function]}
+                              />
                             </Manager>
                           </StatelessTooltip>
                         </MenuState>
@@ -13596,12 +13606,13 @@ exports[`Storyshots Tooltip with placement 1`] = `
                   className="Box-sc-1qu1edy-0 sc-bdVaJa bBCvTo"
                 >
                   <Component
+                    defaultOpen={true}
                     placement="top-start"
                     tooltip="top-start"
                   >
                     <WithGeneratedId>
                       <MenuComponent
-                        defaultOpen={false}
+                        defaultOpen={true}
                         hideDelay="350"
                         id="random-id-6"
                         placement="top-start"
@@ -13609,7 +13620,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         tooltip="top-start"
                       >
                         <MenuState
-                          defaultOpen={false}
+                          defaultOpen={true}
                           hideDelay="350"
                           showDelay="100"
                         >
@@ -13620,7 +13631,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                               Object {
                                 "closeMenu": [Function],
                                 "handleMenuKeydown": [Function],
-                                "isOpen": false,
+                                "isOpen": true,
                                 "openMenu": [Function],
                                 "toggleMenu": [Function],
                               }
@@ -13635,7 +13646,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                 >
                                   <ForwardRef
                                     aria-describedby="random-id-6"
-                                    aria-expanded={false}
+                                    aria-expanded={true}
                                     aria-haspopup={true}
                                     asLink={false}
                                     disabled={false}
@@ -13650,7 +13661,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   >
                                     <Button__WrapperButton
                                       aria-describedby="random-id-6"
-                                      aria-expanded={false}
+                                      aria-expanded={true}
                                       aria-haspopup={true}
                                       disabled={false}
                                       fullWidth={false}
@@ -13662,7 +13673,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                     >
                                       <StyledComponent
                                         aria-describedby="random-id-6"
-                                        aria-expanded={false}
+                                        aria-expanded={true}
                                         aria-haspopup={true}
                                         disabled={false}
                                         forwardedComponent={
@@ -13701,7 +13712,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       >
                                         <button
                                           aria-describedby="random-id-6"
-                                          aria-expanded={false}
+                                          aria-expanded={true}
                                           aria-haspopup={true}
                                           className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
                                           disabled={false}
@@ -13728,7 +13739,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   referenceElement={
                                     <button
                                       aria-describedby="random-id-6"
-                                      aria-expanded="false"
+                                      aria-expanded="true"
                                       aria-haspopup="true"
                                       class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
                                     >
@@ -13743,7 +13754,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                     onFocus={[Function]}
                                     onMouseEnter={[Function]}
                                     onMouseLeave={[Function]}
-                                    open={false}
+                                    open={true}
                                     position={
                                       Object {
                                         "left": 0,
@@ -13935,7 +13946,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "sc-jWBwVP",
                                             "isStatic": false,
-                                            "lastClassName": "hjigbL",
+                                            "lastClassName": "gCXFcy",
                                             "rules": Array [
                                               [Function],
                                               [Function],
@@ -14024,7 +14035,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       onFocus={[Function]}
                                       onMouseEnter={[Function]}
                                       onMouseLeave={[Function]}
-                                      open={false}
+                                      open={true}
                                       position={
                                         Object {
                                           "left": 0,
@@ -14123,13 +14134,13 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       }
                                     >
                                       <div
-                                        className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
+                                        className="Box-sc-1qu1edy-0 sc-jWBwVP gCXFcy"
                                         id="random-id-6"
                                         onBlur={[Function]}
                                         onFocus={[Function]}
                                         onMouseEnter={[Function]}
                                         onMouseLeave={[Function]}
-                                        open={false}
+                                        open={true}
                                         role="tooltip"
                                       >
                                         top-start
@@ -14213,6 +14224,15 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   </Styled(Box)>
                                 </InnerPopper>
                               </Popper>
+                              <DetectOutsideClick
+                                clickRef={
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                  ]
+                                }
+                                onClick={[Function]}
+                              />
                             </Manager>
                           </StatelessTooltip>
                         </MenuState>
@@ -14220,12 +14240,13 @@ exports[`Storyshots Tooltip with placement 1`] = `
                     </WithGeneratedId>
                   </Component>
                   <Component
+                    defaultOpen={true}
                     placement="top"
                     tooltip="top"
                   >
                     <WithGeneratedId>
                       <MenuComponent
-                        defaultOpen={false}
+                        defaultOpen={true}
                         hideDelay="350"
                         id="random-id-7"
                         placement="top"
@@ -14233,7 +14254,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         tooltip="top"
                       >
                         <MenuState
-                          defaultOpen={false}
+                          defaultOpen={true}
                           hideDelay="350"
                           showDelay="100"
                         >
@@ -14244,7 +14265,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                               Object {
                                 "closeMenu": [Function],
                                 "handleMenuKeydown": [Function],
-                                "isOpen": false,
+                                "isOpen": true,
                                 "openMenu": [Function],
                                 "toggleMenu": [Function],
                               }
@@ -14259,7 +14280,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                 >
                                   <ForwardRef
                                     aria-describedby="random-id-7"
-                                    aria-expanded={false}
+                                    aria-expanded={true}
                                     aria-haspopup={true}
                                     asLink={false}
                                     disabled={false}
@@ -14274,7 +14295,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   >
                                     <Button__WrapperButton
                                       aria-describedby="random-id-7"
-                                      aria-expanded={false}
+                                      aria-expanded={true}
                                       aria-haspopup={true}
                                       disabled={false}
                                       fullWidth={false}
@@ -14286,7 +14307,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                     >
                                       <StyledComponent
                                         aria-describedby="random-id-7"
-                                        aria-expanded={false}
+                                        aria-expanded={true}
                                         aria-haspopup={true}
                                         disabled={false}
                                         forwardedComponent={
@@ -14325,7 +14346,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       >
                                         <button
                                           aria-describedby="random-id-7"
-                                          aria-expanded={false}
+                                          aria-expanded={true}
                                           aria-haspopup={true}
                                           className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
                                           disabled={false}
@@ -14352,7 +14373,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   referenceElement={
                                     <button
                                       aria-describedby="random-id-7"
-                                      aria-expanded="false"
+                                      aria-expanded="true"
                                       aria-haspopup="true"
                                       class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
                                     >
@@ -14367,7 +14388,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                     onFocus={[Function]}
                                     onMouseEnter={[Function]}
                                     onMouseLeave={[Function]}
-                                    open={false}
+                                    open={true}
                                     position={
                                       Object {
                                         "left": 0,
@@ -14559,7 +14580,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "sc-jWBwVP",
                                             "isStatic": false,
-                                            "lastClassName": "hjigbL",
+                                            "lastClassName": "gCXFcy",
                                             "rules": Array [
                                               [Function],
                                               [Function],
@@ -14648,7 +14669,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       onFocus={[Function]}
                                       onMouseEnter={[Function]}
                                       onMouseLeave={[Function]}
-                                      open={false}
+                                      open={true}
                                       position={
                                         Object {
                                           "left": 0,
@@ -14747,13 +14768,13 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       }
                                     >
                                       <div
-                                        className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
+                                        className="Box-sc-1qu1edy-0 sc-jWBwVP gCXFcy"
                                         id="random-id-7"
                                         onBlur={[Function]}
                                         onFocus={[Function]}
                                         onMouseEnter={[Function]}
                                         onMouseLeave={[Function]}
-                                        open={false}
+                                        open={true}
                                         role="tooltip"
                                       >
                                         top
@@ -14837,6 +14858,15 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   </Styled(Box)>
                                 </InnerPopper>
                               </Popper>
+                              <DetectOutsideClick
+                                clickRef={
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                  ]
+                                }
+                                onClick={[Function]}
+                              />
                             </Manager>
                           </StatelessTooltip>
                         </MenuState>
@@ -14844,12 +14874,13 @@ exports[`Storyshots Tooltip with placement 1`] = `
                     </WithGeneratedId>
                   </Component>
                   <Component
+                    defaultOpen={true}
                     placement="top-end"
                     tooltip="top-end"
                   >
                     <WithGeneratedId>
                       <MenuComponent
-                        defaultOpen={false}
+                        defaultOpen={true}
                         hideDelay="350"
                         id="random-id-8"
                         placement="top-end"
@@ -14857,7 +14888,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         tooltip="top-end"
                       >
                         <MenuState
-                          defaultOpen={false}
+                          defaultOpen={true}
                           hideDelay="350"
                           showDelay="100"
                         >
@@ -14868,7 +14899,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                               Object {
                                 "closeMenu": [Function],
                                 "handleMenuKeydown": [Function],
-                                "isOpen": false,
+                                "isOpen": true,
                                 "openMenu": [Function],
                                 "toggleMenu": [Function],
                               }
@@ -14883,7 +14914,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                 >
                                   <ForwardRef
                                     aria-describedby="random-id-8"
-                                    aria-expanded={false}
+                                    aria-expanded={true}
                                     aria-haspopup={true}
                                     asLink={false}
                                     disabled={false}
@@ -14898,7 +14929,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   >
                                     <Button__WrapperButton
                                       aria-describedby="random-id-8"
-                                      aria-expanded={false}
+                                      aria-expanded={true}
                                       aria-haspopup={true}
                                       disabled={false}
                                       fullWidth={false}
@@ -14910,7 +14941,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                     >
                                       <StyledComponent
                                         aria-describedby="random-id-8"
-                                        aria-expanded={false}
+                                        aria-expanded={true}
                                         aria-haspopup={true}
                                         disabled={false}
                                         forwardedComponent={
@@ -14949,7 +14980,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       >
                                         <button
                                           aria-describedby="random-id-8"
-                                          aria-expanded={false}
+                                          aria-expanded={true}
                                           aria-haspopup={true}
                                           className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
                                           disabled={false}
@@ -14976,7 +15007,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   referenceElement={
                                     <button
                                       aria-describedby="random-id-8"
-                                      aria-expanded="false"
+                                      aria-expanded="true"
                                       aria-haspopup="true"
                                       class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
                                     >
@@ -14991,7 +15022,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                     onFocus={[Function]}
                                     onMouseEnter={[Function]}
                                     onMouseLeave={[Function]}
-                                    open={false}
+                                    open={true}
                                     position={
                                       Object {
                                         "left": 0,
@@ -15183,7 +15214,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "sc-jWBwVP",
                                             "isStatic": false,
-                                            "lastClassName": "hjigbL",
+                                            "lastClassName": "gCXFcy",
                                             "rules": Array [
                                               [Function],
                                               [Function],
@@ -15272,7 +15303,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       onFocus={[Function]}
                                       onMouseEnter={[Function]}
                                       onMouseLeave={[Function]}
-                                      open={false}
+                                      open={true}
                                       position={
                                         Object {
                                           "left": 0,
@@ -15371,13 +15402,13 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       }
                                     >
                                       <div
-                                        className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
+                                        className="Box-sc-1qu1edy-0 sc-jWBwVP gCXFcy"
                                         id="random-id-8"
                                         onBlur={[Function]}
                                         onFocus={[Function]}
                                         onMouseEnter={[Function]}
                                         onMouseLeave={[Function]}
-                                        open={false}
+                                        open={true}
                                         role="tooltip"
                                       >
                                         top-end
@@ -15461,6 +15492,15 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   </Styled(Box)>
                                 </InnerPopper>
                               </Popper>
+                              <DetectOutsideClick
+                                clickRef={
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                  ]
+                                }
+                                onClick={[Function]}
+                              />
                             </Manager>
                           </StatelessTooltip>
                         </MenuState>
@@ -15795,12 +15835,13 @@ exports[`Storyshots Tooltip with placement 1`] = `
                   className="Box-sc-1qu1edy-0 sc-bdVaJa bBCvTo"
                 >
                   <Component
+                    defaultOpen={true}
                     placement="left-start"
                     tooltip="left-start"
                   >
                     <WithGeneratedId>
                       <MenuComponent
-                        defaultOpen={false}
+                        defaultOpen={true}
                         hideDelay="350"
                         id="random-id-9"
                         placement="left-start"
@@ -15808,7 +15849,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         tooltip="left-start"
                       >
                         <MenuState
-                          defaultOpen={false}
+                          defaultOpen={true}
                           hideDelay="350"
                           showDelay="100"
                         >
@@ -15819,7 +15860,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                               Object {
                                 "closeMenu": [Function],
                                 "handleMenuKeydown": [Function],
-                                "isOpen": false,
+                                "isOpen": true,
                                 "openMenu": [Function],
                                 "toggleMenu": [Function],
                               }
@@ -15834,7 +15875,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                 >
                                   <ForwardRef
                                     aria-describedby="random-id-9"
-                                    aria-expanded={false}
+                                    aria-expanded={true}
                                     aria-haspopup={true}
                                     asLink={false}
                                     disabled={false}
@@ -15849,7 +15890,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   >
                                     <Button__WrapperButton
                                       aria-describedby="random-id-9"
-                                      aria-expanded={false}
+                                      aria-expanded={true}
                                       aria-haspopup={true}
                                       disabled={false}
                                       fullWidth={false}
@@ -15861,7 +15902,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                     >
                                       <StyledComponent
                                         aria-describedby="random-id-9"
-                                        aria-expanded={false}
+                                        aria-expanded={true}
                                         aria-haspopup={true}
                                         disabled={false}
                                         forwardedComponent={
@@ -15900,7 +15941,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       >
                                         <button
                                           aria-describedby="random-id-9"
-                                          aria-expanded={false}
+                                          aria-expanded={true}
                                           aria-haspopup={true}
                                           className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
                                           disabled={false}
@@ -15927,7 +15968,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   referenceElement={
                                     <button
                                       aria-describedby="random-id-9"
-                                      aria-expanded="false"
+                                      aria-expanded="true"
                                       aria-haspopup="true"
                                       class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
                                     >
@@ -15942,7 +15983,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                     onFocus={[Function]}
                                     onMouseEnter={[Function]}
                                     onMouseLeave={[Function]}
-                                    open={false}
+                                    open={true}
                                     position={
                                       Object {
                                         "left": 0,
@@ -16134,7 +16175,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "sc-jWBwVP",
                                             "isStatic": false,
-                                            "lastClassName": "hjigbL",
+                                            "lastClassName": "gCXFcy",
                                             "rules": Array [
                                               [Function],
                                               [Function],
@@ -16223,7 +16264,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       onFocus={[Function]}
                                       onMouseEnter={[Function]}
                                       onMouseLeave={[Function]}
-                                      open={false}
+                                      open={true}
                                       position={
                                         Object {
                                           "left": 0,
@@ -16322,13 +16363,13 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       }
                                     >
                                       <div
-                                        className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
+                                        className="Box-sc-1qu1edy-0 sc-jWBwVP gCXFcy"
                                         id="random-id-9"
                                         onBlur={[Function]}
                                         onFocus={[Function]}
                                         onMouseEnter={[Function]}
                                         onMouseLeave={[Function]}
-                                        open={false}
+                                        open={true}
                                         role="tooltip"
                                       >
                                         left-start
@@ -16412,6 +16453,15 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   </Styled(Box)>
                                 </InnerPopper>
                               </Popper>
+                              <DetectOutsideClick
+                                clickRef={
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                  ]
+                                }
+                                onClick={[Function]}
+                              />
                             </Manager>
                           </StatelessTooltip>
                         </MenuState>
@@ -16419,12 +16469,13 @@ exports[`Storyshots Tooltip with placement 1`] = `
                     </WithGeneratedId>
                   </Component>
                   <Component
+                    defaultOpen={true}
                     placement="left"
                     tooltip="left"
                   >
                     <WithGeneratedId>
                       <MenuComponent
-                        defaultOpen={false}
+                        defaultOpen={true}
                         hideDelay="350"
                         id="random-id-10"
                         placement="left"
@@ -16432,7 +16483,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         tooltip="left"
                       >
                         <MenuState
-                          defaultOpen={false}
+                          defaultOpen={true}
                           hideDelay="350"
                           showDelay="100"
                         >
@@ -16443,7 +16494,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                               Object {
                                 "closeMenu": [Function],
                                 "handleMenuKeydown": [Function],
-                                "isOpen": false,
+                                "isOpen": true,
                                 "openMenu": [Function],
                                 "toggleMenu": [Function],
                               }
@@ -16458,7 +16509,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                 >
                                   <ForwardRef
                                     aria-describedby="random-id-10"
-                                    aria-expanded={false}
+                                    aria-expanded={true}
                                     aria-haspopup={true}
                                     asLink={false}
                                     disabled={false}
@@ -16473,7 +16524,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   >
                                     <Button__WrapperButton
                                       aria-describedby="random-id-10"
-                                      aria-expanded={false}
+                                      aria-expanded={true}
                                       aria-haspopup={true}
                                       disabled={false}
                                       fullWidth={false}
@@ -16485,7 +16536,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                     >
                                       <StyledComponent
                                         aria-describedby="random-id-10"
-                                        aria-expanded={false}
+                                        aria-expanded={true}
                                         aria-haspopup={true}
                                         disabled={false}
                                         forwardedComponent={
@@ -16524,7 +16575,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       >
                                         <button
                                           aria-describedby="random-id-10"
-                                          aria-expanded={false}
+                                          aria-expanded={true}
                                           aria-haspopup={true}
                                           className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
                                           disabled={false}
@@ -16551,7 +16602,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   referenceElement={
                                     <button
                                       aria-describedby="random-id-10"
-                                      aria-expanded="false"
+                                      aria-expanded="true"
                                       aria-haspopup="true"
                                       class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
                                     >
@@ -16566,7 +16617,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                     onFocus={[Function]}
                                     onMouseEnter={[Function]}
                                     onMouseLeave={[Function]}
-                                    open={false}
+                                    open={true}
                                     position={
                                       Object {
                                         "left": 0,
@@ -16758,7 +16809,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "sc-jWBwVP",
                                             "isStatic": false,
-                                            "lastClassName": "hjigbL",
+                                            "lastClassName": "gCXFcy",
                                             "rules": Array [
                                               [Function],
                                               [Function],
@@ -16847,7 +16898,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       onFocus={[Function]}
                                       onMouseEnter={[Function]}
                                       onMouseLeave={[Function]}
-                                      open={false}
+                                      open={true}
                                       position={
                                         Object {
                                           "left": 0,
@@ -16946,13 +16997,13 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       }
                                     >
                                       <div
-                                        className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
+                                        className="Box-sc-1qu1edy-0 sc-jWBwVP gCXFcy"
                                         id="random-id-10"
                                         onBlur={[Function]}
                                         onFocus={[Function]}
                                         onMouseEnter={[Function]}
                                         onMouseLeave={[Function]}
-                                        open={false}
+                                        open={true}
                                         role="tooltip"
                                       >
                                         left
@@ -17036,6 +17087,15 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   </Styled(Box)>
                                 </InnerPopper>
                               </Popper>
+                              <DetectOutsideClick
+                                clickRef={
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                  ]
+                                }
+                                onClick={[Function]}
+                              />
                             </Manager>
                           </StatelessTooltip>
                         </MenuState>
@@ -17043,12 +17103,13 @@ exports[`Storyshots Tooltip with placement 1`] = `
                     </WithGeneratedId>
                   </Component>
                   <Component
+                    defaultOpen={true}
                     placement="left-end"
                     tooltip="left-end"
                   >
                     <WithGeneratedId>
                       <MenuComponent
-                        defaultOpen={false}
+                        defaultOpen={true}
                         hideDelay="350"
                         id="random-id-11"
                         placement="left-end"
@@ -17056,7 +17117,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         tooltip="left-end"
                       >
                         <MenuState
-                          defaultOpen={false}
+                          defaultOpen={true}
                           hideDelay="350"
                           showDelay="100"
                         >
@@ -17067,7 +17128,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                               Object {
                                 "closeMenu": [Function],
                                 "handleMenuKeydown": [Function],
-                                "isOpen": false,
+                                "isOpen": true,
                                 "openMenu": [Function],
                                 "toggleMenu": [Function],
                               }
@@ -17082,7 +17143,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                 >
                                   <ForwardRef
                                     aria-describedby="random-id-11"
-                                    aria-expanded={false}
+                                    aria-expanded={true}
                                     aria-haspopup={true}
                                     asLink={false}
                                     disabled={false}
@@ -17097,7 +17158,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   >
                                     <Button__WrapperButton
                                       aria-describedby="random-id-11"
-                                      aria-expanded={false}
+                                      aria-expanded={true}
                                       aria-haspopup={true}
                                       disabled={false}
                                       fullWidth={false}
@@ -17109,7 +17170,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                     >
                                       <StyledComponent
                                         aria-describedby="random-id-11"
-                                        aria-expanded={false}
+                                        aria-expanded={true}
                                         aria-haspopup={true}
                                         disabled={false}
                                         forwardedComponent={
@@ -17148,7 +17209,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       >
                                         <button
                                           aria-describedby="random-id-11"
-                                          aria-expanded={false}
+                                          aria-expanded={true}
                                           aria-haspopup={true}
                                           className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
                                           disabled={false}
@@ -17175,7 +17236,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   referenceElement={
                                     <button
                                       aria-describedby="random-id-11"
-                                      aria-expanded="false"
+                                      aria-expanded="true"
                                       aria-haspopup="true"
                                       class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
                                     >
@@ -17190,7 +17251,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                     onFocus={[Function]}
                                     onMouseEnter={[Function]}
                                     onMouseLeave={[Function]}
-                                    open={false}
+                                    open={true}
                                     position={
                                       Object {
                                         "left": 0,
@@ -17382,7 +17443,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "sc-jWBwVP",
                                             "isStatic": false,
-                                            "lastClassName": "hjigbL",
+                                            "lastClassName": "gCXFcy",
                                             "rules": Array [
                                               [Function],
                                               [Function],
@@ -17471,7 +17532,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       onFocus={[Function]}
                                       onMouseEnter={[Function]}
                                       onMouseLeave={[Function]}
-                                      open={false}
+                                      open={true}
                                       position={
                                         Object {
                                           "left": 0,
@@ -17570,13 +17631,13 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       }
                                     >
                                       <div
-                                        className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
+                                        className="Box-sc-1qu1edy-0 sc-jWBwVP gCXFcy"
                                         id="random-id-11"
                                         onBlur={[Function]}
                                         onFocus={[Function]}
                                         onMouseEnter={[Function]}
                                         onMouseLeave={[Function]}
-                                        open={false}
+                                        open={true}
                                         role="tooltip"
                                       >
                                         left-end
@@ -17660,6 +17721,15 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   </Styled(Box)>
                                 </InnerPopper>
                               </Popper>
+                              <DetectOutsideClick
+                                clickRef={
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                  ]
+                                }
+                                onClick={[Function]}
+                              />
                             </Manager>
                           </StatelessTooltip>
                         </MenuState>
@@ -17994,12 +18064,13 @@ exports[`Storyshots Tooltip with placement 1`] = `
                   className="Box-sc-1qu1edy-0 sc-bdVaJa bBCvTo"
                 >
                   <Component
+                    defaultOpen={true}
                     placement="right-start"
                     tooltip="right-start"
                   >
                     <WithGeneratedId>
                       <MenuComponent
-                        defaultOpen={false}
+                        defaultOpen={true}
                         hideDelay="350"
                         id="random-id-12"
                         placement="right-start"
@@ -18007,7 +18078,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         tooltip="right-start"
                       >
                         <MenuState
-                          defaultOpen={false}
+                          defaultOpen={true}
                           hideDelay="350"
                           showDelay="100"
                         >
@@ -18018,7 +18089,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                               Object {
                                 "closeMenu": [Function],
                                 "handleMenuKeydown": [Function],
-                                "isOpen": false,
+                                "isOpen": true,
                                 "openMenu": [Function],
                                 "toggleMenu": [Function],
                               }
@@ -18033,7 +18104,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                 >
                                   <ForwardRef
                                     aria-describedby="random-id-12"
-                                    aria-expanded={false}
+                                    aria-expanded={true}
                                     aria-haspopup={true}
                                     asLink={false}
                                     disabled={false}
@@ -18048,7 +18119,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   >
                                     <Button__WrapperButton
                                       aria-describedby="random-id-12"
-                                      aria-expanded={false}
+                                      aria-expanded={true}
                                       aria-haspopup={true}
                                       disabled={false}
                                       fullWidth={false}
@@ -18060,7 +18131,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                     >
                                       <StyledComponent
                                         aria-describedby="random-id-12"
-                                        aria-expanded={false}
+                                        aria-expanded={true}
                                         aria-haspopup={true}
                                         disabled={false}
                                         forwardedComponent={
@@ -18099,7 +18170,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       >
                                         <button
                                           aria-describedby="random-id-12"
-                                          aria-expanded={false}
+                                          aria-expanded={true}
                                           aria-haspopup={true}
                                           className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
                                           disabled={false}
@@ -18126,7 +18197,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   referenceElement={
                                     <button
                                       aria-describedby="random-id-12"
-                                      aria-expanded="false"
+                                      aria-expanded="true"
                                       aria-haspopup="true"
                                       class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
                                     >
@@ -18141,7 +18212,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                     onFocus={[Function]}
                                     onMouseEnter={[Function]}
                                     onMouseLeave={[Function]}
-                                    open={false}
+                                    open={true}
                                     position={
                                       Object {
                                         "left": 0,
@@ -18333,7 +18404,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "sc-jWBwVP",
                                             "isStatic": false,
-                                            "lastClassName": "hjigbL",
+                                            "lastClassName": "gCXFcy",
                                             "rules": Array [
                                               [Function],
                                               [Function],
@@ -18422,7 +18493,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       onFocus={[Function]}
                                       onMouseEnter={[Function]}
                                       onMouseLeave={[Function]}
-                                      open={false}
+                                      open={true}
                                       position={
                                         Object {
                                           "left": 0,
@@ -18521,13 +18592,13 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       }
                                     >
                                       <div
-                                        className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
+                                        className="Box-sc-1qu1edy-0 sc-jWBwVP gCXFcy"
                                         id="random-id-12"
                                         onBlur={[Function]}
                                         onFocus={[Function]}
                                         onMouseEnter={[Function]}
                                         onMouseLeave={[Function]}
-                                        open={false}
+                                        open={true}
                                         role="tooltip"
                                       >
                                         right-start
@@ -18611,6 +18682,15 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   </Styled(Box)>
                                 </InnerPopper>
                               </Popper>
+                              <DetectOutsideClick
+                                clickRef={
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                  ]
+                                }
+                                onClick={[Function]}
+                              />
                             </Manager>
                           </StatelessTooltip>
                         </MenuState>
@@ -18618,12 +18698,13 @@ exports[`Storyshots Tooltip with placement 1`] = `
                     </WithGeneratedId>
                   </Component>
                   <Component
+                    defaultOpen={true}
                     placement="right"
                     tooltip="right"
                   >
                     <WithGeneratedId>
                       <MenuComponent
-                        defaultOpen={false}
+                        defaultOpen={true}
                         hideDelay="350"
                         id="random-id-13"
                         placement="right"
@@ -18631,7 +18712,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         tooltip="right"
                       >
                         <MenuState
-                          defaultOpen={false}
+                          defaultOpen={true}
                           hideDelay="350"
                           showDelay="100"
                         >
@@ -18642,7 +18723,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                               Object {
                                 "closeMenu": [Function],
                                 "handleMenuKeydown": [Function],
-                                "isOpen": false,
+                                "isOpen": true,
                                 "openMenu": [Function],
                                 "toggleMenu": [Function],
                               }
@@ -18657,7 +18738,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                 >
                                   <ForwardRef
                                     aria-describedby="random-id-13"
-                                    aria-expanded={false}
+                                    aria-expanded={true}
                                     aria-haspopup={true}
                                     asLink={false}
                                     disabled={false}
@@ -18672,7 +18753,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   >
                                     <Button__WrapperButton
                                       aria-describedby="random-id-13"
-                                      aria-expanded={false}
+                                      aria-expanded={true}
                                       aria-haspopup={true}
                                       disabled={false}
                                       fullWidth={false}
@@ -18684,7 +18765,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                     >
                                       <StyledComponent
                                         aria-describedby="random-id-13"
-                                        aria-expanded={false}
+                                        aria-expanded={true}
                                         aria-haspopup={true}
                                         disabled={false}
                                         forwardedComponent={
@@ -18723,7 +18804,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       >
                                         <button
                                           aria-describedby="random-id-13"
-                                          aria-expanded={false}
+                                          aria-expanded={true}
                                           aria-haspopup={true}
                                           className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
                                           disabled={false}
@@ -18750,7 +18831,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   referenceElement={
                                     <button
                                       aria-describedby="random-id-13"
-                                      aria-expanded="false"
+                                      aria-expanded="true"
                                       aria-haspopup="true"
                                       class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
                                     >
@@ -18765,7 +18846,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                     onFocus={[Function]}
                                     onMouseEnter={[Function]}
                                     onMouseLeave={[Function]}
-                                    open={false}
+                                    open={true}
                                     position={
                                       Object {
                                         "left": 0,
@@ -18957,7 +19038,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "sc-jWBwVP",
                                             "isStatic": false,
-                                            "lastClassName": "hjigbL",
+                                            "lastClassName": "gCXFcy",
                                             "rules": Array [
                                               [Function],
                                               [Function],
@@ -19046,7 +19127,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       onFocus={[Function]}
                                       onMouseEnter={[Function]}
                                       onMouseLeave={[Function]}
-                                      open={false}
+                                      open={true}
                                       position={
                                         Object {
                                           "left": 0,
@@ -19145,13 +19226,13 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       }
                                     >
                                       <div
-                                        className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
+                                        className="Box-sc-1qu1edy-0 sc-jWBwVP gCXFcy"
                                         id="random-id-13"
                                         onBlur={[Function]}
                                         onFocus={[Function]}
                                         onMouseEnter={[Function]}
                                         onMouseLeave={[Function]}
-                                        open={false}
+                                        open={true}
                                         role="tooltip"
                                       >
                                         right
@@ -19235,6 +19316,15 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   </Styled(Box)>
                                 </InnerPopper>
                               </Popper>
+                              <DetectOutsideClick
+                                clickRef={
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                  ]
+                                }
+                                onClick={[Function]}
+                              />
                             </Manager>
                           </StatelessTooltip>
                         </MenuState>
@@ -19242,12 +19332,13 @@ exports[`Storyshots Tooltip with placement 1`] = `
                     </WithGeneratedId>
                   </Component>
                   <Component
+                    defaultOpen={true}
                     placement="right-end"
                     tooltip="right-end"
                   >
                     <WithGeneratedId>
                       <MenuComponent
-                        defaultOpen={false}
+                        defaultOpen={true}
                         hideDelay="350"
                         id="random-id-14"
                         placement="right-end"
@@ -19255,7 +19346,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         tooltip="right-end"
                       >
                         <MenuState
-                          defaultOpen={false}
+                          defaultOpen={true}
                           hideDelay="350"
                           showDelay="100"
                         >
@@ -19266,7 +19357,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                               Object {
                                 "closeMenu": [Function],
                                 "handleMenuKeydown": [Function],
-                                "isOpen": false,
+                                "isOpen": true,
                                 "openMenu": [Function],
                                 "toggleMenu": [Function],
                               }
@@ -19281,7 +19372,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                 >
                                   <ForwardRef
                                     aria-describedby="random-id-14"
-                                    aria-expanded={false}
+                                    aria-expanded={true}
                                     aria-haspopup={true}
                                     asLink={false}
                                     disabled={false}
@@ -19296,7 +19387,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   >
                                     <Button__WrapperButton
                                       aria-describedby="random-id-14"
-                                      aria-expanded={false}
+                                      aria-expanded={true}
                                       aria-haspopup={true}
                                       disabled={false}
                                       fullWidth={false}
@@ -19308,7 +19399,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                     >
                                       <StyledComponent
                                         aria-describedby="random-id-14"
-                                        aria-expanded={false}
+                                        aria-expanded={true}
                                         aria-haspopup={true}
                                         disabled={false}
                                         forwardedComponent={
@@ -19347,7 +19438,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       >
                                         <button
                                           aria-describedby="random-id-14"
-                                          aria-expanded={false}
+                                          aria-expanded={true}
                                           aria-haspopup={true}
                                           className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
                                           disabled={false}
@@ -19374,7 +19465,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   referenceElement={
                                     <button
                                       aria-describedby="random-id-14"
-                                      aria-expanded="false"
+                                      aria-expanded="true"
                                       aria-haspopup="true"
                                       class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
                                     >
@@ -19389,7 +19480,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                     onFocus={[Function]}
                                     onMouseEnter={[Function]}
                                     onMouseLeave={[Function]}
-                                    open={false}
+                                    open={true}
                                     position={
                                       Object {
                                         "left": 0,
@@ -19581,7 +19672,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "sc-jWBwVP",
                                             "isStatic": false,
-                                            "lastClassName": "hjigbL",
+                                            "lastClassName": "gCXFcy",
                                             "rules": Array [
                                               [Function],
                                               [Function],
@@ -19670,7 +19761,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       onFocus={[Function]}
                                       onMouseEnter={[Function]}
                                       onMouseLeave={[Function]}
-                                      open={false}
+                                      open={true}
                                       position={
                                         Object {
                                           "left": 0,
@@ -19769,13 +19860,13 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       }
                                     >
                                       <div
-                                        className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
+                                        className="Box-sc-1qu1edy-0 sc-jWBwVP gCXFcy"
                                         id="random-id-14"
                                         onBlur={[Function]}
                                         onFocus={[Function]}
                                         onMouseEnter={[Function]}
                                         onMouseLeave={[Function]}
-                                        open={false}
+                                        open={true}
                                         role="tooltip"
                                       >
                                         right-end
@@ -19859,6 +19950,15 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   </Styled(Box)>
                                 </InnerPopper>
                               </Popper>
+                              <DetectOutsideClick
+                                clickRef={
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                  ]
+                                }
+                                onClick={[Function]}
+                              />
                             </Manager>
                           </StatelessTooltip>
                         </MenuState>
@@ -20193,12 +20293,13 @@ exports[`Storyshots Tooltip with placement 1`] = `
                   className="Box-sc-1qu1edy-0 sc-bdVaJa bBCvTo"
                 >
                   <Component
+                    defaultOpen={true}
                     placement="bottom-start"
                     tooltip="bottom-start"
                   >
                     <WithGeneratedId>
                       <MenuComponent
-                        defaultOpen={false}
+                        defaultOpen={true}
                         hideDelay="350"
                         id="random-id-15"
                         placement="bottom-start"
@@ -20206,7 +20307,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         tooltip="bottom-start"
                       >
                         <MenuState
-                          defaultOpen={false}
+                          defaultOpen={true}
                           hideDelay="350"
                           showDelay="100"
                         >
@@ -20217,7 +20318,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                               Object {
                                 "closeMenu": [Function],
                                 "handleMenuKeydown": [Function],
-                                "isOpen": false,
+                                "isOpen": true,
                                 "openMenu": [Function],
                                 "toggleMenu": [Function],
                               }
@@ -20232,7 +20333,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                 >
                                   <ForwardRef
                                     aria-describedby="random-id-15"
-                                    aria-expanded={false}
+                                    aria-expanded={true}
                                     aria-haspopup={true}
                                     asLink={false}
                                     disabled={false}
@@ -20247,7 +20348,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   >
                                     <Button__WrapperButton
                                       aria-describedby="random-id-15"
-                                      aria-expanded={false}
+                                      aria-expanded={true}
                                       aria-haspopup={true}
                                       disabled={false}
                                       fullWidth={false}
@@ -20259,7 +20360,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                     >
                                       <StyledComponent
                                         aria-describedby="random-id-15"
-                                        aria-expanded={false}
+                                        aria-expanded={true}
                                         aria-haspopup={true}
                                         disabled={false}
                                         forwardedComponent={
@@ -20298,7 +20399,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       >
                                         <button
                                           aria-describedby="random-id-15"
-                                          aria-expanded={false}
+                                          aria-expanded={true}
                                           aria-haspopup={true}
                                           className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
                                           disabled={false}
@@ -20325,7 +20426,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   referenceElement={
                                     <button
                                       aria-describedby="random-id-15"
-                                      aria-expanded="false"
+                                      aria-expanded="true"
                                       aria-haspopup="true"
                                       class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
                                     >
@@ -20340,7 +20441,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                     onFocus={[Function]}
                                     onMouseEnter={[Function]}
                                     onMouseLeave={[Function]}
-                                    open={false}
+                                    open={true}
                                     position={
                                       Object {
                                         "left": 0,
@@ -20532,7 +20633,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "sc-jWBwVP",
                                             "isStatic": false,
-                                            "lastClassName": "hjigbL",
+                                            "lastClassName": "gCXFcy",
                                             "rules": Array [
                                               [Function],
                                               [Function],
@@ -20621,7 +20722,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       onFocus={[Function]}
                                       onMouseEnter={[Function]}
                                       onMouseLeave={[Function]}
-                                      open={false}
+                                      open={true}
                                       position={
                                         Object {
                                           "left": 0,
@@ -20720,13 +20821,13 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       }
                                     >
                                       <div
-                                        className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
+                                        className="Box-sc-1qu1edy-0 sc-jWBwVP gCXFcy"
                                         id="random-id-15"
                                         onBlur={[Function]}
                                         onFocus={[Function]}
                                         onMouseEnter={[Function]}
                                         onMouseLeave={[Function]}
-                                        open={false}
+                                        open={true}
                                         role="tooltip"
                                       >
                                         bottom-start
@@ -20810,6 +20911,15 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   </Styled(Box)>
                                 </InnerPopper>
                               </Popper>
+                              <DetectOutsideClick
+                                clickRef={
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                  ]
+                                }
+                                onClick={[Function]}
+                              />
                             </Manager>
                           </StatelessTooltip>
                         </MenuState>
@@ -20817,12 +20927,13 @@ exports[`Storyshots Tooltip with placement 1`] = `
                     </WithGeneratedId>
                   </Component>
                   <Component
+                    defaultOpen={true}
                     placement="bottom"
                     tooltip="bottom"
                   >
                     <WithGeneratedId>
                       <MenuComponent
-                        defaultOpen={false}
+                        defaultOpen={true}
                         hideDelay="350"
                         id="random-id-16"
                         placement="bottom"
@@ -20830,7 +20941,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         tooltip="bottom"
                       >
                         <MenuState
-                          defaultOpen={false}
+                          defaultOpen={true}
                           hideDelay="350"
                           showDelay="100"
                         >
@@ -20841,7 +20952,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                               Object {
                                 "closeMenu": [Function],
                                 "handleMenuKeydown": [Function],
-                                "isOpen": false,
+                                "isOpen": true,
                                 "openMenu": [Function],
                                 "toggleMenu": [Function],
                               }
@@ -20856,7 +20967,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                 >
                                   <ForwardRef
                                     aria-describedby="random-id-16"
-                                    aria-expanded={false}
+                                    aria-expanded={true}
                                     aria-haspopup={true}
                                     asLink={false}
                                     disabled={false}
@@ -20871,7 +20982,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   >
                                     <Button__WrapperButton
                                       aria-describedby="random-id-16"
-                                      aria-expanded={false}
+                                      aria-expanded={true}
                                       aria-haspopup={true}
                                       disabled={false}
                                       fullWidth={false}
@@ -20883,7 +20994,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                     >
                                       <StyledComponent
                                         aria-describedby="random-id-16"
-                                        aria-expanded={false}
+                                        aria-expanded={true}
                                         aria-haspopup={true}
                                         disabled={false}
                                         forwardedComponent={
@@ -20922,7 +21033,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       >
                                         <button
                                           aria-describedby="random-id-16"
-                                          aria-expanded={false}
+                                          aria-expanded={true}
                                           aria-haspopup={true}
                                           className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
                                           disabled={false}
@@ -20949,7 +21060,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   referenceElement={
                                     <button
                                       aria-describedby="random-id-16"
-                                      aria-expanded="false"
+                                      aria-expanded="true"
                                       aria-haspopup="true"
                                       class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
                                     >
@@ -20964,7 +21075,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                     onFocus={[Function]}
                                     onMouseEnter={[Function]}
                                     onMouseLeave={[Function]}
-                                    open={false}
+                                    open={true}
                                     position={
                                       Object {
                                         "left": 0,
@@ -21156,7 +21267,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "sc-jWBwVP",
                                             "isStatic": false,
-                                            "lastClassName": "hjigbL",
+                                            "lastClassName": "gCXFcy",
                                             "rules": Array [
                                               [Function],
                                               [Function],
@@ -21245,7 +21356,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       onFocus={[Function]}
                                       onMouseEnter={[Function]}
                                       onMouseLeave={[Function]}
-                                      open={false}
+                                      open={true}
                                       position={
                                         Object {
                                           "left": 0,
@@ -21344,13 +21455,13 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       }
                                     >
                                       <div
-                                        className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
+                                        className="Box-sc-1qu1edy-0 sc-jWBwVP gCXFcy"
                                         id="random-id-16"
                                         onBlur={[Function]}
                                         onFocus={[Function]}
                                         onMouseEnter={[Function]}
                                         onMouseLeave={[Function]}
-                                        open={false}
+                                        open={true}
                                         role="tooltip"
                                       >
                                         bottom
@@ -21434,6 +21545,15 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   </Styled(Box)>
                                 </InnerPopper>
                               </Popper>
+                              <DetectOutsideClick
+                                clickRef={
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                  ]
+                                }
+                                onClick={[Function]}
+                              />
                             </Manager>
                           </StatelessTooltip>
                         </MenuState>
@@ -21441,12 +21561,13 @@ exports[`Storyshots Tooltip with placement 1`] = `
                     </WithGeneratedId>
                   </Component>
                   <Component
+                    defaultOpen={true}
                     placement="bottom-end"
                     tooltip="bottom-end"
                   >
                     <WithGeneratedId>
                       <MenuComponent
-                        defaultOpen={false}
+                        defaultOpen={true}
                         hideDelay="350"
                         id="random-id-17"
                         placement="bottom-end"
@@ -21454,7 +21575,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         tooltip="bottom-end"
                       >
                         <MenuState
-                          defaultOpen={false}
+                          defaultOpen={true}
                           hideDelay="350"
                           showDelay="100"
                         >
@@ -21465,7 +21586,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                               Object {
                                 "closeMenu": [Function],
                                 "handleMenuKeydown": [Function],
-                                "isOpen": false,
+                                "isOpen": true,
                                 "openMenu": [Function],
                                 "toggleMenu": [Function],
                               }
@@ -21480,7 +21601,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                 >
                                   <ForwardRef
                                     aria-describedby="random-id-17"
-                                    aria-expanded={false}
+                                    aria-expanded={true}
                                     aria-haspopup={true}
                                     asLink={false}
                                     disabled={false}
@@ -21495,7 +21616,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   >
                                     <Button__WrapperButton
                                       aria-describedby="random-id-17"
-                                      aria-expanded={false}
+                                      aria-expanded={true}
                                       aria-haspopup={true}
                                       disabled={false}
                                       fullWidth={false}
@@ -21507,7 +21628,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                     >
                                       <StyledComponent
                                         aria-describedby="random-id-17"
-                                        aria-expanded={false}
+                                        aria-expanded={true}
                                         aria-haspopup={true}
                                         disabled={false}
                                         forwardedComponent={
@@ -21546,7 +21667,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       >
                                         <button
                                           aria-describedby="random-id-17"
-                                          aria-expanded={false}
+                                          aria-expanded={true}
                                           aria-haspopup={true}
                                           className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
                                           disabled={false}
@@ -21573,7 +21694,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   referenceElement={
                                     <button
                                       aria-describedby="random-id-17"
-                                      aria-expanded="false"
+                                      aria-expanded="true"
                                       aria-haspopup="true"
                                       class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
                                     >
@@ -21588,7 +21709,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                     onFocus={[Function]}
                                     onMouseEnter={[Function]}
                                     onMouseLeave={[Function]}
-                                    open={false}
+                                    open={true}
                                     position={
                                       Object {
                                         "left": 0,
@@ -21780,7 +21901,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "sc-jWBwVP",
                                             "isStatic": false,
-                                            "lastClassName": "hjigbL",
+                                            "lastClassName": "gCXFcy",
                                             "rules": Array [
                                               [Function],
                                               [Function],
@@ -21869,7 +21990,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       onFocus={[Function]}
                                       onMouseEnter={[Function]}
                                       onMouseLeave={[Function]}
-                                      open={false}
+                                      open={true}
                                       position={
                                         Object {
                                           "left": 0,
@@ -21968,13 +22089,13 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                       }
                                     >
                                       <div
-                                        className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
+                                        className="Box-sc-1qu1edy-0 sc-jWBwVP gCXFcy"
                                         id="random-id-17"
                                         onBlur={[Function]}
                                         onFocus={[Function]}
                                         onMouseEnter={[Function]}
                                         onMouseLeave={[Function]}
-                                        open={false}
+                                        open={true}
                                         role="tooltip"
                                       >
                                         bottom-end
@@ -22058,6 +22179,15 @@ exports[`Storyshots Tooltip with placement 1`] = `
                                   </Styled(Box)>
                                 </InnerPopper>
                               </Popper>
+                              <DetectOutsideClick
+                                clickRef={
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                  ]
+                                }
+                                onClick={[Function]}
+                              />
                             </Manager>
                           </StatelessTooltip>
                         </MenuState>
@@ -22784,12 +22914,13 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                   className="Box-sc-1qu1edy-0 sc-bdVaJa jAdjeH"
                 >
                   <Component
+                    defaultOpen={true}
                     placement="bottom"
                     tooltip="I am a Tooltip! I have very long text, and my default max-width is 24em (based on 14px font-size), which is equal to 336px, or approximately 45 characters."
                   >
                     <WithGeneratedId>
                       <MenuComponent
-                        defaultOpen={false}
+                        defaultOpen={true}
                         hideDelay="350"
                         id="random-id-4"
                         placement="bottom"
@@ -22797,7 +22928,7 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                         tooltip="I am a Tooltip! I have very long text, and my default max-width is 24em (based on 14px font-size), which is equal to 336px, or approximately 45 characters."
                       >
                         <MenuState
-                          defaultOpen={false}
+                          defaultOpen={true}
                           hideDelay="350"
                           showDelay="100"
                         >
@@ -22808,7 +22939,7 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                               Object {
                                 "closeMenu": [Function],
                                 "handleMenuKeydown": [Function],
-                                "isOpen": false,
+                                "isOpen": true,
                                 "openMenu": [Function],
                                 "toggleMenu": [Function],
                               }
@@ -22823,7 +22954,7 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                                 >
                                   <ForwardRef
                                     aria-describedby="random-id-4"
-                                    aria-expanded={false}
+                                    aria-expanded={true}
                                     aria-haspopup={true}
                                     asLink={false}
                                     disabled={false}
@@ -22838,7 +22969,7 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                                   >
                                     <Button__WrapperButton
                                       aria-describedby="random-id-4"
-                                      aria-expanded={false}
+                                      aria-expanded={true}
                                       aria-haspopup={true}
                                       disabled={false}
                                       fullWidth={false}
@@ -22850,7 +22981,7 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                                     >
                                       <StyledComponent
                                         aria-describedby="random-id-4"
-                                        aria-expanded={false}
+                                        aria-expanded={true}
                                         aria-haspopup={true}
                                         disabled={false}
                                         forwardedComponent={
@@ -22889,7 +23020,7 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                                       >
                                         <button
                                           aria-describedby="random-id-4"
-                                          aria-expanded={false}
+                                          aria-expanded={true}
                                           aria-haspopup={true}
                                           className="Button__WrapperButton-sc-1omxup2-0 idlBaC"
                                           disabled={false}
@@ -22916,7 +23047,7 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                                   referenceElement={
                                     <button
                                       aria-describedby="random-id-4"
-                                      aria-expanded="false"
+                                      aria-expanded="true"
                                       aria-haspopup="true"
                                       class="Button__WrapperButton-sc-1omxup2-0 idlBaC"
                                     >
@@ -22931,7 +23062,7 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                                     onFocus={[Function]}
                                     onMouseEnter={[Function]}
                                     onMouseLeave={[Function]}
-                                    open={false}
+                                    open={true}
                                     position={
                                       Object {
                                         "left": 0,
@@ -23123,7 +23254,7 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                                           "componentStyle": ComponentStyle {
                                             "componentId": "sc-jWBwVP",
                                             "isStatic": false,
-                                            "lastClassName": "hjigbL",
+                                            "lastClassName": "gCXFcy",
                                             "rules": Array [
                                               [Function],
                                               [Function],
@@ -23212,7 +23343,7 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                                       onFocus={[Function]}
                                       onMouseEnter={[Function]}
                                       onMouseLeave={[Function]}
-                                      open={false}
+                                      open={true}
                                       position={
                                         Object {
                                           "left": 0,
@@ -23311,13 +23442,13 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                                       }
                                     >
                                       <div
-                                        className="Box-sc-1qu1edy-0 sc-jWBwVP hjigbL"
+                                        className="Box-sc-1qu1edy-0 sc-jWBwVP gCXFcy"
                                         id="random-id-4"
                                         onBlur={[Function]}
                                         onFocus={[Function]}
                                         onMouseEnter={[Function]}
                                         onMouseLeave={[Function]}
-                                        open={false}
+                                        open={true}
                                         role="tooltip"
                                       >
                                         I am a Tooltip! I have very long text, and my default max-width is 24em (based on 14px font-size), which is equal to 336px, or approximately 45 characters.
@@ -23401,6 +23532,15 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                                   </Styled(Box)>
                                 </InnerPopper>
                               </Popper>
+                              <DetectOutsideClick
+                                clickRef={
+                                  Array [
+                                    undefined,
+                                    undefined,
+                                  ]
+                                }
+                                onClick={[Function]}
+                              />
                             </Manager>
                           </StatelessTooltip>
                         </MenuState>

--- a/docs/src/pages/components/tooltip.js
+++ b/docs/src/pages/components/tooltip.js
@@ -65,6 +65,12 @@ const propsRows = [
     type: "String",
     defaultValue: "undefined",
     description: "className passed to the tooltip container element."
+  },
+  {
+    name: "defaultOpen",
+    type: "boolean",
+    defaultValue: "false",
+    description: "when set to true the tooltip will be open by default"
   }
 ];
 


### PR DESCRIPTION
## Description

Adds an example using defaultOpen to the Tooltip (turns out this prop already existed), I also added some e2e tests for this example and couple new cypress commands for testing whether an item is visible in the viewport.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [x] Documentation only

## Checklist

**Please check all that apply.**

- [x] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [x] Docs updated with correct props and examples
- [x] Updated and reviewed changes to storyshots
- [x] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Changelog updated
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
