### PR TITLE
feat: add auto-complete functionality to month picker input

### DIFF
--- a/components-e2e/cypress/integration/components/MonthPicker.spec.js
+++ b/components-e2e/cypress/integration/components/MonthPicker.spec.js
@@ -91,8 +91,51 @@ describe("Monthpicker", () => {
         cy.get(".react-datepicker__header").contains("2020");
       });
     });
+
+    describe("month autofill", () => {
+      it("does not autofill when typed characters don't match", () => {
+        cy.get("input")
+          .clear()
+          .type("app");
+        getMonthInputComponent().should("have.value", "app");
+      });
+      it("does not autofill when not enough letters are typed", () => {
+        cy.get("input")
+          .clear()
+          .type("de");
+        getMonthInputComponent().should("have.value", "de");
+      });
+      it("autofills when typing characters that match case", () => {
+        cy.get("input")
+          .clear()
+          .type("Apr");
+        cy.get(
+          ".react-datepicker__month-3.react-datepicker__month--selected"
+        ).should("exist");
+        getMonthInputComponent().should("have.value", "Apr 2019");
+      });
+      it("autofills when typing characters that ignore case", () => {
+        cy.get("input")
+          .clear()
+          .type("mar");
+        cy.get(
+          ".react-datepicker__month-2.react-datepicker__month--selected"
+        ).should("exist");
+        getMonthInputComponent().should("have.value", "Mar 2019");
+      });
+      it("uses the last selected year to fill in the year", () => {
+        cy.get("input").type("{backspace}{backspace}30");
+        cy.get("input")
+          .clear()
+          .type("aug");
+        cy.get(
+          ".react-datepicker__month-7.react-datepicker__month--selected"
+        ).should("exist");
+        getMonthInputComponent().should("have.value", "Aug 2030");
+      });
+    });
   });
-  describe("Default", () => {
+  describe("Min and Max date", () => {
     beforeEach(() => {
       cy.renderFromStorybook("monthpicker--with-a-min-and-max-date");
     });
@@ -117,6 +160,32 @@ describe("Monthpicker", () => {
 
         getMonthInputComponent().click();
         getNextMonthButton().should("not.exist");
+      });
+    });
+    describe("month autofill", () => {
+      it("does not autofill when month is not in range", () => {
+        cy.get("input")
+          .clear()
+          .type("jan");
+        getMonthInputComponent().should("have.value", "jan");
+      });
+      it("autofills when month is on range", () => {
+        cy.get("input")
+          .clear()
+          .type("jul");
+        cy.get(
+          ".react-datepicker__month-6.react-datepicker__month--selected"
+        ).should("exist");
+        getMonthInputComponent().should("have.value", "Jul 2019");
+      });
+      it("autofills when month is within range", () => {
+        cy.get("input")
+          .clear()
+          .type("SEP");
+        cy.get(
+          ".react-datepicker__month-8.react-datepicker__month--selected"
+        ).should("exist");
+        getMonthInputComponent().should("have.value", "Sep 2019");
       });
     });
   });

--- a/components-e2e/cypress/integration/components/MonthPicker.spec.js
+++ b/components-e2e/cypress/integration/components/MonthPicker.spec.js
@@ -92,20 +92,20 @@ describe("Monthpicker", () => {
       });
     });
 
