### PR TITLE
feat(DateRange): pick a range of dates 

### DIFF
--- a/components-e2e/cypress/integration/components/DateRange.spec.js
+++ b/components-e2e/cypress/integration/components/DateRange.spec.js
@@ -1,0 +1,39 @@
+describe("Datepicker", () => {
+  const getStartInputComponent = () => cy.get("input").eq(0);
+  const getEndInputComponent = () => cy.get("input").eq(1);
+  const getStartDate = () => cy.get(".nds-datepicker-day--start-date");
+  const getEndDate = () => cy.get(".nds-datepicker-day--end-date");
+  const getInRangeDates = () => cy.get(".nds-datepicker-day--in-range");
+
+  describe("Default", () => {
+    beforeEach(() => {
+      cy.renderFromStorybook("daterange--default-skipstoryshot");
+    });
+
+    it("shows start date in end date input", () => {
+      getEndInputComponent().click();
+      getStartDate().should("exist");
+    });
+    it("shows the end date in the start input", () => {
+      getStartInputComponent().click();
+      getEndDate().should("exist");
+    });
+    it("shows the range of dates", () => {
+      getEndInputComponent().click();
+      cy.get(".react-datepicker__day--004")
+        .first()
+        .click();
+      getStartInputComponent().click();
+      getInRangeDates().should("have.length", 4);
+      getEndInputComponent().click();
+      getInRangeDates().should("have.length", 4);
+    });
+    it("shows an error message if the start date is after the end date", () => {
+      getStartInputComponent().click();
+      cy.get(".react-datepicker__day--008")
+        .first()
+        .click();
+      cy.contains("End date is before start date");
+    });
+  });
+});

