### PR TITLE
fix missing border on input error by passing error prop to InputField

### DIFF
--- a/components/src/Form/__snapshots__/Form.story.storyshot
+++ b/components/src/Form/__snapshots__/Form.story.storyshot
@@ -8563,7 +8563,7 @@ exports[`Storyshots Form Demo form 1`] = `
                                     <ForwardRef
                                       defaultValue="WS2SB6"
                                       disabled={false}
-                                      error={false}
+                                      error={true}
                                       helpText={null}
                                       id="item-code"
                                       labelText="Item code"
@@ -9703,20 +9703,20 @@ exports[`Storyshots Form Demo form 1`] = `
                                                                 className="Box-sc-1qu1edy-0 eMNiba"
                                                               >
                                                                 <InputField__StyledInput
-                                                                  aria-invalid={false}
+                                                                  aria-invalid={true}
                                                                   aria-required={false}
                                                                   defaultValue="WS2SB6"
                                                                   disabled={false}
-                                                                  error={false}
+                                                                  error={true}
                                                                   id="item-code"
                                                                   required={false}
                                                                 >
                                                                   <StyledComponent
-                                                                    aria-invalid={false}
+                                                                    aria-invalid={true}
                                                                     aria-required={false}
                                                                     defaultValue="WS2SB6"
                                                                     disabled={false}