-    describe("month autofill", () => {
-      it("does not autofill when typed characters don't match", () => {
+    describe("month auto-complete", () => {
+      it("does not auto-complete when typed characters don't match", () => {
         cy.get("input")
           .clear()
           .type("app");
         getMonthInputComponent().should("have.value", "app");
       });
-      it("does not autofill when not enough letters are typed", () => {
+      it("does not auto-complete when not enough letters are typed", () => {
         cy.get("input")
           .clear()
           .type("de");
         getMonthInputComponent().should("have.value", "de");
       });
-      it("autofills when typing characters that match case", () => {
+      it("auto-completes when typing characters that match case", () => {
         cy.get("input")
           .clear()
           .type("Apr");
@@ -114,7 +114,7 @@ describe("Monthpicker", () => {
         ).should("exist");
         getMonthInputComponent().should("have.value", "Apr 2019");
       });
-      it("autofills when typing characters that ignore case", () => {
+      it("auto-completes when typing characters that ignore case", () => {
         cy.get("input")
           .clear()
           .type("mar");
@@ -162,14 +162,14 @@ describe("Monthpicker", () => {
         getNextMonthButton().should("not.exist");
       });
     });
-    describe("month autofill", () => {
-      it("does not autofill when month is not in range", () => {
+    describe("month auto-complete", () => {
+      it("does not auto-complete when month is not in range", () => {
         cy.get("input")
           .clear()
           .type("jan");
         getMonthInputComponent().should("have.value", "jan");
       });
-      it("autofills when month is on range", () => {
+      it("auto-completes when month is on range", () => {
         cy.get("input")
           .clear()
           .type("jul");
@@ -178,7 +178,7 @@ describe("Monthpicker", () => {
         ).should("exist");
         getMonthInputComponent().should("have.value", "Jul 2019");
       });
-      it("autofills when month is within range", () => {
+      it("auto-completes when month is within range", () => {
         cy.get("input")
           .clear()
           .type("SEP");

--- a/components/package.json
+++ b/components/package.json
@@ -89,7 +89,8 @@
   },
   "dependencies": {
     "@nulogy/tokens": "^0.20.0",
-    "date-fns": "^2.8.1",
+    "date-fns": "2.9.0",
+    "debounce": "^1.2.0",
     "gatsby-plugin-gtag": "^1.0.12",
     "mockdate": "^2.0.5",
     "polished": "3.0.0",

--- a/components/src/MonthPicker/MonthPicker.js
+++ b/components/src/MonthPicker/MonthPicker.js
@@ -24,7 +24,7 @@ class MonthPicker extends Component {
       selectedDate: props.selected,
       calendarDate: props.selected ? props.selected : new Date()
     };
-    this.debounceAutofill = debounce(this.autofillMonth, 400);
+    this.debounceAutoComplete = debounce(this.autoCompleteMonth, 400);
     registerDatePickerLocales();
   }
 
@@ -42,7 +42,7 @@ class MonthPicker extends Component {
     }
   };
 
-  autofillMonth = (value, currentDate) => {
+  autoCompleteMonth = (value, currentDate) => {
     if (value.length > 2) {
       const STANDALONE_MONTH_FORMAT = "LLL";
       const { minDate, maxDate, locale } = this.props;
@@ -66,10 +66,10 @@ class MonthPicker extends Component {
 
   handleInputChange = event => {
     const { value } = event.target;
-    const { onInputChange, disableAutofill } = this.props;
+    const { onInputChange, disableAutoComplete } = this.props;
     const { calendarDate } = this.state;
-    if (!disableAutofill) {
-      this.debounceAutofill(value, calendarDate);
+    if (!disableAutoComplete) {
+      this.debounceAutoComplete(value, calendarDate);
     }
 
     if (onInputChange) {
@@ -135,7 +135,7 @@ MonthPicker.propTypes = {
   minDate: PropTypes.instanceOf(Date),
   maxDate: PropTypes.instanceOf(Date),
   locale: PropTypes.string,
-  disableAutofill: PropTypes.bool
+  disableAutoComplete: PropTypes.bool
 };
 
 MonthPicker.defaultProps = {
@@ -149,7 +149,7 @@ MonthPicker.defaultProps = {
   minDate: undefined,
   maxDate: undefined,
   locale: undefined,
-  disableAutofill: false
+  disableAutoComplete: false
 };
 
 export default MonthPicker;

--- a/components/src/MonthPicker/MonthPicker.js
+++ b/components/src/MonthPicker/MonthPicker.js
@@ -24,7 +24,7 @@ class MonthPicker extends Component {
       selectedDate: props.selected,
       calendarDate: props.selected ? props.selected : new Date()
     };
-    this.debounceAutoComplete = debounce(this.autoCompleteMonth, 400);
+    this.debounceAutocomplete = debounce(this.autoCompleteMonth, 400);
     registerDatePickerLocales();
   }
 
@@ -66,10 +66,10 @@ class MonthPicker extends Component {
 
   handleInputChange = event => {
     const { value } = event.target;
-    const { onInputChange, disableAutoComplete } = this.props;
+    const { onInputChange, disableAutocomplete } = this.props;
     const { calendarDate } = this.state;
-    if (!disableAutoComplete) {
-      this.debounceAutoComplete(value, calendarDate);
+    if (!disableAutocomplete) {
+      this.debounceAutocomplete(value, calendarDate);
     }
 
     if (onInputChange) {
@@ -135,7 +135,7 @@ MonthPicker.propTypes = {
   minDate: PropTypes.instanceOf(Date),
   maxDate: PropTypes.instanceOf(Date),
   locale: PropTypes.string,
-  disableAutoComplete: PropTypes.bool
+  disableAutocomplete: PropTypes.bool
 };
 
 MonthPicker.defaultProps = {
@@ -149,7 +149,7 @@ MonthPicker.defaultProps = {
   minDate: undefined,
   maxDate: undefined,
   locale: undefined,
-  disableAutoComplete: false
+  disableAutocomplete: false
 };
 
 export default MonthPicker;

--- a/components/src/MonthPicker/MonthPicker.js
+++ b/components/src/MonthPicker/MonthPicker.js
@@ -1,6 +1,9 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import ReactDatePicker from "react-datepicker";
+import eachMonthOfInterval from "date-fns/eachMonthOfInterval";
+import { debounce } from "debounce";
+import { format, isSameYear, isValid } from "date-fns";
 
 import { MonthPickerStyles } from "./MonthPickerStyles";
 import DatePickerInput from "../DatePicker/DatePickerInput";
@@ -9,7 +12,7 @@ import theme from "../theme";
 import { Field } from "../Form";
 import { InputFieldPropTypes, InputFieldDefaultProps } from "../Input/InputField.type";
 import { Icon } from "../Icon";
-import { registerDatePickerLocales } from "../utils/datePickerLocales";
+import { registerDatePickerLocales, supportedDateLocales } from "../utils/datePickerLocales";
 
 const DEFAULT_DATE_FORMAT = "MMM yyyy";
 const DEFAULT_PLACEHOLDER = "Mon YYYY";
@@ -17,13 +20,58 @@ const DEFAULT_PLACEHOLDER = "Mon YYYY";
 class MonthPicker extends Component {
   constructor(props) {
     super(props);
-    this.state = { selectedDate: props.selected };
+    this.state = {
+      selectedDate: props.selected,
+      calendarDate: props.selected ? props.selected : new Date()
+    };
+    this.debounceAutofill = debounce(this.autofillMonth, 400);
     registerDatePickerLocales();
   }
 
+  setSelectedDate = date => {
+    this.setState({
+      selectedDate: date
+    });
+  };
+
+  setCalendarDate = date => {
+    if (date && isValid(date)) {
+      this.setState({
+        calendarDate: date
+      });
+    }
+  };
+
+  autofillMonth = (value, currentDate) => {
+    if (value.length > 2) {
+      const STANDALONE_MONTH_FORMAT = "LLL";
+      const { minDate, maxDate, locale } = this.props;
+      const currentYear = Number(format(currentDate, "yyyy"));
+
+      const months = eachMonthOfInterval({
+        start: isSameYear(currentDate, minDate) ? minDate : new Date(currentYear, 1),
+        end: isSameYear(currentDate, maxDate) ? maxDate : new Date(currentYear, 12)
+      }).map(date => ({
+        label: format(date, STANDALONE_MONTH_FORMAT, { locale: supportedDateLocales[locale] }),
+        date
+      }));
+
+      const matchingMonth = months.filter(month => month.label.toLowerCase() === value.toLowerCase());
+
+      if (matchingMonth.length) {
+        this.handleSelectedDateChange(matchingMonth[0].date);
+      }
+    }
+  };
+
   handleInputChange = event => {
     const { value } = event.target;
-    const { onInputChange } = this.props;
+    const { onInputChange, disableAutofill } = this.props;
+    const { calendarDate } = this.state;
+    if (!disableAutofill) {
+      this.debounceAutofill(value, calendarDate);
+    }
+
     if (onInputChange) {
       onInputChange(value);
     }
@@ -34,9 +82,8 @@ class MonthPicker extends Component {
     if (onChange) {
       onChange(date);
     }
-    this.setState({
-      selectedDate: date
-    });
+    this.setSelectedDate(date);
+    this.setCalendarDate(date);
   };
 
   render() {
@@ -57,6 +104,7 @@ class MonthPicker extends Component {
         <MonthPickerStyles />
         <ReactDatePicker
           selected={selectedDate}
+          openToDate={selectedDate}
           dateFormat={dateFormat}
           onChange={this.handleSelectedDateChange}
           customInput={customInput}
@@ -86,7 +134,8 @@ MonthPicker.propTypes = {
   errorList: PropTypes.arrayOf(PropTypes.string),
   minDate: PropTypes.instanceOf(Date),
   maxDate: PropTypes.instanceOf(Date),
-  locale: PropTypes.string
+  locale: PropTypes.string,
+  disableAutofill: PropTypes.bool
 };
 
 MonthPicker.defaultProps = {
@@ -99,7 +148,8 @@ MonthPicker.defaultProps = {
   errorList: undefined,
   minDate: undefined,
   maxDate: undefined,
-  locale: undefined
+  locale: undefined,
+  disableAutofill: false
 };
 
 export default MonthPicker;

--- a/components/src/MonthPicker/MonthPicker.story.js
+++ b/components/src/MonthPicker/MonthPicker.story.js
@@ -10,7 +10,7 @@ storiesOf("MonthPicker", module)
   .addDecorator(withKnobs)
   .add("default", () => (
     <MonthPicker
-      selected={new Date("2018-01-01T05:00:00.000Z")}
+      selected={new Date("2019-01-01T05:00:00.000Z")}
       onChange={action("date changed")}
       onInputChange={action("input changed")}
       inputProps={{ labelText: "Month" }}

--- a/components/src/MonthPicker/MonthPicker.story.js
+++ b/components/src/MonthPicker/MonthPicker.story.js
@@ -10,7 +10,7 @@ storiesOf("MonthPicker", module)
   .addDecorator(withKnobs)
   .add("default", () => (
     <MonthPicker
-      selected={new Date("2019-01-01T05:00:00.000Z")}
+      selected={new Date("2018-01-01T05:00:00.000Z")}
       onChange={action("date changed")}
       onInputChange={action("input changed")}
       inputProps={{ labelText: "Month" }}
@@ -35,8 +35,8 @@ storiesOf("MonthPicker", module)
   .add("with a min and max date", () => (
     <MonthPicker
       selected={new Date("2019-07-10T05:00:00.000Z")}
-      minDate={new Date("2019-07-05T05:00:00.000Z")}
-      maxDate={new Date("2019-12-05T05:00:00.000Z")}
+      minDate={new Date("2019-07-01T05:00:00.000Z")}
+      maxDate={new Date("2019-12-01T05:00:00.000Z")}
       onChange={action("date changed")}
       onInputChange={action("input changed")}
       inputProps={{ labelText: "Month and Year" }}

--- a/components/src/MonthPicker/__snapshots__/MonthPicker.story.storyshot
+++ b/components/src/MonthPicker/__snapshots__/MonthPicker.story.storyshot
@@ -390,7 +390,7 @@ exports[`Storyshots MonthPicker custom locale 1`] = `
           >
             <MonthPicker
               dateFormat="MMM yyyy"
-              disableAutoComplete={false}
+              disableAutocomplete={false}
               inputProps={
                 Object {
                   "disabled": false,
@@ -2252,7 +2252,7 @@ exports[`Storyshots MonthPicker default 1`] = `
           >
             <MonthPicker
               dateFormat="MMM yyyy"
-              disableAutoComplete={false}
+              disableAutocomplete={false}
               inputProps={
                 Object {
                   "labelText": "Month",
@@ -4528,7 +4528,7 @@ exports[`Storyshots MonthPicker with a min and max date 1`] = `
           >
             <MonthPicker
               dateFormat="MMM yyyy"
-              disableAutoComplete={false}
+              disableAutocomplete={false}
               inputProps={
                 Object {
                   "labelText": "Month and Year",
@@ -6808,7 +6808,7 @@ exports[`Storyshots MonthPicker with custom placeholder 1`] = `
           >
             <MonthPicker
               dateFormat="MMM yyyy"
-              disableAutoComplete={false}
+              disableAutocomplete={false}
               inputProps={
                 Object {
                   "labelText": "Month and Year",
@@ -9082,7 +9082,7 @@ exports[`Storyshots MonthPicker with error state 1`] = `
           >
             <MonthPicker
               dateFormat="yyyy MMM"
-              disableAutoComplete={false}
+              disableAutocomplete={false}
               errorMessage="The date is invalid"
               inputProps={
                 Object {

--- a/components/src/MonthPicker/__snapshots__/MonthPicker.story.storyshot
+++ b/components/src/MonthPicker/__snapshots__/MonthPicker.story.storyshot
@@ -390,7 +390,7 @@ exports[`Storyshots MonthPicker custom locale 1`] = `
           >
             <MonthPicker
               dateFormat="MMM yyyy"
-              disableAutofill={false}
+              disableAutoComplete={false}
               inputProps={
                 Object {
                   "disabled": false,
@@ -2252,7 +2252,7 @@ exports[`Storyshots MonthPicker default 1`] = `
           >
             <MonthPicker
               dateFormat="MMM yyyy"
-              disableAutofill={false}
+              disableAutoComplete={false}
               inputProps={
                 Object {
                   "labelText": "Month",
@@ -4528,7 +4528,7 @@ exports[`Storyshots MonthPicker with a min and max date 1`] = `
           >
             <MonthPicker
               dateFormat="MMM yyyy"
-              disableAutofill={false}
+              disableAutoComplete={false}
               inputProps={
                 Object {
                   "labelText": "Month and Year",
@@ -6808,7 +6808,7 @@ exports[`Storyshots MonthPicker with custom placeholder 1`] = `
           >
             <MonthPicker
               dateFormat="MMM yyyy"
-              disableAutofill={false}
+              disableAutoComplete={false}
               inputProps={
                 Object {
                   "labelText": "Month and Year",
@@ -9082,7 +9082,7 @@ exports[`Storyshots MonthPicker with error state 1`] = `
           >
             <MonthPicker
               dateFormat="yyyy MMM"
-              disableAutofill={false}
+              disableAutoComplete={false}
               errorMessage="The date is invalid"
               inputProps={
                 Object {

--- a/components/src/MonthPicker/__snapshots__/MonthPicker.story.storyshot
+++ b/components/src/MonthPicker/__snapshots__/MonthPicker.story.storyshot
@@ -390,6 +390,7 @@ exports[`Storyshots MonthPicker custom locale 1`] = `
           >
             <MonthPicker
               dateFormat="MMM yyyy"
+              disableAutofill={false}
               inputProps={
                 Object {
                   "disabled": false,
@@ -817,6 +818,7 @@ exports[`Storyshots MonthPicker custom locale 1`] = `
                       onMonthChange={[Function]}
                       onSelect={[Function]}
                       onYearChange={[Function]}
+                      openToDate={2019-07-10T05:00:00.000Z}
                       preventOpenOnFocus={false}
                       previousMonthButtonLabel="Previous Month"
                       previousYearButtonLabel={
@@ -2250,6 +2252,7 @@ exports[`Storyshots MonthPicker default 1`] = `
           >
             <MonthPicker
               dateFormat="MMM yyyy"
+              disableAutofill={false}
               inputProps={
                 Object {
                   "labelText": "Month",
@@ -2257,7 +2260,7 @@ exports[`Storyshots MonthPicker default 1`] = `
               }
               onChange={[Function]}
               onInputChange={[Function]}
-              selected={2019-01-01T05:00:00.000Z}
+              selected={2018-01-01T05:00:00.000Z}
             >
               <Styled(Box)
                 className="nds-month-picker"
@@ -2628,7 +2631,7 @@ exports[`Storyshots MonthPicker default 1`] = `
                       dropdownMode="scroll"
                       excludeDates={
                         Array [
-                          2019-01-01T05:00:00.000Z,
+                          2018-01-01T05:00:00.000Z,
                         ]
                       }
                       inlineFocusSelectedMonth={false}
@@ -2654,6 +2657,7 @@ exports[`Storyshots MonthPicker default 1`] = `
                       onMonthChange={[Function]}
                       onSelect={[Function]}
                       onYearChange={[Function]}
+                      openToDate={2018-01-01T05:00:00.000Z}
                       preventOpenOnFocus={false}
                       previousMonthButtonLabel="Previous Month"
                       previousYearButtonLabel={
@@ -2666,7 +2670,7 @@ exports[`Storyshots MonthPicker default 1`] = `
                       }
                       readOnly={false}
                       renderDayContents={[Function]}
-                      selected={2019-01-01T05:00:00.000Z}
+                      selected={2018-01-01T05:00:00.000Z}
                       shouldCloseOnSelect={true}
                       showMonthYearPicker={true}
                       showPopperArrow={true}
@@ -2716,7 +2720,7 @@ exports[`Storyshots MonthPicker default 1`] = `
                               onInputChange={[Function]}
                               onKeyDown={[Function]}
                               readOnly={false}
-                              value="Jan 2019"
+                              value="Jan 2018"
                             />
                           </div>
                         }
@@ -2752,7 +2756,7 @@ exports[`Storyshots MonthPicker default 1`] = `
                                     onInputChange={[Function]}
                                     onKeyDown={[Function]}
                                     readOnly={false}
-                                    value="Jan 2019"
+                                    value="Jan 2018"
                                   >
                                     <ForwardRef
                                       disabled={false}
@@ -2771,7 +2775,7 @@ exports[`Storyshots MonthPicker default 1`] = `
                                       suffix={null}
                                       suffixAlignment="left"
                                       suffixWidth={null}
-                                      value="Jan 2019"
+                                      value="Jan 2018"
                                     >
                                       <MaybeFieldLabel
                                         helpText={null}
@@ -3913,7 +3917,7 @@ exports[`Storyshots MonthPicker default 1`] = `
                                                                   onClick={[Function]}
                                                                   placeholder="Mon YYYY"
                                                                   required={false}
-                                                                  value="Jan 2019"
+                                                                  value="Jan 2018"
                                                                 >
                                                                   <StyledComponent
                                                                     aria-invalid={false}
@@ -3971,7 +3975,7 @@ exports[`Storyshots MonthPicker default 1`] = `
                                                                     onClick={[Function]}
                                                                     placeholder="Mon YYYY"
                                                                     required={false}
-                                                                    value="Jan 2019"
+                                                                    value="Jan 2018"
                                                                   >
                                                                     <input
                                                                       aria-invalid={false}
@@ -3982,7 +3986,7 @@ exports[`Storyshots MonthPicker default 1`] = `
                                                                       onClick={[Function]}
                                                                       placeholder="Mon YYYY"
                                                                       required={false}
-                                                                      value="Jan 2019"
+                                                                      value="Jan 2018"
                                                                     />
                                                                   </StyledComponent>
                                                                 </InputField__StyledInput>
@@ -4524,13 +4528,14 @@ exports[`Storyshots MonthPicker with a min and max date 1`] = `
           >
             <MonthPicker
               dateFormat="MMM yyyy"
+              disableAutofill={false}
               inputProps={
                 Object {
                   "labelText": "Month and Year",
                 }
               }
-              maxDate={2019-12-05T05:00:00.000Z}
-              minDate={2019-07-05T05:00:00.000Z}
+              maxDate={2019-12-01T05:00:00.000Z}
+              minDate={2019-07-01T05:00:00.000Z}
               onChange={[Function]}
               onInputChange={[Function]}
               selected={2019-07-10T05:00:00.000Z}
@@ -4908,8 +4913,8 @@ exports[`Storyshots MonthPicker with a min and max date 1`] = `
                         ]
                       }
                       inlineFocusSelectedMonth={false}
-                      maxDate={2019-12-05T05:00:00.000Z}
-                      minDate={2019-07-05T05:00:00.000Z}
+                      maxDate={2019-12-01T05:00:00.000Z}
+                      minDate={2019-07-01T05:00:00.000Z}
                       monthsShown={1}
                       nextMonthButtonLabel="Next Month"
                       nextYearButtonLabel={
@@ -4932,6 +4937,7 @@ exports[`Storyshots MonthPicker with a min and max date 1`] = `
                       onMonthChange={[Function]}
                       onSelect={[Function]}
                       onYearChange={[Function]}
+                      openToDate={2019-07-10T05:00:00.000Z}
                       preventOpenOnFocus={false}
                       previousMonthButtonLabel="Previous Month"
                       previousYearButtonLabel={
@@ -6802,6 +6808,7 @@ exports[`Storyshots MonthPicker with custom placeholder 1`] = `
           >
             <MonthPicker
               dateFormat="MMM yyyy"
+              disableAutofill={false}
               inputProps={
                 Object {
                   "labelText": "Month and Year",
@@ -9075,6 +9082,7 @@ exports[`Storyshots MonthPicker with error state 1`] = `
           >
             <MonthPicker
               dateFormat="yyyy MMM"
+              disableAutofill={false}
               errorMessage="The date is invalid"
               inputProps={
                 Object {

--- a/components/src/MonthRange/MonthRange.js
+++ b/components/src/MonthRange/MonthRange.js
@@ -23,7 +23,7 @@ const MonthRange = ({
   minDate,
   maxDate,
   locale,
-  disableAutofill
+  disableAutoComplete
 }) => {
   const [startMonth, setStartMonth] = useState(defaultStartDate);
   const [endMonth, setEndMonth] = useState(defaultEndDate);
@@ -67,7 +67,7 @@ const MonthRange = ({
       minDate={minDate}
       maxDate={maxDate}
       locale={locale}
-      disableAutofill={disableAutofill}
+      disableAutoComplete={disableAutoComplete}
     />
   );
 
@@ -81,7 +81,7 @@ const MonthRange = ({
       minDate={minDate}
       maxDate={maxDate}
       locale={locale}
-      disableAutofill={disableAutofill}
+      disableAutoComplete={disableAutoComplete}
     />
   );
 
@@ -116,7 +116,7 @@ MonthRange.propTypes = {
   minDate: PropTypes.instanceOf(Date),
   maxDate: PropTypes.instanceOf(Date),
   locale: PropTypes.string,
-  disableAutofill: PropTypes.bool
+  disableAutoComplete: PropTypes.bool
 };
 
 MonthRange.defaultProps = {
@@ -139,7 +139,7 @@ MonthRange.defaultProps = {
   minDate: null,
   maxDate: null,
   locale: undefined,
-  disableAutofill: false
+  disableAutoComplete: false
 };
 
 export default MonthRange;

--- a/components/src/MonthRange/MonthRange.js
+++ b/components/src/MonthRange/MonthRange.js
@@ -23,7 +23,7 @@ const MonthRange = ({
   minDate,
   maxDate,
   locale,
-  disableAutoComplete
+  disableAutocomplete
 }) => {
   const [startMonth, setStartMonth] = useState(defaultStartDate);
   const [endMonth, setEndMonth] = useState(defaultEndDate);
@@ -67,7 +67,7 @@ const MonthRange = ({
       minDate={minDate}
       maxDate={maxDate}
       locale={locale}
-      disableAutoComplete={disableAutoComplete}
+      disableAutocomplete={disableAutocomplete}
     />
   );
 
@@ -81,7 +81,7 @@ const MonthRange = ({
       minDate={minDate}
       maxDate={maxDate}
       locale={locale}
-      disableAutoComplete={disableAutoComplete}
+      disableAutocomplete={disableAutocomplete}
     />
   );
 
@@ -116,7 +116,7 @@ MonthRange.propTypes = {
   minDate: PropTypes.instanceOf(Date),
   maxDate: PropTypes.instanceOf(Date),
   locale: PropTypes.string,
-  disableAutoComplete: PropTypes.bool
+  disableAutocomplete: PropTypes.bool
 };
 
 MonthRange.defaultProps = {
@@ -139,7 +139,7 @@ MonthRange.defaultProps = {
   minDate: null,
   maxDate: null,
   locale: undefined,
-  disableAutoComplete: false
+  disableAutocomplete: false
 };
 
 export default MonthRange;

--- a/components/src/MonthRange/MonthRange.js
+++ b/components/src/MonthRange/MonthRange.js
@@ -22,7 +22,8 @@ const MonthRange = ({
   labelProps,
   minDate,
   maxDate,
-  locale
+  locale,
+  disableAutofill
 }) => {
   const [startMonth, setStartMonth] = useState(defaultStartDate);
   const [endMonth, setEndMonth] = useState(defaultEndDate);
@@ -66,6 +67,7 @@ const MonthRange = ({
       minDate={minDate}
       maxDate={maxDate}
       locale={locale}
+      disableAutofill={disableAutofill}
     />
   );
 
@@ -79,6 +81,7 @@ const MonthRange = ({
       minDate={minDate}
       maxDate={maxDate}
       locale={locale}
+      disableAutofill={disableAutofill}
     />
   );
 
@@ -112,7 +115,8 @@ MonthRange.propTypes = {
   labelProps: PropTypes.shape(FieldLabelProps),
   minDate: PropTypes.instanceOf(Date),
   maxDate: PropTypes.instanceOf(Date),
-  locale: PropTypes.string
+  locale: PropTypes.string,
+  disableAutofill: PropTypes.bool
 };
 
 MonthRange.defaultProps = {
@@ -134,7 +138,8 @@ MonthRange.defaultProps = {
   },
   minDate: null,
   maxDate: null,
-  locale: undefined
+  locale: undefined,
+  disableAutofill: false
 };
 
 export default MonthRange;

--- a/components/src/MonthRange/__snapshots__/MonthRange.story.storyshot
+++ b/components/src/MonthRange/__snapshots__/MonthRange.story.storyshot
@@ -391,7 +391,7 @@ exports[`Storyshots MonthRange custom locale 1`] = `
             <MonthRange
               defaultEndDate={2019-09-10T05:00:00.000Z}
               defaultStartDate={2019-07-05T05:00:00.000Z}
-              disableAutoComplete={false}
+              disableAutocomplete={false}
               disableRangeValidation={false}
               endDateErrorMessage={null}
               endDateInputProps={
@@ -450,7 +450,7 @@ exports[`Storyshots MonthRange custom locale 1`] = `
                 endComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
-                    disableAutoComplete={false}
+                    disableAutocomplete={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -494,7 +494,7 @@ exports[`Storyshots MonthRange custom locale 1`] = `
                 startComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
-                    disableAutoComplete={false}
+                    disableAutocomplete={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -1334,7 +1334,7 @@ exports[`Storyshots MonthRange custom locale 1`] = `
                     >
                       <MonthPicker
                         dateFormat="MMM yyyy"
-                        disableAutoComplete={false}
+                        disableAutocomplete={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -3204,7 +3204,7 @@ exports[`Storyshots MonthRange custom locale 1`] = `
                       </Styled(Box)>
                       <MonthPicker
                         dateFormat="MMM yyyy"
-                        disableAutoComplete={false}
+                        disableAutocomplete={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -5088,7 +5088,7 @@ exports[`Storyshots MonthRange customizing input props 1`] = `
             <MonthRange
               defaultEndDate={null}
               defaultStartDate={null}
-              disableAutoComplete={false}
+              disableAutocomplete={false}
               disableRangeValidation={false}
               endDateErrorMessage={null}
               endDateInputProps={
@@ -5122,7 +5122,7 @@ exports[`Storyshots MonthRange customizing input props 1`] = `
                 endComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
-                    disableAutoComplete={false}
+                    disableAutocomplete={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -5153,7 +5153,7 @@ exports[`Storyshots MonthRange customizing input props 1`] = `
                 startComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
-                    disableAutoComplete={false}
+                    disableAutocomplete={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -5980,7 +5980,7 @@ exports[`Storyshots MonthRange customizing input props 1`] = `
                     >
                       <MonthPicker
                         dateFormat="MMM yyyy"
-                        disableAutoComplete={false}
+                        disableAutocomplete={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -7800,7 +7800,7 @@ exports[`Storyshots MonthRange customizing input props 1`] = `
                       </Styled(Box)>
                       <MonthPicker
                         dateFormat="MMM yyyy"
-                        disableAutoComplete={false}
+                        disableAutocomplete={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -9634,7 +9634,7 @@ exports[`Storyshots MonthRange default 1`] = `
             <MonthRange
               defaultEndDate={null}
               defaultStartDate={null}
-              disableAutoComplete={false}
+              disableAutocomplete={false}
               disableRangeValidation={false}
               endDateErrorMessage={null}
               endDateInputProps={
@@ -9692,7 +9692,7 @@ exports[`Storyshots MonthRange default 1`] = `
                 endComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
-                    disableAutoComplete={false}
+                    disableAutocomplete={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -9735,7 +9735,7 @@ exports[`Storyshots MonthRange default 1`] = `
                 startComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
-                    disableAutoComplete={false}
+                    disableAutocomplete={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -10574,7 +10574,7 @@ exports[`Storyshots MonthRange default 1`] = `
                     >
                       <MonthPicker
                         dateFormat="MMM yyyy"
-                        disableAutoComplete={false}
+                        disableAutocomplete={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -12442,7 +12442,7 @@ exports[`Storyshots MonthRange default 1`] = `
                       </Styled(Box)>
                       <MonthPicker
                         dateFormat="MMM yyyy"
-                        disableAutoComplete={false}
+                        disableAutocomplete={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -14324,7 +14324,7 @@ exports[`Storyshots MonthRange default start and end date 1`] = `
             <MonthRange
               defaultEndDate={2019-09-10T05:00:00.000Z}
               defaultStartDate={2019-07-05T05:00:00.000Z}
-              disableAutoComplete={false}
+              disableAutocomplete={false}
               disableRangeValidation={false}
               endDateErrorMessage={null}
               endDateInputProps={
@@ -14382,7 +14382,7 @@ exports[`Storyshots MonthRange default start and end date 1`] = `
                 endComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
-                    disableAutoComplete={false}
+                    disableAutocomplete={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -14425,7 +14425,7 @@ exports[`Storyshots MonthRange default start and end date 1`] = `
                 startComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
-                    disableAutoComplete={false}
+                    disableAutocomplete={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -15264,7 +15264,7 @@ exports[`Storyshots MonthRange default start and end date 1`] = `
                     >
                       <MonthPicker
                         dateFormat="MMM yyyy"
-                        disableAutoComplete={false}
+                        disableAutocomplete={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -17132,7 +17132,7 @@ exports[`Storyshots MonthRange default start and end date 1`] = `
                       </Styled(Box)>
                       <MonthPicker
                         dateFormat="MMM yyyy"
-                        disableAutoComplete={false}
+                        disableAutocomplete={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -19014,7 +19014,7 @@ exports[`Storyshots MonthRange disabled range validation 1`] = `
             <MonthRange
               defaultEndDate={2019-07-05T05:00:00.000Z}
               defaultStartDate={2019-09-10T05:00:00.000Z}
-              disableAutoComplete={false}
+              disableAutocomplete={false}
               disableRangeValidation={true}
               endDateErrorMessage={null}
               endDateInputProps={
@@ -19072,7 +19072,7 @@ exports[`Storyshots MonthRange disabled range validation 1`] = `
                 endComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
-                    disableAutoComplete={false}
+                    disableAutocomplete={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -19114,7 +19114,7 @@ exports[`Storyshots MonthRange disabled range validation 1`] = `
                 startComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
-                    disableAutoComplete={false}
+                    disableAutocomplete={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -19953,7 +19953,7 @@ exports[`Storyshots MonthRange disabled range validation 1`] = `
                     >
                       <MonthPicker
                         dateFormat="MMM yyyy"
-                        disableAutoComplete={false}
+                        disableAutocomplete={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -21821,7 +21821,7 @@ exports[`Storyshots MonthRange disabled range validation 1`] = `
                       </Styled(Box)>
                       <MonthPicker
                         dateFormat="MMM yyyy"
-                        disableAutoComplete={false}
+                        disableAutocomplete={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -23698,7 +23698,7 @@ exports[`Storyshots MonthRange individual input error 1`] = `
             <MonthRange
               defaultEndDate={2019-09-10T05:00:00.000Z}
               defaultStartDate={null}
-              disableAutoComplete={false}
+              disableAutocomplete={false}
               disableRangeValidation={false}
               endDateErrorMessage={null}
               endDateInputProps={
@@ -23744,7 +23744,7 @@ exports[`Storyshots MonthRange individual input error 1`] = `
                 endComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
-                    disableAutoComplete={false}
+                    disableAutocomplete={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -23787,7 +23787,7 @@ exports[`Storyshots MonthRange individual input error 1`] = `
                 startComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
-                    disableAutoComplete={false}
+                    disableAutocomplete={false}
                     errorMessage="Start date is required"
                     inputProps={
                       Object {
@@ -24614,7 +24614,7 @@ exports[`Storyshots MonthRange individual input error 1`] = `
                     >
                       <MonthPicker
                         dateFormat="MMM yyyy"
-                        disableAutoComplete={false}
+                        disableAutocomplete={false}
                         errorMessage="Start date is required"
                         inputProps={
                           Object {
@@ -26973,7 +26973,7 @@ exports[`Storyshots MonthRange individual input error 1`] = `
                       </Styled(Box)>
                       <MonthPicker
                         dateFormat="MMM yyyy"
-                        disableAutoComplete={false}
+                        disableAutocomplete={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -28855,7 +28855,7 @@ exports[`Storyshots MonthRange with custom error 1`] = `
             <MonthRange
               defaultEndDate={2019-09-10T05:00:00.000Z}
               defaultStartDate={2019-07-05T05:00:00.000Z}
-              disableAutoComplete={false}
+              disableAutocomplete={false}
               disableRangeValidation={false}
               endDateErrorMessage={null}
               endDateInputProps={
@@ -28913,7 +28913,7 @@ exports[`Storyshots MonthRange with custom error 1`] = `
                 endComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
-                    disableAutoComplete={false}
+                    disableAutocomplete={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -28956,7 +28956,7 @@ exports[`Storyshots MonthRange with custom error 1`] = `
                 startComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
-                    disableAutoComplete={false}
+                    disableAutocomplete={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -29795,7 +29795,7 @@ exports[`Storyshots MonthRange with custom error 1`] = `
                     >
                       <MonthPicker
                         dateFormat="MMM yyyy"
-                        disableAutoComplete={false}
+                        disableAutocomplete={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -31663,7 +31663,7 @@ exports[`Storyshots MonthRange with custom error 1`] = `
                       </Styled(Box)>
                       <MonthPicker
                         dateFormat="MMM yyyy"
-                        disableAutoComplete={false}
+                        disableAutocomplete={false}
                         errorMessage={null}
                         inputProps={
                           Object {

--- a/components/src/MonthRange/__snapshots__/MonthRange.story.storyshot
+++ b/components/src/MonthRange/__snapshots__/MonthRange.story.storyshot
@@ -391,6 +391,7 @@ exports[`Storyshots MonthRange custom locale 1`] = `
             <MonthRange
               defaultEndDate={2019-09-10T05:00:00.000Z}
               defaultStartDate={2019-07-05T05:00:00.000Z}
+              disableAutofill={false}
               disableRangeValidation={false}
               endDateErrorMessage={null}
               endDateInputProps={
@@ -449,6 +450,7 @@ exports[`Storyshots MonthRange custom locale 1`] = `
                 endComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
+                    disableAutofill={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -492,6 +494,7 @@ exports[`Storyshots MonthRange custom locale 1`] = `
                 startComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
+                    disableAutofill={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -1331,6 +1334,7 @@ exports[`Storyshots MonthRange custom locale 1`] = `
                     >
                       <MonthPicker
                         dateFormat="MMM yyyy"
+                        disableAutofill={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -1764,6 +1768,7 @@ exports[`Storyshots MonthRange custom locale 1`] = `
                                 onMonthChange={[Function]}
                                 onSelect={[Function]}
                                 onYearChange={[Function]}
+                                openToDate={2019-07-05T05:00:00.000Z}
                                 preventOpenOnFocus={false}
                                 previousMonthButtonLabel="Previous Month"
                                 previousYearButtonLabel={
@@ -3199,6 +3204,7 @@ exports[`Storyshots MonthRange custom locale 1`] = `
                       </Styled(Box)>
                       <MonthPicker
                         dateFormat="MMM yyyy"
+                        disableAutofill={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -3632,6 +3638,7 @@ exports[`Storyshots MonthRange custom locale 1`] = `
                                 onMonthChange={[Function]}
                                 onSelect={[Function]}
                                 onYearChange={[Function]}
+                                openToDate={2019-09-10T05:00:00.000Z}
                                 preventOpenOnFocus={false}
                                 previousMonthButtonLabel="Previous Month"
                                 previousYearButtonLabel={
@@ -5081,6 +5088,7 @@ exports[`Storyshots MonthRange customizing input props 1`] = `
             <MonthRange
               defaultEndDate={null}
               defaultStartDate={null}
+              disableAutofill={false}
               disableRangeValidation={false}
               endDateErrorMessage={null}
               endDateInputProps={
@@ -5114,6 +5122,7 @@ exports[`Storyshots MonthRange customizing input props 1`] = `
                 endComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
+                    disableAutofill={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -5144,6 +5153,7 @@ exports[`Storyshots MonthRange customizing input props 1`] = `
                 startComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
+                    disableAutofill={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -5970,6 +5980,7 @@ exports[`Storyshots MonthRange customizing input props 1`] = `
                     >
                       <MonthPicker
                         dateFormat="MMM yyyy"
+                        disableAutofill={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -6377,6 +6388,7 @@ exports[`Storyshots MonthRange customizing input props 1`] = `
                                 onMonthChange={[Function]}
                                 onSelect={[Function]}
                                 onYearChange={[Function]}
+                                openToDate={null}
                                 preventOpenOnFocus={false}
                                 previousMonthButtonLabel="Previous Month"
                                 previousYearButtonLabel={
@@ -7788,6 +7800,7 @@ exports[`Storyshots MonthRange customizing input props 1`] = `
                       </Styled(Box)>
                       <MonthPicker
                         dateFormat="MMM yyyy"
+                        disableAutofill={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -8195,6 +8208,7 @@ exports[`Storyshots MonthRange customizing input props 1`] = `
                                 onMonthChange={[Function]}
                                 onSelect={[Function]}
                                 onYearChange={[Function]}
+                                openToDate={null}
                                 preventOpenOnFocus={false}
                                 previousMonthButtonLabel="Previous Month"
                                 previousYearButtonLabel={
@@ -9620,6 +9634,7 @@ exports[`Storyshots MonthRange default 1`] = `
             <MonthRange
               defaultEndDate={null}
               defaultStartDate={null}
+              disableAutofill={false}
               disableRangeValidation={false}
               endDateErrorMessage={null}
               endDateInputProps={
@@ -9677,6 +9692,7 @@ exports[`Storyshots MonthRange default 1`] = `
                 endComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
+                    disableAutofill={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -9719,6 +9735,7 @@ exports[`Storyshots MonthRange default 1`] = `
                 startComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
+                    disableAutofill={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -10557,6 +10574,7 @@ exports[`Storyshots MonthRange default 1`] = `
                     >
                       <MonthPicker
                         dateFormat="MMM yyyy"
+                        disableAutofill={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -10988,6 +11006,7 @@ exports[`Storyshots MonthRange default 1`] = `
                                 onMonthChange={[Function]}
                                 onSelect={[Function]}
                                 onYearChange={[Function]}
+                                openToDate={null}
                                 preventOpenOnFocus={false}
                                 previousMonthButtonLabel="Previous Month"
                                 previousYearButtonLabel={
@@ -12423,6 +12442,7 @@ exports[`Storyshots MonthRange default 1`] = `
                       </Styled(Box)>
                       <MonthPicker
                         dateFormat="MMM yyyy"
+                        disableAutofill={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -12854,6 +12874,7 @@ exports[`Storyshots MonthRange default 1`] = `
                                 onMonthChange={[Function]}
                                 onSelect={[Function]}
                                 onYearChange={[Function]}
+                                openToDate={null}
                                 preventOpenOnFocus={false}
                                 previousMonthButtonLabel="Previous Month"
                                 previousYearButtonLabel={
@@ -14303,6 +14324,7 @@ exports[`Storyshots MonthRange default start and end date 1`] = `
             <MonthRange
               defaultEndDate={2019-09-10T05:00:00.000Z}
               defaultStartDate={2019-07-05T05:00:00.000Z}
+              disableAutofill={false}
               disableRangeValidation={false}
               endDateErrorMessage={null}
               endDateInputProps={
@@ -14360,6 +14382,7 @@ exports[`Storyshots MonthRange default start and end date 1`] = `
                 endComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
+                    disableAutofill={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -14402,6 +14425,7 @@ exports[`Storyshots MonthRange default start and end date 1`] = `
                 startComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
+                    disableAutofill={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -15240,6 +15264,7 @@ exports[`Storyshots MonthRange default start and end date 1`] = `
                     >
                       <MonthPicker
                         dateFormat="MMM yyyy"
+                        disableAutofill={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -15671,6 +15696,7 @@ exports[`Storyshots MonthRange default start and end date 1`] = `
                                 onMonthChange={[Function]}
                                 onSelect={[Function]}
                                 onYearChange={[Function]}
+                                openToDate={2019-07-05T05:00:00.000Z}
                                 preventOpenOnFocus={false}
                                 previousMonthButtonLabel="Previous Month"
                                 previousYearButtonLabel={
@@ -17106,6 +17132,7 @@ exports[`Storyshots MonthRange default start and end date 1`] = `
                       </Styled(Box)>
                       <MonthPicker
                         dateFormat="MMM yyyy"
+                        disableAutofill={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -17537,6 +17564,7 @@ exports[`Storyshots MonthRange default start and end date 1`] = `
                                 onMonthChange={[Function]}
                                 onSelect={[Function]}
                                 onYearChange={[Function]}
+                                openToDate={2019-09-10T05:00:00.000Z}
                                 preventOpenOnFocus={false}
                                 previousMonthButtonLabel="Previous Month"
                                 previousYearButtonLabel={
@@ -18986,6 +19014,7 @@ exports[`Storyshots MonthRange disabled range validation 1`] = `
             <MonthRange
               defaultEndDate={2019-07-05T05:00:00.000Z}
               defaultStartDate={2019-09-10T05:00:00.000Z}
+              disableAutofill={false}
               disableRangeValidation={true}
               endDateErrorMessage={null}
               endDateInputProps={
@@ -19043,6 +19072,7 @@ exports[`Storyshots MonthRange disabled range validation 1`] = `
                 endComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
+                    disableAutofill={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -19084,6 +19114,7 @@ exports[`Storyshots MonthRange disabled range validation 1`] = `
                 startComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
+                    disableAutofill={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -19922,6 +19953,7 @@ exports[`Storyshots MonthRange disabled range validation 1`] = `
                     >
                       <MonthPicker
                         dateFormat="MMM yyyy"
+                        disableAutofill={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -20353,6 +20385,7 @@ exports[`Storyshots MonthRange disabled range validation 1`] = `
                                 onMonthChange={[Function]}
                                 onSelect={[Function]}
                                 onYearChange={[Function]}
+                                openToDate={2019-09-10T05:00:00.000Z}
                                 preventOpenOnFocus={false}
                                 previousMonthButtonLabel="Previous Month"
                                 previousYearButtonLabel={
@@ -21788,6 +21821,7 @@ exports[`Storyshots MonthRange disabled range validation 1`] = `
                       </Styled(Box)>
                       <MonthPicker
                         dateFormat="MMM yyyy"
+                        disableAutofill={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -22219,6 +22253,7 @@ exports[`Storyshots MonthRange disabled range validation 1`] = `
                                 onMonthChange={[Function]}
                                 onSelect={[Function]}
                                 onYearChange={[Function]}
+                                openToDate={2019-07-05T05:00:00.000Z}
                                 preventOpenOnFocus={false}
                                 previousMonthButtonLabel="Previous Month"
                                 previousYearButtonLabel={
@@ -23663,6 +23698,7 @@ exports[`Storyshots MonthRange individual input error 1`] = `
             <MonthRange
               defaultEndDate={2019-09-10T05:00:00.000Z}
               defaultStartDate={null}
+              disableAutofill={false}
               disableRangeValidation={false}
               endDateErrorMessage={null}
               endDateInputProps={
@@ -23708,6 +23744,7 @@ exports[`Storyshots MonthRange individual input error 1`] = `
                 endComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
+                    disableAutofill={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -23750,6 +23787,7 @@ exports[`Storyshots MonthRange individual input error 1`] = `
                 startComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
+                    disableAutofill={false}
                     errorMessage="Start date is required"
                     inputProps={
                       Object {
@@ -24576,6 +24614,7 @@ exports[`Storyshots MonthRange individual input error 1`] = `
                     >
                       <MonthPicker
                         dateFormat="MMM yyyy"
+                        disableAutofill={false}
                         errorMessage="Start date is required"
                         inputProps={
                           Object {
@@ -24984,6 +25023,7 @@ exports[`Storyshots MonthRange individual input error 1`] = `
                                 onMonthChange={[Function]}
                                 onSelect={[Function]}
                                 onYearChange={[Function]}
+                                openToDate={null}
                                 preventOpenOnFocus={false}
                                 previousMonthButtonLabel="Previous Month"
                                 previousYearButtonLabel={
@@ -26933,6 +26973,7 @@ exports[`Storyshots MonthRange individual input error 1`] = `
                       </Styled(Box)>
                       <MonthPicker
                         dateFormat="MMM yyyy"
+                        disableAutofill={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -27364,6 +27405,7 @@ exports[`Storyshots MonthRange individual input error 1`] = `
                                 onMonthChange={[Function]}
                                 onSelect={[Function]}
                                 onYearChange={[Function]}
+                                openToDate={2019-09-10T05:00:00.000Z}
                                 preventOpenOnFocus={false}
                                 previousMonthButtonLabel="Previous Month"
                                 previousYearButtonLabel={
@@ -28813,6 +28855,7 @@ exports[`Storyshots MonthRange with custom error 1`] = `
             <MonthRange
               defaultEndDate={2019-09-10T05:00:00.000Z}
               defaultStartDate={2019-07-05T05:00:00.000Z}
+              disableAutofill={false}
               disableRangeValidation={false}
               endDateErrorMessage={null}
               endDateInputProps={
@@ -28870,6 +28913,7 @@ exports[`Storyshots MonthRange with custom error 1`] = `
                 endComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
+                    disableAutofill={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -28912,6 +28956,7 @@ exports[`Storyshots MonthRange with custom error 1`] = `
                 startComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
+                    disableAutofill={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -29750,6 +29795,7 @@ exports[`Storyshots MonthRange with custom error 1`] = `
                     >
                       <MonthPicker
                         dateFormat="MMM yyyy"
+                        disableAutofill={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -30181,6 +30227,7 @@ exports[`Storyshots MonthRange with custom error 1`] = `
                                 onMonthChange={[Function]}
                                 onSelect={[Function]}
                                 onYearChange={[Function]}
+                                openToDate={2019-07-05T05:00:00.000Z}
                                 preventOpenOnFocus={false}
                                 previousMonthButtonLabel="Previous Month"
                                 previousYearButtonLabel={
@@ -31616,6 +31663,7 @@ exports[`Storyshots MonthRange with custom error 1`] = `
                       </Styled(Box)>
                       <MonthPicker
                         dateFormat="MMM yyyy"
+                        disableAutofill={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -32047,6 +32095,7 @@ exports[`Storyshots MonthRange with custom error 1`] = `
                                 onMonthChange={[Function]}
                                 onSelect={[Function]}
                                 onYearChange={[Function]}
+                                openToDate={2019-09-10T05:00:00.000Z}
                                 preventOpenOnFocus={false}
                                 previousMonthButtonLabel="Previous Month"
                                 previousYearButtonLabel={

--- a/components/src/MonthRange/__snapshots__/MonthRange.story.storyshot
+++ b/components/src/MonthRange/__snapshots__/MonthRange.story.storyshot
@@ -391,7 +391,7 @@ exports[`Storyshots MonthRange custom locale 1`] = `
             <MonthRange
               defaultEndDate={2019-09-10T05:00:00.000Z}
               defaultStartDate={2019-07-05T05:00:00.000Z}
-              disableAutofill={false}
+              disableAutoComplete={false}
               disableRangeValidation={false}
               endDateErrorMessage={null}
               endDateInputProps={
@@ -450,7 +450,7 @@ exports[`Storyshots MonthRange custom locale 1`] = `
                 endComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
-                    disableAutofill={false}
+                    disableAutoComplete={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -494,7 +494,7 @@ exports[`Storyshots MonthRange custom locale 1`] = `
                 startComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
-                    disableAutofill={false}
+                    disableAutoComplete={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -1334,7 +1334,7 @@ exports[`Storyshots MonthRange custom locale 1`] = `
                     >
                       <MonthPicker
                         dateFormat="MMM yyyy"
-                        disableAutofill={false}
+                        disableAutoComplete={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -3204,7 +3204,7 @@ exports[`Storyshots MonthRange custom locale 1`] = `
                       </Styled(Box)>
                       <MonthPicker
                         dateFormat="MMM yyyy"
-                        disableAutofill={false}
+                        disableAutoComplete={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -5088,7 +5088,7 @@ exports[`Storyshots MonthRange customizing input props 1`] = `
             <MonthRange
               defaultEndDate={null}
               defaultStartDate={null}
-              disableAutofill={false}
+              disableAutoComplete={false}
               disableRangeValidation={false}
               endDateErrorMessage={null}
               endDateInputProps={
@@ -5122,7 +5122,7 @@ exports[`Storyshots MonthRange customizing input props 1`] = `
                 endComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
-                    disableAutofill={false}
+                    disableAutoComplete={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -5153,7 +5153,7 @@ exports[`Storyshots MonthRange customizing input props 1`] = `
                 startComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
-                    disableAutofill={false}
+                    disableAutoComplete={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -5980,7 +5980,7 @@ exports[`Storyshots MonthRange customizing input props 1`] = `
                     >
                       <MonthPicker
                         dateFormat="MMM yyyy"
-                        disableAutofill={false}
+                        disableAutoComplete={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -7800,7 +7800,7 @@ exports[`Storyshots MonthRange customizing input props 1`] = `
                       </Styled(Box)>
                       <MonthPicker
                         dateFormat="MMM yyyy"
-                        disableAutofill={false}
+                        disableAutoComplete={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -9634,7 +9634,7 @@ exports[`Storyshots MonthRange default 1`] = `
             <MonthRange
               defaultEndDate={null}
               defaultStartDate={null}
-              disableAutofill={false}
+              disableAutoComplete={false}
               disableRangeValidation={false}
               endDateErrorMessage={null}
               endDateInputProps={
@@ -9692,7 +9692,7 @@ exports[`Storyshots MonthRange default 1`] = `
                 endComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
-                    disableAutofill={false}
+                    disableAutoComplete={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -9735,7 +9735,7 @@ exports[`Storyshots MonthRange default 1`] = `
                 startComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
-                    disableAutofill={false}
+                    disableAutoComplete={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -10574,7 +10574,7 @@ exports[`Storyshots MonthRange default 1`] = `
                     >
                       <MonthPicker
                         dateFormat="MMM yyyy"
-                        disableAutofill={false}
+                        disableAutoComplete={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -12442,7 +12442,7 @@ exports[`Storyshots MonthRange default 1`] = `
                       </Styled(Box)>
                       <MonthPicker
                         dateFormat="MMM yyyy"
-                        disableAutofill={false}
+                        disableAutoComplete={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -14324,7 +14324,7 @@ exports[`Storyshots MonthRange default start and end date 1`] = `
             <MonthRange
               defaultEndDate={2019-09-10T05:00:00.000Z}
               defaultStartDate={2019-07-05T05:00:00.000Z}
-              disableAutofill={false}
+              disableAutoComplete={false}
               disableRangeValidation={false}
               endDateErrorMessage={null}
               endDateInputProps={
@@ -14382,7 +14382,7 @@ exports[`Storyshots MonthRange default start and end date 1`] = `
                 endComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
-                    disableAutofill={false}
+                    disableAutoComplete={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -14425,7 +14425,7 @@ exports[`Storyshots MonthRange default start and end date 1`] = `
                 startComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
-                    disableAutofill={false}
+                    disableAutoComplete={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -15264,7 +15264,7 @@ exports[`Storyshots MonthRange default start and end date 1`] = `
                     >
                       <MonthPicker
                         dateFormat="MMM yyyy"
-                        disableAutofill={false}
+                        disableAutoComplete={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -17132,7 +17132,7 @@ exports[`Storyshots MonthRange default start and end date 1`] = `
                       </Styled(Box)>
                       <MonthPicker
                         dateFormat="MMM yyyy"
-                        disableAutofill={false}
+                        disableAutoComplete={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -19014,7 +19014,7 @@ exports[`Storyshots MonthRange disabled range validation 1`] = `
             <MonthRange
               defaultEndDate={2019-07-05T05:00:00.000Z}
               defaultStartDate={2019-09-10T05:00:00.000Z}
-              disableAutofill={false}
+              disableAutoComplete={false}
               disableRangeValidation={true}
               endDateErrorMessage={null}
               endDateInputProps={
@@ -19072,7 +19072,7 @@ exports[`Storyshots MonthRange disabled range validation 1`] = `
                 endComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
-                    disableAutofill={false}
+                    disableAutoComplete={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -19114,7 +19114,7 @@ exports[`Storyshots MonthRange disabled range validation 1`] = `
                 startComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
-                    disableAutofill={false}
+                    disableAutoComplete={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -19953,7 +19953,7 @@ exports[`Storyshots MonthRange disabled range validation 1`] = `
                     >
                       <MonthPicker
                         dateFormat="MMM yyyy"
-                        disableAutofill={false}
+                        disableAutoComplete={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -21821,7 +21821,7 @@ exports[`Storyshots MonthRange disabled range validation 1`] = `
                       </Styled(Box)>
                       <MonthPicker
                         dateFormat="MMM yyyy"
-                        disableAutofill={false}
+                        disableAutoComplete={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -23698,7 +23698,7 @@ exports[`Storyshots MonthRange individual input error 1`] = `
             <MonthRange
               defaultEndDate={2019-09-10T05:00:00.000Z}
               defaultStartDate={null}
-              disableAutofill={false}
+              disableAutoComplete={false}
               disableRangeValidation={false}
               endDateErrorMessage={null}
               endDateInputProps={
@@ -23744,7 +23744,7 @@ exports[`Storyshots MonthRange individual input error 1`] = `
                 endComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
-                    disableAutofill={false}
+                    disableAutoComplete={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -23787,7 +23787,7 @@ exports[`Storyshots MonthRange individual input error 1`] = `
                 startComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
-                    disableAutofill={false}
+                    disableAutoComplete={false}
                     errorMessage="Start date is required"
                     inputProps={
                       Object {
@@ -24614,7 +24614,7 @@ exports[`Storyshots MonthRange individual input error 1`] = `
                     >
                       <MonthPicker
                         dateFormat="MMM yyyy"
-                        disableAutofill={false}
+                        disableAutoComplete={false}
                         errorMessage="Start date is required"
                         inputProps={
                           Object {
@@ -26973,7 +26973,7 @@ exports[`Storyshots MonthRange individual input error 1`] = `
                       </Styled(Box)>
                       <MonthPicker
                         dateFormat="MMM yyyy"
-                        disableAutofill={false}
+                        disableAutoComplete={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -28855,7 +28855,7 @@ exports[`Storyshots MonthRange with custom error 1`] = `
             <MonthRange
               defaultEndDate={2019-09-10T05:00:00.000Z}
               defaultStartDate={2019-07-05T05:00:00.000Z}
-              disableAutofill={false}
+              disableAutoComplete={false}
               disableRangeValidation={false}
               endDateErrorMessage={null}
               endDateInputProps={
@@ -28913,7 +28913,7 @@ exports[`Storyshots MonthRange with custom error 1`] = `
                 endComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
-                    disableAutofill={false}
+                    disableAutoComplete={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -28956,7 +28956,7 @@ exports[`Storyshots MonthRange with custom error 1`] = `
                 startComponent={
                   <MonthPicker
                     dateFormat="MMM yyyy"
-                    disableAutofill={false}
+                    disableAutoComplete={false}
                     errorMessage={null}
                     inputProps={
                       Object {
@@ -29795,7 +29795,7 @@ exports[`Storyshots MonthRange with custom error 1`] = `
                     >
                       <MonthPicker
                         dateFormat="MMM yyyy"
-                        disableAutofill={false}
+                        disableAutoComplete={false}
                         errorMessage={null}
                         inputProps={
                           Object {
@@ -31663,7 +31663,7 @@ exports[`Storyshots MonthRange with custom error 1`] = `
                       </Styled(Box)>
                       <MonthPicker
                         dateFormat="MMM yyyy"
-                        disableAutofill={false}
+                        disableAutoComplete={false}
                         errorMessage={null}
                         inputProps={
                           Object {

--- a/components/src/StoriesForTests/__snapshots__/MonthPicker.story.storyshot
+++ b/components/src/StoriesForTests/__snapshots__/MonthPicker.story.storyshot
@@ -390,7 +390,7 @@ exports[`Storyshots StoriesForTests/Monthpicker default 1`] = `
           >
             <MonthPicker
               dateFormat="MMM yyyy"
-              disableAutoComplete={false}
+              disableAutocomplete={false}
               inputProps={
                 Object {
                   "disabled": false,
@@ -2250,7 +2250,7 @@ exports[`Storyshots StoriesForTests/Monthpicker with a min and max date 1`] = `
           >
             <MonthPicker
               dateFormat="MMM yyyy"
-              disableAutoComplete={false}
+              disableAutocomplete={false}
               inputProps={
                 Object {
                   "labelText": "Month and Year",

--- a/components/src/StoriesForTests/__snapshots__/MonthPicker.story.storyshot
+++ b/components/src/StoriesForTests/__snapshots__/MonthPicker.story.storyshot
@@ -390,6 +390,7 @@ exports[`Storyshots StoriesForTests/Monthpicker default 1`] = `
           >
             <MonthPicker
               dateFormat="MMM yyyy"
+              disableAutofill={false}
               inputProps={
                 Object {
                   "disabled": false,
@@ -815,6 +816,7 @@ exports[`Storyshots StoriesForTests/Monthpicker default 1`] = `
                       onMonthChange={[Function]}
                       onSelect={[Function]}
                       onYearChange={[Function]}
+                      openToDate={2019-01-01T05:00:00.000Z}
                       preventOpenOnFocus={false}
                       previousMonthButtonLabel="Previous Month"
                       previousYearButtonLabel={
@@ -2248,13 +2250,14 @@ exports[`Storyshots StoriesForTests/Monthpicker with a min and max date 1`] = `
           >
             <MonthPicker
               dateFormat="MMM yyyy"
+              disableAutofill={false}
               inputProps={
                 Object {
                   "labelText": "Month and Year",
                 }
               }
-              maxDate={2019-12-05T05:00:00.000Z}
-              minDate={2019-07-05T05:00:00.000Z}
+              maxDate={2019-12-01T05:00:00.000Z}
+              minDate={2019-07-01T05:00:00.000Z}
               selected={2019-07-10T05:00:00.000Z}
             >
               <Styled(Box)
@@ -2630,8 +2633,8 @@ exports[`Storyshots StoriesForTests/Monthpicker with a min and max date 1`] = `
                         ]
                       }
                       inlineFocusSelectedMonth={false}
-                      maxDate={2019-12-05T05:00:00.000Z}
-                      minDate={2019-07-05T05:00:00.000Z}
+                      maxDate={2019-12-01T05:00:00.000Z}
+                      minDate={2019-07-01T05:00:00.000Z}
                       monthsShown={1}
                       nextMonthButtonLabel="Next Month"
                       nextYearButtonLabel={
@@ -2654,6 +2657,7 @@ exports[`Storyshots StoriesForTests/Monthpicker with a min and max date 1`] = `
                       onMonthChange={[Function]}
                       onSelect={[Function]}
                       onYearChange={[Function]}
+                      openToDate={2019-07-10T05:00:00.000Z}
                       preventOpenOnFocus={false}
                       previousMonthButtonLabel="Previous Month"
                       previousYearButtonLabel={

--- a/components/src/StoriesForTests/__snapshots__/MonthPicker.story.storyshot
+++ b/components/src/StoriesForTests/__snapshots__/MonthPicker.story.storyshot
@@ -390,7 +390,7 @@ exports[`Storyshots StoriesForTests/Monthpicker default 1`] = `
           >
             <MonthPicker
               dateFormat="MMM yyyy"
-              disableAutofill={false}
+              disableAutoComplete={false}
               inputProps={
                 Object {
                   "disabled": false,
@@ -2250,7 +2250,7 @@ exports[`Storyshots StoriesForTests/Monthpicker with a min and max date 1`] = `
           >
             <MonthPicker
               dateFormat="MMM yyyy"
-              disableAutofill={false}
+              disableAutoComplete={false}
               inputProps={
                 Object {
                   "labelText": "Month and Year",

--- a/docs/src/pages/components/month-picker.js
+++ b/docs/src/pages/components/month-picker.js
@@ -59,7 +59,7 @@ const propsRows = [
   },
   localeProp,
   {
-    name: "disableAutoComplete",
+    name: "disableAutocomplete",
     type: "boolean",
     defaultValue: "false",
     description: "Disables auto-completing the year after typing in the month"

--- a/docs/src/pages/components/month-picker.js
+++ b/docs/src/pages/components/month-picker.js
@@ -59,10 +59,10 @@ const propsRows = [
   },
   localeProp,
   {
-    name: "disableAutofill",
+    name: "disableAutoComplete",
     type: "boolean",
     defaultValue: "false",
-    description: "Disables autofilling the year after typing in the month"
+    description: "Disables auto-completing the year after typing in the month"
   }
 ];
 

--- a/docs/src/pages/components/month-picker.js
+++ b/docs/src/pages/components/month-picker.js
@@ -57,7 +57,13 @@ const propsRows = [
     defaultValue: "undefined",
     description: "The latest date that can be selected"
   },
-  localeProp
+  localeProp,
+  {
+    name: "disableAutofill",
+    type: "boolean",
+    defaultValue: "false",
+    description: "Disables autofilling the year after typing in the month"
+  }
 ];
 
 export default () => (

--- a/docs/src/pages/components/month-range.js
+++ b/docs/src/pages/components/month-range.js
@@ -102,7 +102,13 @@ const propsRows = [
     defaultValue: "false",
     description: "Disables the the end date before start date error message."
   },
-  localeProp
+  localeProp,
+  {
+    name: "disableAutofill",
+    type: "boolean",
+    defaultValue: "false",
+    description: "Disables autofilling the year after typing in the month"
+  }
 ];
 
 export default () => (

--- a/docs/src/pages/components/month-range.js
+++ b/docs/src/pages/components/month-range.js
@@ -104,10 +104,10 @@ const propsRows = [
   },
   localeProp,
   {
-    name: "disableAutofill",
+    name: "disableAutoComplete",
     type: "boolean",
     defaultValue: "false",
-    description: "Disables autofilling the year after typing in the month"
+    description: "Disables auto-completing the year after typing in the month"
   }
 ];
 

--- a/docs/src/pages/components/month-range.js
+++ b/docs/src/pages/components/month-range.js
@@ -104,7 +104,7 @@ const propsRows = [
   },
   localeProp,
   {
-    name: "disableAutoComplete",
+    name: "disableAutocomplete",
     type: "boolean",
     defaultValue: "false",
     description: "Disables auto-completing the year after typing in the month"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8672,12 +8672,17 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
+date-fns@2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.9.0.tgz#d0b175a5c37ed5f17b97e2272bbc1fa5aec677d2"
+  integrity sha512-khbFLu/MlzLjEzy9Gh8oY1hNt/Dvxw3J6Rbc28cVoYWQaC1S3YI4xwkF9ZWcjDLscbZlY9hISMr66RFzZagLsA==
+
 date-fns@^1.23.0, date-fns@^1.27.2:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-date-fns@^2.0.1, date-fns@^2.8.1:
+date-fns@^2.0.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.8.1.tgz#2109362ccb6c87c3ca011e9e31f702bc09e4123b"
   integrity sha512-EL/C8IHvYRwAHYgFRse4MGAPSqlJVlOrhVYZ75iQBKrnv+ZedmYsgwH3t+BCDuZDXpoo07+q9j4qgSSOa7irJg==
@@ -8691,6 +8696,11 @@ dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
+
+debounce@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
+  integrity sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==
 
 debug@2, debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.3, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"


### PR DESCRIPTION
## Description

Add auto-complete functionality to the month picker input:
- When a user types in at least three letters the matching month is selected and the year is filled in with the last selected year. ex: if the original selection is “Jan 2019”, and typing in “jul” should auto fill to “Jul 2019”

- Added a disableAutoComplete prop in case this functionality doesn't work for some implementations (ex: passing in a totally different date format than the default)

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [x] Docs updated with correct props and examples
- [x] Updated and reviewed changes to storyshots
- [x] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
