### PR TITLE
update arrows in datepicker to match updated designs

### DIFF
--- a/components/src/DatePicker/DatePickerHeader.js
+++ b/components/src/DatePicker/DatePickerHeader.js
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { format } from "date-fns";
-import styled from "styled-components";
 
 import theme from "../theme";
 
@@ -16,7 +15,6 @@ const DatePickerHeader = ({ date, decreaseMonth, increaseMonth, prevMonthButtonD
       label="go to previous month"
       onClick={decreaseMonth}
       disabled={prevMonthButtonDisabled}
-      ml="x1"
     />
     <Text fontWeight="bold" color={theme.colors.blackBlue} px="x1" ml="half" fontSize="large">
       {format(date, "MMMM yyyy")}
@@ -26,7 +24,6 @@ const DatePickerHeader = ({ date, decreaseMonth, increaseMonth, prevMonthButtonD
       label="go to next month"
       onClick={increaseMonth}
       disabled={nextMonthButtonDisabled}
-      mr="x2"
     />
   </Flex>
 );

--- a/components/src/DatePicker/DatePickerHeader.js
+++ b/components/src/DatePicker/DatePickerHeader.js
@@ -9,29 +9,25 @@ import { Flex } from "../Flex";
 import { Text } from "../Type";
 import { ControlIcon } from "../Button";
 
-const StyledNavigationButton = styled(ControlIcon)({
-  marginLeft: theme.space.x2
-});
-
 const DatePickerHeader = ({ date, decreaseMonth, increaseMonth, prevMonthButtonDisabled, nextMonthButtonDisabled }) => (
-  <Flex justifyContent="space-between" alignItems="center" py="half">
+  <Flex justifyContent="space-between" alignItems="center" py="half" px="x1">
+    <ControlIcon
+      icon="leftArrow"
+      label="go to previous month"
+      onClick={decreaseMonth}
+      disabled={prevMonthButtonDisabled}
+      ml="x1"
+    />
     <Text fontWeight="bold" color={theme.colors.blackBlue} px="x1" ml="half" fontSize="large">
       {format(date, "MMMM yyyy")}
     </Text>
-    <Flex pr="x2">
-      <StyledNavigationButton
-        icon="leftArrow"
-        label="go to previous month"
-        onClick={decreaseMonth}
-        disabled={prevMonthButtonDisabled}
-      />
-      <StyledNavigationButton
-        icon="rightArrow"
-        label="go to next month"
-        onClick={increaseMonth}
-        disabled={nextMonthButtonDisabled}
-      />
-    </Flex>
+    <ControlIcon
+      icon="rightArrow"
+      label="go to next month"
+      onClick={increaseMonth}
+      disabled={nextMonthButtonDisabled}
+      mr="x2"
+    />
   </Flex>
 );
 

--- a/components/src/Datepicker/DatePickerHeader.js
+++ b/components/src/Datepicker/DatePickerHeader.js
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { format } from "date-fns";
-import styled from "styled-components";
 
 import theme from "../theme";
 
@@ -16,7 +15,6 @@ const DatePickerHeader = ({ date, decreaseMonth, increaseMonth, prevMonthButtonD
       label="go to previous month"
       onClick={decreaseMonth}
       disabled={prevMonthButtonDisabled}
-      ml="x1"
     />
     <Text fontWeight="bold" color={theme.colors.blackBlue} px="x1" ml="half" fontSize="large">
       {format(date, "MMMM yyyy")}
@@ -26,7 +24,6 @@ const DatePickerHeader = ({ date, decreaseMonth, increaseMonth, prevMonthButtonD
       label="go to next month"
       onClick={increaseMonth}
       disabled={nextMonthButtonDisabled}
-      mr="x2"
     />
   </Flex>
 );

--- a/components/src/Datepicker/DatePickerHeader.js
+++ b/components/src/Datepicker/DatePickerHeader.js
@@ -9,29 +9,25 @@ import { Flex } from "../Flex";
 import { Text } from "../Type";
 import { ControlIcon } from "../Button";
 
-const StyledNavigationButton = styled(ControlIcon)({
-  marginLeft: theme.space.x2
-});
-
 const DatePickerHeader = ({ date, decreaseMonth, increaseMonth, prevMonthButtonDisabled, nextMonthButtonDisabled }) => (
-  <Flex justifyContent="space-between" alignItems="center" py="half">
+  <Flex justifyContent="space-between" alignItems="center" py="half" px="x1">
+    <ControlIcon
+      icon="leftArrow"
+      label="go to previous month"
+      onClick={decreaseMonth}
+      disabled={prevMonthButtonDisabled}
+      ml="x1"
+    />
     <Text fontWeight="bold" color={theme.colors.blackBlue} px="x1" ml="half" fontSize="large">
       {format(date, "MMMM yyyy")}
     </Text>
-    <Flex pr="x2">
-      <StyledNavigationButton
-        icon="leftArrow"
-        label="go to previous month"
-        onClick={decreaseMonth}
-        disabled={prevMonthButtonDisabled}
-      />
-      <StyledNavigationButton
-        icon="rightArrow"
-        label="go to next month"
-        onClick={increaseMonth}
-        disabled={nextMonthButtonDisabled}
-      />
-    </Flex>
+    <ControlIcon
+      icon="rightArrow"
+      label="go to next month"
+      onClick={increaseMonth}
+      disabled={nextMonthButtonDisabled}
+      mr="x2"
+    />
   </Flex>
 );
 

--- a/components/src/TimePicker/__snapshots__/TimePicker.story.storyshot
+++ b/components/src/TimePicker/__snapshots__/TimePicker.story.storyshot
@@ -407,7 +407,7 @@ exports[`Storyshots TimePicker default 1`] = `
                       "$$typeof": Symbol(react.forward_ref),
                       "attrs": Array [],
                       "componentStyle": ComponentStyle {
-                        "componentId": "sc-fBuWsC",
+                        "componentId": "sc-jhAzac",
                         "isStatic": false,
                         "rules": Array [
                           [Function],
@@ -416,7 +416,7 @@ exports[`Storyshots TimePicker default 1`] = `
                       "displayName": "Styled(SelectOption)",
                       "foldedComponentIds": Array [],
                       "render": [Function],
-                      "styledComponentId": "sc-fBuWsC",
+                      "styledComponentId": "sc-jhAzac",
                       "target": [Function],
                       "toString": [Function],
                       "usesTheme": false,
@@ -1644,7 +1644,7 @@ exports[`Storyshots TimePicker default 1`] = `
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "sc-fBuWsC",
+                                              "componentId": "sc-jhAzac",
                                               "isStatic": false,
                                               "rules": Array [
                                                 [Function],
@@ -1653,7 +1653,7 @@ exports[`Storyshots TimePicker default 1`] = `
                                             "displayName": "Styled(SelectOption)",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "sc-fBuWsC",
+                                            "styledComponentId": "sc-jhAzac",
                                             "target": [Function],
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -2097,7 +2097,7 @@ exports[`Storyshots TimePicker default 1`] = `
                                               "$$typeof": Symbol(react.forward_ref),
                                               "attrs": Array [],
                                               "componentStyle": ComponentStyle {
-                                                "componentId": "sc-fBuWsC",
+                                                "componentId": "sc-jhAzac",
                                                 "isStatic": false,
                                                 "rules": Array [
                                                   [Function],
@@ -2106,7 +2106,7 @@ exports[`Storyshots TimePicker default 1`] = `
                                               "displayName": "Styled(SelectOption)",
                                               "foldedComponentIds": Array [],
                                               "render": [Function],
-                                              "styledComponentId": "sc-fBuWsC",
+                                              "styledComponentId": "sc-jhAzac",
                                               "target": [Function],
                                               "toString": [Function],
                                               "usesTheme": false,
@@ -2980,7 +2980,7 @@ exports[`Storyshots TimePicker default 1`] = `
                                                   "$$typeof": Symbol(react.forward_ref),
                                                   "attrs": Array [],
                                                   "componentStyle": ComponentStyle {
-                                                    "componentId": "sc-fBuWsC",
+                                                    "componentId": "sc-jhAzac",
                                                     "isStatic": false,
                                                     "rules": Array [
                                                       [Function],
@@ -2989,7 +2989,7 @@ exports[`Storyshots TimePicker default 1`] = `
                                                   "displayName": "Styled(SelectOption)",
                                                   "foldedComponentIds": Array [],
                                                   "render": [Function],
-                                                  "styledComponentId": "sc-fBuWsC",
+                                                  "styledComponentId": "sc-jhAzac",
                                                   "target": [Function],
                                                   "toString": [Function],
                                                   "usesTheme": false,
@@ -3912,7 +3912,7 @@ exports[`Storyshots TimePicker default 1`] = `
                                                         "$$typeof": Symbol(react.forward_ref),
                                                         "attrs": Array [],
                                                         "componentStyle": ComponentStyle {
-                                                          "componentId": "sc-fBuWsC",
+                                                          "componentId": "sc-jhAzac",
                                                           "isStatic": false,
                                                           "rules": Array [
                                                             [Function],
@@ -3921,7 +3921,7 @@ exports[`Storyshots TimePicker default 1`] = `
                                                         "displayName": "Styled(SelectOption)",
                                                         "foldedComponentIds": Array [],
                                                         "render": [Function],
-                                                        "styledComponentId": "sc-fBuWsC",
+                                                        "styledComponentId": "sc-jhAzac",
                                                         "target": [Function],
                                                         "toString": [Function],
                                                         "usesTheme": false,
@@ -4826,7 +4826,7 @@ exports[`Storyshots TimePicker default 1`] = `
                                                           "$$typeof": Symbol(react.forward_ref),
                                                           "attrs": Array [],
                                                           "componentStyle": ComponentStyle {
-                                                            "componentId": "sc-fBuWsC",
+                                                            "componentId": "sc-jhAzac",
                                                             "isStatic": false,
                                                             "rules": Array [
                                                               [Function],
@@ -4835,7 +4835,7 @@ exports[`Storyshots TimePicker default 1`] = `
                                                           "displayName": "Styled(SelectOption)",
                                                           "foldedComponentIds": Array [],
                                                           "render": [Function],
-                                                          "styledComponentId": "sc-fBuWsC",
+                                                          "styledComponentId": "sc-jhAzac",
                                                           "target": [Function],
                                                           "toString": [Function],
                                                           "usesTheme": false,
@@ -5763,7 +5763,7 @@ exports[`Storyshots TimePicker default 1`] = `
                                                                 "$$typeof": Symbol(react.forward_ref),
                                                                 "attrs": Array [],
                                                                 "componentStyle": ComponentStyle {
-                                                                  "componentId": "sc-fBuWsC",
+                                                                  "componentId": "sc-jhAzac",
                                                                   "isStatic": false,
                                                                   "rules": Array [
                                                                     [Function],
@@ -5772,7 +5772,7 @@ exports[`Storyshots TimePicker default 1`] = `
                                                                 "displayName": "Styled(SelectOption)",
                                                                 "foldedComponentIds": Array [],
                                                                 "render": [Function],
-                                                                "styledComponentId": "sc-fBuWsC",
+                                                                "styledComponentId": "sc-jhAzac",
                                                                 "target": [Function],
                                                                 "toString": [Function],
                                                                 "usesTheme": false,
@@ -6690,7 +6690,7 @@ exports[`Storyshots TimePicker default 1`] = `
                                                                       "$$typeof": Symbol(react.forward_ref),
                                                                       "attrs": Array [],
                                                                       "componentStyle": ComponentStyle {
-                                                                        "componentId": "sc-fBuWsC",
+                                                                        "componentId": "sc-jhAzac",
                                                                         "isStatic": false,
                                                                         "rules": Array [
                                                                           [Function],
@@ -6699,7 +6699,7 @@ exports[`Storyshots TimePicker default 1`] = `
                                                                       "displayName": "Styled(SelectOption)",
                                                                       "foldedComponentIds": Array [],
                                                                       "render": [Function],
-                                                                      "styledComponentId": "sc-fBuWsC",
+                                                                      "styledComponentId": "sc-jhAzac",
                                                                       "target": [Function],
                                                                       "toString": [Function],
                                                                       "usesTheme": false,
@@ -7227,7 +7227,7 @@ exports[`Storyshots TimePicker default 1`] = `
                                                                       "$$typeof": Symbol(react.forward_ref),
                                                                       "attrs": Array [],
                                                                       "componentStyle": ComponentStyle {
-                                                                        "componentId": "sc-fBuWsC",
+                                                                        "componentId": "sc-jhAzac",
                                                                         "isStatic": false,
                                                                         "rules": Array [
                                                                           [Function],
@@ -7236,7 +7236,7 @@ exports[`Storyshots TimePicker default 1`] = `
                                                                       "displayName": "Styled(SelectOption)",
                                                                       "foldedComponentIds": Array [],
                                                                       "render": [Function],
-                                                                      "styledComponentId": "sc-fBuWsC",
+                                                                      "styledComponentId": "sc-jhAzac",
                                                                       "target": [Function],
                                                                       "toString": [Function],
                                                                       "usesTheme": false,
@@ -8231,7 +8231,7 @@ exports[`Storyshots TimePicker default 1`] = `
                                                                 "$$typeof": Symbol(react.forward_ref),
                                                                 "attrs": Array [],
                                                                 "componentStyle": ComponentStyle {
-                                                                  "componentId": "sc-fBuWsC",
+                                                                  "componentId": "sc-jhAzac",
                                                                   "isStatic": false,
                                                                   "rules": Array [
                                                                     [Function],
@@ -8240,7 +8240,7 @@ exports[`Storyshots TimePicker default 1`] = `
                                                                 "displayName": "Styled(SelectOption)",
                                                                 "foldedComponentIds": Array [],
                                                                 "render": [Function],
-                                                                "styledComponentId": "sc-fBuWsC",
+                                                                "styledComponentId": "sc-jhAzac",
                                                                 "target": [Function],
                                                                 "toString": [Function],
                                                                 "usesTheme": false,
@@ -9153,7 +9153,7 @@ exports[`Storyshots TimePicker default 1`] = `
                                                                       "$$typeof": Symbol(react.forward_ref),
                                                                       "attrs": Array [],
                                                                       "componentStyle": ComponentStyle {
-                                                                        "componentId": "sc-fBuWsC",
+                                                                        "componentId": "sc-jhAzac",
                                                                         "isStatic": false,
                                                                         "rules": Array [
                                                                           [Function],
@@ -9162,7 +9162,7 @@ exports[`Storyshots TimePicker default 1`] = `
                                                                       "displayName": "Styled(SelectOption)",
                                                                       "foldedComponentIds": Array [],
                                                                       "render": [Function],
-                                                                      "styledComponentId": "sc-fBuWsC",
+                                                                      "styledComponentId": "sc-jhAzac",
                                                                       "target": [Function],
                                                                       "toString": [Function],
                                                                       "usesTheme": false,
@@ -10086,7 +10086,7 @@ exports[`Storyshots TimePicker default 1`] = `
                                                                       "$$typeof": Symbol(react.forward_ref),
                                                                       "attrs": Array [],
                                                                       "componentStyle": ComponentStyle {
-                                                                        "componentId": "sc-fBuWsC",
+                                                                        "componentId": "sc-jhAzac",
                                                                         "isStatic": false,
                                                                         "rules": Array [
                                                                           [Function],
@@ -10095,7 +10095,7 @@ exports[`Storyshots TimePicker default 1`] = `
                                                                       "displayName": "Styled(SelectOption)",
                                                                       "foldedComponentIds": Array [],
                                                                       "render": [Function],
-                                                                      "styledComponentId": "sc-fBuWsC",
+                                                                      "styledComponentId": "sc-jhAzac",
                                                                       "target": [Function],
                                                                       "toString": [Function],
                                                                       "usesTheme": false,
@@ -10998,7 +10998,7 @@ exports[`Storyshots TimePicker default 1`] = `
                                                                         "$$typeof": Symbol(react.forward_ref),
                                                                         "attrs": Array [],
                                                                         "componentStyle": ComponentStyle {
-                                                                          "componentId": "sc-fBuWsC",
+                                                                          "componentId": "sc-jhAzac",
                                                                           "isStatic": false,
                                                                           "rules": Array [
                                                                             [Function],
@@ -11007,7 +11007,7 @@ exports[`Storyshots TimePicker default 1`] = `
                                                                         "displayName": "Styled(SelectOption)",
                                                                         "foldedComponentIds": Array [],
                                                                         "render": [Function],
-                                                                        "styledComponentId": "sc-fBuWsC",
+                                                                        "styledComponentId": "sc-jhAzac",
                                                                         "target": [Function],
                                                                         "toString": [Function],
                                                                         "usesTheme": false,
@@ -11531,9 +11531,9 @@ exports[`Storyshots TimePicker default 1`] = `
                                                                             },
                                                                             "attrs": Array [],
                                                                             "componentStyle": ComponentStyle {
-                                                                              "componentId": "sc-jhAzac",
+                                                                              "componentId": "sc-hzDkRC",
                                                                               "isStatic": false,
-                                                                              "lastClassName": "hzvqhO",
+                                                                              "lastClassName": "jVaXaN",
                                                                               "rules": Array [
                                                                                 [Function],
                                                                                 [Function],
@@ -11555,7 +11555,7 @@ exports[`Storyshots TimePicker default 1`] = `
                                                                               "title": [Function],
                                                                             },
                                                                             "render": [Function],
-                                                                            "styledComponentId": "sc-jhAzac",
+                                                                            "styledComponentId": "sc-hzDkRC",
                                                                             "target": Object {
                                                                               "$$typeof": Symbol(react.forward_ref),
                                                                               "defaultProps": Object {
@@ -11587,7 +11587,7 @@ exports[`Storyshots TimePicker default 1`] = `
                                                                         title={null}
                                                                       >
                                                                         <ForwardRef
-                                                                          className="sc-bwzfXH sc-jhAzac hzvqhO"
+                                                                          className="sc-bwzfXH sc-hzDkRC jVaXaN"
                                                                           color="currentColor"
                                                                           focusable={false}
                                                                           icon="queryBuilder"
@@ -11596,7 +11596,7 @@ exports[`Storyshots TimePicker default 1`] = `
                                                                         >
                                                                           <svg
                                                                             aria-hidden={true}
-                                                                            className="sc-bwzfXH sc-jhAzac hzvqhO"
+                                                                            className="sc-bwzfXH sc-hzDkRC jVaXaN"
                                                                             color="currentColor"
                                                                             fill="currentColor"
                                                                             focusable={false}
@@ -12063,7 +12063,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                       "$$typeof": Symbol(react.forward_ref),
                       "attrs": Array [],
                       "componentStyle": ComponentStyle {
-                        "componentId": "sc-fBuWsC",
+                        "componentId": "sc-jhAzac",
                         "isStatic": false,
                         "rules": Array [
                           [Function],
@@ -12072,7 +12072,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                       "displayName": "Styled(SelectOption)",
                       "foldedComponentIds": Array [],
                       "render": [Function],
-                      "styledComponentId": "sc-fBuWsC",
+                      "styledComponentId": "sc-jhAzac",
                       "target": [Function],
                       "toString": [Function],
                       "usesTheme": false,
@@ -13300,7 +13300,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "sc-fBuWsC",
+                                              "componentId": "sc-jhAzac",
                                               "isStatic": false,
                                               "rules": Array [
                                                 [Function],
@@ -13309,7 +13309,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                                             "displayName": "Styled(SelectOption)",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "sc-fBuWsC",
+                                            "styledComponentId": "sc-jhAzac",
                                             "target": [Function],
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -13753,7 +13753,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                                               "$$typeof": Symbol(react.forward_ref),
                                               "attrs": Array [],
                                               "componentStyle": ComponentStyle {
-                                                "componentId": "sc-fBuWsC",
+                                                "componentId": "sc-jhAzac",
                                                 "isStatic": false,
                                                 "rules": Array [
                                                   [Function],
@@ -13762,7 +13762,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                                               "displayName": "Styled(SelectOption)",
                                               "foldedComponentIds": Array [],
                                               "render": [Function],
-                                              "styledComponentId": "sc-fBuWsC",
+                                              "styledComponentId": "sc-jhAzac",
                                               "target": [Function],
                                               "toString": [Function],
                                               "usesTheme": false,
@@ -14636,7 +14636,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                                                   "$$typeof": Symbol(react.forward_ref),
                                                   "attrs": Array [],
                                                   "componentStyle": ComponentStyle {
-                                                    "componentId": "sc-fBuWsC",
+                                                    "componentId": "sc-jhAzac",
                                                     "isStatic": false,
                                                     "rules": Array [
                                                       [Function],
@@ -14645,7 +14645,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                                                   "displayName": "Styled(SelectOption)",
                                                   "foldedComponentIds": Array [],
                                                   "render": [Function],
-                                                  "styledComponentId": "sc-fBuWsC",
+                                                  "styledComponentId": "sc-jhAzac",
                                                   "target": [Function],
                                                   "toString": [Function],
                                                   "usesTheme": false,
@@ -15568,7 +15568,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                                                         "$$typeof": Symbol(react.forward_ref),
                                                         "attrs": Array [],
                                                         "componentStyle": ComponentStyle {
-                                                          "componentId": "sc-fBuWsC",
+                                                          "componentId": "sc-jhAzac",
                                                           "isStatic": false,
                                                           "rules": Array [
                                                             [Function],
@@ -15577,7 +15577,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                                                         "displayName": "Styled(SelectOption)",
                                                         "foldedComponentIds": Array [],
                                                         "render": [Function],
-                                                        "styledComponentId": "sc-fBuWsC",
+                                                        "styledComponentId": "sc-jhAzac",
                                                         "target": [Function],
                                                         "toString": [Function],
                                                         "usesTheme": false,
@@ -16482,7 +16482,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                                                           "$$typeof": Symbol(react.forward_ref),
                                                           "attrs": Array [],
                                                           "componentStyle": ComponentStyle {
-                                                            "componentId": "sc-fBuWsC",
+                                                            "componentId": "sc-jhAzac",
                                                             "isStatic": false,
                                                             "rules": Array [
                                                               [Function],
@@ -16491,7 +16491,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                                                           "displayName": "Styled(SelectOption)",
                                                           "foldedComponentIds": Array [],
                                                           "render": [Function],
-                                                          "styledComponentId": "sc-fBuWsC",
+                                                          "styledComponentId": "sc-jhAzac",
                                                           "target": [Function],
                                                           "toString": [Function],
                                                           "usesTheme": false,
@@ -17419,7 +17419,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                                                                 "$$typeof": Symbol(react.forward_ref),
                                                                 "attrs": Array [],
                                                                 "componentStyle": ComponentStyle {
-                                                                  "componentId": "sc-fBuWsC",
+                                                                  "componentId": "sc-jhAzac",
                                                                   "isStatic": false,
                                                                   "rules": Array [
                                                                     [Function],
@@ -17428,7 +17428,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                                                                 "displayName": "Styled(SelectOption)",
                                                                 "foldedComponentIds": Array [],
                                                                 "render": [Function],
-                                                                "styledComponentId": "sc-fBuWsC",
+                                                                "styledComponentId": "sc-jhAzac",
                                                                 "target": [Function],
                                                                 "toString": [Function],
                                                                 "usesTheme": false,
@@ -18346,7 +18346,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                                                                       "$$typeof": Symbol(react.forward_ref),
                                                                       "attrs": Array [],
                                                                       "componentStyle": ComponentStyle {
-                                                                        "componentId": "sc-fBuWsC",
+                                                                        "componentId": "sc-jhAzac",
                                                                         "isStatic": false,
                                                                         "rules": Array [
                                                                           [Function],
@@ -18355,7 +18355,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                                                                       "displayName": "Styled(SelectOption)",
                                                                       "foldedComponentIds": Array [],
                                                                       "render": [Function],
-                                                                      "styledComponentId": "sc-fBuWsC",
+                                                                      "styledComponentId": "sc-jhAzac",
                                                                       "target": [Function],
                                                                       "toString": [Function],
                                                                       "usesTheme": false,
@@ -18883,7 +18883,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                                                                       "$$typeof": Symbol(react.forward_ref),
                                                                       "attrs": Array [],
                                                                       "componentStyle": ComponentStyle {
-                                                                        "componentId": "sc-fBuWsC",
+                                                                        "componentId": "sc-jhAzac",
                                                                         "isStatic": false,
                                                                         "rules": Array [
                                                                           [Function],
@@ -18892,7 +18892,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                                                                       "displayName": "Styled(SelectOption)",
                                                                       "foldedComponentIds": Array [],
                                                                       "render": [Function],
-                                                                      "styledComponentId": "sc-fBuWsC",
+                                                                      "styledComponentId": "sc-jhAzac",
                                                                       "target": [Function],
                                                                       "toString": [Function],
                                                                       "usesTheme": false,
@@ -19887,7 +19887,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                                                                 "$$typeof": Symbol(react.forward_ref),
                                                                 "attrs": Array [],
                                                                 "componentStyle": ComponentStyle {
-                                                                  "componentId": "sc-fBuWsC",
+                                                                  "componentId": "sc-jhAzac",
                                                                   "isStatic": false,
                                                                   "rules": Array [
                                                                     [Function],
@@ -19896,7 +19896,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                                                                 "displayName": "Styled(SelectOption)",
                                                                 "foldedComponentIds": Array [],
                                                                 "render": [Function],
-                                                                "styledComponentId": "sc-fBuWsC",
+                                                                "styledComponentId": "sc-jhAzac",
                                                                 "target": [Function],
                                                                 "toString": [Function],
                                                                 "usesTheme": false,
@@ -20809,7 +20809,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                                                                       "$$typeof": Symbol(react.forward_ref),
                                                                       "attrs": Array [],
                                                                       "componentStyle": ComponentStyle {
-                                                                        "componentId": "sc-fBuWsC",
+                                                                        "componentId": "sc-jhAzac",
                                                                         "isStatic": false,
                                                                         "rules": Array [
                                                                           [Function],
@@ -20818,7 +20818,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                                                                       "displayName": "Styled(SelectOption)",
                                                                       "foldedComponentIds": Array [],
                                                                       "render": [Function],
-                                                                      "styledComponentId": "sc-fBuWsC",
+                                                                      "styledComponentId": "sc-jhAzac",
                                                                       "target": [Function],
                                                                       "toString": [Function],
                                                                       "usesTheme": false,
@@ -21742,7 +21742,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                                                                       "$$typeof": Symbol(react.forward_ref),
                                                                       "attrs": Array [],
                                                                       "componentStyle": ComponentStyle {
-                                                                        "componentId": "sc-fBuWsC",
+                                                                        "componentId": "sc-jhAzac",
                                                                         "isStatic": false,
                                                                         "rules": Array [
                                                                           [Function],
@@ -21751,7 +21751,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                                                                       "displayName": "Styled(SelectOption)",
                                                                       "foldedComponentIds": Array [],
                                                                       "render": [Function],
-                                                                      "styledComponentId": "sc-fBuWsC",
+                                                                      "styledComponentId": "sc-jhAzac",
                                                                       "target": [Function],
                                                                       "toString": [Function],
                                                                       "usesTheme": false,
@@ -22654,7 +22654,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                                                                         "$$typeof": Symbol(react.forward_ref),
                                                                         "attrs": Array [],
                                                                         "componentStyle": ComponentStyle {
-                                                                          "componentId": "sc-fBuWsC",
+                                                                          "componentId": "sc-jhAzac",
                                                                           "isStatic": false,
                                                                           "rules": Array [
                                                                             [Function],
@@ -22663,7 +22663,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                                                                         "displayName": "Styled(SelectOption)",
                                                                         "foldedComponentIds": Array [],
                                                                         "render": [Function],
-                                                                        "styledComponentId": "sc-fBuWsC",
+                                                                        "styledComponentId": "sc-jhAzac",
                                                                         "target": [Function],
                                                                         "toString": [Function],
                                                                         "usesTheme": false,
@@ -23187,9 +23187,9 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                                                                             },
                                                                             "attrs": Array [],
                                                                             "componentStyle": ComponentStyle {
-                                                                              "componentId": "sc-jhAzac",
+                                                                              "componentId": "sc-hzDkRC",
                                                                               "isStatic": false,
-                                                                              "lastClassName": "hzvqhO",
+                                                                              "lastClassName": "jVaXaN",
                                                                               "rules": Array [
                                                                                 [Function],
                                                                                 [Function],
@@ -23211,7 +23211,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                                                                               "title": [Function],
                                                                             },
                                                                             "render": [Function],
-                                                                            "styledComponentId": "sc-jhAzac",
+                                                                            "styledComponentId": "sc-hzDkRC",
                                                                             "target": Object {
                                                                               "$$typeof": Symbol(react.forward_ref),
                                                                               "defaultProps": Object {
@@ -23243,7 +23243,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                                                                         title={null}
                                                                       >
                                                                         <ForwardRef
-                                                                          className="sc-bwzfXH sc-jhAzac hzvqhO"
+                                                                          className="sc-bwzfXH sc-hzDkRC jVaXaN"
                                                                           color="currentColor"
                                                                           focusable={false}
                                                                           icon="queryBuilder"
@@ -23252,7 +23252,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                                                                         >
                                                                           <svg
                                                                             aria-hidden={true}
-                                                                            className="sc-bwzfXH sc-jhAzac hzvqhO"
+                                                                            className="sc-bwzfXH sc-hzDkRC jVaXaN"
                                                                             color="currentColor"
                                                                             fill="currentColor"
                                                                             focusable={false}
@@ -23720,7 +23720,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                       "$$typeof": Symbol(react.forward_ref),
                       "attrs": Array [],
                       "componentStyle": ComponentStyle {
-                        "componentId": "sc-fBuWsC",
+                        "componentId": "sc-jhAzac",
                         "isStatic": false,
                         "rules": Array [
                           [Function],
@@ -23729,7 +23729,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                       "displayName": "Styled(SelectOption)",
                       "foldedComponentIds": Array [],
                       "render": [Function],
-                      "styledComponentId": "sc-fBuWsC",
+                      "styledComponentId": "sc-jhAzac",
                       "target": [Function],
                       "toString": [Function],
                       "usesTheme": false,
@@ -24957,7 +24957,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                                             "$$typeof": Symbol(react.forward_ref),
                                             "attrs": Array [],
                                             "componentStyle": ComponentStyle {
-                                              "componentId": "sc-fBuWsC",
+                                              "componentId": "sc-jhAzac",
                                               "isStatic": false,
                                               "rules": Array [
                                                 [Function],
@@ -24966,7 +24966,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                                             "displayName": "Styled(SelectOption)",
                                             "foldedComponentIds": Array [],
                                             "render": [Function],
-                                            "styledComponentId": "sc-fBuWsC",
+                                            "styledComponentId": "sc-jhAzac",
                                             "target": [Function],
                                             "toString": [Function],
                                             "usesTheme": false,
@@ -25410,7 +25410,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                                               "$$typeof": Symbol(react.forward_ref),
                                               "attrs": Array [],
                                               "componentStyle": ComponentStyle {
-                                                "componentId": "sc-fBuWsC",
+                                                "componentId": "sc-jhAzac",
                                                 "isStatic": false,
                                                 "rules": Array [
                                                   [Function],
@@ -25419,7 +25419,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                                               "displayName": "Styled(SelectOption)",
                                               "foldedComponentIds": Array [],
                                               "render": [Function],
-                                              "styledComponentId": "sc-fBuWsC",
+                                              "styledComponentId": "sc-jhAzac",
                                               "target": [Function],
                                               "toString": [Function],
                                               "usesTheme": false,
@@ -26293,7 +26293,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                                                   "$$typeof": Symbol(react.forward_ref),
                                                   "attrs": Array [],
                                                   "componentStyle": ComponentStyle {
-                                                    "componentId": "sc-fBuWsC",
+                                                    "componentId": "sc-jhAzac",
                                                     "isStatic": false,
                                                     "rules": Array [
                                                       [Function],
@@ -26302,7 +26302,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                                                   "displayName": "Styled(SelectOption)",
                                                   "foldedComponentIds": Array [],
                                                   "render": [Function],
-                                                  "styledComponentId": "sc-fBuWsC",
+                                                  "styledComponentId": "sc-jhAzac",
                                                   "target": [Function],
                                                   "toString": [Function],
                                                   "usesTheme": false,
@@ -27225,7 +27225,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                                                         "$$typeof": Symbol(react.forward_ref),
                                                         "attrs": Array [],
                                                         "componentStyle": ComponentStyle {
-                                                          "componentId": "sc-fBuWsC",
+                                                          "componentId": "sc-jhAzac",
                                                           "isStatic": false,
                                                           "rules": Array [
                                                             [Function],
@@ -27234,7 +27234,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                                                         "displayName": "Styled(SelectOption)",
                                                         "foldedComponentIds": Array [],
                                                         "render": [Function],
-                                                        "styledComponentId": "sc-fBuWsC",
+                                                        "styledComponentId": "sc-jhAzac",
                                                         "target": [Function],
                                                         "toString": [Function],
                                                         "usesTheme": false,
@@ -28139,7 +28139,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                                                           "$$typeof": Symbol(react.forward_ref),
                                                           "attrs": Array [],
                                                           "componentStyle": ComponentStyle {
-                                                            "componentId": "sc-fBuWsC",
+                                                            "componentId": "sc-jhAzac",
                                                             "isStatic": false,
                                                             "rules": Array [
                                                               [Function],
@@ -28148,7 +28148,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                                                           "displayName": "Styled(SelectOption)",
                                                           "foldedComponentIds": Array [],
                                                           "render": [Function],
-                                                          "styledComponentId": "sc-fBuWsC",
+                                                          "styledComponentId": "sc-jhAzac",
                                                           "target": [Function],
                                                           "toString": [Function],
                                                           "usesTheme": false,
@@ -29076,7 +29076,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                                                                 "$$typeof": Symbol(react.forward_ref),
                                                                 "attrs": Array [],
                                                                 "componentStyle": ComponentStyle {
-                                                                  "componentId": "sc-fBuWsC",
+                                                                  "componentId": "sc-jhAzac",
                                                                   "isStatic": false,
                                                                   "rules": Array [
                                                                     [Function],
@@ -29085,7 +29085,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                                                                 "displayName": "Styled(SelectOption)",
                                                                 "foldedComponentIds": Array [],
                                                                 "render": [Function],
-                                                                "styledComponentId": "sc-fBuWsC",
+                                                                "styledComponentId": "sc-jhAzac",
                                                                 "target": [Function],
                                                                 "toString": [Function],
                                                                 "usesTheme": false,
@@ -30003,7 +30003,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                                                                       "$$typeof": Symbol(react.forward_ref),
                                                                       "attrs": Array [],
                                                                       "componentStyle": ComponentStyle {
-                                                                        "componentId": "sc-fBuWsC",
+                                                                        "componentId": "sc-jhAzac",
                                                                         "isStatic": false,
                                                                         "rules": Array [
                                                                           [Function],
@@ -30012,7 +30012,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                                                                       "displayName": "Styled(SelectOption)",
                                                                       "foldedComponentIds": Array [],
                                                                       "render": [Function],
-                                                                      "styledComponentId": "sc-fBuWsC",
+                                                                      "styledComponentId": "sc-jhAzac",
                                                                       "target": [Function],
                                                                       "toString": [Function],
                                                                       "usesTheme": false,
@@ -30540,7 +30540,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                                                                       "$$typeof": Symbol(react.forward_ref),
                                                                       "attrs": Array [],
                                                                       "componentStyle": ComponentStyle {
-                                                                        "componentId": "sc-fBuWsC",
+                                                                        "componentId": "sc-jhAzac",
                                                                         "isStatic": false,
                                                                         "rules": Array [
                                                                           [Function],
@@ -30549,7 +30549,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                                                                       "displayName": "Styled(SelectOption)",
                                                                       "foldedComponentIds": Array [],
                                                                       "render": [Function],
-                                                                      "styledComponentId": "sc-fBuWsC",
+                                                                      "styledComponentId": "sc-jhAzac",
                                                                       "target": [Function],
                                                                       "toString": [Function],
                                                                       "usesTheme": false,
@@ -31544,7 +31544,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                                                                 "$$typeof": Symbol(react.forward_ref),
                                                                 "attrs": Array [],
                                                                 "componentStyle": ComponentStyle {
-                                                                  "componentId": "sc-fBuWsC",
+                                                                  "componentId": "sc-jhAzac",
                                                                   "isStatic": false,
                                                                   "rules": Array [
                                                                     [Function],
@@ -31553,7 +31553,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                                                                 "displayName": "Styled(SelectOption)",
                                                                 "foldedComponentIds": Array [],
                                                                 "render": [Function],
-                                                                "styledComponentId": "sc-fBuWsC",
+                                                                "styledComponentId": "sc-jhAzac",
                                                                 "target": [Function],
                                                                 "toString": [Function],
                                                                 "usesTheme": false,
@@ -32466,7 +32466,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                                                                       "$$typeof": Symbol(react.forward_ref),
                                                                       "attrs": Array [],
                                                                       "componentStyle": ComponentStyle {
-                                                                        "componentId": "sc-fBuWsC",
+                                                                        "componentId": "sc-jhAzac",
                                                                         "isStatic": false,
                                                                         "rules": Array [
                                                                           [Function],
@@ -32475,7 +32475,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                                                                       "displayName": "Styled(SelectOption)",
                                                                       "foldedComponentIds": Array [],
                                                                       "render": [Function],
-                                                                      "styledComponentId": "sc-fBuWsC",
+                                                                      "styledComponentId": "sc-jhAzac",
                                                                       "target": [Function],
                                                                       "toString": [Function],
                                                                       "usesTheme": false,
@@ -33399,7 +33399,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                                                                       "$$typeof": Symbol(react.forward_ref),
                                                                       "attrs": Array [],
                                                                       "componentStyle": ComponentStyle {
-                                                                        "componentId": "sc-fBuWsC",
+                                                                        "componentId": "sc-jhAzac",
                                                                         "isStatic": false,
                                                                         "rules": Array [
                                                                           [Function],
@@ -33408,7 +33408,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                                                                       "displayName": "Styled(SelectOption)",
                                                                       "foldedComponentIds": Array [],
                                                                       "render": [Function],
-                                                                      "styledComponentId": "sc-fBuWsC",
+                                                                      "styledComponentId": "sc-jhAzac",
                                                                       "target": [Function],
                                                                       "toString": [Function],
                                                                       "usesTheme": false,
@@ -34311,7 +34311,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                                                                         "$$typeof": Symbol(react.forward_ref),
                                                                         "attrs": Array [],
                                                                         "componentStyle": ComponentStyle {
-                                                                          "componentId": "sc-fBuWsC",
+                                                                          "componentId": "sc-jhAzac",
                                                                           "isStatic": false,
                                                                           "rules": Array [
                                                                             [Function],
@@ -34320,7 +34320,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                                                                         "displayName": "Styled(SelectOption)",
                                                                         "foldedComponentIds": Array [],
                                                                         "render": [Function],
-                                                                        "styledComponentId": "sc-fBuWsC",
+                                                                        "styledComponentId": "sc-jhAzac",
                                                                         "target": [Function],
                                                                         "toString": [Function],
                                                                         "usesTheme": false,
@@ -34844,9 +34844,9 @@ exports[`Storyshots TimePicker with error state 1`] = `
                                                                             },
                                                                             "attrs": Array [],
                                                                             "componentStyle": ComponentStyle {
-                                                                              "componentId": "sc-jhAzac",
+                                                                              "componentId": "sc-hzDkRC",
                                                                               "isStatic": false,
-                                                                              "lastClassName": "hzvqhO",
+                                                                              "lastClassName": "jVaXaN",
                                                                               "rules": Array [
                                                                                 [Function],
                                                                                 [Function],
@@ -34868,7 +34868,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                                                                               "title": [Function],
                                                                             },
                                                                             "render": [Function],
-                                                                            "styledComponentId": "sc-jhAzac",
+                                                                            "styledComponentId": "sc-hzDkRC",
                                                                             "target": Object {
                                                                               "$$typeof": Symbol(react.forward_ref),
                                                                               "defaultProps": Object {
@@ -34900,7 +34900,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                                                                         title={null}
                                                                       >
                                                                         <ForwardRef
-                                                                          className="sc-bwzfXH sc-jhAzac hzvqhO"
+                                                                          className="sc-bwzfXH sc-hzDkRC jVaXaN"
                                                                           color="currentColor"
                                                                           focusable={false}
                                                                           icon="queryBuilder"
@@ -34909,7 +34909,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                                                                         >
                                                                           <svg
                                                                             aria-hidden={true}
-                                                                            className="sc-bwzfXH sc-jhAzac hzvqhO"
+                                                                            className="sc-bwzfXH sc-hzDkRC jVaXaN"
                                                                             color="currentColor"
                                                                             fill="currentColor"
                                                                             focusable={false}


### PR DESCRIPTION
## Description

Updates arrows from being on the right side to being on either side of the date picker to match the updated designs.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
