### PR TITLE
chore: Replaces `value` with `checked` in docs for Radio/Checkbox

### DIFF
--- a/docs/src/shared/radioProps.js
+++ b/docs/src/shared/radioProps.js
@@ -12,10 +12,10 @@ const radioProps = [
     description: "Identified that groups inputs together"
   },
   {
-    name: "value",
+    name: "checked",
     type: "String",
     defaultValue: "undefined",
-    description: "Value of selection for submission"
+    description: "Value of input field for submission"
   },
   {
     name: "defaultChecked",


### PR DESCRIPTION
## Description

Fixes inaccurate documentation for the `Checkbox` and `Radio` components. The prop `value` should instead be `checked`.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [x] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [x] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