--- a/components/src/DatePicker/DatePicker.js
+++ b/components/src/DatePicker/DatePicker.js
@@ -37,7 +37,7 @@ class DatePicker extends Component {
   };
 
   render() {
-    const { dateFormat, errorMessage, errorList, inputProps, minDate, maxDate } = this.props;
+    const { dateFormat, errorMessage, errorList, inputProps, minDate, maxDate, highlightDates } = this.props;
     const { selectedDate } = this.state;
     const customInputProps = {
       ...inputProps,
@@ -58,11 +58,11 @@ class DatePicker extends Component {
           onChange={this.handleSelectedDateChange}
           customInput={customInput}
           renderCustomHeader={DatePickerHeader}
-          excludeDates={[selectedDate]}
           disabledKeyboardNavigation
           strictParsing
           minDate={minDate}
           maxDate={maxDate}
+          highlightDates={highlightDates}
         />
         <InlineValidation mt="x1" errorMessage={errorMessage} errorList={errorList} />
       </Field>
@@ -79,7 +79,8 @@ DatePicker.propTypes = {
   errorMessage: PropTypes.string,
   errorList: PropTypes.arrayOf(PropTypes.string),
   minDate: PropTypes.instanceOf(Date),
-  maxDate: PropTypes.instanceOf(Date)
+  maxDate: PropTypes.instanceOf(Date),
+  highlightDates: PropTypes.arrayOf(PropTypes.shape({}))
 };
 
 DatePicker.defaultProps = {
@@ -91,7 +92,8 @@ DatePicker.defaultProps = {
   errorMessage: undefined,
   errorList: undefined,
   minDate: undefined,
-  maxDate: undefined
+  maxDate: undefined,
+  highlightDates: undefined
 };
 
 export default DatePicker;

--- a/components/src/DatePicker/DatePickerStyles.js
+++ b/components/src/DatePicker/DatePickerStyles.js
@@ -40,8 +40,7 @@ export const DatePickerStyles = createGlobalStyle({
         display: "inline-block",
         width: theme.space.x5,
         color: theme.colors.darkGrey,
-        textAlign: "center",
-        margin: theme.space.half
+        textAlign: "center"
       }
     },
     ".react-datepicker__day": {
@@ -51,10 +50,13 @@ export const DatePickerStyles = createGlobalStyle({
       color: theme.colors.darkGrey,
       border: "2px solid transparent",
       display: "inline-block",
-      width: theme.space.x5,
       lineHeight: theme.space.x5,
       textAlign: "center",
-      margin: theme.space.half,
+      width: theme.space.x5,
+      marginRight: 0,
+      marginLeft: 0,
+      marginTop: theme.space.half,
+      marginBottom: theme.space.half,
       "&:hover": {
         backgroundColor: theme.colors.lightBlue,
         color: theme.colors.black

--- a/components/src/DatePicker/DatePickerStyles.js
+++ b/components/src/DatePicker/DatePickerStyles.js
@@ -49,6 +49,7 @@ export const DatePickerStyles = createGlobalStyle({
       fontSize: theme.fontSizes.medium,
       borderRadius: theme.radii.medium,
       color: theme.colors.darkGrey,
+      border: "1px solid transparent",
       display: "inline-block",
       width: theme.space.x5,
       lineHeight: theme.space.x5,
@@ -87,6 +88,8 @@ export const DatePickerStyles = createGlobalStyle({
     ".react-datepicker__day--selected": {
       color: theme.colors.white,
       background: theme.colors.darkBlue,
+      border: `1px solid ${theme.colors.darkBlue}`,
+      lineHeight: theme.space.x5,
       cursor: "initial",
       "&:hover": {
         color: theme.colors.white,

--- a/components/src/DatePicker/DatePickerStyles.js
+++ b/components/src/DatePicker/DatePickerStyles.js
@@ -49,7 +49,7 @@ export const DatePickerStyles = createGlobalStyle({
       fontSize: theme.fontSizes.medium,
       borderRadius: theme.radii.medium,
       color: theme.colors.darkGrey,
-      border: "1px solid transparent",
+      border: "2px solid transparent",
       display: "inline-block",
       width: theme.space.x5,
       lineHeight: theme.space.x5,
@@ -88,7 +88,7 @@ export const DatePickerStyles = createGlobalStyle({
     ".react-datepicker__day--selected": {
       color: theme.colors.white,
       background: theme.colors.darkBlue,
-      border: `1px solid ${theme.colors.darkBlue}`,
+      border: `2px solid ${theme.colors.darkBlue}`,
       lineHeight: theme.space.x5,
       cursor: "initial",
       "&:hover": {

--- a/components/src/DateRange/DateRange.js
+++ b/components/src/DateRange/DateRange.js
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
-import { isBefore } from "date-fns";
+import { isBefore, addDays, differenceInDays } from "date-fns";
 import { DatePicker } from "../DatePicker";
 import { RangeContainer } from "../RangeContainer";
 import { InputFieldPropTypes, InputFieldDefaultProps } from "../Input/InputField.type";
 import { FieldLabelDefaultProps, FieldLabelProps } from "../FieldLabel/FieldLabel.type";
+import { DateRangeStyles } from "./DateRangeStyles";
 
 const DateRange = ({
   dateFormat,
@@ -55,6 +56,25 @@ const DateRange = ({
     }
   };
 
+  const getAllDaysInRange = () => {
+    if (endDate && startDate && isBefore(startDate, endDate)) {
+      const days = Array(differenceInDays(new Date(endDate), new Date(startDate)) + 1);
+      return days.fill(0).map((_, i) => addDays(new Date(startDate), i));
+    }
+    return [];
+  };
+
+  const highlightDates = [
+    {
+      "nds-datepicker-day--start-date": [new Date(startDate)]
+    },
+    {
+      "nds-datepicker-day--end-date": [new Date(endDate)]
+    },
+    {
+      "nds-datepicker-day--in-range": getAllDaysInRange()
+    }
+  ];
   const startDateInput = (
     <DatePicker
       dateFormat={dateFormat}
@@ -64,6 +84,7 @@ const DateRange = ({
       errorMessage={startDateErrorMessage}
       minDate={minDate}
       maxDate={maxDate}
+      highlightDates={highlightDates}
     />
   );
 
@@ -76,6 +97,7 @@ const DateRange = ({
       errorMessage={endDateErrorMessage}
       minDate={minDate}
       maxDate={maxDate}
+      highlightDates={highlightDates}
     />
   );
 
@@ -84,12 +106,15 @@ const DateRange = ({
   }, [startDate, endDate]);
 
   return (
-    <RangeContainer
-      labelProps={labelProps}
-      startComponent={startDateInput}
-      endComponent={endDateInput}
-      errorMessages={!disableRangeValidation ? [rangeError, errorMessage] : [errorMessage]}
-    />
+    <>
+      <DateRangeStyles />
+      <RangeContainer
+        labelProps={labelProps}
+        startComponent={startDateInput}
+        endComponent={endDateInput}
+        errorMessages={!disableRangeValidation ? [rangeError, errorMessage] : [errorMessage]}
+      />
+    </>
   );
 };
 

--- a/components/src/DateRange/DateRange.js
+++ b/components/src/DateRange/DateRange.js
@@ -1,11 +1,11 @@
 import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
-import { isBefore, addDays, differenceInDays } from "date-fns";
+import { isBefore } from "date-fns";
 import { DatePicker } from "../DatePicker";
 import { RangeContainer } from "../RangeContainer";
 import { InputFieldPropTypes, InputFieldDefaultProps } from "../Input/InputField.type";
 import { FieldLabelDefaultProps, FieldLabelProps } from "../FieldLabel/FieldLabel.type";
-import { DateRangeStyles } from "./DateRangeStyles";
+import { DateRangeStyles, highlightDates } from "./DateRangeStyles";
 
 const DateRange = ({
   dateFormat,
@@ -56,25 +56,6 @@ const DateRange = ({
     }
   };
 
-  const getAllDaysInRange = () => {
-    if (endDate && startDate && isBefore(startDate, endDate)) {
-      const days = Array(differenceInDays(new Date(endDate), new Date(startDate)) + 1);
-      return days.fill(0).map((_, i) => addDays(new Date(startDate), i));
-    }
-    return [];
-  };
-
-  const highlightDates = [
-    {
-      "nds-datepicker-day--start-date": [new Date(startDate)]
-    },
-    {
-      "nds-datepicker-day--end-date": [new Date(endDate)]
-    },
-    {
-      "nds-datepicker-day--in-range": getAllDaysInRange()
-    }
-  ];
   const startDateInput = (
     <DatePicker
       dateFormat={dateFormat}
@@ -84,7 +65,7 @@ const DateRange = ({
       errorMessage={startDateErrorMessage}
       minDate={minDate}
       maxDate={maxDate}
-      highlightDates={highlightDates}
+      highlightDates={highlightDates(startDate, endDate)}
     />
   );
 
@@ -97,7 +78,7 @@ const DateRange = ({
       errorMessage={endDateErrorMessage}
       minDate={minDate}
       maxDate={maxDate}
-      highlightDates={highlightDates}
+      highlightDates={highlightDates(startDate, endDate)}
     />
   );
 

--- a/components/src/DateRange/DateRange.js
+++ b/components/src/DateRange/DateRange.js
@@ -1,0 +1,143 @@
+import React, { useState, useEffect } from "react";
+import PropTypes from "prop-types";
+import { isBefore } from "date-fns";
+import { DatePicker } from "../DatePicker";
+import { Text } from "../Type";
+import { Flex } from "../Flex";
+import { Box } from "../Box";
+import { InlineValidation } from "../Validation";
+import { InputFieldPropTypes, InputFieldDefaultProps } from "../Input/InputField.type";
+import { FieldLabel } from "../FieldLabel";
+import { FieldLabelDefaultProps, FieldLabelProps } from "../FieldLabel/FieldLabel.type";
+
+const DateRange = ({
+  dateFormat,
+  onRangeChange,
+  onStartDateChange,
+  onEndDateChange,
+  errorMessage,
+  startDateErrorMessage,
+  endDateErrorMessage,
+  defaultStartDate,
+  defaultEndDate,
+  endDateInputProps,
+  startDateInputProps,
+  disableRangeValidation,
+  labelProps,
+  minDate,
+  maxDate
+}) => {
+  const [startMonth, setStartMonth] = useState(defaultStartDate);
+  const [endMonth, setEndMonth] = useState(defaultEndDate);
+  const [rangeError, setRangeError] = useState();
+
+  const changeStartDateHandler = date => {
+    setStartMonth(date);
+    if (onStartDateChange) {
+      onStartDateChange(date);
+    }
+  };
+  const changeEndDateHandler = date => {
+    setEndMonth(date);
+    if (onEndDateChange) {
+      onEndDateChange(date);
+    }
+  };
+
+  const validateDateRange = () => {
+    let error;
+    if (endMonth && startMonth && isBefore(endMonth, startMonth)) {
+      error = "End date is before start Month";
+    }
+    setRangeError(error);
+    if (onRangeChange) {
+      onRangeChange({
+        startDate: startMonth,
+        endDate: endMonth,
+        error
+      });
+    }
+  };
+
+  useEffect(() => {
+    validateDateRange();
+  }, [startMonth, endMonth]);
+
+  return (
+    <>
+      <FieldLabel {...labelProps}>
+        <Box
+          display="inline-flex"
+          justifyContent="center"
+          alignItems="flex-start"
+          mb={rangeError || errorMessage ? "x1" : "x3"}
+        >
+          <DatePicker
+            dateFormat={dateFormat}
+            selected={startMonth}
+            onChange={changeStartDateHandler}
+            inputProps={startDateInputProps}
+            errorMessage={startDateErrorMessage}
+            minDate={minDate}
+            maxDate={maxDate}
+          />
+          <Flex px="x2" alignItems="center" maxHeight="38px">
+            <Text>-</Text>
+          </Flex>
+          <DatePicker
+            dateFormat={dateFormat}
+            selected={endMonth}
+            onChange={changeEndDateHandler}
+            inputProps={endDateInputProps}
+            errorMessage={endDateErrorMessage}
+            minDate={minDate}
+            maxDate={maxDate}
+          />
+        </Box>
+      </FieldLabel>
+      {!disableRangeValidation && <InlineValidation errorMessage={rangeError} />}
+      <InlineValidation errorMessage={errorMessage} />
+    </>
+  );
+};
+
+DateRange.propTypes = {
+  dateFormat: PropTypes.string,
+  onRangeChange: PropTypes.func,
+  onStartDateChange: PropTypes.func,
+  onEndDateChange: PropTypes.func,
+  endDateErrorMessage: PropTypes.string,
+  startDateErrorMessage: PropTypes.string,
+  errorMessage: PropTypes.string,
+  defaultStartDate: PropTypes.instanceOf(Date),
+  defaultEndDate: PropTypes.instanceOf(Date),
+  endDateInputProps: PropTypes.shape(InputFieldPropTypes),
+  startDateInputProps: PropTypes.shape(InputFieldPropTypes),
+  disableRangeValidation: PropTypes.bool,
+  labelProps: PropTypes.shape(FieldLabelProps),
+  minDate: PropTypes.instanceOf(Date),
+  maxDate: PropTypes.instanceOf(Date)
+};
+
+DateRange.defaultProps = {
+  dateFormat: undefined,
+  onRangeChange: null,
+  onStartDateChange: null,
+  onEndDateChange: null,
+  endDateErrorMessage: null,
+  startDateErrorMessage: null,
+  errorMessage: null,
+  defaultStartDate: null,
+  defaultEndDate: null,
+  endDateInputProps: InputFieldDefaultProps,
+  startDateInputProps: InputFieldDefaultProps,
+  disableRangeValidation: false,
+  labelProps: {
+    ...FieldLabelDefaultProps,
+    labelText: "Month Range"
+  },
+  minDate: null,
+  maxDate: null
+};
+
+export default DateRange;

--- a/components/src/DateRange/DateRange.js
+++ b/components/src/DateRange/DateRange.js
@@ -2,12 +2,8 @@ import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { isBefore } from "date-fns";
 import { DatePicker } from "../DatePicker";
-import { Text } from "../Type";
-import { Flex } from "../Flex";
-import { Box } from "../Box";
-import { InlineValidation } from "../Validation";
+import { RangeContainer } from "../RangeContainer";
 import { InputFieldPropTypes, InputFieldDefaultProps } from "../Input/InputField.type";
-import { FieldLabel } from "../FieldLabel";
 import { FieldLabelDefaultProps, FieldLabelProps } from "../FieldLabel/FieldLabel.type";
 
 const DateRange = ({
@@ -27,18 +23,18 @@ const DateRange = ({
   minDate,
   maxDate
 }) => {
-  const [startMonth, setStartMonth] = useState(defaultStartDate);
-  const [endMonth, setEndMonth] = useState(defaultEndDate);
+  const [startDate, setStartDate] = useState(defaultStartDate);
+  const [endDate, setEndDate] = useState(defaultEndDate);
   const [rangeError, setRangeError] = useState();
 
   const changeStartDateHandler = date => {
-    setStartMonth(date);
+    setStartDate(date);
     if (onStartDateChange) {
       onStartDateChange(date);
     }
   };
   const changeEndDateHandler = date => {
-    setEndMonth(date);
+    setEndDate(date);
     if (onEndDateChange) {
       onEndDateChange(date);
     }
@@ -46,58 +42,54 @@ const DateRange = ({
 
   const validateDateRange = () => {
     let error;
-    if (endMonth && startMonth && isBefore(endMonth, startMonth)) {
-      error = "End date is before start Month";
+    if (endDate && startDate && isBefore(endDate, startDate)) {
+      error = "End date is before start date";
     }
     setRangeError(error);
     if (onRangeChange) {
       onRangeChange({
-        startDate: startMonth,
-        endDate: endMonth,
+        startDate,
+        endDate,
         error
       });
     }
   };
 
+  const startDateInput = (
+    <DatePicker
+      dateFormat={dateFormat}
+      selected={startDate}
+      onChange={changeStartDateHandler}
+      inputProps={{ error: rangeError, ...startDateInputProps }}
+      errorMessage={startDateErrorMessage}
+      minDate={minDate}
+      maxDate={maxDate}
+    />
+  );
+
+  const endDateInput = (
+    <DatePicker
+      dateFormat={dateFormat}
+      selected={endDate}
+      onChange={changeEndDateHandler}
+      inputProps={endDateInputProps}
+      errorMessage={endDateErrorMessage}
+      minDate={minDate}
+      maxDate={maxDate}
+    />
+  );
+
   useEffect(() => {
     validateDateRange();
-  }, [startMonth, endMonth]);
+  }, [startDate, endDate]);
 
   return (
-    <>
-      <FieldLabel {...labelProps}>
-        <Box
-          display="inline-flex"
-          justifyContent="center"
-          alignItems="flex-start"
-          mb={rangeError || errorMessage ? "x1" : "x3"}
-        >
-          <DatePicker
-            dateFormat={dateFormat}
-            selected={startMonth}
-            onChange={changeStartDateHandler}
-            inputProps={startDateInputProps}
-            errorMessage={startDateErrorMessage}
-            minDate={minDate}
-            maxDate={maxDate}
-          />
-          <Flex px="x2" alignItems="center" maxHeight="38px">
-            <Text>-</Text>
-          </Flex>
-          <DatePicker
-            dateFormat={dateFormat}
-            selected={endMonth}
-            onChange={changeEndDateHandler}
-            inputProps={endDateInputProps}
-            errorMessage={endDateErrorMessage}
-            minDate={minDate}
-            maxDate={maxDate}
-          />
-        </Box>
-      </FieldLabel>
-      {!disableRangeValidation && <InlineValidation errorMessage={rangeError} />}
-      <InlineValidation errorMessage={errorMessage} />
-    </>
+    <RangeContainer
+      labelProps={labelProps}
+      startComponent={startDateInput}
+      endComponent={endDateInput}
+      errorMessages={!disableRangeValidation ? [rangeError, errorMessage] : [errorMessage]}
+    />
   );
 };
 
@@ -134,7 +126,7 @@ DateRange.defaultProps = {
   disableRangeValidation: false,
   labelProps: {
     ...FieldLabelDefaultProps,
-    labelText: "Month Range"
+    labelText: "Date Range"
   },
   minDate: null,
   maxDate: null

--- a/components/src/DateRange/DateRange.spec.js
+++ b/components/src/DateRange/DateRange.spec.js
@@ -1,0 +1,92 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+import MockDate from "mockdate";
+import { DateRange } from ".";
+
+describe("MonthRange", () => {
+  describe("range selection", () => {
+    beforeEach(() => {
+      const now = new Date("2020-02-01T00:00:00.000Z");
+      MockDate.set(now);
+      expect.extend({
+        toMatchDate(received, date) {
+          const pass =
+            date.getMonth() === received.getMonth() &&
+            date.getYear() === received.getYear() &&
+            date.getDay() === received.getDay();
+          if (pass) {
+            return {
+              message: () => `expected ${received} not to match ${date}`,
+              pass: true
+            };
+          } else {
+            return {
+              message: () => `expected ${received} to match ${date}`,
+              pass: false
+            };
+          }
+        }
+      });
+    });
+    afterEach(() => {
+      MockDate.reset();
+    });
+    it("returns the selected range when the range changes", () => {
+      const onRangeChange = jest.fn();
+      const { container } = render(<DateRange onRangeChange={onRangeChange} />);
+      const startDateInput = container.querySelectorAll("input")[0];
+      fireEvent.click(startDateInput);
+      fireEvent.click(container.querySelectorAll(".react-datepicker__day--001")[0]);
+      const endDateInput = container.querySelectorAll("input")[1];
+      fireEvent.click(endDateInput);
+      fireEvent.click(container.querySelectorAll(".react-datepicker__day--005")[0]);
+      const onChangeCalls = onRangeChange.mock.calls;
+      const latestCall = onChangeCalls[onChangeCalls.length - 1][0];
+      expect(latestCall.startDate).toMatchMonthAndYear(new Date("2020-02-01T00:00:00.000Z"));
+      expect(latestCall.endDate).toMatchMonthAndYear(new Date("2020-02-05T00:00:00.000Z"));
+      expect(latestCall.error).toBeUndefined();
+    });
+    it("returns the selected range with an error if the range is invalid", () => {
+      const onRangeChange = jest.fn();
+      const { container } = render(<DateRange onRangeChange={onRangeChange} />);
+      const startDateInput = container.querySelectorAll("input")[0];
+      fireEvent.click(startDateInput);
+      fireEvent.click(container.querySelectorAll(".react-datepicker__day--005")[0]);
+      const endDateInput = container.querySelectorAll("input")[1];
+      fireEvent.click(endDateInput);
+      fireEvent.click(container.querySelectorAll(".react-datepicker__day--001")[0]);
+      const onChangeCalls = onRangeChange.mock.calls;
+      const latestCall = onChangeCalls[onChangeCalls.length - 1][0];
+      expect(latestCall.startDate).toMatchMonthAndYear(new Date("2020-02-01T00:00:00.000Z"));
+      expect(latestCall.endDate).toMatchMonthAndYear(new Date("2020-02-05T00:00:00.000Z"));
+      expect(latestCall.error).toEqual("End date is before start date");
+    });
+    it("returns the start date when the start date changes", () => {
+      const onStartDateChange = jest.fn();
+      const onEndDateChange = jest.fn();
+      const { container } = render(
+        <DateRange onStartDateChange={onStartDateChange} onEndDateChange={onEndDateChange} />
+      );
+      const startDateInput = container.querySelectorAll("input")[0];
+      fireEvent.click(startDateInput);
+      fireEvent.click(container.querySelectorAll(".react-datepicker__day--001")[0]);
+      const onChangeCalls = onStartDateChange.mock.calls;
+      const latestCall = onChangeCalls[onChangeCalls.length - 1][0];
+      expect(latestCall).toMatchMonthAndYear(new Date("2020-02-01T00:00:00.000Z"));
+      expect(onEndDateChange).not.toHaveBeenCalled();
+    });
+    it("returns the end date when the end date changes", () => {
+      const onStartDateChange = jest.fn();
+      const onEndDateChange = jest.fn();
+      const { container } = render(
+        <DateRange onStartDateChange={onStartDateChange} onEndDateChange={onEndDateChange} />
+      );
+      const endDateInput = container.querySelectorAll("input")[1];
+      fireEvent.click(endDateInput);
+      fireEvent.click(container.querySelectorAll(".react-datepicker__day--005")[0]);
+      const latestCall = onEndDateChange.mock.calls[0][0];
+      expect(latestCall).toMatchMonthAndYear(new Date("2020-02-05T00:00:00.000Z"));
+      expect(onStartDateChange).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/components/src/DateRange/DateRange.spec.js
+++ b/components/src/DateRange/DateRange.spec.js
@@ -1,83 +1,20 @@
-/* eslint-disable no-global-assign */
 import React from "react";
 import { render, fireEvent } from "@testing-library/react";
-import MockDate from "mockdate";
 import { DateRange } from ".";
+import { resetDate, mockDate } from "../testing/mockUtils/mockDates";
+import "../testing/matchers/toMatchDate";
 
 describe("DateRange", () => {
   describe("range selection", () => {
-    const now = new Date("2020-02-01T00:00:00.000Z");
-    let _Date = null;
     beforeEach(() => {
-      MockDate.set(now);
-
-      function replaceDate() {
-        if (_Date) {
-          return;
-        }
-
-        _Date = Date;
-
-        // eslint-disable-next-line func-names
-        Object.getOwnPropertyNames(Date).forEach(function(name) {
-          _Date[name] = Date[name];
-        });
-
-        // set Date ctor to always return same date
-        // eslint-disable-next-line func-names
-        // eslint-disable-next-line no-global-assign
-        // eslint-disable-next-line func-names
-        Date = function() {
-          return new _Date("2020-02-01T00:00:00.000Z");
-        };
-
-        // eslint-disable-next-line func-names
-        Object.getOwnPropertyNames(_Date).forEach(function(name) {
-          Date[name] = _Date[name];
-        });
-      }
-      replaceDate();
-      expect.extend({
-        toMatchDate(received, date) {
-          const pass =
-            date.getMonth() === received.getMonth() &&
-            date.getYear() === received.getYear() &&
-            date.getDay() === received.getDay();
-          if (pass) {
-            return {
-              message: () => `expected ${received} not to match ${date}`,
-              pass: true
-            };
-          } else {
-            return {
-              message: () => `expected ${received} to match ${date}`,
-              pass: false
-            };
-          }
-        }
-      });
+      mockDate("2020-02-01T11:01:58.135Z");
     });
     afterEach(() => {
-      function repairDate() {
-        if (_Date === null) {
-          return;
-        }
-
-        // eslint-disable-next-line no-global-assign
-        Date = _Date;
-        // eslint-disable-next-line func-names
-        Object.getOwnPropertyNames(_Date).forEach(function(name) {
-          Date[name] = _Date[name];
-        });
-
-        _Date = null;
-      }
-      repairDate();
-      MockDate.reset();
+      resetDate();
     });
     it("returns the selected range when the range changes", () => {
       const onRangeChange = jest.fn();
-      const { container } = render(<DateRange onRangeChange={onRangeChange} defaultStartDate={now} />);
+      const { container } = render(<DateRange onRangeChange={onRangeChange} />);
       const startDateInput = container.querySelectorAll("input")[0];
       fireEvent.click(startDateInput);
       fireEvent.click(container.querySelectorAll(".react-datepicker__day--001")[0]);
@@ -86,13 +23,13 @@ describe("DateRange", () => {
       fireEvent.click(container.querySelectorAll(".react-datepicker__day--005")[0]);
       const onChangeCalls = onRangeChange.mock.calls;
       const latestCall = onChangeCalls[onChangeCalls.length - 1][0];
-      expect(latestCall.startDate).toMatchDate(new Date("Wed, 01 Jan 2020"));
-      expect(latestCall.endDate).toMatchDate(new Date("2020-02-05T00:00:00.000Z"));
+      expect(latestCall.startDate).toMatchDate(new Date("2020-02-01T11:01:58.135Z"));
+      expect(latestCall.endDate).toMatchDate(new Date("2020-02-05T11:01:58.135Z"));
       expect(latestCall.error).toBeUndefined();
     });
     it("returns the selected range with an error if the range is invalid", () => {
       const onRangeChange = jest.fn();
-      const { container } = render(<DateRange onRangeChange={onRangeChange} defaultStartDate={now} />);
+      const { container } = render(<DateRange onRangeChange={onRangeChange} />);
       const startDateInput = container.querySelectorAll("input")[0];
       fireEvent.click(startDateInput);
       fireEvent.click(container.querySelectorAll(".react-datepicker__day--005")[0]);
@@ -101,35 +38,35 @@ describe("DateRange", () => {
       fireEvent.click(container.querySelectorAll(".react-datepicker__day--001")[0]);
       const onChangeCalls = onRangeChange.mock.calls;
       const latestCall = onChangeCalls[onChangeCalls.length - 1][0];
-      expect(latestCall.startDate).toMatchDate(new Date("2020-02-01T00:00:00.000Z"));
-      expect(latestCall.endDate).toMatchDate(new Date("2020-02-05T00:00:00.000Z"));
+      expect(latestCall.startDate).toMatchDate(new Date("2020-02-05T11:01:58.135Z"));
+      expect(latestCall.endDate).toMatchDate(new Date("2020-02-01T11:01:58.135Z"));
       expect(latestCall.error).toEqual("End date is before start date");
     });
     it("returns the start date when the start date changes", () => {
       const onStartDateChange = jest.fn();
       const onEndDateChange = jest.fn();
       const { container } = render(
-        <DateRange onStartDateChange={onStartDateChange} onEndDateChange={onEndDateChange} defaultStartDate={now} />
+        <DateRange onStartDateChange={onStartDateChange} onEndDateChange={onEndDateChange} />
       );
       const startDateInput = container.querySelectorAll("input")[0];
       fireEvent.click(startDateInput);
       fireEvent.click(container.querySelectorAll(".react-datepicker__day--001")[0]);
       const onChangeCalls = onStartDateChange.mock.calls;
       const latestCall = onChangeCalls[onChangeCalls.length - 1][0];
-      expect(latestCall).toMatchDate(new Date("2020-02-01T00:00:00.000Z"));
+      expect(latestCall).toMatchDate(new Date("2020-02-01T11:01:58.135Z"));
       expect(onEndDateChange).not.toHaveBeenCalled();
     });
     it("returns the end date when the end date changes", () => {
       const onStartDateChange = jest.fn();
       const onEndDateChange = jest.fn();
       const { container } = render(
-        <DateRange onStartDateChange={onStartDateChange} onEndDateChange={onEndDateChange} defaultStartDate={now} />
+        <DateRange onStartDateChange={onStartDateChange} onEndDateChange={onEndDateChange} />
       );
       const endDateInput = container.querySelectorAll("input")[1];
       fireEvent.click(endDateInput);
       fireEvent.click(container.querySelectorAll(".react-datepicker__day--005")[0]);
       const latestCall = onEndDateChange.mock.calls[0][0];
-      expect(latestCall).toMatchDate(new Date("2020-02-05T00:00:00.000Z"));
+      expect(latestCall).toMatchDate(new Date("2020-02-05T11:01:58.135Z"));
       expect(onStartDateChange).not.toHaveBeenCalled();
     });
   });

--- a/components/src/DateRange/DateRange.spec.js
+++ b/components/src/DateRange/DateRange.spec.js
@@ -1,13 +1,42 @@
+/* eslint-disable no-global-assign */
 import React from "react";
 import { render, fireEvent } from "@testing-library/react";
 import MockDate from "mockdate";
 import { DateRange } from ".";
 
-describe("MonthRange", () => {
+describe("DateRange", () => {
   describe("range selection", () => {
+    const now = new Date("2020-02-01T00:00:00.000Z");
+    let _Date = null;
     beforeEach(() => {
-      const now = new Date("2020-02-01T00:00:00.000Z");
       MockDate.set(now);
+
+      function replaceDate() {
+        if (_Date) {
+          return;
+        }
+
+        _Date = Date;
+
+        // eslint-disable-next-line func-names
+        Object.getOwnPropertyNames(Date).forEach(function(name) {
+          _Date[name] = Date[name];
+        });
+
+        // set Date ctor to always return same date
+        // eslint-disable-next-line func-names
+        // eslint-disable-next-line no-global-assign
+        // eslint-disable-next-line func-names
+        Date = function() {
+          return new _Date("2020-02-01T00:00:00.000Z");
+        };
+
+        // eslint-disable-next-line func-names
+        Object.getOwnPropertyNames(_Date).forEach(function(name) {
+          Date[name] = _Date[name];
+        });
+      }
+      replaceDate();
       expect.extend({
         toMatchDate(received, date) {
           const pass =
@@ -29,11 +58,26 @@ describe("MonthRange", () => {
       });
     });
     afterEach(() => {
+      function repairDate() {
+        if (_Date === null) {
+          return;
+        }
+
+        // eslint-disable-next-line no-global-assign
+        Date = _Date;
+        // eslint-disable-next-line func-names
+        Object.getOwnPropertyNames(_Date).forEach(function(name) {
+          Date[name] = _Date[name];
+        });
+
+        _Date = null;
+      }
+      repairDate();
       MockDate.reset();
     });
     it("returns the selected range when the range changes", () => {
       const onRangeChange = jest.fn();
-      const { container } = render(<DateRange onRangeChange={onRangeChange} />);
+      const { container } = render(<DateRange onRangeChange={onRangeChange} defaultStartDate={now} />);
       const startDateInput = container.querySelectorAll("input")[0];
       fireEvent.click(startDateInput);
       fireEvent.click(container.querySelectorAll(".react-datepicker__day--001")[0]);
@@ -42,13 +86,13 @@ describe("MonthRange", () => {
       fireEvent.click(container.querySelectorAll(".react-datepicker__day--005")[0]);
       const onChangeCalls = onRangeChange.mock.calls;
       const latestCall = onChangeCalls[onChangeCalls.length - 1][0];
-      expect(latestCall.startDate).toMatchMonthAndYear(new Date("2020-02-01T00:00:00.000Z"));
-      expect(latestCall.endDate).toMatchMonthAndYear(new Date("2020-02-05T00:00:00.000Z"));
+      expect(latestCall.startDate).toMatchDate(new Date("Wed, 01 Jan 2020"));
+      expect(latestCall.endDate).toMatchDate(new Date("2020-02-05T00:00:00.000Z"));
       expect(latestCall.error).toBeUndefined();
     });
     it("returns the selected range with an error if the range is invalid", () => {
       const onRangeChange = jest.fn();
-      const { container } = render(<DateRange onRangeChange={onRangeChange} />);
+      const { container } = render(<DateRange onRangeChange={onRangeChange} defaultStartDate={now} />);
       const startDateInput = container.querySelectorAll("input")[0];
       fireEvent.click(startDateInput);
       fireEvent.click(container.querySelectorAll(".react-datepicker__day--005")[0]);
@@ -57,35 +101,35 @@ describe("MonthRange", () => {
       fireEvent.click(container.querySelectorAll(".react-datepicker__day--001")[0]);
       const onChangeCalls = onRangeChange.mock.calls;
       const latestCall = onChangeCalls[onChangeCalls.length - 1][0];
-      expect(latestCall.startDate).toMatchMonthAndYear(new Date("2020-02-01T00:00:00.000Z"));
-      expect(latestCall.endDate).toMatchMonthAndYear(new Date("2020-02-05T00:00:00.000Z"));
+      expect(latestCall.startDate).toMatchDate(new Date("2020-02-01T00:00:00.000Z"));
+      expect(latestCall.endDate).toMatchDate(new Date("2020-02-05T00:00:00.000Z"));
       expect(latestCall.error).toEqual("End date is before start date");
     });
     it("returns the start date when the start date changes", () => {
       const onStartDateChange = jest.fn();
       const onEndDateChange = jest.fn();
       const { container } = render(
-        <DateRange onStartDateChange={onStartDateChange} onEndDateChange={onEndDateChange} />
+        <DateRange onStartDateChange={onStartDateChange} onEndDateChange={onEndDateChange} defaultStartDate={now} />
       );
       const startDateInput = container.querySelectorAll("input")[0];
       fireEvent.click(startDateInput);
       fireEvent.click(container.querySelectorAll(".react-datepicker__day--001")[0]);
       const onChangeCalls = onStartDateChange.mock.calls;
       const latestCall = onChangeCalls[onChangeCalls.length - 1][0];
-      expect(latestCall).toMatchMonthAndYear(new Date("2020-02-01T00:00:00.000Z"));
+      expect(latestCall).toMatchDate(new Date("2020-02-01T00:00:00.000Z"));
       expect(onEndDateChange).not.toHaveBeenCalled();
     });
     it("returns the end date when the end date changes", () => {
       const onStartDateChange = jest.fn();
       const onEndDateChange = jest.fn();
       const { container } = render(
-        <DateRange onStartDateChange={onStartDateChange} onEndDateChange={onEndDateChange} />
+        <DateRange onStartDateChange={onStartDateChange} onEndDateChange={onEndDateChange} defaultStartDate={now} />
       );
       const endDateInput = container.querySelectorAll("input")[1];
       fireEvent.click(endDateInput);
       fireEvent.click(container.querySelectorAll(".react-datepicker__day--005")[0]);
       const latestCall = onEndDateChange.mock.calls[0][0];
-      expect(latestCall).toMatchMonthAndYear(new Date("2020-02-05T00:00:00.000Z"));
+      expect(latestCall).toMatchDate(new Date("2020-02-05T00:00:00.000Z"));
       expect(onStartDateChange).not.toHaveBeenCalled();
     });
   });

--- a/components/src/DateRange/DateRange.story.js
+++ b/components/src/DateRange/DateRange.story.js
@@ -1,0 +1,62 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+
+import DateRange from "./DateRange";
+
+storiesOf("DateRange", module)
+  .add("default (SkipStoryshot)", () => (
+    <DateRange
+      onRangeChange={action("range changed")}
+      onStartDateChange={action("start date changed")}
+      onEndDateChange={action("end date changed")}
+    />
+  ))
+  .add("default start and end date (SkipStoryshot)", () => (
+    <DateRange
+      defaultStartDate={new Date("2019-07-05T05:00:00.000Z")}
+      defaultEndDate={new Date("2019-09-10T05:00:00.000Z")}
+      onRangeChange={action("range changed")}
+      onStartDateChange={action("start date changed")}
+      onEndDateChange={action("end date changed")}
+    />
+  ))
+  .add("disabled range validation (SkipStoryshot)", () => (
+    <DateRange
+      disableRangeValidation
+      defaultEndDate={new Date("2019-07-05T05:00:00.000Z")}
+      defaultStartDate={new Date("2019-09-10T05:00:00.000Z")}
+      onRangeChange={action("range changed")}
+      onStartDateChange={action("start date changed")}
+      onEndDateChange={action("end date changed")}
+    />
+  ))
+  .add("with custom error (SkipStoryshot)", () => (
+    <DateRange
+      errorMessage="This range conflicts with another range"
+      defaultStartDate={new Date("2019-07-05T05:00:00.000Z")}
+      defaultEndDate={new Date("2019-09-10T05:00:00.000Z")}
+      onRangeChange={action("range changed")}
+      onStartDateChange={action("start date changed")}
+      onEndDateChange={action("end date changed")}
+    />
+  ))
+  .add("customizing input props (SkipStoryshot)", () => (
+    <DateRange
+      startDateInputProps={{ placeholder: "From (Mon YYYY)" }}
+      endDateInputProps={{ placeholder: "To (Mon YYYY)" }}
+      onRangeChange={action("range changed")}
+      onStartDateChange={action("start date changed")}
+      onEndDateChange={action("end date changed")}
+    />
+  ))
+  .add("individual input error (SkipStoryshot)", () => (
+    <DateRange
+      startDateErrorMessage="Start date is required"
+      startDateInputProps={{ required: true }}
+      defaultEndDate={new Date("2019-09-10T05:00:00.000Z")}
+      onRangeChange={action("range changed")}
+      onStartDateChange={action("start date changed")}
+      onEndDateChange={action("end date changed")}
+    />
+  ));

--- a/components/src/DateRange/DateRangeStyles.js
+++ b/components/src/DateRange/DateRangeStyles.js
@@ -1,14 +1,41 @@
 import { createGlobalStyle } from "styled-components";
+import { isBefore, addDays, differenceInDays } from "date-fns";
+
 import theme from "../theme";
+
+const START_DATE_CLASS = "nds-datepicker-day--start-date";
+const END_DATE_CLASS = "nds-datepicker-day--end-date";
+const IN_RANGE_CLASS = "nds-datepicker-day--in-range";
+
+const getAllDaysInRange = (startDate, endDate) => {
+  if (endDate && startDate && isBefore(startDate, endDate)) {
+    const days = Array(differenceInDays(new Date(endDate), new Date(startDate)) + 1);
+    return days.fill(0).map((_, i) => addDays(new Date(startDate), i));
+  }
+  return [];
+};
+
+export const highlightDates = (startDate, endDate) => {
+  return [
+    {
+      [START_DATE_CLASS]: [new Date(startDate)]
+    },
+    {
+      [END_DATE_CLASS]: [new Date(endDate)]
+    },
+    {
+      [IN_RANGE_CLASS]: getAllDaysInRange(startDate, endDate)
+    }
+  ];
+};
 
 export const DateRangeStyles = createGlobalStyle({
   ".nds-date-picker": {
-    ".react-datepicker__day.nds-datepicker-day--in-range": {
+    [`.react-datepicker__day.${IN_RANGE_CLASS}`]: {
       backgroundColor: theme.colors.whiteGrey,
-      color: theme.colors.black,
-      borderRadius: 0
+      color: theme.colors.black
     },
-    ".react-datepicker__day.nds-datepicker-day--start-date,  .react-datepicker__day.nds-datepicker-day--end-date": {
+    [`.react-datepicker__day.${START_DATE_CLASS},  .react-datepicker__day.${END_DATE_CLASS}`]: {
       color: theme.colors.white,
       background: theme.colors.darkBlue,
       borderRadius: theme.radii.medium,

--- a/components/src/DateRange/DateRangeStyles.js
+++ b/components/src/DateRange/DateRangeStyles.js
@@ -4,11 +4,8 @@ import theme from "../theme";
 export const DateRangeStyles = createGlobalStyle({
   ".nds-date-picker": {
     ".react-datepicker__day.nds-datepicker-day--in-range": {
-      backgroundColor: theme.colors.lightBlue,
+      backgroundColor: theme.colors.whiteGrey,
       color: theme.colors.black,
-      width: "48px",
-      marginRight: 0,
-      marginLeft: 0,
       borderRadius: 0
     },
     ".react-datepicker__day.nds-datepicker-day--start-date,  .react-datepicker__day.nds-datepicker-day--end-date": {

--- a/components/src/DateRange/DateRangeStyles.js
+++ b/components/src/DateRange/DateRangeStyles.js
@@ -1,0 +1,25 @@
+import { createGlobalStyle } from "styled-components";
+import theme from "../theme";
+
+export const DateRangeStyles = createGlobalStyle({
+  ".nds-date-picker": {
+    ".react-datepicker__day.nds-datepicker-day--in-range": {
+      backgroundColor: theme.colors.lightBlue,
+      color: theme.colors.black,
+      width: "48px",
+      marginRight: 0,
+      marginLeft: 0,
+      borderRadius: 0
+    },
+    ".react-datepicker__day.nds-datepicker-day--start-date,  .react-datepicker__day.nds-datepicker-day--end-date": {
+      color: theme.colors.white,
+      background: theme.colors.darkBlue,
+      borderRadius: theme.radii.medium,
+      cursor: "initial",
+      "&:hover": {
+        color: theme.colors.white,
+        background: theme.colors.darkBlue
+      }
+    }
+  }
+});

--- a/components/src/DateRange/index.js
+++ b/components/src/DateRange/index.js
@@ -1,0 +1,1 @@
+export { default as DateRange } from "./DateRange";

--- a/components/src/MonthRange/MonthRange.js
+++ b/components/src/MonthRange/MonthRange.js
@@ -2,12 +2,8 @@ import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { isBefore } from "date-fns";
 import { MonthPicker } from "../MonthPicker";
-import { Text } from "../Type";
-import { Flex } from "../Flex";
-import { Box } from "../Box";
-import { InlineValidation } from "../Validation";
 import { InputFieldPropTypes, InputFieldDefaultProps } from "../Input/InputField.type";
-import { FieldLabel } from "../FieldLabel";
+import { RangeContainer } from "../RangeContainer";
 import { FieldLabelDefaultProps, FieldLabelProps } from "../FieldLabel/FieldLabel.type";
 
 const MonthRange = ({
@@ -59,45 +55,41 @@ const MonthRange = ({
     }
   };
 
+  const startDateInput = (
+    <MonthPicker
+      dateFormat={dateFormat}
+      selected={startMonth}
+      onChange={changeStartDateHandler}
+      inputProps={startDateInputProps}
+      errorMessage={startDateErrorMessage}
+      minDate={minDate}
+      maxDate={maxDate}
+    />
+  );
+
+  const endDateInput = (
+    <MonthPicker
+      dateFormat={dateFormat}
+      selected={endMonth}
+      onChange={changeEndDateHandler}
+      inputProps={endDateInputProps}
+      errorMessage={endDateErrorMessage}
+      minDate={minDate}
+      maxDate={maxDate}
+    />
+  );
+
   useEffect(() => {
     validateDateRange();
   }, [startMonth, endMonth]);
 
   return (
-    <>
-      <FieldLabel {...labelProps}>
-        <Box
-          display="inline-flex"
-          justifyContent="center"
-          alignItems="flex-start"
-          mb={rangeError || errorMessage ? "x1" : "x3"}
-        >
-          <MonthPicker
-            dateFormat={dateFormat}
-            selected={startMonth}
-            onChange={changeStartDateHandler}
-            inputProps={startDateInputProps}
-            errorMessage={startDateErrorMessage}
-            minDate={minDate}
-            maxDate={maxDate}
-          />
-          <Flex px="x2" alignItems="center" maxHeight="38px">
-            <Text>-</Text>
-          </Flex>
-          <MonthPicker
-            dateFormat={dateFormat}
-            selected={endMonth}
-            onChange={changeEndDateHandler}
-            inputProps={endDateInputProps}
-            errorMessage={endDateErrorMessage}
-            minDate={minDate}
-            maxDate={maxDate}
-          />
-        </Box>
-      </FieldLabel>
-      {!disableRangeValidation && <InlineValidation errorMessage={rangeError} />}
-      <InlineValidation errorMessage={errorMessage} />
-    </>
+    <RangeContainer
+      labelProps={labelProps}
+      startComponent={startDateInput}
+      endComponent={endDateInput}
+      errorMessages={!disableRangeValidation ? [rangeError, errorMessage] : [errorMessage]}
+    />
   );
 };
 

--- a/components/src/MonthRange/MonthRange.spec.js
+++ b/components/src/MonthRange/MonthRange.spec.js
@@ -1,32 +1,16 @@
 import React from "react";
 import { render, fireEvent } from "@testing-library/react";
-import MockDate from "mockdate";
 import { MonthRange } from ".";
+import { resetDate, mockDate } from "../testing/mockUtils/mockDates";
+import "../testing/matchers/toMatchDate";
 
 describe("MonthRange", () => {
   describe("range selection", () => {
     beforeEach(() => {
-      const now = new Date("2020-02-01T00:00:00.000Z");
-      MockDate.set(now);
-      expect.extend({
-        toMatchMonthAndYear(received, date) {
-          const pass = date.getMonth() === received.getMonth() && date.getYear() === received.getYear();
-          if (pass) {
-            return {
-              message: () => `expected ${received} not to match month and year of ${date}`,
-              pass: true
-            };
-          } else {
-            return {
-              message: () => `expected ${received} to match month and year of ${date}`,
-              pass: false
-            };
-          }
-        }
-      });
+      mockDate("2020-02-01T11:01:58.135Z");
     });
     afterEach(() => {
-      MockDate.reset();
+      resetDate();
     });
     test("returns the selected range when the range changes", () => {
       const onRangeChange = jest.fn();
@@ -39,8 +23,8 @@ describe("MonthRange", () => {
       fireEvent.click(container.querySelectorAll(".react-datepicker__month-5")[0]);
       const onChangeCalls = onRangeChange.mock.calls;
       const latestCall = onChangeCalls[onChangeCalls.length - 1][0];
-      expect(latestCall.startDate).toMatchMonthAndYear(new Date("2020-04-01T04:00:00.000Z"));
-      expect(latestCall.endDate).toMatchMonthAndYear(new Date("2020-06-01T04:00:00.000Z"));
+      expect(latestCall.startDate).toMatchDate(new Date("2020-04-01T04:00:00.000Z"));
+      expect(latestCall.endDate).toMatchDate(new Date("2020-06-01T04:00:00.000Z"));
       expect(latestCall.error).toBeUndefined();
     });
     it("returns the selected range with an error if the range is invalid", () => {
@@ -54,8 +38,8 @@ describe("MonthRange", () => {
       fireEvent.click(container.querySelectorAll(".react-datepicker__month-3")[0]);
       const onChangeCalls = onRangeChange.mock.calls;
       const latestCall = onChangeCalls[onChangeCalls.length - 1][0];
-      expect(latestCall.startDate).toMatchMonthAndYear(new Date("2020-06-01T04:00:00.000Z"));
-      expect(latestCall.endDate).toMatchMonthAndYear(new Date("2020-04-01T04:00:00.000Z"));
+      expect(latestCall.startDate).toMatchDate(new Date("2020-06-01T04:00:00.000Z"));
+      expect(latestCall.endDate).toMatchDate(new Date("2020-04-01T04:00:00.000Z"));
       expect(latestCall.error).toEqual("End date is before start Month");
     });
     it("returns the start date when the start date changes", () => {
@@ -69,7 +53,7 @@ describe("MonthRange", () => {
       fireEvent.click(container.querySelectorAll(".react-datepicker__month-3")[0]);
       const onChangeCalls = onStartDateChange.mock.calls;
       const latestCall = onChangeCalls[onChangeCalls.length - 1][0];
-      expect(latestCall).toMatchMonthAndYear(new Date("2020-04-01T04:00:00.000Z"));
+      expect(latestCall).toMatchDate(new Date("2020-04-01T04:00:00.000Z"));
       expect(onEndDateChange).not.toHaveBeenCalled();
     });
     it("returns the end date when the end date changes", () => {
@@ -82,7 +66,7 @@ describe("MonthRange", () => {
       fireEvent.click(endDateInput);
       fireEvent.click(container.querySelectorAll(".react-datepicker__month-10")[0]);
       const latestCall = onEndDateChange.mock.calls[0][0];
-      expect(latestCall).toMatchMonthAndYear(new Date("2020-11-01T04:00:00.000Z"));
+      expect(latestCall).toMatchDate(new Date("2020-11-01T04:00:00.000Z"));
       expect(onStartDateChange).not.toHaveBeenCalled();
     });
   });

--- a/components/src/RangeContainer/RangeContainer.js
+++ b/components/src/RangeContainer/RangeContainer.js
@@ -11,7 +11,13 @@ import { InlineValidation } from "../Validation";
 const RangeContainer = ({ labelProps, startComponent, endComponent, errorMessages, ...props }) => (
   <>
     <FieldLabel {...labelProps} {...props} />
-    <Box display="inline-flex" justifyContent="center" alignItems="flex-start" mb={errorMessages.length ? "x1" : "x3"}>
+    <Box
+      display="inline-flex"
+      justifyContent="center"
+      alignItems="flex-start"
+      mt="x1"
+      mb={errorMessages.length ? "x1" : "x3"}
+    >
       {startComponent}
       <Flex px="x2" alignItems="center" maxHeight="38px">
         <Text>-</Text>

--- a/components/src/RangeContainer/RangeContainer.js
+++ b/components/src/RangeContainer/RangeContainer.js
@@ -1,0 +1,49 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import { Text } from "../Type";
+import { Flex } from "../Flex";
+import { Box } from "../Box";
+import { FieldLabel } from "../FieldLabel";
+import { FieldLabelDefaultProps, FieldLabelProps } from "../FieldLabel/FieldLabel.type";
+import { InlineValidation } from "../Validation";
+
+const RangeContainer = ({ labelProps, startComponent, endComponent, errorMessages, ...props }) => (
+  <>
+    <FieldLabel {...labelProps} {...props}>
+      <Box
+        display="inline-flex"
+        justifyContent="center"
+        alignItems="flex-start"
+        mb={errorMessages.length ? "x1" : "x3"}
+      >
+        {startComponent}
+        <Flex px="x2" alignItems="center" maxHeight="38px">
+          <Text>-</Text>
+        </Flex>
+        {endComponent}
+      </Box>
+    </FieldLabel>
+    {errorMessages.map(errorMessage => (
+      <InlineValidation errorMessage={errorMessage} />
+    ))}
+  </>
+);
+
+RangeContainer.propTypes = {
+  labelProps: PropTypes.shape(FieldLabelProps),
+  startComponent: PropTypes.node,
+  endComponent: PropTypes.node,
+  errorMessages: PropTypes.arrayOf(PropTypes.string)
+};
+
+RangeContainer.defaultProps = {
+  labelProps: {
+    ...FieldLabelDefaultProps,
+    labelText: "Range"
+  },
+  startComponent: null,
+  endComponent: null,
+  errorMessages: []
+};
+export default RangeContainer;

--- a/components/src/RangeContainer/RangeContainer.js
+++ b/components/src/RangeContainer/RangeContainer.js
@@ -24,8 +24,9 @@ const RangeContainer = ({ labelProps, startComponent, endComponent, errorMessage
         {endComponent}
       </Box>
     </FieldLabel>
-    {errorMessages.map(errorMessage => (
-      <InlineValidation key={errorMessage} errorMessage={errorMessage} />
+    {errorMessages.map((errorMessage, i) => (
+      // eslint-disable-next-line react/no-array-index-key
+      <InlineValidation key={i} errorMessage={errorMessage} />
     ))}
   </>
 );

--- a/components/src/RangeContainer/RangeContainer.js
+++ b/components/src/RangeContainer/RangeContainer.js
@@ -10,20 +10,14 @@ import { InlineValidation } from "../Validation";
 
 const RangeContainer = ({ labelProps, startComponent, endComponent, errorMessages, ...props }) => (
   <>
-    <FieldLabel {...labelProps} {...props}>
-      <Box
-        display="inline-flex"
-        justifyContent="center"
-        alignItems="flex-start"
-        mb={errorMessages.length ? "x1" : "x3"}
-      >
-        {startComponent}
-        <Flex px="x2" alignItems="center" maxHeight="38px">
-          <Text>-</Text>
-        </Flex>
-        {endComponent}
-      </Box>
-    </FieldLabel>
+    <FieldLabel {...labelProps} {...props} />
+    <Box display="inline-flex" justifyContent="center" alignItems="flex-start" mb={errorMessages.length ? "x1" : "x3"}>
+      {startComponent}
+      <Flex px="x2" alignItems="center" maxHeight="38px">
+        <Text>-</Text>
+      </Flex>
+      {endComponent}
+    </Box>
     {errorMessages.map((errorMessage, i) => (
       // eslint-disable-next-line react/no-array-index-key
       <InlineValidation key={i} errorMessage={errorMessage} />

--- a/components/src/RangeContainer/RangeContainer.js
+++ b/components/src/RangeContainer/RangeContainer.js
@@ -25,7 +25,7 @@ const RangeContainer = ({ labelProps, startComponent, endComponent, errorMessage
       </Box>
     </FieldLabel>
     {errorMessages.map(errorMessage => (
-      <InlineValidation errorMessage={errorMessage} />
+      <InlineValidation key={errorMessage} errorMessage={errorMessage} />
     ))}
   </>
 );

--- a/components/src/RangeContainer/RangeContainer.story.js
+++ b/components/src/RangeContainer/RangeContainer.story.js
@@ -1,0 +1,5 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { RangeContainer } from ".";
+
+storiesOf("RangeContainer", module).add("RangeContainer", () => <RangeContainer>Example</RangeContainer>);

--- a/components/src/RangeContainer/__snapshots__/RangeContainer.story.storyshot
+++ b/components/src/RangeContainer/__snapshots__/RangeContainer.story.storyshot
@@ -681,7 +681,7 @@ exports[`Storyshots RangeContainer RangeContainer 1`] = `
                                   "componentStyle": ComponentStyle {
                                     "componentId": "Box-sc-1qu1edy-0",
                                     "isStatic": false,
-                                    "lastClassName": "bhFymm",
+                                    "lastClassName": "gtQyvp",
                                     "rules": Array [
                                       [Function],
                                       [Function],
@@ -867,6 +867,7 @@ exports[`Storyshots RangeContainer RangeContainer 1`] = `
                 display="inline-flex"
                 justifyContent="center"
                 mb="x3"
+                mt="x1"
                 theme={
                   Object {
                     "borders": Array [],
@@ -1050,7 +1051,7 @@ exports[`Storyshots RangeContainer RangeContainer 1`] = `
                       "componentStyle": ComponentStyle {
                         "componentId": "Box-sc-1qu1edy-0",
                         "isStatic": false,
-                        "lastClassName": "bhFymm",
+                        "lastClassName": "gtQyvp",
                         "rules": Array [
                           [Function],
                           [Function],
@@ -1121,6 +1122,7 @@ exports[`Storyshots RangeContainer RangeContainer 1`] = `
                   forwardedRef={null}
                   justifyContent="center"
                   mb="x3"
+                  mt="x1"
                   theme={
                     Object {
                       "borders": Array [],
@@ -1209,7 +1211,7 @@ exports[`Storyshots RangeContainer RangeContainer 1`] = `
                   }
                 >
                   <div
-                    className="Box-sc-1qu1edy-0 bhFymm"
+                    className="Box-sc-1qu1edy-0 gtQyvp"
                     display="inline-flex"
                   >
                     <Styled(Box)

--- a/components/src/RangeContainer/__snapshots__/RangeContainer.story.storyshot
+++ b/components/src/RangeContainer/__snapshots__/RangeContainer.story.storyshot
@@ -855,13 +855,461 @@ exports[`Storyshots RangeContainer RangeContainer 1`] = `
                               </div>
                             </StyledComponent>
                           </Box>
-                          <Box
-                            alignItems="flex-start"
-                            display="inline-flex"
-                            justifyContent="center"
-                            mb="x3"
-                            theme={
-                              Object {
+                          Example
+                        </label>
+                      </StyledComponent>
+                    </FieldLabel__Label>
+                  </BaseFieldLabel>
+                </StyledComponent>
+              </Styled(BaseFieldLabel)>
+              <Box
+                alignItems="flex-start"
+                display="inline-flex"
+                justifyContent="center"
+                mb="x3"
+                theme={
+                  Object {
+                    "borders": Array [],
+                    "breakpoints": Object {
+                      "extraLarge": "1920px",
+                      "extraSmall": "0px",
+                      "large": "1360px",
+                      "medium": "1024px",
+                      "small": "768px",
+                    },
+                    "colors": Object {
+                      "black": "#011e38",
+                      "blackBlue": "#122b47",
+                      "blue": "#216beb",
+                      "darkBlue": "#00438f",
+                      "darkGrey": "#434d59",
+                      "green": "#008059",
+                      "grey": "#c0c8d1",
+                      "lightBlue": "#e1ebfa",
+                      "lightGreen": "#e9f7f2",
+                      "lightGrey": "#e4e7eb",
+                      "lightRed": "#fae6ea",
+                      "lightYellow": "#fcf5e3",
+                      "red": "#cc1439",
+                      "white": "#ffffff",
+                      "whiteGrey": "#f0f2f5",
+                      "yellow": "#ffbb00",
+                    },
+                    "fontSizes": Object {
+                      "large": "20px",
+                      "larger": "26px",
+                      "largest": "46px",
+                      "medium": "16px",
+                      "small": "14px",
+                      "smaller": "12px",
+                    },
+                    "fontWeights": Object {
+                      "bold": "600",
+                      "light": "300",
+                      "medium": "500",
+                      "normal": "400",
+                    },
+                    "fonts": Object {
+                      "base": "'IBM Plex Sans', sans-serif",
+                      "mono": "'IBM Plex Mono', monospace",
+                    },
+                    "lineHeights": Object {
+                      "base": "1.5",
+                      "sectionTitle": "1.23076923",
+                      "smallTextBase": "1.71428571",
+                      "smallTextCompressed": "1.14285714",
+                      "smallerText": "1.33333333",
+                      "subsectionTitle": "1.2",
+                      "title": "1.04347826",
+                    },
+                    "radii": Object {
+                      "circle": "50%",
+                      "medium": "4px",
+                      "small": "2px",
+                    },
+                    "shadows": Object {
+                      "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                      "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                      "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                      "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                      "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                    },
+                    "space": Object {
+                      "half": "4px",
+                      "none": "0px",
+                      "x1": "8px",
+                      "x2": "16px",
+                      "x3": "24px",
+                      "x4": "32px",
+                      "x5": "40px",
+                      "x6": "48px",
+                      "x8": "64px",
+                    },
+                    "zIndex": Object {
+                      "content": 100,
+                      "overlay": 1000,
+                      "tabsBar": 210,
+                      "tabsScollIndicator": 200,
+                    },
+                  }
+                }
+              >
+                <StyledComponent
+                  alignItems="flex-start"
+                  display="inline-flex"
+                  forwardedComponent={
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "_foldedDefaultProps": Object {
+                        "theme": Object {
+                          "borders": Array [],
+                          "breakpoints": Object {
+                            "extraLarge": "1920px",
+                            "extraSmall": "0px",
+                            "large": "1360px",
+                            "medium": "1024px",
+                            "small": "768px",
+                          },
+                          "colors": Object {
+                            "black": "#011e38",
+                            "blackBlue": "#122b47",
+                            "blue": "#216beb",
+                            "darkBlue": "#00438f",
+                            "darkGrey": "#434d59",
+                            "green": "#008059",
+                            "grey": "#c0c8d1",
+                            "lightBlue": "#e1ebfa",
+                            "lightGreen": "#e9f7f2",
+                            "lightGrey": "#e4e7eb",
+                            "lightRed": "#fae6ea",
+                            "lightYellow": "#fcf5e3",
+                            "red": "#cc1439",
+                            "white": "#ffffff",
+                            "whiteGrey": "#f0f2f5",
+                            "yellow": "#ffbb00",
+                          },
+                          "fontSizes": Object {
+                            "large": "20px",
+                            "larger": "26px",
+                            "largest": "46px",
+                            "medium": "16px",
+                            "small": "14px",
+                            "smaller": "12px",
+                          },
+                          "fontWeights": Object {
+                            "bold": "600",
+                            "light": "300",
+                            "medium": "500",
+                            "normal": "400",
+                          },
+                          "fonts": Object {
+                            "base": "'IBM Plex Sans', sans-serif",
+                            "mono": "'IBM Plex Mono', monospace",
+                          },
+                          "lineHeights": Object {
+                            "base": "1.5",
+                            "sectionTitle": "1.23076923",
+                            "smallTextBase": "1.71428571",
+                            "smallTextCompressed": "1.14285714",
+                            "smallerText": "1.33333333",
+                            "subsectionTitle": "1.2",
+                            "title": "1.04347826",
+                          },
+                          "radii": Object {
+                            "circle": "50%",
+                            "medium": "4px",
+                            "small": "2px",
+                          },
+                          "shadows": Object {
+                            "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                            "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                            "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                            "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                            "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                          },
+                          "space": Object {
+                            "half": "4px",
+                            "none": "0px",
+                            "x1": "8px",
+                            "x2": "16px",
+                            "x3": "24px",
+                            "x4": "32px",
+                            "x5": "40px",
+                            "x6": "48px",
+                            "x8": "64px",
+                          },
+                          "zIndex": Object {
+                            "content": 100,
+                            "overlay": 1000,
+                            "tabsBar": 210,
+                            "tabsScollIndicator": 200,
+                          },
+                        },
+                      },
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "Box-sc-1qu1edy-0",
+                        "isStatic": false,
+                        "lastClassName": "bhFymm",
+                        "rules": Array [
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                          [Function],
+                        ],
+                      },
+                      "displayName": "Box",
+                      "foldedComponentIds": Array [],
+                      "propTypes": Object {
+                        "bg": [Function],
+                        "border": [Function],
+                        "borderBottom": [Function],
+                        "borderLeft": [Function],
+                        "borderRadius": [Function],
+                        "borderRight": [Function],
+                        "borderTop": [Function],
+                        "boxShadow": [Function],
+                        "color": [Function],
+                        "display": [Function],
+                        "flexGrow": [Function],
+                        "height": [Function],
+                        "m": [Function],
+                        "maxHeight": [Function],
+                        "maxWidth": [Function],
+                        "mb": [Function],
+                        "minHeight": [Function],
+                        "minWidth": [Function],
+                        "ml": [Function],
+                        "mr": [Function],
+                        "mt": [Function],
+                        "mx": [Function],
+                        "my": [Function],
+                        "order": [Function],
+                        "p": [Function],
+                        "pb": [Function],
+                        "pl": [Function],
+                        "position": [Function],
+                        "pr": [Function],
+                        "pt": [Function],
+                        "px": [Function],
+                        "py": [Function],
+                        "textAlign": [Function],
+                        "width": [Function],
+                      },
+                      "render": [Function],
+                      "styledComponentId": "Box-sc-1qu1edy-0",
+                      "target": "div",
+                      "toString": [Function],
+                      "usesTheme": false,
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    }
+                  }
+                  forwardedRef={null}
+                  justifyContent="center"
+                  mb="x3"
+                  theme={
+                    Object {
+                      "borders": Array [],
+                      "breakpoints": Object {
+                        "extraLarge": "1920px",
+                        "extraSmall": "0px",
+                        "large": "1360px",
+                        "medium": "1024px",
+                        "small": "768px",
+                      },
+                      "colors": Object {
+                        "black": "#011e38",
+                        "blackBlue": "#122b47",
+                        "blue": "#216beb",
+                        "darkBlue": "#00438f",
+                        "darkGrey": "#434d59",
+                        "green": "#008059",
+                        "grey": "#c0c8d1",
+                        "lightBlue": "#e1ebfa",
+                        "lightGreen": "#e9f7f2",
+                        "lightGrey": "#e4e7eb",
+                        "lightRed": "#fae6ea",
+                        "lightYellow": "#fcf5e3",
+                        "red": "#cc1439",
+                        "white": "#ffffff",
+                        "whiteGrey": "#f0f2f5",
+                        "yellow": "#ffbb00",
+                      },
+                      "fontSizes": Object {
+                        "large": "20px",
+                        "larger": "26px",
+                        "largest": "46px",
+                        "medium": "16px",
+                        "small": "14px",
+                        "smaller": "12px",
+                      },
+                      "fontWeights": Object {
+                        "bold": "600",
+                        "light": "300",
+                        "medium": "500",
+                        "normal": "400",
+                      },
+                      "fonts": Object {
+                        "base": "'IBM Plex Sans', sans-serif",
+                        "mono": "'IBM Plex Mono', monospace",
+                      },
+                      "lineHeights": Object {
+                        "base": "1.5",
+                        "sectionTitle": "1.23076923",
+                        "smallTextBase": "1.71428571",
+                        "smallTextCompressed": "1.14285714",
+                        "smallerText": "1.33333333",
+                        "subsectionTitle": "1.2",
+                        "title": "1.04347826",
+                      },
+                      "radii": Object {
+                        "circle": "50%",
+                        "medium": "4px",
+                        "small": "2px",
+                      },
+                      "shadows": Object {
+                        "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                        "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                        "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                        "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                        "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                      },
+                      "space": Object {
+                        "half": "4px",
+                        "none": "0px",
+                        "x1": "8px",
+                        "x2": "16px",
+                        "x3": "24px",
+                        "x4": "32px",
+                        "x5": "40px",
+                        "x6": "48px",
+                        "x8": "64px",
+                      },
+                      "zIndex": Object {
+                        "content": 100,
+                        "overlay": 1000,
+                        "tabsBar": 210,
+                        "tabsScollIndicator": 200,
+                      },
+                    }
+                  }
+                >
+                  <div
+                    className="Box-sc-1qu1edy-0 bhFymm"
+                    display="inline-flex"
+                  >
+                    <Styled(Box)
+                      alignItems="center"
+                      maxHeight="38px"
+                      px="x2"
+                      theme={
+                        Object {
+                          "borders": Array [],
+                          "breakpoints": Object {
+                            "extraLarge": "1920px",
+                            "extraSmall": "0px",
+                            "large": "1360px",
+                            "medium": "1024px",
+                            "small": "768px",
+                          },
+                          "colors": Object {
+                            "black": "#011e38",
+                            "blackBlue": "#122b47",
+                            "blue": "#216beb",
+                            "darkBlue": "#00438f",
+                            "darkGrey": "#434d59",
+                            "green": "#008059",
+                            "grey": "#c0c8d1",
+                            "lightBlue": "#e1ebfa",
+                            "lightGreen": "#e9f7f2",
+                            "lightGrey": "#e4e7eb",
+                            "lightRed": "#fae6ea",
+                            "lightYellow": "#fcf5e3",
+                            "red": "#cc1439",
+                            "white": "#ffffff",
+                            "whiteGrey": "#f0f2f5",
+                            "yellow": "#ffbb00",
+                          },
+                          "fontSizes": Object {
+                            "large": "20px",
+                            "larger": "26px",
+                            "largest": "46px",
+                            "medium": "16px",
+                            "small": "14px",
+                            "smaller": "12px",
+                          },
+                          "fontWeights": Object {
+                            "bold": "600",
+                            "light": "300",
+                            "medium": "500",
+                            "normal": "400",
+                          },
+                          "fonts": Object {
+                            "base": "'IBM Plex Sans', sans-serif",
+                            "mono": "'IBM Plex Mono', monospace",
+                          },
+                          "lineHeights": Object {
+                            "base": "1.5",
+                            "sectionTitle": "1.23076923",
+                            "smallTextBase": "1.71428571",
+                            "smallTextCompressed": "1.14285714",
+                            "smallerText": "1.33333333",
+                            "subsectionTitle": "1.2",
+                            "title": "1.04347826",
+                          },
+                          "radii": Object {
+                            "circle": "50%",
+                            "medium": "4px",
+                            "small": "2px",
+                          },
+                          "shadows": Object {
+                            "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                            "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                            "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                            "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                            "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                          },
+                          "space": Object {
+                            "half": "4px",
+                            "none": "0px",
+                            "x1": "8px",
+                            "x2": "16px",
+                            "x3": "24px",
+                            "x4": "32px",
+                            "x5": "40px",
+                            "x6": "48px",
+                            "x8": "64px",
+                          },
+                          "zIndex": Object {
+                            "content": 100,
+                            "overlay": 1000,
+                            "tabsBar": 210,
+                            "tabsScollIndicator": 200,
+                          },
+                        }
+                      }
+                    >
+                      <StyledComponent
+                        alignItems="center"
+                        forwardedComponent={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "_foldedDefaultProps": Object {
+                              "theme": Object {
                                 "borders": Array [],
                                 "breakpoints": Object {
                                   "extraLarge": "1920px",
@@ -944,116 +1392,181 @@ exports[`Storyshots RangeContainer RangeContainer 1`] = `
                                   "tabsBar": 210,
                                   "tabsScollIndicator": 200,
                                 },
-                              }
-                            }
+                              },
+                            },
+                            "attrs": Array [],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "sc-bdVaJa",
+                              "isStatic": false,
+                              "lastClassName": "cRonwR",
+                              "rules": Array [
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                "display: flex;",
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                              ],
+                            },
+                            "displayName": "Styled(Box)",
+                            "foldedComponentIds": Array [
+                              "Box-sc-1qu1edy-0",
+                            ],
+                            "propTypes": Object {
+                              "alignItems": [Function],
+                              "flexDirection": [Function],
+                              "flexWrap": [Function],
+                              "justifyContent": [Function],
+                            },
+                            "render": [Function],
+                            "styledComponentId": "sc-bdVaJa",
+                            "target": "div",
+                            "toString": [Function],
+                            "usesTheme": false,
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          }
+                        }
+                        forwardedRef={null}
+                        maxHeight="38px"
+                        px="x2"
+                        theme={
+                          Object {
+                            "borders": Array [],
+                            "breakpoints": Object {
+                              "extraLarge": "1920px",
+                              "extraSmall": "0px",
+                              "large": "1360px",
+                              "medium": "1024px",
+                              "small": "768px",
+                            },
+                            "colors": Object {
+                              "black": "#011e38",
+                              "blackBlue": "#122b47",
+                              "blue": "#216beb",
+                              "darkBlue": "#00438f",
+                              "darkGrey": "#434d59",
+                              "green": "#008059",
+                              "grey": "#c0c8d1",
+                              "lightBlue": "#e1ebfa",
+                              "lightGreen": "#e9f7f2",
+                              "lightGrey": "#e4e7eb",
+                              "lightRed": "#fae6ea",
+                              "lightYellow": "#fcf5e3",
+                              "red": "#cc1439",
+                              "white": "#ffffff",
+                              "whiteGrey": "#f0f2f5",
+                              "yellow": "#ffbb00",
+                            },
+                            "fontSizes": Object {
+                              "large": "20px",
+                              "larger": "26px",
+                              "largest": "46px",
+                              "medium": "16px",
+                              "small": "14px",
+                              "smaller": "12px",
+                            },
+                            "fontWeights": Object {
+                              "bold": "600",
+                              "light": "300",
+                              "medium": "500",
+                              "normal": "400",
+                            },
+                            "fonts": Object {
+                              "base": "'IBM Plex Sans', sans-serif",
+                              "mono": "'IBM Plex Mono', monospace",
+                            },
+                            "lineHeights": Object {
+                              "base": "1.5",
+                              "sectionTitle": "1.23076923",
+                              "smallTextBase": "1.71428571",
+                              "smallTextCompressed": "1.14285714",
+                              "smallerText": "1.33333333",
+                              "subsectionTitle": "1.2",
+                              "title": "1.04347826",
+                            },
+                            "radii": Object {
+                              "circle": "50%",
+                              "medium": "4px",
+                              "small": "2px",
+                            },
+                            "shadows": Object {
+                              "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                              "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                              "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                              "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                              "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                            },
+                            "space": Object {
+                              "half": "4px",
+                              "none": "0px",
+                              "x1": "8px",
+                              "x2": "16px",
+                              "x3": "24px",
+                              "x4": "32px",
+                              "x5": "40px",
+                              "x6": "48px",
+                              "x8": "64px",
+                            },
+                            "zIndex": Object {
+                              "content": 100,
+                              "overlay": 1000,
+                              "tabsBar": 210,
+                              "tabsScollIndicator": 200,
+                            },
+                          }
+                        }
+                      >
+                        <div
+                          className="Box-sc-1qu1edy-0 sc-bdVaJa cRonwR"
+                        >
+                          <styled.p
+                            color="currentColor"
+                            disabled={false}
+                            fontSize="16px"
+                            inline={false}
+                            lineHeight="1.5"
+                            m={0}
                           >
                             <StyledComponent
-                              alignItems="flex-start"
-                              display="inline-flex"
+                              color="currentColor"
+                              disabled={false}
+                              fontSize="16px"
                               forwardedComponent={
                                 Object {
                                   "$$typeof": Symbol(react.forward_ref),
                                   "_foldedDefaultProps": Object {
-                                    "theme": Object {
-                                      "borders": Array [],
-                                      "breakpoints": Object {
-                                        "extraLarge": "1920px",
-                                        "extraSmall": "0px",
-                                        "large": "1360px",
-                                        "medium": "1024px",
-                                        "small": "768px",
-                                      },
-                                      "colors": Object {
-                                        "black": "#011e38",
-                                        "blackBlue": "#122b47",
-                                        "blue": "#216beb",
-                                        "darkBlue": "#00438f",
-                                        "darkGrey": "#434d59",
-                                        "green": "#008059",
-                                        "grey": "#c0c8d1",
-                                        "lightBlue": "#e1ebfa",
-                                        "lightGreen": "#e9f7f2",
-                                        "lightGrey": "#e4e7eb",
-                                        "lightRed": "#fae6ea",
-                                        "lightYellow": "#fcf5e3",
-                                        "red": "#cc1439",
-                                        "white": "#ffffff",
-                                        "whiteGrey": "#f0f2f5",
-                                        "yellow": "#ffbb00",
-                                      },
-                                      "fontSizes": Object {
-                                        "large": "20px",
-                                        "larger": "26px",
-                                        "largest": "46px",
-                                        "medium": "16px",
-                                        "small": "14px",
-                                        "smaller": "12px",
-                                      },
-                                      "fontWeights": Object {
-                                        "bold": "600",
-                                        "light": "300",
-                                        "medium": "500",
-                                        "normal": "400",
-                                      },
-                                      "fonts": Object {
-                                        "base": "'IBM Plex Sans', sans-serif",
-                                        "mono": "'IBM Plex Mono', monospace",
-                                      },
-                                      "lineHeights": Object {
-                                        "base": "1.5",
-                                        "sectionTitle": "1.23076923",
-                                        "smallTextBase": "1.71428571",
-                                        "smallTextCompressed": "1.14285714",
-                                        "smallerText": "1.33333333",
-                                        "subsectionTitle": "1.2",
-                                        "title": "1.04347826",
-                                      },
-                                      "radii": Object {
-                                        "circle": "50%",
-                                        "medium": "4px",
-                                        "small": "2px",
-                                      },
-                                      "shadows": Object {
-                                        "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                        "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                        "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                        "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                        "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                                      },
-                                      "space": Object {
-                                        "half": "4px",
-                                        "none": "0px",
-                                        "x1": "8px",
-                                        "x2": "16px",
-                                        "x3": "24px",
-                                        "x4": "32px",
-                                        "x5": "40px",
-                                        "x6": "48px",
-                                        "x8": "64px",
-                                      },
-                                      "zIndex": Object {
-                                        "content": 100,
-                                        "overlay": 1000,
-                                        "tabsBar": 210,
-                                        "tabsScollIndicator": 200,
-                                      },
-                                    },
+                                    "color": "currentColor",
+                                    "disabled": false,
+                                    "fontSize": "16px",
+                                    "inline": false,
+                                    "lineHeight": "1.5",
+                                    "m": 0,
                                   },
-                                  "attrs": Array [],
+                                  "attrs": Array [
+                                    [Function],
+                                  ],
                                   "componentStyle": ComponentStyle {
-                                    "componentId": "Box-sc-1qu1edy-0",
+                                    "componentId": "sc-bxivhb",
                                     "isStatic": false,
-                                    "lastClassName": "bhFymm",
+                                    "lastClassName": "bWRApy",
                                     "rules": Array [
-                                      [Function],
-                                      [Function],
-                                      [Function],
-                                      [Function],
-                                      [Function],
-                                      [Function],
-                                      [Function],
-                                      [Function],
-                                      [Function],
                                       [Function],
                                       [Function],
                                       [Function],
@@ -1064,47 +1577,15 @@ exports[`Storyshots RangeContainer RangeContainer 1`] = `
                                       [Function],
                                     ],
                                   },
-                                  "displayName": "Box",
+                                  "displayName": "styled.p",
                                   "foldedComponentIds": Array [],
                                   "propTypes": Object {
-                                    "bg": [Function],
-                                    "border": [Function],
-                                    "borderBottom": [Function],
-                                    "borderLeft": [Function],
-                                    "borderRadius": [Function],
-                                    "borderRight": [Function],
-                                    "borderTop": [Function],
-                                    "boxShadow": [Function],
-                                    "color": [Function],
-                                    "display": [Function],
-                                    "flexGrow": [Function],
-                                    "height": [Function],
-                                    "m": [Function],
-                                    "maxHeight": [Function],
-                                    "maxWidth": [Function],
-                                    "mb": [Function],
-                                    "minHeight": [Function],
-                                    "minWidth": [Function],
-                                    "ml": [Function],
-                                    "mr": [Function],
-                                    "mt": [Function],
-                                    "mx": [Function],
-                                    "my": [Function],
-                                    "order": [Function],
-                                    "p": [Function],
-                                    "pb": [Function],
-                                    "pl": [Function],
-                                    "position": [Function],
-                                    "pr": [Function],
-                                    "pt": [Function],
-                                    "px": [Function],
-                                    "py": [Function],
-                                    "textAlign": [Function],
-                                    "width": [Function],
+                                    "disabled": [Function],
+                                    "inline": [Function],
                                   },
                                   "render": [Function],
-                                  "styledComponentId": "Box-sc-1qu1edy-0",
-                                  "target": "div",
+                                  "styledComponentId": "sc-bxivhb",
+                                  "target": "p",
                                   "toString": [Function],
                                   "usesTheme": false,
                                   "warnTooManyClasses": [Function],
@@ -1112,506 +1593,26 @@ exports[`Storyshots RangeContainer RangeContainer 1`] = `
                                 }
                               }
                               forwardedRef={null}
-                              justifyContent="center"
-                              mb="x3"
-                              theme={
-                                Object {
-                                  "borders": Array [],
-                                  "breakpoints": Object {
-                                    "extraLarge": "1920px",
-                                    "extraSmall": "0px",
-                                    "large": "1360px",
-                                    "medium": "1024px",
-                                    "small": "768px",
-                                  },
-                                  "colors": Object {
-                                    "black": "#011e38",
-                                    "blackBlue": "#122b47",
-                                    "blue": "#216beb",
-                                    "darkBlue": "#00438f",
-                                    "darkGrey": "#434d59",
-                                    "green": "#008059",
-                                    "grey": "#c0c8d1",
-                                    "lightBlue": "#e1ebfa",
-                                    "lightGreen": "#e9f7f2",
-                                    "lightGrey": "#e4e7eb",
-                                    "lightRed": "#fae6ea",
-                                    "lightYellow": "#fcf5e3",
-                                    "red": "#cc1439",
-                                    "white": "#ffffff",
-                                    "whiteGrey": "#f0f2f5",
-                                    "yellow": "#ffbb00",
-                                  },
-                                  "fontSizes": Object {
-                                    "large": "20px",
-                                    "larger": "26px",
-                                    "largest": "46px",
-                                    "medium": "16px",
-                                    "small": "14px",
-                                    "smaller": "12px",
-                                  },
-                                  "fontWeights": Object {
-                                    "bold": "600",
-                                    "light": "300",
-                                    "medium": "500",
-                                    "normal": "400",
-                                  },
-                                  "fonts": Object {
-                                    "base": "'IBM Plex Sans', sans-serif",
-                                    "mono": "'IBM Plex Mono', monospace",
-                                  },
-                                  "lineHeights": Object {
-                                    "base": "1.5",
-                                    "sectionTitle": "1.23076923",
-                                    "smallTextBase": "1.71428571",
-                                    "smallTextCompressed": "1.14285714",
-                                    "smallerText": "1.33333333",
-                                    "subsectionTitle": "1.2",
-                                    "title": "1.04347826",
-                                  },
-                                  "radii": Object {
-                                    "circle": "50%",
-                                    "medium": "4px",
-                                    "small": "2px",
-                                  },
-                                  "shadows": Object {
-                                    "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                    "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                    "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                    "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                    "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                                  },
-                                  "space": Object {
-                                    "half": "4px",
-                                    "none": "0px",
-                                    "x1": "8px",
-                                    "x2": "16px",
-                                    "x3": "24px",
-                                    "x4": "32px",
-                                    "x5": "40px",
-                                    "x6": "48px",
-                                    "x8": "64px",
-                                  },
-                                  "zIndex": Object {
-                                    "content": 100,
-                                    "overlay": 1000,
-                                    "tabsBar": 210,
-                                    "tabsScollIndicator": 200,
-                                  },
-                                }
-                              }
+                              inline={false}
+                              lineHeight="1.5"
+                              m={0}
                             >
-                              <div
-                                className="Box-sc-1qu1edy-0 bhFymm"
-                                display="inline-flex"
+                              <p
+                                className="sc-bxivhb bWRApy"
+                                color="currentColor"
+                                disabled={false}
+                                fontSize="16px"
                               >
-                                <Styled(Box)
-                                  alignItems="center"
-                                  maxHeight="38px"
-                                  px="x2"
-                                  theme={
-                                    Object {
-                                      "borders": Array [],
-                                      "breakpoints": Object {
-                                        "extraLarge": "1920px",
-                                        "extraSmall": "0px",
-                                        "large": "1360px",
-                                        "medium": "1024px",
-                                        "small": "768px",
-                                      },
-                                      "colors": Object {
-                                        "black": "#011e38",
-                                        "blackBlue": "#122b47",
-                                        "blue": "#216beb",
-                                        "darkBlue": "#00438f",
-                                        "darkGrey": "#434d59",
-                                        "green": "#008059",
-                                        "grey": "#c0c8d1",
-                                        "lightBlue": "#e1ebfa",
-                                        "lightGreen": "#e9f7f2",
-                                        "lightGrey": "#e4e7eb",
-                                        "lightRed": "#fae6ea",
-                                        "lightYellow": "#fcf5e3",
-                                        "red": "#cc1439",
-                                        "white": "#ffffff",
-                                        "whiteGrey": "#f0f2f5",
-                                        "yellow": "#ffbb00",
-                                      },
-                                      "fontSizes": Object {
-                                        "large": "20px",
-                                        "larger": "26px",
-                                        "largest": "46px",
-                                        "medium": "16px",
-                                        "small": "14px",
-                                        "smaller": "12px",
-                                      },
-                                      "fontWeights": Object {
-                                        "bold": "600",
-                                        "light": "300",
-                                        "medium": "500",
-                                        "normal": "400",
-                                      },
-                                      "fonts": Object {
-                                        "base": "'IBM Plex Sans', sans-serif",
-                                        "mono": "'IBM Plex Mono', monospace",
-                                      },
-                                      "lineHeights": Object {
-                                        "base": "1.5",
-                                        "sectionTitle": "1.23076923",
-                                        "smallTextBase": "1.71428571",
-                                        "smallTextCompressed": "1.14285714",
-                                        "smallerText": "1.33333333",
-                                        "subsectionTitle": "1.2",
-                                        "title": "1.04347826",
-                                      },
-                                      "radii": Object {
-                                        "circle": "50%",
-                                        "medium": "4px",
-                                        "small": "2px",
-                                      },
-                                      "shadows": Object {
-                                        "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                        "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                        "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                        "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                        "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                                      },
-                                      "space": Object {
-                                        "half": "4px",
-                                        "none": "0px",
-                                        "x1": "8px",
-                                        "x2": "16px",
-                                        "x3": "24px",
-                                        "x4": "32px",
-                                        "x5": "40px",
-                                        "x6": "48px",
-                                        "x8": "64px",
-                                      },
-                                      "zIndex": Object {
-                                        "content": 100,
-                                        "overlay": 1000,
-                                        "tabsBar": 210,
-                                        "tabsScollIndicator": 200,
-                                      },
-                                    }
-                                  }
-                                >
-                                  <StyledComponent
-                                    alignItems="center"
-                                    forwardedComponent={
-                                      Object {
-                                        "$$typeof": Symbol(react.forward_ref),
-                                        "_foldedDefaultProps": Object {
-                                          "theme": Object {
-                                            "borders": Array [],
-                                            "breakpoints": Object {
-                                              "extraLarge": "1920px",
-                                              "extraSmall": "0px",
-                                              "large": "1360px",
-                                              "medium": "1024px",
-                                              "small": "768px",
-                                            },
-                                            "colors": Object {
-                                              "black": "#011e38",
-                                              "blackBlue": "#122b47",
-                                              "blue": "#216beb",
-                                              "darkBlue": "#00438f",
-                                              "darkGrey": "#434d59",
-                                              "green": "#008059",
-                                              "grey": "#c0c8d1",
-                                              "lightBlue": "#e1ebfa",
-                                              "lightGreen": "#e9f7f2",
-                                              "lightGrey": "#e4e7eb",
-                                              "lightRed": "#fae6ea",
-                                              "lightYellow": "#fcf5e3",
-                                              "red": "#cc1439",
-                                              "white": "#ffffff",
-                                              "whiteGrey": "#f0f2f5",
-                                              "yellow": "#ffbb00",
-                                            },
-                                            "fontSizes": Object {
-                                              "large": "20px",
-                                              "larger": "26px",
-                                              "largest": "46px",
-                                              "medium": "16px",
-                                              "small": "14px",
-                                              "smaller": "12px",
-                                            },
-                                            "fontWeights": Object {
-                                              "bold": "600",
-                                              "light": "300",
-                                              "medium": "500",
-                                              "normal": "400",
-                                            },
-                                            "fonts": Object {
-                                              "base": "'IBM Plex Sans', sans-serif",
-                                              "mono": "'IBM Plex Mono', monospace",
-                                            },
-                                            "lineHeights": Object {
-                                              "base": "1.5",
-                                              "sectionTitle": "1.23076923",
-                                              "smallTextBase": "1.71428571",
-                                              "smallTextCompressed": "1.14285714",
-                                              "smallerText": "1.33333333",
-                                              "subsectionTitle": "1.2",
-                                              "title": "1.04347826",
-                                            },
-                                            "radii": Object {
-                                              "circle": "50%",
-                                              "medium": "4px",
-                                              "small": "2px",
-                                            },
-                                            "shadows": Object {
-                                              "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                              "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                              "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                              "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                              "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                                            },
-                                            "space": Object {
-                                              "half": "4px",
-                                              "none": "0px",
-                                              "x1": "8px",
-                                              "x2": "16px",
-                                              "x3": "24px",
-                                              "x4": "32px",
-                                              "x5": "40px",
-                                              "x6": "48px",
-                                              "x8": "64px",
-                                            },
-                                            "zIndex": Object {
-                                              "content": 100,
-                                              "overlay": 1000,
-                                              "tabsBar": 210,
-                                              "tabsScollIndicator": 200,
-                                            },
-                                          },
-                                        },
-                                        "attrs": Array [],
-                                        "componentStyle": ComponentStyle {
-                                          "componentId": "sc-bdVaJa",
-                                          "isStatic": false,
-                                          "lastClassName": "cRonwR",
-                                          "rules": Array [
-                                            [Function],
-                                            [Function],
-                                            [Function],
-                                            [Function],
-                                            [Function],
-                                            [Function],
-                                            [Function],
-                                            [Function],
-                                            [Function],
-                                            [Function],
-                                            [Function],
-                                            [Function],
-                                            [Function],
-                                            [Function],
-                                            [Function],
-                                            [Function],
-                                            [Function],
-                                            "display: flex;",
-                                            [Function],
-                                            [Function],
-                                            [Function],
-                                            [Function],
-                                          ],
-                                        },
-                                        "displayName": "Styled(Box)",
-                                        "foldedComponentIds": Array [
-                                          "Box-sc-1qu1edy-0",
-                                        ],
-                                        "propTypes": Object {
-                                          "alignItems": [Function],
-                                          "flexDirection": [Function],
-                                          "flexWrap": [Function],
-                                          "justifyContent": [Function],
-                                        },
-                                        "render": [Function],
-                                        "styledComponentId": "sc-bdVaJa",
-                                        "target": "div",
-                                        "toString": [Function],
-                                        "usesTheme": false,
-                                        "warnTooManyClasses": [Function],
-                                        "withComponent": [Function],
-                                      }
-                                    }
-                                    forwardedRef={null}
-                                    maxHeight="38px"
-                                    px="x2"
-                                    theme={
-                                      Object {
-                                        "borders": Array [],
-                                        "breakpoints": Object {
-                                          "extraLarge": "1920px",
-                                          "extraSmall": "0px",
-                                          "large": "1360px",
-                                          "medium": "1024px",
-                                          "small": "768px",
-                                        },
-                                        "colors": Object {
-                                          "black": "#011e38",
-                                          "blackBlue": "#122b47",
-                                          "blue": "#216beb",
-                                          "darkBlue": "#00438f",
-                                          "darkGrey": "#434d59",
-                                          "green": "#008059",
-                                          "grey": "#c0c8d1",
-                                          "lightBlue": "#e1ebfa",
-                                          "lightGreen": "#e9f7f2",
-                                          "lightGrey": "#e4e7eb",
-                                          "lightRed": "#fae6ea",
-                                          "lightYellow": "#fcf5e3",
-                                          "red": "#cc1439",
-                                          "white": "#ffffff",
-                                          "whiteGrey": "#f0f2f5",
-                                          "yellow": "#ffbb00",
-                                        },
-                                        "fontSizes": Object {
-                                          "large": "20px",
-                                          "larger": "26px",
-                                          "largest": "46px",
-                                          "medium": "16px",
-                                          "small": "14px",
-                                          "smaller": "12px",
-                                        },
-                                        "fontWeights": Object {
-                                          "bold": "600",
-                                          "light": "300",
-                                          "medium": "500",
-                                          "normal": "400",
-                                        },
-                                        "fonts": Object {
-                                          "base": "'IBM Plex Sans', sans-serif",
-                                          "mono": "'IBM Plex Mono', monospace",
-                                        },
-                                        "lineHeights": Object {
-                                          "base": "1.5",
-                                          "sectionTitle": "1.23076923",
-                                          "smallTextBase": "1.71428571",
-                                          "smallTextCompressed": "1.14285714",
-                                          "smallerText": "1.33333333",
-                                          "subsectionTitle": "1.2",
-                                          "title": "1.04347826",
-                                        },
-                                        "radii": Object {
-                                          "circle": "50%",
-                                          "medium": "4px",
-                                          "small": "2px",
-                                        },
-                                        "shadows": Object {
-                                          "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
-                                          "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
-                                          "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
-                                          "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
-                                          "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
-                                        },
-                                        "space": Object {
-                                          "half": "4px",
-                                          "none": "0px",
-                                          "x1": "8px",
-                                          "x2": "16px",
-                                          "x3": "24px",
-                                          "x4": "32px",
-                                          "x5": "40px",
-                                          "x6": "48px",
-                                          "x8": "64px",
-                                        },
-                                        "zIndex": Object {
-                                          "content": 100,
-                                          "overlay": 1000,
-                                          "tabsBar": 210,
-                                          "tabsScollIndicator": 200,
-                                        },
-                                      }
-                                    }
-                                  >
-                                    <div
-                                      className="Box-sc-1qu1edy-0 sc-bdVaJa cRonwR"
-                                    >
-                                      <styled.p
-                                        color="currentColor"
-                                        disabled={false}
-                                        fontSize="16px"
-                                        inline={false}
-                                        lineHeight="1.5"
-                                        m={0}
-                                      >
-                                        <StyledComponent
-                                          color="currentColor"
-                                          disabled={false}
-                                          fontSize="16px"
-                                          forwardedComponent={
-                                            Object {
-                                              "$$typeof": Symbol(react.forward_ref),
-                                              "_foldedDefaultProps": Object {
-                                                "color": "currentColor",
-                                                "disabled": false,
-                                                "fontSize": "16px",
-                                                "inline": false,
-                                                "lineHeight": "1.5",
-                                                "m": 0,
-                                              },
-                                              "attrs": Array [
-                                                [Function],
-                                              ],
-                                              "componentStyle": ComponentStyle {
-                                                "componentId": "sc-bxivhb",
-                                                "isStatic": false,
-                                                "lastClassName": "bWRApy",
-                                                "rules": Array [
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                ],
-                                              },
-                                              "displayName": "styled.p",
-                                              "foldedComponentIds": Array [],
-                                              "propTypes": Object {
-                                                "disabled": [Function],
-                                                "inline": [Function],
-                                              },
-                                              "render": [Function],
-                                              "styledComponentId": "sc-bxivhb",
-                                              "target": "p",
-                                              "toString": [Function],
-                                              "usesTheme": false,
-                                              "warnTooManyClasses": [Function],
-                                              "withComponent": [Function],
-                                            }
-                                          }
-                                          forwardedRef={null}
-                                          inline={false}
-                                          lineHeight="1.5"
-                                          m={0}
-                                        >
-                                          <p
-                                            className="sc-bxivhb bWRApy"
-                                            color="currentColor"
-                                            disabled={false}
-                                            fontSize="16px"
-                                          >
-                                            -
-                                          </p>
-                                        </StyledComponent>
-                                      </styled.p>
-                                    </div>
-                                  </StyledComponent>
-                                </Styled(Box)>
-                              </div>
+                                -
+                              </p>
                             </StyledComponent>
-                          </Box>
-                        </label>
+                          </styled.p>
+                        </div>
                       </StyledComponent>
-                    </FieldLabel__Label>
-                  </BaseFieldLabel>
+                    </Styled(Box)>
+                  </div>
                 </StyledComponent>
-              </Styled(BaseFieldLabel)>
+              </Box>
             </RangeContainer>
           </ThemeProvider>
         </div>

--- a/components/src/RangeContainer/__snapshots__/RangeContainer.story.storyshot
+++ b/components/src/RangeContainer/__snapshots__/RangeContainer.story.storyshot
@@ -1,0 +1,1622 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots RangeContainer RangeContainer 1`] = `
+<div
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
+>
+  <NDSProvider
+    theme={
+      Object {
+        "borders": Array [],
+        "breakpoints": Object {
+          "extraLarge": "1920px",
+          "extraSmall": "0px",
+          "large": "1360px",
+          "medium": "1024px",
+          "small": "768px",
+        },
+        "colors": Object {
+          "black": "#011e38",
+          "blackBlue": "#122b47",
+          "blue": "#216beb",
+          "darkBlue": "#00438f",
+          "darkGrey": "#434d59",
+          "green": "#008059",
+          "grey": "#c0c8d1",
+          "lightBlue": "#e1ebfa",
+          "lightGreen": "#e9f7f2",
+          "lightGrey": "#e4e7eb",
+          "lightRed": "#fae6ea",
+          "lightYellow": "#fcf5e3",
+          "red": "#cc1439",
+          "white": "#ffffff",
+          "whiteGrey": "#f0f2f5",
+          "yellow": "#ffbb00",
+        },
+        "fontSizes": Object {
+          "large": "20px",
+          "larger": "26px",
+          "largest": "46px",
+          "medium": "16px",
+          "small": "14px",
+          "smaller": "12px",
+        },
+        "fontWeights": Object {
+          "bold": "600",
+          "light": "300",
+          "medium": "500",
+          "normal": "400",
+        },
+        "fonts": Object {
+          "base": "'IBM Plex Sans', sans-serif",
+          "mono": "'IBM Plex Mono', monospace",
+        },
+        "lineHeights": Object {
+          "base": "1.5",
+          "sectionTitle": "1.23076923",
+          "smallTextBase": "1.71428571",
+          "smallTextCompressed": "1.14285714",
+          "smallerText": "1.33333333",
+          "subsectionTitle": "1.2",
+          "title": "1.04347826",
+        },
+        "radii": Object {
+          "circle": "50%",
+          "medium": "4px",
+          "small": "2px",
+        },
+        "shadows": Object {
+          "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+          "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+          "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+          "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+          "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+        },
+        "space": Object {
+          "half": "4px",
+          "none": "0px",
+          "x1": "8px",
+          "x2": "16px",
+          "x3": "24px",
+          "x4": "32px",
+          "x5": "40px",
+          "x6": "48px",
+          "x8": "64px",
+        },
+        "zIndex": Object {
+          "content": 100,
+          "overlay": 1000,
+          "tabsBar": 210,
+          "tabsScollIndicator": 200,
+        },
+      }
+    }
+  >
+    <GlobalStyleComponent />
+    <NDSProvider__GlobalStyles
+      theme={
+        Object {
+          "borders": Array [],
+          "breakpoints": Object {
+            "extraLarge": "1920px",
+            "extraSmall": "0px",
+            "large": "1360px",
+            "medium": "1024px",
+            "small": "768px",
+          },
+          "colors": Object {
+            "black": "#011e38",
+            "blackBlue": "#122b47",
+            "blue": "#216beb",
+            "darkBlue": "#00438f",
+            "darkGrey": "#434d59",
+            "green": "#008059",
+            "grey": "#c0c8d1",
+            "lightBlue": "#e1ebfa",
+            "lightGreen": "#e9f7f2",
+            "lightGrey": "#e4e7eb",
+            "lightRed": "#fae6ea",
+            "lightYellow": "#fcf5e3",
+            "red": "#cc1439",
+            "white": "#ffffff",
+            "whiteGrey": "#f0f2f5",
+            "yellow": "#ffbb00",
+          },
+          "fontSizes": Object {
+            "large": "20px",
+            "larger": "26px",
+            "largest": "46px",
+            "medium": "16px",
+            "small": "14px",
+            "smaller": "12px",
+          },
+          "fontWeights": Object {
+            "bold": "600",
+            "light": "300",
+            "medium": "500",
+            "normal": "400",
+          },
+          "fonts": Object {
+            "base": "'IBM Plex Sans', sans-serif",
+            "mono": "'IBM Plex Mono', monospace",
+          },
+          "lineHeights": Object {
+            "base": "1.5",
+            "sectionTitle": "1.23076923",
+            "smallTextBase": "1.71428571",
+            "smallTextCompressed": "1.14285714",
+            "smallerText": "1.33333333",
+            "subsectionTitle": "1.2",
+            "title": "1.04347826",
+          },
+          "radii": Object {
+            "circle": "50%",
+            "medium": "4px",
+            "small": "2px",
+          },
+          "shadows": Object {
+            "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+            "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+            "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+            "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+            "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+          },
+          "space": Object {
+            "half": "4px",
+            "none": "0px",
+            "x1": "8px",
+            "x2": "16px",
+            "x3": "24px",
+            "x4": "32px",
+            "x5": "40px",
+            "x6": "48px",
+            "x8": "64px",
+          },
+          "zIndex": Object {
+            "content": 100,
+            "overlay": 1000,
+            "tabsBar": 210,
+            "tabsScollIndicator": 200,
+          },
+        }
+      }
+    >
+      <StyledComponent
+        forwardedComponent={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "attrs": Array [],
+            "componentStyle": ComponentStyle {
+              "componentId": "NDSProvider__GlobalStyles-f28eoq-0",
+              "isStatic": false,
+              "lastClassName": "gWUgWA",
+              "rules": Array [
+                [Function],
+              ],
+            },
+            "displayName": "NDSProvider__GlobalStyles",
+            "foldedComponentIds": Array [],
+            "render": [Function],
+            "styledComponentId": "NDSProvider__GlobalStyles-f28eoq-0",
+            "target": "div",
+            "toString": [Function],
+            "usesTheme": false,
+            "warnTooManyClasses": [Function],
+            "withComponent": [Function],
+          }
+        }
+        forwardedRef={null}
+        theme={
+          Object {
+            "borders": Array [],
+            "breakpoints": Object {
+              "extraLarge": "1920px",
+              "extraSmall": "0px",
+              "large": "1360px",
+              "medium": "1024px",
+              "small": "768px",
+            },
+            "colors": Object {
+              "black": "#011e38",
+              "blackBlue": "#122b47",
+              "blue": "#216beb",
+              "darkBlue": "#00438f",
+              "darkGrey": "#434d59",
+              "green": "#008059",
+              "grey": "#c0c8d1",
+              "lightBlue": "#e1ebfa",
+              "lightGreen": "#e9f7f2",
+              "lightGrey": "#e4e7eb",
+              "lightRed": "#fae6ea",
+              "lightYellow": "#fcf5e3",
+              "red": "#cc1439",
+              "white": "#ffffff",
+              "whiteGrey": "#f0f2f5",
+              "yellow": "#ffbb00",
+            },
+            "fontSizes": Object {
+              "large": "20px",
+              "larger": "26px",
+              "largest": "46px",
+              "medium": "16px",
+              "small": "14px",
+              "smaller": "12px",
+            },
+            "fontWeights": Object {
+              "bold": "600",
+              "light": "300",
+              "medium": "500",
+              "normal": "400",
+            },
+            "fonts": Object {
+              "base": "'IBM Plex Sans', sans-serif",
+              "mono": "'IBM Plex Mono', monospace",
+            },
+            "lineHeights": Object {
+              "base": "1.5",
+              "sectionTitle": "1.23076923",
+              "smallTextBase": "1.71428571",
+              "smallTextCompressed": "1.14285714",
+              "smallerText": "1.33333333",
+              "subsectionTitle": "1.2",
+              "title": "1.04347826",
+            },
+            "radii": Object {
+              "circle": "50%",
+              "medium": "4px",
+              "small": "2px",
+            },
+            "shadows": Object {
+              "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+              "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+              "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+              "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+              "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+            },
+            "space": Object {
+              "half": "4px",
+              "none": "0px",
+              "x1": "8px",
+              "x2": "16px",
+              "x3": "24px",
+              "x4": "32px",
+              "x5": "40px",
+              "x6": "48px",
+              "x8": "64px",
+            },
+            "zIndex": Object {
+              "content": 100,
+              "overlay": 1000,
+              "tabsBar": 210,
+              "tabsScollIndicator": 200,
+            },
+          }
+        }
+      >
+        <div
+          className="NDSProvider__GlobalStyles-f28eoq-0 gWUgWA"
+        >
+          <ThemeProvider
+            theme={
+              Object {
+                "borders": Array [],
+                "breakpoints": Object {
+                  "extraLarge": "1920px",
+                  "extraSmall": "0px",
+                  "large": "1360px",
+                  "medium": "1024px",
+                  "small": "768px",
+                },
+                "colors": Object {
+                  "black": "#011e38",
+                  "blackBlue": "#122b47",
+                  "blue": "#216beb",
+                  "darkBlue": "#00438f",
+                  "darkGrey": "#434d59",
+                  "green": "#008059",
+                  "grey": "#c0c8d1",
+                  "lightBlue": "#e1ebfa",
+                  "lightGreen": "#e9f7f2",
+                  "lightGrey": "#e4e7eb",
+                  "lightRed": "#fae6ea",
+                  "lightYellow": "#fcf5e3",
+                  "red": "#cc1439",
+                  "white": "#ffffff",
+                  "whiteGrey": "#f0f2f5",
+                  "yellow": "#ffbb00",
+                },
+                "fontSizes": Object {
+                  "large": "20px",
+                  "larger": "26px",
+                  "largest": "46px",
+                  "medium": "16px",
+                  "small": "14px",
+                  "smaller": "12px",
+                },
+                "fontWeights": Object {
+                  "bold": "600",
+                  "light": "300",
+                  "medium": "500",
+                  "normal": "400",
+                },
+                "fonts": Object {
+                  "base": "'IBM Plex Sans', sans-serif",
+                  "mono": "'IBM Plex Mono', monospace",
+                },
+                "lineHeights": Object {
+                  "base": "1.5",
+                  "sectionTitle": "1.23076923",
+                  "smallTextBase": "1.71428571",
+                  "smallTextCompressed": "1.14285714",
+                  "smallerText": "1.33333333",
+                  "subsectionTitle": "1.2",
+                  "title": "1.04347826",
+                },
+                "radii": Object {
+                  "circle": "50%",
+                  "medium": "4px",
+                  "small": "2px",
+                },
+                "shadows": Object {
+                  "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                  "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                  "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                  "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                  "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                },
+                "space": Object {
+                  "half": "4px",
+                  "none": "0px",
+                  "x1": "8px",
+                  "x2": "16px",
+                  "x3": "24px",
+                  "x4": "32px",
+                  "x5": "40px",
+                  "x6": "48px",
+                  "x8": "64px",
+                },
+                "zIndex": Object {
+                  "content": 100,
+                  "overlay": 1000,
+                  "tabsBar": 210,
+                  "tabsScollIndicator": 200,
+                },
+              }
+            }
+          >
+            <RangeContainer
+              endComponent={null}
+              errorMessages={Array []}
+              labelProps={
+                Object {
+                  "children": null,
+                  "helpText": null,
+                  "id": undefined,
+                  "labelText": "Range",
+                  "requirementText": null,
+                }
+              }
+              startComponent={null}
+            >
+              <Styled(BaseFieldLabel)
+                helpText={null}
+                labelText="Range"
+                requirementText={null}
+              >
+                <StyledComponent
+                  forwardedComponent={
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "attrs": Array [],
+                      "componentStyle": ComponentStyle {
+                        "componentId": "sc-kAzzGY",
+                        "isStatic": false,
+                        "lastClassName": "jHprQs",
+                        "rules": Array [],
+                      },
+                      "displayName": "Styled(BaseFieldLabel)",
+                      "foldedComponentIds": Array [],
+                      "render": [Function],
+                      "styledComponentId": "sc-kAzzGY",
+                      "target": [Function],
+                      "toString": [Function],
+                      "usesTheme": false,
+                      "warnTooManyClasses": [Function],
+                      "withComponent": [Function],
+                    }
+                  }
+                  forwardedRef={null}
+                  helpText={null}
+                  labelText="Range"
+                  requirementText={null}
+                >
+                  <BaseFieldLabel
+                    className="sc-kAzzGY jHprQs"
+                    helpText={null}
+                    labelText="Range"
+                    requirementText={null}
+                  >
+                    <FieldLabel__Label
+                      className="sc-kAzzGY jHprQs"
+                      color="#011e38"
+                      style={
+                        Object {
+                          "display": "block",
+                        }
+                      }
+                    >
+                      <StyledComponent
+                        className="sc-kAzzGY jHprQs"
+                        color="#011e38"
+                        forwardedComponent={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "_foldedDefaultProps": Object {
+                              "color": "#011e38",
+                            },
+                            "attrs": Array [],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "FieldLabel__Label-sc-1t1cp4f-0",
+                              "isStatic": false,
+                              "lastClassName": "gFwPaD",
+                              "rules": Array [
+                                [Function],
+                                [Function],
+                              ],
+                            },
+                            "displayName": "FieldLabel__Label",
+                            "foldedComponentIds": Array [],
+                            "propTypes": Object {
+                              "color": [Function],
+                            },
+                            "render": [Function],
+                            "styledComponentId": "FieldLabel__Label-sc-1t1cp4f-0",
+                            "target": "label",
+                            "toString": [Function],
+                            "usesTheme": false,
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          }
+                        }
+                        forwardedRef={null}
+                        style={
+                          Object {
+                            "display": "block",
+                          }
+                        }
+                      >
+                        <label
+                          className="FieldLabel__Label-sc-1t1cp4f-0 gFwPaD sc-kAzzGY jHprQs"
+                          color="#011e38"
+                          style={
+                            Object {
+                              "display": "block",
+                            }
+                          }
+                        >
+                          <Box
+                            mb="x1"
+                            theme={
+                              Object {
+                                "borders": Array [],
+                                "breakpoints": Object {
+                                  "extraLarge": "1920px",
+                                  "extraSmall": "0px",
+                                  "large": "1360px",
+                                  "medium": "1024px",
+                                  "small": "768px",
+                                },
+                                "colors": Object {
+                                  "black": "#011e38",
+                                  "blackBlue": "#122b47",
+                                  "blue": "#216beb",
+                                  "darkBlue": "#00438f",
+                                  "darkGrey": "#434d59",
+                                  "green": "#008059",
+                                  "grey": "#c0c8d1",
+                                  "lightBlue": "#e1ebfa",
+                                  "lightGreen": "#e9f7f2",
+                                  "lightGrey": "#e4e7eb",
+                                  "lightRed": "#fae6ea",
+                                  "lightYellow": "#fcf5e3",
+                                  "red": "#cc1439",
+                                  "white": "#ffffff",
+                                  "whiteGrey": "#f0f2f5",
+                                  "yellow": "#ffbb00",
+                                },
+                                "fontSizes": Object {
+                                  "large": "20px",
+                                  "larger": "26px",
+                                  "largest": "46px",
+                                  "medium": "16px",
+                                  "small": "14px",
+                                  "smaller": "12px",
+                                },
+                                "fontWeights": Object {
+                                  "bold": "600",
+                                  "light": "300",
+                                  "medium": "500",
+                                  "normal": "400",
+                                },
+                                "fonts": Object {
+                                  "base": "'IBM Plex Sans', sans-serif",
+                                  "mono": "'IBM Plex Mono', monospace",
+                                },
+                                "lineHeights": Object {
+                                  "base": "1.5",
+                                  "sectionTitle": "1.23076923",
+                                  "smallTextBase": "1.71428571",
+                                  "smallTextCompressed": "1.14285714",
+                                  "smallerText": "1.33333333",
+                                  "subsectionTitle": "1.2",
+                                  "title": "1.04347826",
+                                },
+                                "radii": Object {
+                                  "circle": "50%",
+                                  "medium": "4px",
+                                  "small": "2px",
+                                },
+                                "shadows": Object {
+                                  "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                  "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                  "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                  "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                  "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                },
+                                "space": Object {
+                                  "half": "4px",
+                                  "none": "0px",
+                                  "x1": "8px",
+                                  "x2": "16px",
+                                  "x3": "24px",
+                                  "x4": "32px",
+                                  "x5": "40px",
+                                  "x6": "48px",
+                                  "x8": "64px",
+                                },
+                                "zIndex": Object {
+                                  "content": 100,
+                                  "overlay": 1000,
+                                  "tabsBar": 210,
+                                  "tabsScollIndicator": 200,
+                                },
+                              }
+                            }
+                          >
+                            <StyledComponent
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "_foldedDefaultProps": Object {
+                                    "theme": Object {
+                                      "borders": Array [],
+                                      "breakpoints": Object {
+                                        "extraLarge": "1920px",
+                                        "extraSmall": "0px",
+                                        "large": "1360px",
+                                        "medium": "1024px",
+                                        "small": "768px",
+                                      },
+                                      "colors": Object {
+                                        "black": "#011e38",
+                                        "blackBlue": "#122b47",
+                                        "blue": "#216beb",
+                                        "darkBlue": "#00438f",
+                                        "darkGrey": "#434d59",
+                                        "green": "#008059",
+                                        "grey": "#c0c8d1",
+                                        "lightBlue": "#e1ebfa",
+                                        "lightGreen": "#e9f7f2",
+                                        "lightGrey": "#e4e7eb",
+                                        "lightRed": "#fae6ea",
+                                        "lightYellow": "#fcf5e3",
+                                        "red": "#cc1439",
+                                        "white": "#ffffff",
+                                        "whiteGrey": "#f0f2f5",
+                                        "yellow": "#ffbb00",
+                                      },
+                                      "fontSizes": Object {
+                                        "large": "20px",
+                                        "larger": "26px",
+                                        "largest": "46px",
+                                        "medium": "16px",
+                                        "small": "14px",
+                                        "smaller": "12px",
+                                      },
+                                      "fontWeights": Object {
+                                        "bold": "600",
+                                        "light": "300",
+                                        "medium": "500",
+                                        "normal": "400",
+                                      },
+                                      "fonts": Object {
+                                        "base": "'IBM Plex Sans', sans-serif",
+                                        "mono": "'IBM Plex Mono', monospace",
+                                      },
+                                      "lineHeights": Object {
+                                        "base": "1.5",
+                                        "sectionTitle": "1.23076923",
+                                        "smallTextBase": "1.71428571",
+                                        "smallTextCompressed": "1.14285714",
+                                        "smallerText": "1.33333333",
+                                        "subsectionTitle": "1.2",
+                                        "title": "1.04347826",
+                                      },
+                                      "radii": Object {
+                                        "circle": "50%",
+                                        "medium": "4px",
+                                        "small": "2px",
+                                      },
+                                      "shadows": Object {
+                                        "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                        "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                        "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                        "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                        "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                      },
+                                      "space": Object {
+                                        "half": "4px",
+                                        "none": "0px",
+                                        "x1": "8px",
+                                        "x2": "16px",
+                                        "x3": "24px",
+                                        "x4": "32px",
+                                        "x5": "40px",
+                                        "x6": "48px",
+                                        "x8": "64px",
+                                      },
+                                      "zIndex": Object {
+                                        "content": 100,
+                                        "overlay": 1000,
+                                        "tabsBar": 210,
+                                        "tabsScollIndicator": 200,
+                                      },
+                                    },
+                                  },
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "Box-sc-1qu1edy-0",
+                                    "isStatic": false,
+                                    "lastClassName": "bhFymm",
+                                    "rules": Array [
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                    ],
+                                  },
+                                  "displayName": "Box",
+                                  "foldedComponentIds": Array [],
+                                  "propTypes": Object {
+                                    "bg": [Function],
+                                    "border": [Function],
+                                    "borderBottom": [Function],
+                                    "borderLeft": [Function],
+                                    "borderRadius": [Function],
+                                    "borderRight": [Function],
+                                    "borderTop": [Function],
+                                    "boxShadow": [Function],
+                                    "color": [Function],
+                                    "display": [Function],
+                                    "flexGrow": [Function],
+                                    "height": [Function],
+                                    "m": [Function],
+                                    "maxHeight": [Function],
+                                    "maxWidth": [Function],
+                                    "mb": [Function],
+                                    "minHeight": [Function],
+                                    "minWidth": [Function],
+                                    "ml": [Function],
+                                    "mr": [Function],
+                                    "mt": [Function],
+                                    "mx": [Function],
+                                    "my": [Function],
+                                    "order": [Function],
+                                    "p": [Function],
+                                    "pb": [Function],
+                                    "pl": [Function],
+                                    "position": [Function],
+                                    "pr": [Function],
+                                    "pt": [Function],
+                                    "px": [Function],
+                                    "py": [Function],
+                                    "textAlign": [Function],
+                                    "width": [Function],
+                                  },
+                                  "render": [Function],
+                                  "styledComponentId": "Box-sc-1qu1edy-0",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "usesTheme": false,
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              mb="x1"
+                              theme={
+                                Object {
+                                  "borders": Array [],
+                                  "breakpoints": Object {
+                                    "extraLarge": "1920px",
+                                    "extraSmall": "0px",
+                                    "large": "1360px",
+                                    "medium": "1024px",
+                                    "small": "768px",
+                                  },
+                                  "colors": Object {
+                                    "black": "#011e38",
+                                    "blackBlue": "#122b47",
+                                    "blue": "#216beb",
+                                    "darkBlue": "#00438f",
+                                    "darkGrey": "#434d59",
+                                    "green": "#008059",
+                                    "grey": "#c0c8d1",
+                                    "lightBlue": "#e1ebfa",
+                                    "lightGreen": "#e9f7f2",
+                                    "lightGrey": "#e4e7eb",
+                                    "lightRed": "#fae6ea",
+                                    "lightYellow": "#fcf5e3",
+                                    "red": "#cc1439",
+                                    "white": "#ffffff",
+                                    "whiteGrey": "#f0f2f5",
+                                    "yellow": "#ffbb00",
+                                  },
+                                  "fontSizes": Object {
+                                    "large": "20px",
+                                    "larger": "26px",
+                                    "largest": "46px",
+                                    "medium": "16px",
+                                    "small": "14px",
+                                    "smaller": "12px",
+                                  },
+                                  "fontWeights": Object {
+                                    "bold": "600",
+                                    "light": "300",
+                                    "medium": "500",
+                                    "normal": "400",
+                                  },
+                                  "fonts": Object {
+                                    "base": "'IBM Plex Sans', sans-serif",
+                                    "mono": "'IBM Plex Mono', monospace",
+                                  },
+                                  "lineHeights": Object {
+                                    "base": "1.5",
+                                    "sectionTitle": "1.23076923",
+                                    "smallTextBase": "1.71428571",
+                                    "smallTextCompressed": "1.14285714",
+                                    "smallerText": "1.33333333",
+                                    "subsectionTitle": "1.2",
+                                    "title": "1.04347826",
+                                  },
+                                  "radii": Object {
+                                    "circle": "50%",
+                                    "medium": "4px",
+                                    "small": "2px",
+                                  },
+                                  "shadows": Object {
+                                    "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                    "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                    "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                    "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                    "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                  },
+                                  "space": Object {
+                                    "half": "4px",
+                                    "none": "0px",
+                                    "x1": "8px",
+                                    "x2": "16px",
+                                    "x3": "24px",
+                                    "x4": "32px",
+                                    "x5": "40px",
+                                    "x6": "48px",
+                                    "x8": "64px",
+                                  },
+                                  "zIndex": Object {
+                                    "content": 100,
+                                    "overlay": 1000,
+                                    "tabsBar": 210,
+                                    "tabsScollIndicator": 200,
+                                  },
+                                }
+                              }
+                            >
+                              <div
+                                className="Box-sc-1qu1edy-0 dufoOa"
+                              >
+                                <span
+                                  style={
+                                    Object {
+                                      "fontSize": "14px",
+                                      "fontWeight": "600",
+                                      "lineHeight": "1.71428571",
+                                    }
+                                  }
+                                >
+                                  Range
+                                </span>
+                              </div>
+                            </StyledComponent>
+                          </Box>
+                          <Box
+                            alignItems="flex-start"
+                            display="inline-flex"
+                            justifyContent="center"
+                            mb="x3"
+                            theme={
+                              Object {
+                                "borders": Array [],
+                                "breakpoints": Object {
+                                  "extraLarge": "1920px",
+                                  "extraSmall": "0px",
+                                  "large": "1360px",
+                                  "medium": "1024px",
+                                  "small": "768px",
+                                },
+                                "colors": Object {
+                                  "black": "#011e38",
+                                  "blackBlue": "#122b47",
+                                  "blue": "#216beb",
+                                  "darkBlue": "#00438f",
+                                  "darkGrey": "#434d59",
+                                  "green": "#008059",
+                                  "grey": "#c0c8d1",
+                                  "lightBlue": "#e1ebfa",
+                                  "lightGreen": "#e9f7f2",
+                                  "lightGrey": "#e4e7eb",
+                                  "lightRed": "#fae6ea",
+                                  "lightYellow": "#fcf5e3",
+                                  "red": "#cc1439",
+                                  "white": "#ffffff",
+                                  "whiteGrey": "#f0f2f5",
+                                  "yellow": "#ffbb00",
+                                },
+                                "fontSizes": Object {
+                                  "large": "20px",
+                                  "larger": "26px",
+                                  "largest": "46px",
+                                  "medium": "16px",
+                                  "small": "14px",
+                                  "smaller": "12px",
+                                },
+                                "fontWeights": Object {
+                                  "bold": "600",
+                                  "light": "300",
+                                  "medium": "500",
+                                  "normal": "400",
+                                },
+                                "fonts": Object {
+                                  "base": "'IBM Plex Sans', sans-serif",
+                                  "mono": "'IBM Plex Mono', monospace",
+                                },
+                                "lineHeights": Object {
+                                  "base": "1.5",
+                                  "sectionTitle": "1.23076923",
+                                  "smallTextBase": "1.71428571",
+                                  "smallTextCompressed": "1.14285714",
+                                  "smallerText": "1.33333333",
+                                  "subsectionTitle": "1.2",
+                                  "title": "1.04347826",
+                                },
+                                "radii": Object {
+                                  "circle": "50%",
+                                  "medium": "4px",
+                                  "small": "2px",
+                                },
+                                "shadows": Object {
+                                  "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                  "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                  "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                  "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                  "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                },
+                                "space": Object {
+                                  "half": "4px",
+                                  "none": "0px",
+                                  "x1": "8px",
+                                  "x2": "16px",
+                                  "x3": "24px",
+                                  "x4": "32px",
+                                  "x5": "40px",
+                                  "x6": "48px",
+                                  "x8": "64px",
+                                },
+                                "zIndex": Object {
+                                  "content": 100,
+                                  "overlay": 1000,
+                                  "tabsBar": 210,
+                                  "tabsScollIndicator": 200,
+                                },
+                              }
+                            }
+                          >
+                            <StyledComponent
+                              alignItems="flex-start"
+                              display="inline-flex"
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "_foldedDefaultProps": Object {
+                                    "theme": Object {
+                                      "borders": Array [],
+                                      "breakpoints": Object {
+                                        "extraLarge": "1920px",
+                                        "extraSmall": "0px",
+                                        "large": "1360px",
+                                        "medium": "1024px",
+                                        "small": "768px",
+                                      },
+                                      "colors": Object {
+                                        "black": "#011e38",
+                                        "blackBlue": "#122b47",
+                                        "blue": "#216beb",
+                                        "darkBlue": "#00438f",
+                                        "darkGrey": "#434d59",
+                                        "green": "#008059",
+                                        "grey": "#c0c8d1",
+                                        "lightBlue": "#e1ebfa",
+                                        "lightGreen": "#e9f7f2",
+                                        "lightGrey": "#e4e7eb",
+                                        "lightRed": "#fae6ea",
+                                        "lightYellow": "#fcf5e3",
+                                        "red": "#cc1439",
+                                        "white": "#ffffff",
+                                        "whiteGrey": "#f0f2f5",
+                                        "yellow": "#ffbb00",
+                                      },
+                                      "fontSizes": Object {
+                                        "large": "20px",
+                                        "larger": "26px",
+                                        "largest": "46px",
+                                        "medium": "16px",
+                                        "small": "14px",
+                                        "smaller": "12px",
+                                      },
+                                      "fontWeights": Object {
+                                        "bold": "600",
+                                        "light": "300",
+                                        "medium": "500",
+                                        "normal": "400",
+                                      },
+                                      "fonts": Object {
+                                        "base": "'IBM Plex Sans', sans-serif",
+                                        "mono": "'IBM Plex Mono', monospace",
+                                      },
+                                      "lineHeights": Object {
+                                        "base": "1.5",
+                                        "sectionTitle": "1.23076923",
+                                        "smallTextBase": "1.71428571",
+                                        "smallTextCompressed": "1.14285714",
+                                        "smallerText": "1.33333333",
+                                        "subsectionTitle": "1.2",
+                                        "title": "1.04347826",
+                                      },
+                                      "radii": Object {
+                                        "circle": "50%",
+                                        "medium": "4px",
+                                        "small": "2px",
+                                      },
+                                      "shadows": Object {
+                                        "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                        "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                        "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                        "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                        "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                      },
+                                      "space": Object {
+                                        "half": "4px",
+                                        "none": "0px",
+                                        "x1": "8px",
+                                        "x2": "16px",
+                                        "x3": "24px",
+                                        "x4": "32px",
+                                        "x5": "40px",
+                                        "x6": "48px",
+                                        "x8": "64px",
+                                      },
+                                      "zIndex": Object {
+                                        "content": 100,
+                                        "overlay": 1000,
+                                        "tabsBar": 210,
+                                        "tabsScollIndicator": 200,
+                                      },
+                                    },
+                                  },
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "Box-sc-1qu1edy-0",
+                                    "isStatic": false,
+                                    "lastClassName": "bhFymm",
+                                    "rules": Array [
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                    ],
+                                  },
+                                  "displayName": "Box",
+                                  "foldedComponentIds": Array [],
+                                  "propTypes": Object {
+                                    "bg": [Function],
+                                    "border": [Function],
+                                    "borderBottom": [Function],
+                                    "borderLeft": [Function],
+                                    "borderRadius": [Function],
+                                    "borderRight": [Function],
+                                    "borderTop": [Function],
+                                    "boxShadow": [Function],
+                                    "color": [Function],
+                                    "display": [Function],
+                                    "flexGrow": [Function],
+                                    "height": [Function],
+                                    "m": [Function],
+                                    "maxHeight": [Function],
+                                    "maxWidth": [Function],
+                                    "mb": [Function],
+                                    "minHeight": [Function],
+                                    "minWidth": [Function],
+                                    "ml": [Function],
+                                    "mr": [Function],
+                                    "mt": [Function],
+                                    "mx": [Function],
+                                    "my": [Function],
+                                    "order": [Function],
+                                    "p": [Function],
+                                    "pb": [Function],
+                                    "pl": [Function],
+                                    "position": [Function],
+                                    "pr": [Function],
+                                    "pt": [Function],
+                                    "px": [Function],
+                                    "py": [Function],
+                                    "textAlign": [Function],
+                                    "width": [Function],
+                                  },
+                                  "render": [Function],
+                                  "styledComponentId": "Box-sc-1qu1edy-0",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "usesTheme": false,
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              justifyContent="center"
+                              mb="x3"
+                              theme={
+                                Object {
+                                  "borders": Array [],
+                                  "breakpoints": Object {
+                                    "extraLarge": "1920px",
+                                    "extraSmall": "0px",
+                                    "large": "1360px",
+                                    "medium": "1024px",
+                                    "small": "768px",
+                                  },
+                                  "colors": Object {
+                                    "black": "#011e38",
+                                    "blackBlue": "#122b47",
+                                    "blue": "#216beb",
+                                    "darkBlue": "#00438f",
+                                    "darkGrey": "#434d59",
+                                    "green": "#008059",
+                                    "grey": "#c0c8d1",
+                                    "lightBlue": "#e1ebfa",
+                                    "lightGreen": "#e9f7f2",
+                                    "lightGrey": "#e4e7eb",
+                                    "lightRed": "#fae6ea",
+                                    "lightYellow": "#fcf5e3",
+                                    "red": "#cc1439",
+                                    "white": "#ffffff",
+                                    "whiteGrey": "#f0f2f5",
+                                    "yellow": "#ffbb00",
+                                  },
+                                  "fontSizes": Object {
+                                    "large": "20px",
+                                    "larger": "26px",
+                                    "largest": "46px",
+                                    "medium": "16px",
+                                    "small": "14px",
+                                    "smaller": "12px",
+                                  },
+                                  "fontWeights": Object {
+                                    "bold": "600",
+                                    "light": "300",
+                                    "medium": "500",
+                                    "normal": "400",
+                                  },
+                                  "fonts": Object {
+                                    "base": "'IBM Plex Sans', sans-serif",
+                                    "mono": "'IBM Plex Mono', monospace",
+                                  },
+                                  "lineHeights": Object {
+                                    "base": "1.5",
+                                    "sectionTitle": "1.23076923",
+                                    "smallTextBase": "1.71428571",
+                                    "smallTextCompressed": "1.14285714",
+                                    "smallerText": "1.33333333",
+                                    "subsectionTitle": "1.2",
+                                    "title": "1.04347826",
+                                  },
+                                  "radii": Object {
+                                    "circle": "50%",
+                                    "medium": "4px",
+                                    "small": "2px",
+                                  },
+                                  "shadows": Object {
+                                    "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                    "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                    "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                    "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                    "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                  },
+                                  "space": Object {
+                                    "half": "4px",
+                                    "none": "0px",
+                                    "x1": "8px",
+                                    "x2": "16px",
+                                    "x3": "24px",
+                                    "x4": "32px",
+                                    "x5": "40px",
+                                    "x6": "48px",
+                                    "x8": "64px",
+                                  },
+                                  "zIndex": Object {
+                                    "content": 100,
+                                    "overlay": 1000,
+                                    "tabsBar": 210,
+                                    "tabsScollIndicator": 200,
+                                  },
+                                }
+                              }
+                            >
+                              <div
+                                className="Box-sc-1qu1edy-0 bhFymm"
+                                display="inline-flex"
+                              >
+                                <Styled(Box)
+                                  alignItems="center"
+                                  maxHeight="38px"
+                                  px="x2"
+                                  theme={
+                                    Object {
+                                      "borders": Array [],
+                                      "breakpoints": Object {
+                                        "extraLarge": "1920px",
+                                        "extraSmall": "0px",
+                                        "large": "1360px",
+                                        "medium": "1024px",
+                                        "small": "768px",
+                                      },
+                                      "colors": Object {
+                                        "black": "#011e38",
+                                        "blackBlue": "#122b47",
+                                        "blue": "#216beb",
+                                        "darkBlue": "#00438f",
+                                        "darkGrey": "#434d59",
+                                        "green": "#008059",
+                                        "grey": "#c0c8d1",
+                                        "lightBlue": "#e1ebfa",
+                                        "lightGreen": "#e9f7f2",
+                                        "lightGrey": "#e4e7eb",
+                                        "lightRed": "#fae6ea",
+                                        "lightYellow": "#fcf5e3",
+                                        "red": "#cc1439",
+                                        "white": "#ffffff",
+                                        "whiteGrey": "#f0f2f5",
+                                        "yellow": "#ffbb00",
+                                      },
+                                      "fontSizes": Object {
+                                        "large": "20px",
+                                        "larger": "26px",
+                                        "largest": "46px",
+                                        "medium": "16px",
+                                        "small": "14px",
+                                        "smaller": "12px",
+                                      },
+                                      "fontWeights": Object {
+                                        "bold": "600",
+                                        "light": "300",
+                                        "medium": "500",
+                                        "normal": "400",
+                                      },
+                                      "fonts": Object {
+                                        "base": "'IBM Plex Sans', sans-serif",
+                                        "mono": "'IBM Plex Mono', monospace",
+                                      },
+                                      "lineHeights": Object {
+                                        "base": "1.5",
+                                        "sectionTitle": "1.23076923",
+                                        "smallTextBase": "1.71428571",
+                                        "smallTextCompressed": "1.14285714",
+                                        "smallerText": "1.33333333",
+                                        "subsectionTitle": "1.2",
+                                        "title": "1.04347826",
+                                      },
+                                      "radii": Object {
+                                        "circle": "50%",
+                                        "medium": "4px",
+                                        "small": "2px",
+                                      },
+                                      "shadows": Object {
+                                        "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                        "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                        "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                        "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                        "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                      },
+                                      "space": Object {
+                                        "half": "4px",
+                                        "none": "0px",
+                                        "x1": "8px",
+                                        "x2": "16px",
+                                        "x3": "24px",
+                                        "x4": "32px",
+                                        "x5": "40px",
+                                        "x6": "48px",
+                                        "x8": "64px",
+                                      },
+                                      "zIndex": Object {
+                                        "content": 100,
+                                        "overlay": 1000,
+                                        "tabsBar": 210,
+                                        "tabsScollIndicator": 200,
+                                      },
+                                    }
+                                  }
+                                >
+                                  <StyledComponent
+                                    alignItems="center"
+                                    forwardedComponent={
+                                      Object {
+                                        "$$typeof": Symbol(react.forward_ref),
+                                        "_foldedDefaultProps": Object {
+                                          "theme": Object {
+                                            "borders": Array [],
+                                            "breakpoints": Object {
+                                              "extraLarge": "1920px",
+                                              "extraSmall": "0px",
+                                              "large": "1360px",
+                                              "medium": "1024px",
+                                              "small": "768px",
+                                            },
+                                            "colors": Object {
+                                              "black": "#011e38",
+                                              "blackBlue": "#122b47",
+                                              "blue": "#216beb",
+                                              "darkBlue": "#00438f",
+                                              "darkGrey": "#434d59",
+                                              "green": "#008059",
+                                              "grey": "#c0c8d1",
+                                              "lightBlue": "#e1ebfa",
+                                              "lightGreen": "#e9f7f2",
+                                              "lightGrey": "#e4e7eb",
+                                              "lightRed": "#fae6ea",
+                                              "lightYellow": "#fcf5e3",
+                                              "red": "#cc1439",
+                                              "white": "#ffffff",
+                                              "whiteGrey": "#f0f2f5",
+                                              "yellow": "#ffbb00",
+                                            },
+                                            "fontSizes": Object {
+                                              "large": "20px",
+                                              "larger": "26px",
+                                              "largest": "46px",
+                                              "medium": "16px",
+                                              "small": "14px",
+                                              "smaller": "12px",
+                                            },
+                                            "fontWeights": Object {
+                                              "bold": "600",
+                                              "light": "300",
+                                              "medium": "500",
+                                              "normal": "400",
+                                            },
+                                            "fonts": Object {
+                                              "base": "'IBM Plex Sans', sans-serif",
+                                              "mono": "'IBM Plex Mono', monospace",
+                                            },
+                                            "lineHeights": Object {
+                                              "base": "1.5",
+                                              "sectionTitle": "1.23076923",
+                                              "smallTextBase": "1.71428571",
+                                              "smallTextCompressed": "1.14285714",
+                                              "smallerText": "1.33333333",
+                                              "subsectionTitle": "1.2",
+                                              "title": "1.04347826",
+                                            },
+                                            "radii": Object {
+                                              "circle": "50%",
+                                              "medium": "4px",
+                                              "small": "2px",
+                                            },
+                                            "shadows": Object {
+                                              "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                              "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                              "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                              "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                              "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                            },
+                                            "space": Object {
+                                              "half": "4px",
+                                              "none": "0px",
+                                              "x1": "8px",
+                                              "x2": "16px",
+                                              "x3": "24px",
+                                              "x4": "32px",
+                                              "x5": "40px",
+                                              "x6": "48px",
+                                              "x8": "64px",
+                                            },
+                                            "zIndex": Object {
+                                              "content": 100,
+                                              "overlay": 1000,
+                                              "tabsBar": 210,
+                                              "tabsScollIndicator": 200,
+                                            },
+                                          },
+                                        },
+                                        "attrs": Array [],
+                                        "componentStyle": ComponentStyle {
+                                          "componentId": "sc-bdVaJa",
+                                          "isStatic": false,
+                                          "lastClassName": "cRonwR",
+                                          "rules": Array [
+                                            [Function],
+                                            [Function],
+                                            [Function],
+                                            [Function],
+                                            [Function],
+                                            [Function],
+                                            [Function],
+                                            [Function],
+                                            [Function],
+                                            [Function],
+                                            [Function],
+                                            [Function],
+                                            [Function],
+                                            [Function],
+                                            [Function],
+                                            [Function],
+                                            [Function],
+                                            "display: flex;",
+                                            [Function],
+                                            [Function],
+                                            [Function],
+                                            [Function],
+                                          ],
+                                        },
+                                        "displayName": "Styled(Box)",
+                                        "foldedComponentIds": Array [
+                                          "Box-sc-1qu1edy-0",
+                                        ],
+                                        "propTypes": Object {
+                                          "alignItems": [Function],
+                                          "flexDirection": [Function],
+                                          "flexWrap": [Function],
+                                          "justifyContent": [Function],
+                                        },
+                                        "render": [Function],
+                                        "styledComponentId": "sc-bdVaJa",
+                                        "target": "div",
+                                        "toString": [Function],
+                                        "usesTheme": false,
+                                        "warnTooManyClasses": [Function],
+                                        "withComponent": [Function],
+                                      }
+                                    }
+                                    forwardedRef={null}
+                                    maxHeight="38px"
+                                    px="x2"
+                                    theme={
+                                      Object {
+                                        "borders": Array [],
+                                        "breakpoints": Object {
+                                          "extraLarge": "1920px",
+                                          "extraSmall": "0px",
+                                          "large": "1360px",
+                                          "medium": "1024px",
+                                          "small": "768px",
+                                        },
+                                        "colors": Object {
+                                          "black": "#011e38",
+                                          "blackBlue": "#122b47",
+                                          "blue": "#216beb",
+                                          "darkBlue": "#00438f",
+                                          "darkGrey": "#434d59",
+                                          "green": "#008059",
+                                          "grey": "#c0c8d1",
+                                          "lightBlue": "#e1ebfa",
+                                          "lightGreen": "#e9f7f2",
+                                          "lightGrey": "#e4e7eb",
+                                          "lightRed": "#fae6ea",
+                                          "lightYellow": "#fcf5e3",
+                                          "red": "#cc1439",
+                                          "white": "#ffffff",
+                                          "whiteGrey": "#f0f2f5",
+                                          "yellow": "#ffbb00",
+                                        },
+                                        "fontSizes": Object {
+                                          "large": "20px",
+                                          "larger": "26px",
+                                          "largest": "46px",
+                                          "medium": "16px",
+                                          "small": "14px",
+                                          "smaller": "12px",
+                                        },
+                                        "fontWeights": Object {
+                                          "bold": "600",
+                                          "light": "300",
+                                          "medium": "500",
+                                          "normal": "400",
+                                        },
+                                        "fonts": Object {
+                                          "base": "'IBM Plex Sans', sans-serif",
+                                          "mono": "'IBM Plex Mono', monospace",
+                                        },
+                                        "lineHeights": Object {
+                                          "base": "1.5",
+                                          "sectionTitle": "1.23076923",
+                                          "smallTextBase": "1.71428571",
+                                          "smallTextCompressed": "1.14285714",
+                                          "smallerText": "1.33333333",
+                                          "subsectionTitle": "1.2",
+                                          "title": "1.04347826",
+                                        },
+                                        "radii": Object {
+                                          "circle": "50%",
+                                          "medium": "4px",
+                                          "small": "2px",
+                                        },
+                                        "shadows": Object {
+                                          "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                                          "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                                          "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                                          "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                                          "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                                        },
+                                        "space": Object {
+                                          "half": "4px",
+                                          "none": "0px",
+                                          "x1": "8px",
+                                          "x2": "16px",
+                                          "x3": "24px",
+                                          "x4": "32px",
+                                          "x5": "40px",
+                                          "x6": "48px",
+                                          "x8": "64px",
+                                        },
+                                        "zIndex": Object {
+                                          "content": 100,
+                                          "overlay": 1000,
+                                          "tabsBar": 210,
+                                          "tabsScollIndicator": 200,
+                                        },
+                                      }
+                                    }
+                                  >
+                                    <div
+                                      className="Box-sc-1qu1edy-0 sc-bdVaJa cRonwR"
+                                    >
+                                      <styled.p
+                                        color="currentColor"
+                                        disabled={false}
+                                        fontSize="16px"
+                                        inline={false}
+                                        lineHeight="1.5"
+                                        m={0}
+                                      >
+                                        <StyledComponent
+                                          color="currentColor"
+                                          disabled={false}
+                                          fontSize="16px"
+                                          forwardedComponent={
+                                            Object {
+                                              "$$typeof": Symbol(react.forward_ref),
+                                              "_foldedDefaultProps": Object {
+                                                "color": "currentColor",
+                                                "disabled": false,
+                                                "fontSize": "16px",
+                                                "inline": false,
+                                                "lineHeight": "1.5",
+                                                "m": 0,
+                                              },
+                                              "attrs": Array [
+                                                [Function],
+                                              ],
+                                              "componentStyle": ComponentStyle {
+                                                "componentId": "sc-bxivhb",
+                                                "isStatic": false,
+                                                "lastClassName": "bWRApy",
+                                                "rules": Array [
+                                                  [Function],
+                                                  [Function],
+                                                  [Function],
+                                                  [Function],
+                                                  [Function],
+                                                  [Function],
+                                                  [Function],
+                                                  [Function],
+                                                ],
+                                              },
+                                              "displayName": "styled.p",
+                                              "foldedComponentIds": Array [],
+                                              "propTypes": Object {
+                                                "disabled": [Function],
+                                                "inline": [Function],
+                                              },
+                                              "render": [Function],
+                                              "styledComponentId": "sc-bxivhb",
+                                              "target": "p",
+                                              "toString": [Function],
+                                              "usesTheme": false,
+                                              "warnTooManyClasses": [Function],
+                                              "withComponent": [Function],
+                                            }
+                                          }
+                                          forwardedRef={null}
+                                          inline={false}
+                                          lineHeight="1.5"
+                                          m={0}
+                                        >
+                                          <p
+                                            className="sc-bxivhb bWRApy"
+                                            color="currentColor"
+                                            disabled={false}
+                                            fontSize="16px"
+                                          >
+                                            -
+                                          </p>
+                                        </StyledComponent>
+                                      </styled.p>
+                                    </div>
+                                  </StyledComponent>
+                                </Styled(Box)>
+                              </div>
+                            </StyledComponent>
+                          </Box>
+                        </label>
+                      </StyledComponent>
+                    </FieldLabel__Label>
+                  </BaseFieldLabel>
+                </StyledComponent>
+              </Styled(BaseFieldLabel)>
+            </RangeContainer>
+          </ThemeProvider>
+        </div>
+      </StyledComponent>
+    </NDSProvider__GlobalStyles>
+  </NDSProvider>
+</div>
+`;

--- a/components/src/RangeContainer/index.js
+++ b/components/src/RangeContainer/index.js
@@ -1,0 +1,1 @@
+export { default as RangeContainer } from "./RangeContainer";

--- a/components/src/StoriesForTests/DateRange.story.js
+++ b/components/src/StoriesForTests/DateRange.story.js
@@ -1,0 +1,7 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { DateRange } from "../DateRange";
+
+storiesOf("StoriesForTests/DateRange", module).add("default (SkipStoryshot)", () => (
+  <DateRange defaultStartDate={new Date("Fri, 01 Jan 2019")} defaultEndDate={new Date("Fri, 05 Jan 2019")} />
+));

--- a/components/src/index.js
+++ b/components/src/index.js
@@ -39,3 +39,4 @@ export { DateRange } from "./DateRange";
 export { MonthPicker } from "./MonthPicker";
 export { MonthRange } from "./MonthRange";
 export { TimePicker } from "./TimePicker";
+export { RangeContainer } from "./RangeContainer";

--- a/components/src/index.js
+++ b/components/src/index.js
@@ -35,6 +35,7 @@ export { DemoPage } from "./DemoPage";
 export { StatusIndicator } from "./StatusIndicator";
 export { Pagination } from "./Pagination";
 export { DatePicker } from "./DatePicker";
+export { DateRange } from "./DateRange";
 export { MonthPicker } from "./MonthPicker";
 export { MonthRange } from "./MonthRange";
 export { TimePicker } from "./TimePicker";

--- a/components/src/testing/matchers/toMatchDate.js
+++ b/components/src/testing/matchers/toMatchDate.js
@@ -1,0 +1,19 @@
+expect.extend({
+  toMatchDate(received, date) {
+    const pass =
+      date.getMonth() === received.getMonth() &&
+      date.getYear() === received.getYear() &&
+      date.getDay() === received.getDay();
+    if (pass) {
+      return {
+        message: () => `expected ${received} not to match ${date}`,
+        pass: true
+      };
+    } else {
+      return {
+        message: () => `expected ${received} to match ${date}`,
+        pass: false
+      };
+    }
+  }
+});

--- a/components/src/testing/mockUtils/mockDates.js
+++ b/components/src/testing/mockUtils/mockDates.js
@@ -1,0 +1,18 @@
+let realDate;
+export const mockDate = date => {
+  const currentDate = new Date(date);
+  realDate = Date;
+  global.Date = class extends Date {
+    constructor(...args) {
+      if (args.length > 0) {
+        // eslint-disable-next-line constructor-super
+        return super(...args);
+      }
+
+      return currentDate;
+    }
+  };
+};
+export const resetDate = () => {
+  global.Date = realDate;
+};

--- a/docs/src/pages/components/date-range.js
+++ b/docs/src/pages/components/date-range.js
@@ -3,7 +3,7 @@ import { Helmet } from "react-helmet";
 import {
   SectionTitle,
   Title,
-  MonthRange,
+  DateRange,
   ListItem,
   List,
   Link
@@ -106,18 +106,18 @@ const propsRows = [
 export default () => (
   <Layout>
     <Helmet>
-      <title>Month Range</title>
+      <title>Date Range</title>
     </Helmet>
     <Intro>
-      <Title>Month Range</Title>
+      <Title>Date Range</Title>
       <IntroText>
-        Month ranges allow users to easily enter a range of months. If the end
+        Date ranges allow users to easily enter a range of dates. If the end
         date is before the start date, by default an error message will be
         displayed.
       </IntroText>
     </Intro>
     <DocSection>
-      <MonthRange />
+      <DateRange />
       <Highlight className="js">
         {`import { MonthRange } from "@nulogy/components";
 
@@ -145,6 +145,9 @@ export default () => (
       <List>
         <ListItem>
           <Link href="/components/date-picker">Date Picker</Link>
+        </ListItem>
+        <ListItem>
+          <Link href="/components/month-range">Month Range</Link>
         </ListItem>
         <ListItem>
           <Link href="/components/time-picker">Time Picker</Link>

--- a/docs/src/pages/components/date-range.js
+++ b/docs/src/pages/components/date-range.js
@@ -91,9 +91,9 @@ const propsRows = [
   {
     name: "labelProps",
     type: "Object",
-    defaultValue: "{ labelText: 'Month Range'}",
+    defaultValue: "{ labelText: 'Date Range'}",
     description:
-      "Options for the month range label. See fieldLabelProps for available option keys."
+      "Options for the month range label. See Label Props for available option keys."
   },
   {
     name: "disableRangeValidation",
@@ -119,9 +119,9 @@ export default () => (
     <DocSection>
       <DateRange />
       <Highlight className="js">
-        {`import { MonthRange } from "@nulogy/components";
+        {`import { DateRange } from "@nulogy/components";
 
-<MonthPicker
+<DateRange
         onRangeChange={(val) => val}
       />
 `}
@@ -159,7 +159,7 @@ export default () => (
       <SectionTitle>Resources</SectionTitle>
       <List>
         <ListItem>
-          <Link href="https://storybook.nulogy.design/?path=/story/monthpicker--default-skipstoryshot">
+          <Link href="https://storybook.nulogy.design/?path=/story/daterange--default-skipstoryshot">
             View in Storybook
           </Link>
         </ListItem>

--- a/docs/src/pages/components/month-range.js
+++ b/docs/src/pages/components/month-range.js
@@ -121,7 +121,7 @@ export default () => (
       <Highlight className="js">
         {`import { MonthRange } from "@nulogy/components";
 
-<MonthPicker
+<MonthRange
         onRangeChange={(val) => val}
       />
 `}
@@ -156,7 +156,7 @@ export default () => (
       <SectionTitle>Resources</SectionTitle>
       <List>
         <ListItem>
-          <Link href="https://storybook.nulogy.design/?path=/story/monthpicker--default-skipstoryshot">
+          <Link href="https://storybook.nulogy.design/?path=/story/monthrange--default-skipstoryshot">
             View in Storybook
           </Link>
         </ListItem>

--- a/docs/src/shared/menuData.js
+++ b/docs/src/shared/menuData.js
@@ -64,6 +64,10 @@ export const menuData = [
         href: "/components/date-picker"
       },
       {
+        name: "Date Range",
+        href: "/components/date-range"
+      },
+      {
         name: "Dropdown Menu",
         href: "/components/dropdown-menu"
       },


### PR DESCRIPTION
## Description

- Adds a DateRange component
- Adds a RangeContainer component for internal use that accepts the input components from the start and end of the range, and wraps the label, range "-" and error messages that is reused in the DateRange and MonthRange and should be useful for the upcoming TimeRange as well
- Cleans up the tests with helpers for mocking the currentDate and a shared custom date matcher that are used in the DateRange and MonthRange test (*Still need to skip storyshots right now since this only works for the by explicitly setting the date in the spec tests - I plan to continue that work in the NDS-1286)
- Adds highlighting for selected dates (visually indicate start date when selecting end date and vice versa)

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [x] Storybook updated with examples of new functionality
- [x] Storybook uses variable and realistic data (ex: short and long text)
- [x] Docs updated with correct props and examples
- [x] Updated and reviewed changes to storyshots
- [x] e2e tests added for component iterations
- [x] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