-                                                                    error={false}
+                                                                    error={true}
                                                                     forwardedComponent={
                                                                       Object {
                                                                         "$$typeof": Symbol(react.forward_ref),
@@ -9768,9 +9768,9 @@ exports[`Storyshots Form Demo form 1`] = `
                                                                     required={false}
                                                                   >
                                                                     <input
-                                                                      aria-invalid={false}
+                                                                      aria-invalid={true}
                                                                       aria-required={false}
-                                                                      className="InputField__StyledInput-sc-6cu4mg-0 iDpjn"
+                                                                      className="InputField__StyledInput-sc-6cu4mg-0 bghieQ"
                                                                       defaultValue="WS2SB6"
                                                                       disabled={false}
                                                                       id="item-code"
@@ -23725,7 +23725,7 @@ exports[`Storyshots Form Demo form 1`] = `
                                     <ForwardRef
                                       defaultValue="235432"
                                       disabled={false}
-                                      error={false}
+                                      error={true}
                                       helpText={null}
                                       id="items"
                                       labelText="Item"
@@ -24865,20 +24865,20 @@ exports[`Storyshots Form Demo form 1`] = `
                                                                 className="Box-sc-1qu1edy-0 eMNiba"
                                                               >
                                                                 <InputField__StyledInput
-                                                                  aria-invalid={false}
+                                                                  aria-invalid={true}
                                                                   aria-required={false}
                                                                   defaultValue="235432"
                                                                   disabled={false}
-                                                                  error={false}
+                                                                  error={true}
                                                                   id="items"
                                                                   required={false}
                                                                 >
                                                                   <StyledComponent
-                                                                    aria-invalid={false}
+                                                                    aria-invalid={true}
                                                                     aria-required={false}
                                                                     defaultValue="235432"
                                                                     disabled={false}
-                                                                    error={false}
+                                                                    error={true}
                                                                     forwardedComponent={
                                                                       Object {
                                                                         "$$typeof": Symbol(react.forward_ref),
@@ -24930,9 +24930,9 @@ exports[`Storyshots Form Demo form 1`] = `
                                                                     required={false}
                                                                   >
                                                                     <input
-                                                                      aria-invalid={false}
+                                                                      aria-invalid={true}
                                                                       aria-required={false}
-                                                                      className="InputField__StyledInput-sc-6cu4mg-0 iDpjn"
+                                                                      className="InputField__StyledInput-sc-6cu4mg-0 bghieQ"
                                                                       defaultValue="235432"
                                                                       disabled={false}
                                                                       id="items"

--- a/components/src/Input/Input.js
+++ b/components/src/Input/Input.js
@@ -8,7 +8,7 @@ import { InputFieldDefaultProps, InputFieldPropTypes } from "./InputField.type";
 
 const Input = forwardRef(({ errorMessage, errorList, className, ...props }, ref) => (
   <Field className={className} ref={ref}>
-    <InputField {...props} />
+    <InputField {...props} error={!!(errorMessage || errorList)} />
     <InlineValidation mt="x1" errorMessage={errorMessage} errorList={errorList} />
   </Field>
 ));

--- a/components/src/Input/__snapshots__/Input.story.storyshot
+++ b/components/src/Input/__snapshots__/Input.story.storyshot
@@ -31763,7 +31763,7 @@ exports[`Storyshots Input with error list  1`] = `
                   >
                     <ForwardRef
                       disabled={false}
-                      error={false}
+                      error={true}
                       helpText={null}
                       labelText="Label"
                       onBlur={[Function]}
@@ -32904,19 +32904,19 @@ exports[`Storyshots Input with error list  1`] = `
                                                 className="Box-sc-1qu1edy-0 eMNiba"
                                               >
                                                 <InputField__StyledInput
-                                                  aria-invalid={false}
+                                                  aria-invalid={true}
                                                   aria-required={false}
                                                   disabled={false}
-                                                  error={false}
+                                                  error={true}
                                                   onBlur={[Function]}
                                                   onChange={[Function]}
                                                   required={false}
                                                 >
                                                   <StyledComponent
-                                                    aria-invalid={false}
+                                                    aria-invalid={true}
                                                     aria-required={false}
                                                     disabled={false}
-                                                    error={false}
+                                                    error={true}
                                                     forwardedComponent={
                                                       Object {
                                                         "$$typeof": Symbol(react.forward_ref),
@@ -32924,7 +32924,7 @@ exports[`Storyshots Input with error list  1`] = `
                                                         "componentStyle": ComponentStyle {
                                                           "componentId": "InputField__StyledInput-sc-6cu4mg-0",
                                                           "isStatic": false,
-                                                          "lastClassName": "iDpjn",
+                                                          "lastClassName": "bghieQ",
                                                           "rules": Array [
                                                             "display: block;",
                                                             "flex-grow: 1;",
@@ -32969,9 +32969,9 @@ exports[`Storyshots Input with error list  1`] = `
                                                     required={false}
                                                   >
                                                     <input
-                                                      aria-invalid={false}
+                                                      aria-invalid={true}
                                                       aria-required={false}
-                                                      className="InputField__StyledInput-sc-6cu4mg-0 iDpjn"
+                                                      className="InputField__StyledInput-sc-6cu4mg-0 bghieQ"
                                                       disabled={false}
                                                       onBlur={[Function]}
                                                       onChange={[Function]}
@@ -34520,7 +34520,7 @@ exports[`Storyshots Input with error message 1`] = `
                   >
                     <ForwardRef
                       disabled={false}
-                      error={false}
+                      error={true}
                       helpText={null}
                       labelText="Label"
                       onBlur={[Function]}
@@ -35661,19 +35661,19 @@ exports[`Storyshots Input with error message 1`] = `
                                                 className="Box-sc-1qu1edy-0 eMNiba"
                                               >
                                                 <InputField__StyledInput
-                                                  aria-invalid={false}
+                                                  aria-invalid={true}
                                                   aria-required={false}
                                                   disabled={false}
-                                                  error={false}
+                                                  error={true}
                                                   onBlur={[Function]}
                                                   onChange={[Function]}
                                                   required={false}
                                                 >
                                                   <StyledComponent
-                                                    aria-invalid={false}
+                                                    aria-invalid={true}
                                                     aria-required={false}
                                                     disabled={false}
-                                                    error={false}
+                                                    error={true}
                                                     forwardedComponent={
                                                       Object {
                                                         "$$typeof": Symbol(react.forward_ref),
@@ -35681,7 +35681,7 @@ exports[`Storyshots Input with error message 1`] = `
                                                         "componentStyle": ComponentStyle {
                                                           "componentId": "InputField__StyledInput-sc-6cu4mg-0",
                                                           "isStatic": false,
-                                                          "lastClassName": "iDpjn",
+                                                          "lastClassName": "bghieQ",
                                                           "rules": Array [
                                                             "display: block;",
                                                             "flex-grow: 1;",
@@ -35726,9 +35726,9 @@ exports[`Storyshots Input with error message 1`] = `
                                                     required={false}
                                                   >
                                                     <input
-                                                      aria-invalid={false}
+                                                      aria-invalid={true}
                                                       aria-required={false}
-                                                      className="InputField__StyledInput-sc-6cu4mg-0 iDpjn"
+                                                      className="InputField__StyledInput-sc-6cu4mg-0 bghieQ"
                                                       disabled={false}
                                                       onBlur={[Function]}
                                                       onChange={[Function]}


### PR DESCRIPTION
## Description

Fixes the bug where the red border doesn't show up when the input is in the error state. I missed passing  the error prop to InputField when refactoring the input component.

Planning to release a new version after merging this so this fix is included in what we send out.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [x] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
