### PR TITLE
fix: dropdown menu not opening

### DIFF
--- a/components/src/DropdownMenu/DropdownMenu.js
+++ b/components/src/DropdownMenu/DropdownMenu.js
@@ -93,7 +93,7 @@ class StatelessDropdownMenu extends React.Component {
           }
         </Reference>
         {isOpen && (
-          <Popper placement={false} modifiers={modifiers || transformPropsToModifiers({ boundariesElement })}>
+          <Popper placement={placement} modifiers={modifiers || transformPropsToModifiers({ boundariesElement })}>
             {popperProps => (
               <DropdownMenuContainer
                 className={className}


### PR DESCRIPTION
## Description

Fix earlier mistake where placement somehow got set to false rather than passed down preventing the dropdown from opening

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
