### PR TITLE
feat: add loading icon to icons: <Icon icon="loading" />

### DIFF
--- a/components/src/Icon/Icon.js
+++ b/components/src/Icon/Icon.js
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import { space, color } from "styled-system";
 import icons from "../../icons/icons.json";
 import theme from "../theme";
+import LoadingIcon from "./LoadingIcon";
 
 const iconNames = Object.keys(icons);
 
@@ -19,22 +20,25 @@ const getPathElements = icon => (
 
 const Svg = React.forwardRef((props, ref) => {
   const { icon, className, title, size, color: fillColor, focusable } = props;
-
-  if (!icons[icon]) return false;
+  if (icon === "loading") {
+    return <LoadingIcon color={theme.colors[fillColor] ? theme.colors[fillColor] : fillColor} {...props} />;
+  }
   return (
-    <svg
-      ref={ref}
-      aria-hidden={title == null}
-      width={size}
-      height={size}
-      fill={theme.colors[fillColor] ? theme.colors[fillColor] : fillColor}
-      viewBox={icons[icon].viewBox}
-      focusable={focusable}
-      className={className}
-      {...props}
-    >
-      {getPathElements(icons[icon])}
-    </svg>
+    icons[icon] && (
+      <svg
+        ref={ref}
+        aria-hidden={title == null}
+        width={size}
+        height={size}
+        fill={theme.colors[fillColor] ? theme.colors[fillColor] : fillColor}
+        viewBox={icons[icon].viewBox}
+        focusable={focusable}
+        className={className}
+        {...props}
+      >
+        {getPathElements(icons[icon])}
+      </svg>
+    )
   );
 });
 

--- a/components/src/Icon/Icon.story.js
+++ b/components/src/Icon/Icon.story.js
@@ -5,8 +5,8 @@ import { Box, Flex, Icon, InlineIcon } from "../index";
 import theme from "../theme";
 import icons from "../../icons/icons.json";
 
-const iconNames = Object.keys(icons);
-const iconSubset = iconNames.slice(0, 5);
+const iconNames = [...Object.keys(icons), "loading"];
+const iconSubset = [...iconNames.slice(0, 5), "loading"];
 
 const IconCode = ({ icon }) => (
   <code>

--- a/components/src/Icon/LoadingIcon.js
+++ b/components/src/Icon/LoadingIcon.js
@@ -1,0 +1,57 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { generateId } from "../utils";
+
+const LoadingIcon = ({ color, size, title, ...props }) => {
+  const id = generateId();
+  return (
+    // Modified svg By Sam Herbert (@sherb), for everyone. More @ http://goo.gl/7AJzbL
+    <svg title={title} width={size} height={size} viewBox="0 0 38 38" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <defs>
+        <linearGradient x1="8.042%" y1="0%" x2="65.682%" y2="23.865%" id={id}>
+          <stop stopColor={color} stopOpacity="0" offset="0%" />
+          <stop stopColor={color} stopOpacity=".631" offset="63.146%" />
+          <stop stopColor={color} offset="100%" />
+        </linearGradient>
+      </defs>
+      <g fill="none" fillRule="evenodd">
+        <g transform="translate(1 1)">
+          <path d="M36 18c0-9.94-8.06-18-18-18" id="Oval-2" stroke={`url(#${id})`} strokeWidth="2">
+            <animateTransform
+              attributeName="transform"
+              type="rotate"
+              from="0 18 18"
+              to="360 18 18"
+              dur="0.9s"
+              repeatCount="indefinite"
+            />
+          </path>
+          <circle fill={color} cx="36" cy="18" r="1">
+            <animateTransform
+              attributeName="transform"
+              type="rotate"
+              from="0 18 18"
+              to="360 18 18"
+              dur="0.9s"
+              repeatCount="indefinite"
+            />
+          </circle>
+        </g>
+      </g>
+    </svg>
+  );
+};
+
+LoadingIcon.propTypes = {
+  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  color: PropTypes.string,
+  title: PropTypes.string
+};
+
+LoadingIcon.defaultProps = {
+  color: "currentColor",
+  size: "24px",
+  title: "Loading"
+};
+
+export default LoadingIcon;

--- a/components/src/Icon/__snapshots__/Icon.story.storyshot
+++ b/components/src/Icon/__snapshots__/Icon.story.storyshot
@@ -5861,6 +5861,215 @@ exports[`Storyshots Icon Icon 1`] = `
               </IconCode>
             </div>
           </Styled(Box)>
+          <Styled(Box)
+            key="loading"
+            my="x2"
+            theme={
+              Object {
+                "borders": Array [],
+                "breakpoints": Object {
+                  "extraLarge": "1920px",
+                  "extraSmall": "0px",
+                  "large": "1360px",
+                  "medium": "1024px",
+                  "small": "768px",
+                },
+                "colors": Object {
+                  "black": "#011e38",
+                  "blackBlue": "#122b47",
+                  "blue": "#216beb",
+                  "darkBlue": "#00438f",
+                  "darkGrey": "#434d59",
+                  "green": "#008059",
+                  "grey": "#c0c8d1",
+                  "lightBlue": "#e1ebfa",
+                  "lightGreen": "#e9f7f2",
+                  "lightGrey": "#e4e7eb",
+                  "lightRed": "#fae6ea",
+                  "lightYellow": "#fcf5e3",
+                  "red": "#cc1439",
+                  "white": "#ffffff",
+                  "whiteGrey": "#f0f2f5",
+                  "yellow": "#ffbb00",
+                },
+                "fontSizes": Object {
+                  "large": "20px",
+                  "larger": "26px",
+                  "largest": "46px",
+                  "medium": "16px",
+                  "small": "14px",
+                  "smaller": "12px",
+                },
+                "fontWeights": Object {
+                  "bold": "600",
+                  "light": "300",
+                  "medium": "500",
+                  "normal": "400",
+                },
+                "fonts": Object {
+                  "base": "'IBM Plex Sans', sans-serif",
+                  "mono": "'IBM Plex Mono', monospace",
+                },
+                "lineHeights": Object {
+                  "base": "1.5",
+                  "sectionTitle": "1.23076923",
+                  "smallTextBase": "1.71428571",
+                  "smallTextCompressed": "1.14285714",
+                  "smallerText": "1.33333333",
+                  "subsectionTitle": "1.2",
+                  "title": "1.04347826",
+                },
+                "radii": Object {
+                  "circle": "50%",
+                  "medium": "4px",
+                  "small": "2px",
+                },
+                "shadows": Object {
+                  "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                  "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                  "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                  "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                  "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                },
+                "space": Object {
+                  "half": "4px",
+                  "none": "0px",
+                  "x1": "8px",
+                  "x2": "16px",
+                  "x3": "24px",
+                  "x4": "32px",
+                  "x5": "40px",
+                  "x6": "48px",
+                  "x8": "64px",
+                },
+                "zIndex": Object {
+                  "content": 100,
+                  "overlay": 1000,
+                  "tabsBar": 210,
+                  "tabsScollIndicator": 200,
+                },
+              }
+            }
+          >
+            <div
+              className="Box-sc-1qu1edy-0 sc-AykKC eJLKpo"
+            >
+              <Styled(Component)
+                color="currentColor"
+                icon="loading"
+                mr="20px"
+                size="24px"
+                title={null}
+              >
+                <ForwardRef
+                  className="sc-AykKD fwiOPE"
+                  color="currentColor"
+                  focusable={false}
+                  icon="loading"
+                  mr="20px"
+                  size="24px"
+                  title={null}
+                >
+                  <LoadingIcon
+                    className="sc-AykKD fwiOPE"
+                    color="currentColor"
+                    focusable={false}
+                    icon="loading"
+                    mr="20px"
+                    size="24px"
+                    title={null}
+                  >
+                    <svg
+                      className="sc-AykKD fwiOPE"
+                      focusable={false}
+                      height="24px"
+                      icon="loading"
+                      mr="20px"
+                      title={null}
+                      viewBox="0 0 38 38"
+                      width="24px"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <defs>
+                        <linearGradient
+                          id="random-id-1"
+                          x1="8.042%"
+                          x2="65.682%"
+                          y1="0%"
+                          y2="23.865%"
+                        >
+                          <stop
+                            offset="0%"
+                            stopColor="currentColor"
+                            stopOpacity="0"
+                          />
+                          <stop
+                            offset="63.146%"
+                            stopColor="currentColor"
+                            stopOpacity=".631"
+                          />
+                          <stop
+                            offset="100%"
+                            stopColor="currentColor"
+                          />
+                        </linearGradient>
+                      </defs>
+                      <g
+                        fill="none"
+                        fillRule="evenodd"
+                      >
+                        <g
+                          transform="translate(1 1)"
+                        >
+                          <path
+                            d="M36 18c0-9.94-8.06-18-18-18"
+                            id="Oval-2"
+                            stroke="url(#random-id-1)"
+                            strokeWidth="2"
+                          >
+                            <animateTransform
+                              attributeName="transform"
+                              dur="0.9s"
+                              from="0 18 18"
+                              repeatCount="indefinite"
+                              to="360 18 18"
+                              type="rotate"
+                            />
+                          </path>
+                          <circle
+                            cx="36"
+                            cy="18"
+                            fill="currentColor"
+                            r="1"
+                          >
+                            <animateTransform
+                              attributeName="transform"
+                              dur="0.9s"
+                              from="0 18 18"
+                              repeatCount="indefinite"
+                              to="360 18 18"
+                              type="rotate"
+                            />
+                          </circle>
+                        </g>
+                      </g>
+                    </svg>
+                  </LoadingIcon>
+                </ForwardRef>
+              </Styled(Component)>
+              <IconCode
+                icon="loading"
+              >
+                <code>
+                  &lt;Icon icon="
+                  <b>
+                    loading
+                  </b>
+                  "&gt;
+                </code>
+              </IconCode>
+            </div>
+          </Styled(Box)>
         </ThemeProvider>
       </div>
     </NDSProvider__GlobalStyles>
@@ -6384,6 +6593,116 @@ exports[`Storyshots Icon InlineIcon 1`] = `
                 </span>
               </Icon__IconContainer>
             </InlineIcon>
+            <InlineIcon
+              icon="loading"
+              key="loading"
+            >
+              <Icon__IconContainer
+                icon="loading"
+              >
+                <span
+                  className="Icon__IconContainer-fc7twp-0 cKMFdt"
+                >
+                  <Styled(Component)
+                    icon="loading"
+                    size="1.25em"
+                  >
+                    <ForwardRef
+                      className="sc-AykKE hrqlIQ"
+                      color="currentColor"
+                      focusable={false}
+                      icon="loading"
+                      size="1.25em"
+                      title={null}
+                    >
+                      <LoadingIcon
+                        className="sc-AykKE hrqlIQ"
+                        color="currentColor"
+                        focusable={false}
+                        icon="loading"
+                        size="1.25em"
+                        title={null}
+                      >
+                        <svg
+                          className="sc-AykKE hrqlIQ"
+                          focusable={false}
+                          height="1.25em"
+                          icon="loading"
+                          title={null}
+                          viewBox="0 0 38 38"
+                          width="1.25em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <defs>
+                            <linearGradient
+                              id="random-id-2"
+                              x1="8.042%"
+                              x2="65.682%"
+                              y1="0%"
+                              y2="23.865%"
+                            >
+                              <stop
+                                offset="0%"
+                                stopColor="currentColor"
+                                stopOpacity="0"
+                              />
+                              <stop
+                                offset="63.146%"
+                                stopColor="currentColor"
+                                stopOpacity=".631"
+                              />
+                              <stop
+                                offset="100%"
+                                stopColor="currentColor"
+                              />
+                            </linearGradient>
+                          </defs>
+                          <g
+                            fill="none"
+                            fillRule="evenodd"
+                          >
+                            <g
+                              transform="translate(1 1)"
+                            >
+                              <path
+                                d="M36 18c0-9.94-8.06-18-18-18"
+                                id="Oval-2"
+                                stroke="url(#random-id-2)"
+                                strokeWidth="2"
+                              >
+                                <animateTransform
+                                  attributeName="transform"
+                                  dur="0.9s"
+                                  from="0 18 18"
+                                  repeatCount="indefinite"
+                                  to="360 18 18"
+                                  type="rotate"
+                                />
+                              </path>
+                              <circle
+                                cx="36"
+                                cy="18"
+                                fill="currentColor"
+                                r="1"
+                              >
+                                <animateTransform
+                                  attributeName="transform"
+                                  dur="0.9s"
+                                  from="0 18 18"
+                                  repeatCount="indefinite"
+                                  to="360 18 18"
+                                  type="rotate"
+                                />
+                              </circle>
+                            </g>
+                          </g>
+                        </svg>
+                      </LoadingIcon>
+                    </ForwardRef>
+                  </Styled(Component)>
+                </span>
+              </Icon__IconContainer>
+            </InlineIcon>
           </p>
           <p
             key="2"
@@ -6620,6 +6939,116 @@ exports[`Storyshots Icon InlineIcon 1`] = `
                           key="0"
                         />
                       </svg>
+                    </ForwardRef>
+                  </Styled(Component)>
+                </span>
+              </Icon__IconContainer>
+            </InlineIcon>
+            <InlineIcon
+              icon="loading"
+              key="loading"
+            >
+              <Icon__IconContainer
+                icon="loading"
+              >
+                <span
+                  className="Icon__IconContainer-fc7twp-0 cKMFdt"
+                >
+                  <Styled(Component)
+                    icon="loading"
+                    size="1.25em"
+                  >
+                    <ForwardRef
+                      className="sc-AykKE hrqlIQ"
+                      color="currentColor"
+                      focusable={false}
+                      icon="loading"
+                      size="1.25em"
+                      title={null}
+                    >
+                      <LoadingIcon
+                        className="sc-AykKE hrqlIQ"
+                        color="currentColor"
+                        focusable={false}
+                        icon="loading"
+                        size="1.25em"
+                        title={null}
+                      >
+                        <svg
+                          className="sc-AykKE hrqlIQ"
+                          focusable={false}
+                          height="1.25em"
+                          icon="loading"
+                          title={null}
+                          viewBox="0 0 38 38"
+                          width="1.25em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <defs>
+                            <linearGradient
+                              id="random-id-3"
+                              x1="8.042%"
+                              x2="65.682%"
+                              y1="0%"
+                              y2="23.865%"
+                            >
+                              <stop
+                                offset="0%"
+                                stopColor="currentColor"
+                                stopOpacity="0"
+                              />
+                              <stop
+                                offset="63.146%"
+                                stopColor="currentColor"
+                                stopOpacity=".631"
+                              />
+                              <stop
+                                offset="100%"
+                                stopColor="currentColor"
+                              />
+                            </linearGradient>
+                          </defs>
+                          <g
+                            fill="none"
+                            fillRule="evenodd"
+                          >
+                            <g
+                              transform="translate(1 1)"
+                            >
+                              <path
+                                d="M36 18c0-9.94-8.06-18-18-18"
+                                id="Oval-2"
+                                stroke="url(#random-id-3)"
+                                strokeWidth="2"
+                              >
+                                <animateTransform
+                                  attributeName="transform"
+                                  dur="0.9s"
+                                  from="0 18 18"
+                                  repeatCount="indefinite"
+                                  to="360 18 18"
+                                  type="rotate"
+                                />
+                              </path>
+                              <circle
+                                cx="36"
+                                cy="18"
+                                fill="currentColor"
+                                r="1"
+                              >
+                                <animateTransform
+                                  attributeName="transform"
+                                  dur="0.9s"
+                                  from="0 18 18"
+                                  repeatCount="indefinite"
+                                  to="360 18 18"
+                                  type="rotate"
+                                />
+                              </circle>
+                            </g>
+                          </g>
+                        </svg>
+                      </LoadingIcon>
                     </ForwardRef>
                   </Styled(Component)>
                 </span>
@@ -6866,6 +7295,116 @@ exports[`Storyshots Icon InlineIcon 1`] = `
                 </span>
               </Icon__IconContainer>
             </InlineIcon>
+            <InlineIcon
+              icon="loading"
+              key="loading"
+            >
+              <Icon__IconContainer
+                icon="loading"
+              >
+                <span
+                  className="Icon__IconContainer-fc7twp-0 cKMFdt"
+                >
+                  <Styled(Component)
+                    icon="loading"
+                    size="1.25em"
+                  >
+                    <ForwardRef
+                      className="sc-AykKE hrqlIQ"
+                      color="currentColor"
+                      focusable={false}
+                      icon="loading"
+                      size="1.25em"
+                      title={null}
+                    >
+                      <LoadingIcon
+                        className="sc-AykKE hrqlIQ"
+                        color="currentColor"
+                        focusable={false}
+                        icon="loading"
+                        size="1.25em"
+                        title={null}
+                      >
+                        <svg
+                          className="sc-AykKE hrqlIQ"
+                          focusable={false}
+                          height="1.25em"
+                          icon="loading"
+                          title={null}
+                          viewBox="0 0 38 38"
+                          width="1.25em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <defs>
+                            <linearGradient
+                              id="random-id-4"
+                              x1="8.042%"
+                              x2="65.682%"
+                              y1="0%"
+                              y2="23.865%"
+                            >
+                              <stop
+                                offset="0%"
+                                stopColor="currentColor"
+                                stopOpacity="0"
+                              />
+                              <stop
+                                offset="63.146%"
+                                stopColor="currentColor"
+                                stopOpacity=".631"
+                              />
+                              <stop
+                                offset="100%"
+                                stopColor="currentColor"
+                              />
+                            </linearGradient>
+                          </defs>
+                          <g
+                            fill="none"
+                            fillRule="evenodd"
+                          >
+                            <g
+                              transform="translate(1 1)"
+                            >
+                              <path
+                                d="M36 18c0-9.94-8.06-18-18-18"
+                                id="Oval-2"
+                                stroke="url(#random-id-4)"
+                                strokeWidth="2"
+                              >
+                                <animateTransform
+                                  attributeName="transform"
+                                  dur="0.9s"
+                                  from="0 18 18"
+                                  repeatCount="indefinite"
+                                  to="360 18 18"
+                                  type="rotate"
+                                />
+                              </path>
+                              <circle
+                                cx="36"
+                                cy="18"
+                                fill="currentColor"
+                                r="1"
+                              >
+                                <animateTransform
+                                  attributeName="transform"
+                                  dur="0.9s"
+                                  from="0 18 18"
+                                  repeatCount="indefinite"
+                                  to="360 18 18"
+                                  type="rotate"
+                                />
+                              </circle>
+                            </g>
+                          </g>
+                        </svg>
+                      </LoadingIcon>
+                    </ForwardRef>
+                  </Styled(Component)>
+                </span>
+              </Icon__IconContainer>
+            </InlineIcon>
           </p>
           <p
             key="4"
@@ -7102,6 +7641,116 @@ exports[`Storyshots Icon InlineIcon 1`] = `
                           key="0"
                         />
                       </svg>
+                    </ForwardRef>
+                  </Styled(Component)>
+                </span>
+              </Icon__IconContainer>
+            </InlineIcon>
+            <InlineIcon
+              icon="loading"
+              key="loading"
+            >
+              <Icon__IconContainer
+                icon="loading"
+              >
+                <span
+                  className="Icon__IconContainer-fc7twp-0 cKMFdt"
+                >
+                  <Styled(Component)
+                    icon="loading"
+                    size="1.25em"
+                  >
+                    <ForwardRef
+                      className="sc-AykKE hrqlIQ"
+                      color="currentColor"
+                      focusable={false}
+                      icon="loading"
+                      size="1.25em"
+                      title={null}
+                    >
+                      <LoadingIcon
+                        className="sc-AykKE hrqlIQ"
+                        color="currentColor"
+                        focusable={false}
+                        icon="loading"
+                        size="1.25em"
+                        title={null}
+                      >
+                        <svg
+                          className="sc-AykKE hrqlIQ"
+                          focusable={false}
+                          height="1.25em"
+                          icon="loading"
+                          title={null}
+                          viewBox="0 0 38 38"
+                          width="1.25em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <defs>
+                            <linearGradient
+                              id="random-id-5"
+                              x1="8.042%"
+                              x2="65.682%"
+                              y1="0%"
+                              y2="23.865%"
+                            >
+                              <stop
+                                offset="0%"
+                                stopColor="currentColor"
+                                stopOpacity="0"
+                              />
+                              <stop
+                                offset="63.146%"
+                                stopColor="currentColor"
+                                stopOpacity=".631"
+                              />
+                              <stop
+                                offset="100%"
+                                stopColor="currentColor"
+                              />
+                            </linearGradient>
+                          </defs>
+                          <g
+                            fill="none"
+                            fillRule="evenodd"
+                          >
+                            <g
+                              transform="translate(1 1)"
+                            >
+                              <path
+                                d="M36 18c0-9.94-8.06-18-18-18"
+                                id="Oval-2"
+                                stroke="url(#random-id-5)"
+                                strokeWidth="2"
+                              >
+                                <animateTransform
+                                  attributeName="transform"
+                                  dur="0.9s"
+                                  from="0 18 18"
+                                  repeatCount="indefinite"
+                                  to="360 18 18"
+                                  type="rotate"
+                                />
+                              </path>
+                              <circle
+                                cx="36"
+                                cy="18"
+                                fill="currentColor"
+                                r="1"
+                              >
+                                <animateTransform
+                                  attributeName="transform"
+                                  dur="0.9s"
+                                  from="0 18 18"
+                                  repeatCount="indefinite"
+                                  to="360 18 18"
+                                  type="rotate"
+                                />
+                              </circle>
+                            </g>
+                          </g>
+                        </svg>
+                      </LoadingIcon>
                     </ForwardRef>
                   </Styled(Component)>
                 </span>
@@ -7662,6 +8311,106 @@ exports[`Storyshots Icon With a color 1`] = `
                   </svg>
                 </ForwardRef>
               </Styled(Component)>
+              <Styled(Component)
+                color="#cc1439"
+                icon="loading"
+                key="loading"
+                size="24px"
+                title={null}
+              >
+                <ForwardRef
+                  className="sc-AykKD clTyrU"
+                  color="#cc1439"
+                  focusable={false}
+                  icon="loading"
+                  size="24px"
+                  title={null}
+                >
+                  <LoadingIcon
+                    className="sc-AykKD clTyrU"
+                    color="#cc1439"
+                    focusable={false}
+                    icon="loading"
+                    size="24px"
+                    title={null}
+                  >
+                    <svg
+                      className="sc-AykKD clTyrU"
+                      focusable={false}
+                      height="24px"
+                      icon="loading"
+                      title={null}
+                      viewBox="0 0 38 38"
+                      width="24px"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <defs>
+                        <linearGradient
+                          id="random-id-6"
+                          x1="8.042%"
+                          x2="65.682%"
+                          y1="0%"
+                          y2="23.865%"
+                        >
+                          <stop
+                            offset="0%"
+                            stopColor="#cc1439"
+                            stopOpacity="0"
+                          />
+                          <stop
+                            offset="63.146%"
+                            stopColor="#cc1439"
+                            stopOpacity=".631"
+                          />
+                          <stop
+                            offset="100%"
+                            stopColor="#cc1439"
+                          />
+                        </linearGradient>
+                      </defs>
+                      <g
+                        fill="none"
+                        fillRule="evenodd"
+                      >
+                        <g
+                          transform="translate(1 1)"
+                        >
+                          <path
+                            d="M36 18c0-9.94-8.06-18-18-18"
+                            id="Oval-2"
+                            stroke="url(#random-id-6)"
+                            strokeWidth="2"
+                          >
+                            <animateTransform
+                              attributeName="transform"
+                              dur="0.9s"
+                              from="0 18 18"
+                              repeatCount="indefinite"
+                              to="360 18 18"
+                              type="rotate"
+                            />
+                          </path>
+                          <circle
+                            cx="36"
+                            cy="18"
+                            fill="#cc1439"
+                            r="1"
+                          >
+                            <animateTransform
+                              attributeName="transform"
+                              dur="0.9s"
+                              from="0 18 18"
+                              repeatCount="indefinite"
+                              to="360 18 18"
+                              type="rotate"
+                            />
+                          </circle>
+                        </g>
+                      </g>
+                    </svg>
+                  </LoadingIcon>
+                </ForwardRef>
+              </Styled(Component)>
             </div>
           </Box>
           <Box
@@ -7933,6 +8682,106 @@ exports[`Storyshots Icon With a color 1`] = `
                       key="0"
                     />
                   </svg>
+                </ForwardRef>
+              </Styled(Component)>
+              <Styled(Component)
+                color="#ffbb00"
+                icon="loading"
+                key="loading"
+                size="24px"
+                title={null}
+              >
+                <ForwardRef
+                  className="sc-AykKD eXzbYd"
+                  color="#ffbb00"
+                  focusable={false}
+                  icon="loading"
+                  size="24px"
+                  title={null}
+                >
+                  <LoadingIcon
+                    className="sc-AykKD eXzbYd"
+                    color="#ffbb00"
+                    focusable={false}
+                    icon="loading"
+                    size="24px"
+                    title={null}
+                  >
+                    <svg
+                      className="sc-AykKD eXzbYd"
+                      focusable={false}
+                      height="24px"
+                      icon="loading"
+                      title={null}
+                      viewBox="0 0 38 38"
+                      width="24px"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <defs>
+                        <linearGradient
+                          id="random-id-7"
+                          x1="8.042%"
+                          x2="65.682%"
+                          y1="0%"
+                          y2="23.865%"
+                        >
+                          <stop
+                            offset="0%"
+                            stopColor="#ffbb00"
+                            stopOpacity="0"
+                          />
+                          <stop
+                            offset="63.146%"
+                            stopColor="#ffbb00"
+                            stopOpacity=".631"
+                          />
+                          <stop
+                            offset="100%"
+                            stopColor="#ffbb00"
+                          />
+                        </linearGradient>
+                      </defs>
+                      <g
+                        fill="none"
+                        fillRule="evenodd"
+                      >
+                        <g
+                          transform="translate(1 1)"
+                        >
+                          <path
+                            d="M36 18c0-9.94-8.06-18-18-18"
+                            id="Oval-2"
+                            stroke="url(#random-id-7)"
+                            strokeWidth="2"
+                          >
+                            <animateTransform
+                              attributeName="transform"
+                              dur="0.9s"
+                              from="0 18 18"
+                              repeatCount="indefinite"
+                              to="360 18 18"
+                              type="rotate"
+                            />
+                          </path>
+                          <circle
+                            cx="36"
+                            cy="18"
+                            fill="#ffbb00"
+                            r="1"
+                          >
+                            <animateTransform
+                              attributeName="transform"
+                              dur="0.9s"
+                              from="0 18 18"
+                              repeatCount="indefinite"
+                              to="360 18 18"
+                              type="rotate"
+                            />
+                          </circle>
+                        </g>
+                      </g>
+                    </svg>
+                  </LoadingIcon>
                 </ForwardRef>
               </Styled(Component)>
             </div>
@@ -8208,6 +9057,106 @@ exports[`Storyshots Icon With a color 1`] = `
                   </svg>
                 </ForwardRef>
               </Styled(Component)>
+              <Styled(Component)
+                color="#008059"
+                icon="loading"
+                key="loading"
+                size="24px"
+                title={null}
+              >
+                <ForwardRef
+                  className="sc-AykKD eGOLD"
+                  color="#008059"
+                  focusable={false}
+                  icon="loading"
+                  size="24px"
+                  title={null}
+                >
+                  <LoadingIcon
+                    className="sc-AykKD eGOLD"
+                    color="#008059"
+                    focusable={false}
+                    icon="loading"
+                    size="24px"
+                    title={null}
+                  >
+                    <svg
+                      className="sc-AykKD eGOLD"
+                      focusable={false}
+                      height="24px"
+                      icon="loading"
+                      title={null}
+                      viewBox="0 0 38 38"
+                      width="24px"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <defs>
+                        <linearGradient
+                          id="random-id-8"
+                          x1="8.042%"
+                          x2="65.682%"
+                          y1="0%"
+                          y2="23.865%"
+                        >
+                          <stop
+                            offset="0%"
+                            stopColor="#008059"
+                            stopOpacity="0"
+                          />
+                          <stop
+                            offset="63.146%"
+                            stopColor="#008059"
+                            stopOpacity=".631"
+                          />
+                          <stop
+                            offset="100%"
+                            stopColor="#008059"
+                          />
+                        </linearGradient>
+                      </defs>
+                      <g
+                        fill="none"
+                        fillRule="evenodd"
+                      >
+                        <g
+                          transform="translate(1 1)"
+                        >
+                          <path
+                            d="M36 18c0-9.94-8.06-18-18-18"
+                            id="Oval-2"
+                            stroke="url(#random-id-8)"
+                            strokeWidth="2"
+                          >
+                            <animateTransform
+                              attributeName="transform"
+                              dur="0.9s"
+                              from="0 18 18"
+                              repeatCount="indefinite"
+                              to="360 18 18"
+                              type="rotate"
+                            />
+                          </path>
+                          <circle
+                            cx="36"
+                            cy="18"
+                            fill="#008059"
+                            r="1"
+                          >
+                            <animateTransform
+                              attributeName="transform"
+                              dur="0.9s"
+                              from="0 18 18"
+                              repeatCount="indefinite"
+                              to="360 18 18"
+                              type="rotate"
+                            />
+                          </circle>
+                        </g>
+                      </g>
+                    </svg>
+                  </LoadingIcon>
+                </ForwardRef>
+              </Styled(Component)>
             </div>
           </Box>
           <Box
@@ -8481,6 +9430,106 @@ exports[`Storyshots Icon With a color 1`] = `
                   </svg>
                 </ForwardRef>
               </Styled(Component)>
+              <Styled(Component)
+                color="#216beb"
+                icon="loading"
+                key="loading"
+                size="24px"
+                title={null}
+              >
+                <ForwardRef
+                  className="sc-AykKD kbaGLP"
+                  color="#216beb"
+                  focusable={false}
+                  icon="loading"
+                  size="24px"
+                  title={null}
+                >
+                  <LoadingIcon
+                    className="sc-AykKD kbaGLP"
+                    color="#216beb"
+                    focusable={false}
+                    icon="loading"
+                    size="24px"
+                    title={null}
+                  >
+                    <svg
+                      className="sc-AykKD kbaGLP"
+                      focusable={false}
+                      height="24px"
+                      icon="loading"
+                      title={null}
+                      viewBox="0 0 38 38"
+                      width="24px"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <defs>
+                        <linearGradient
+                          id="random-id-9"
+                          x1="8.042%"
+                          x2="65.682%"
+                          y1="0%"
+                          y2="23.865%"
+                        >
+                          <stop
+                            offset="0%"
+                            stopColor="#216beb"
+                            stopOpacity="0"
+                          />
+                          <stop
+                            offset="63.146%"
+                            stopColor="#216beb"
+                            stopOpacity=".631"
+                          />
+                          <stop
+                            offset="100%"
+                            stopColor="#216beb"
+                          />
+                        </linearGradient>
+                      </defs>
+                      <g
+                        fill="none"
+                        fillRule="evenodd"
+                      >
+                        <g
+                          transform="translate(1 1)"
+                        >
+                          <path
+                            d="M36 18c0-9.94-8.06-18-18-18"
+                            id="Oval-2"
+                            stroke="url(#random-id-9)"
+                            strokeWidth="2"
+                          >
+                            <animateTransform
+                              attributeName="transform"
+                              dur="0.9s"
+                              from="0 18 18"
+                              repeatCount="indefinite"
+                              to="360 18 18"
+                              type="rotate"
+                            />
+                          </path>
+                          <circle
+                            cx="36"
+                            cy="18"
+                            fill="#216beb"
+                            r="1"
+                          >
+                            <animateTransform
+                              attributeName="transform"
+                              dur="0.9s"
+                              from="0 18 18"
+                              repeatCount="indefinite"
+                              to="360 18 18"
+                              type="rotate"
+                            />
+                          </circle>
+                        </g>
+                      </g>
+                    </svg>
+                  </LoadingIcon>
+                </ForwardRef>
+              </Styled(Component)>
             </div>
           </Box>
           <Box
@@ -8752,6 +9801,106 @@ exports[`Storyshots Icon With a color 1`] = `
                       key="0"
                     />
                   </svg>
+                </ForwardRef>
+              </Styled(Component)>
+              <Styled(Component)
+                color="#122b47"
+                icon="loading"
+                key="loading"
+                size="24px"
+                title={null}
+              >
+                <ForwardRef
+                  className="sc-AykKD aLmVb"
+                  color="#122b47"
+                  focusable={false}
+                  icon="loading"
+                  size="24px"
+                  title={null}
+                >
+                  <LoadingIcon
+                    className="sc-AykKD aLmVb"
+                    color="#122b47"
+                    focusable={false}
+                    icon="loading"
+                    size="24px"
+                    title={null}
+                  >
+                    <svg
+                      className="sc-AykKD aLmVb"
+                      focusable={false}
+                      height="24px"
+                      icon="loading"
+                      title={null}
+                      viewBox="0 0 38 38"
+                      width="24px"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <defs>
+                        <linearGradient
+                          id="random-id-10"
+                          x1="8.042%"
+                          x2="65.682%"
+                          y1="0%"
+                          y2="23.865%"
+                        >
+                          <stop
+                            offset="0%"
+                            stopColor="#122b47"
+                            stopOpacity="0"
+                          />
+                          <stop
+                            offset="63.146%"
+                            stopColor="#122b47"
+                            stopOpacity=".631"
+                          />
+                          <stop
+                            offset="100%"
+                            stopColor="#122b47"
+                          />
+                        </linearGradient>
+                      </defs>
+                      <g
+                        fill="none"
+                        fillRule="evenodd"
+                      >
+                        <g
+                          transform="translate(1 1)"
+                        >
+                          <path
+                            d="M36 18c0-9.94-8.06-18-18-18"
+                            id="Oval-2"
+                            stroke="url(#random-id-10)"
+                            strokeWidth="2"
+                          >
+                            <animateTransform
+                              attributeName="transform"
+                              dur="0.9s"
+                              from="0 18 18"
+                              repeatCount="indefinite"
+                              to="360 18 18"
+                              type="rotate"
+                            />
+                          </path>
+                          <circle
+                            cx="36"
+                            cy="18"
+                            fill="#122b47"
+                            r="1"
+                          >
+                            <animateTransform
+                              attributeName="transform"
+                              dur="0.9s"
+                              from="0 18 18"
+                              repeatCount="indefinite"
+                              to="360 18 18"
+                              type="rotate"
+                            />
+                          </circle>
+                        </g>
+                      </g>
+                    </svg>
+                  </LoadingIcon>
                 </ForwardRef>
               </Styled(Component)>
             </div>
@@ -9310,6 +10459,106 @@ exports[`Storyshots Icon With a size 1`] = `
                   </svg>
                 </ForwardRef>
               </Styled(Component)>
+              <Styled(Component)
+                color="currentColor"
+                icon="loading"
+                key="loading"
+                size="8px"
+                title={null}
+              >
+                <ForwardRef
+                  className="sc-AykKD eBQUbO"
+                  color="currentColor"
+                  focusable={false}
+                  icon="loading"
+                  size="8px"
+                  title={null}
+                >
+                  <LoadingIcon
+                    className="sc-AykKD eBQUbO"
+                    color="currentColor"
+                    focusable={false}
+                    icon="loading"
+                    size="8px"
+                    title={null}
+                  >
+                    <svg
+                      className="sc-AykKD eBQUbO"
+                      focusable={false}
+                      height="8px"
+                      icon="loading"
+                      title={null}
+                      viewBox="0 0 38 38"
+                      width="8px"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <defs>
+                        <linearGradient
+                          id="random-id-11"
+                          x1="8.042%"
+                          x2="65.682%"
+                          y1="0%"
+                          y2="23.865%"
+                        >
+                          <stop
+                            offset="0%"
+                            stopColor="currentColor"
+                            stopOpacity="0"
+                          />
+                          <stop
+                            offset="63.146%"
+                            stopColor="currentColor"
+                            stopOpacity=".631"
+                          />
+                          <stop
+                            offset="100%"
+                            stopColor="currentColor"
+                          />
+                        </linearGradient>
+                      </defs>
+                      <g
+                        fill="none"
+                        fillRule="evenodd"
+                      >
+                        <g
+                          transform="translate(1 1)"
+                        >
+                          <path
+                            d="M36 18c0-9.94-8.06-18-18-18"
+                            id="Oval-2"
+                            stroke="url(#random-id-11)"
+                            strokeWidth="2"
+                          >
+                            <animateTransform
+                              attributeName="transform"
+                              dur="0.9s"
+                              from="0 18 18"
+                              repeatCount="indefinite"
+                              to="360 18 18"
+                              type="rotate"
+                            />
+                          </path>
+                          <circle
+                            cx="36"
+                            cy="18"
+                            fill="currentColor"
+                            r="1"
+                          >
+                            <animateTransform
+                              attributeName="transform"
+                              dur="0.9s"
+                              from="0 18 18"
+                              repeatCount="indefinite"
+                              to="360 18 18"
+                              type="rotate"
+                            />
+                          </circle>
+                        </g>
+                      </g>
+                    </svg>
+                  </LoadingIcon>
+                </ForwardRef>
+              </Styled(Component)>
             </div>
           </Box>
           <Box
@@ -9583,6 +10832,106 @@ exports[`Storyshots Icon With a size 1`] = `
                   </svg>
                 </ForwardRef>
               </Styled(Component)>
+              <Styled(Component)
+                color="currentColor"
+                icon="loading"
+                key="loading"
+                size="16px"
+                title={null}
+              >
+                <ForwardRef
+                  className="sc-AykKD bUUoDN"
+                  color="currentColor"
+                  focusable={false}
+                  icon="loading"
+                  size="16px"
+                  title={null}
+                >
+                  <LoadingIcon
+                    className="sc-AykKD bUUoDN"
+                    color="currentColor"
+                    focusable={false}
+                    icon="loading"
+                    size="16px"
+                    title={null}
+                  >
+                    <svg
+                      className="sc-AykKD bUUoDN"
+                      focusable={false}
+                      height="16px"
+                      icon="loading"
+                      title={null}
+                      viewBox="0 0 38 38"
+                      width="16px"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <defs>
+                        <linearGradient
+                          id="random-id-12"
+                          x1="8.042%"
+                          x2="65.682%"
+                          y1="0%"
+                          y2="23.865%"
+                        >
+                          <stop
+                            offset="0%"
+                            stopColor="currentColor"
+                            stopOpacity="0"
+                          />
+                          <stop
+                            offset="63.146%"
+                            stopColor="currentColor"
+                            stopOpacity=".631"
+                          />
+                          <stop
+                            offset="100%"
+                            stopColor="currentColor"
+                          />
+                        </linearGradient>
+                      </defs>
+                      <g
+                        fill="none"
+                        fillRule="evenodd"
+                      >
+                        <g
+                          transform="translate(1 1)"
+                        >
+                          <path
+                            d="M36 18c0-9.94-8.06-18-18-18"
+                            id="Oval-2"
+                            stroke="url(#random-id-12)"
+                            strokeWidth="2"
+                          >
+                            <animateTransform
+                              attributeName="transform"
+                              dur="0.9s"
+                              from="0 18 18"
+                              repeatCount="indefinite"
+                              to="360 18 18"
+                              type="rotate"
+                            />
+                          </path>
+                          <circle
+                            cx="36"
+                            cy="18"
+                            fill="currentColor"
+                            r="1"
+                          >
+                            <animateTransform
+                              attributeName="transform"
+                              dur="0.9s"
+                              from="0 18 18"
+                              repeatCount="indefinite"
+                              to="360 18 18"
+                              type="rotate"
+                            />
+                          </circle>
+                        </g>
+                      </g>
+                    </svg>
+                  </LoadingIcon>
+                </ForwardRef>
+              </Styled(Component)>
             </div>
           </Box>
           <Box
@@ -9854,6 +11203,106 @@ exports[`Storyshots Icon With a size 1`] = `
                       key="0"
                     />
                   </svg>
+                </ForwardRef>
+              </Styled(Component)>
+              <Styled(Component)
+                color="currentColor"
+                icon="loading"
+                key="loading"
+                size="24px"
+                title={null}
+              >
+                <ForwardRef
+                  className="sc-AykKD bZVMDg"
+                  color="currentColor"
+                  focusable={false}
+                  icon="loading"
+                  size="24px"
+                  title={null}
+                >
+                  <LoadingIcon
+                    className="sc-AykKD bZVMDg"
+                    color="currentColor"
+                    focusable={false}
+                    icon="loading"
+                    size="24px"
+                    title={null}
+                  >
+                    <svg
+                      className="sc-AykKD bZVMDg"
+                      focusable={false}
+                      height="24px"
+                      icon="loading"
+                      title={null}
+                      viewBox="0 0 38 38"
+                      width="24px"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <defs>
+                        <linearGradient
+                          id="random-id-13"
+                          x1="8.042%"
+                          x2="65.682%"
+                          y1="0%"
+                          y2="23.865%"
+                        >
+                          <stop
+                            offset="0%"
+                            stopColor="currentColor"
+                            stopOpacity="0"
+                          />
+                          <stop
+                            offset="63.146%"
+                            stopColor="currentColor"
+                            stopOpacity=".631"
+                          />
+                          <stop
+                            offset="100%"
+                            stopColor="currentColor"
+                          />
+                        </linearGradient>
+                      </defs>
+                      <g
+                        fill="none"
+                        fillRule="evenodd"
+                      >
+                        <g
+                          transform="translate(1 1)"
+                        >
+                          <path
+                            d="M36 18c0-9.94-8.06-18-18-18"
+                            id="Oval-2"
+                            stroke="url(#random-id-13)"
+                            strokeWidth="2"
+                          >
+                            <animateTransform
+                              attributeName="transform"
+                              dur="0.9s"
+                              from="0 18 18"
+                              repeatCount="indefinite"
+                              to="360 18 18"
+                              type="rotate"
+                            />
+                          </path>
+                          <circle
+                            cx="36"
+                            cy="18"
+                            fill="currentColor"
+                            r="1"
+                          >
+                            <animateTransform
+                              attributeName="transform"
+                              dur="0.9s"
+                              from="0 18 18"
+                              repeatCount="indefinite"
+                              to="360 18 18"
+                              type="rotate"
+                            />
+                          </circle>
+                        </g>
+                      </g>
+                    </svg>
+                  </LoadingIcon>
                 </ForwardRef>
               </Styled(Component)>
             </div>

--- a/components/src/StoriesForTests/__snapshots__/Tooltip.story.storyshot
+++ b/components/src/StoriesForTests/__snapshots__/Tooltip.story.storyshot
@@ -287,7 +287,7 @@ exports[`Storyshots StoriesForTests/Tooltip Base 1`] = `
             <ForwardRef
               defaultOpen={false}
               hideDelay="350"
-              id="random-id-1"
+              id="random-id-14"
               modifiers={null}
               openOnClick={false}
               openOnHover={true}
@@ -313,7 +313,7 @@ exports[`Storyshots StoriesForTests/Tooltip Base 1`] = `
                     setReferenceNode={[Function]}
                   >
                     <ForwardRef
-                      aria-describedby="random-id-1"
+                      aria-describedby="random-id-14"
                       aria-expanded={false}
                       aria-haspopup={true}
                       aria-label="Open"
@@ -329,7 +329,7 @@ exports[`Storyshots StoriesForTests/Tooltip Base 1`] = `
                       size="medium"
                     >
                       <Button__WrapperButton
-                        aria-describedby="random-id-1"
+                        aria-describedby="random-id-14"
                         aria-expanded={false}
                         aria-haspopup={true}
                         aria-label="Open"
@@ -342,7 +342,7 @@ exports[`Storyshots StoriesForTests/Tooltip Base 1`] = `
                         size="medium"
                       >
                         <button
-                          aria-describedby="random-id-1"
+                          aria-describedby="random-id-14"
                           aria-expanded={false}
                           aria-haspopup={true}
                           aria-label="Open"
@@ -371,7 +371,7 @@ exports[`Storyshots StoriesForTests/Tooltip Base 1`] = `
                     positionFixed={false}
                     referenceElement={
                       <button
-                        aria-describedby="random-id-1"
+                        aria-describedby="random-id-14"
                         aria-expanded="false"
                         aria-haspopup="true"
                         aria-label="Open"
@@ -383,7 +383,7 @@ exports[`Storyshots StoriesForTests/Tooltip Base 1`] = `
                   >
                     <Styled(Box)
                       className=" nds-popper-pop-up"
-                      id="random-id-1"
+                      id="random-id-14"
                       maxWidth="24em"
                       onBlur={[Function]}
                       onFocus={[Function]}
@@ -489,7 +489,7 @@ exports[`Storyshots StoriesForTests/Tooltip Base 1`] = `
                     >
                       <div
                         className="Box-sc-1qu1edy-0 sc-fzXfNh kAYrkP  nds-popper-pop-up"
-                        id="random-id-1"
+                        id="random-id-14"
                         onBlur={[Function]}
                         onFocus={[Function]}
                         onMouseEnter={[Function]}
@@ -810,7 +810,7 @@ exports[`Storyshots StoriesForTests/Tooltip Open by default 1`] = `
             <ForwardRef
               defaultOpen={true}
               hideDelay="350"
-              id="random-id-2"
+              id="random-id-15"
               modifiers={null}
               openOnClick={false}
               openOnHover={true}
@@ -836,7 +836,7 @@ exports[`Storyshots StoriesForTests/Tooltip Open by default 1`] = `
                     setReferenceNode={[Function]}
                   >
                     <ForwardRef
-                      aria-describedby="random-id-2"
+                      aria-describedby="random-id-15"
                       aria-expanded={true}
                       aria-haspopup={true}
                       aria-label="Close"
@@ -852,7 +852,7 @@ exports[`Storyshots StoriesForTests/Tooltip Open by default 1`] = `
                       size="medium"
                     >
                       <Button__WrapperButton
-                        aria-describedby="random-id-2"
+                        aria-describedby="random-id-15"
                         aria-expanded={true}
                         aria-haspopup={true}
                         aria-label="Close"
@@ -865,7 +865,7 @@ exports[`Storyshots StoriesForTests/Tooltip Open by default 1`] = `
                         size="medium"
                       >
                         <button
-                          aria-describedby="random-id-2"
+                          aria-describedby="random-id-15"
                           aria-expanded={true}
                           aria-haspopup={true}
                           aria-label="Close"
@@ -894,7 +894,7 @@ exports[`Storyshots StoriesForTests/Tooltip Open by default 1`] = `
                     positionFixed={false}
                     referenceElement={
                       <button
-                        aria-describedby="random-id-2"
+                        aria-describedby="random-id-15"
                         aria-expanded="true"
                         aria-haspopup="true"
                         aria-label="Close"
@@ -906,7 +906,7 @@ exports[`Storyshots StoriesForTests/Tooltip Open by default 1`] = `
                   >
                     <Styled(Box)
                       className=" nds-popper-pop-up"
-                      id="random-id-2"
+                      id="random-id-15"
                       maxWidth="24em"
                       onBlur={[Function]}
                       onFocus={[Function]}
@@ -1012,7 +1012,7 @@ exports[`Storyshots StoriesForTests/Tooltip Open by default 1`] = `
                     >
                       <div
                         className="Box-sc-1qu1edy-0 sc-fzXfNh qNuDP  nds-popper-pop-up"
-                        id="random-id-2"
+                        id="random-id-15"
                         onBlur={[Function]}
                         onFocus={[Function]}
                         onMouseEnter={[Function]}

--- a/components/src/Tooltip/__snapshots__/Tooltip.story.storyshot
+++ b/components/src/Tooltip/__snapshots__/Tooltip.story.storyshot
@@ -379,7 +379,7 @@ exports[`Storyshots Tooltip Tooltip 1`] = `
                 <ForwardRef
                   defaultOpen={false}
                   hideDelay="350"
-                  id="random-id-3"
+                  id="random-id-16"
                   modifiers={null}
                   openOnClick={false}
                   openOnHover={true}
@@ -405,7 +405,7 @@ exports[`Storyshots Tooltip Tooltip 1`] = `
                         setReferenceNode={[Function]}
                       >
                         <ForwardRef
-                          aria-describedby="random-id-3"
+                          aria-describedby="random-id-16"
                           aria-expanded={false}
                           aria-haspopup={true}
                           aria-label="Open"
@@ -421,7 +421,7 @@ exports[`Storyshots Tooltip Tooltip 1`] = `
                           size="medium"
                         >
                           <Button__WrapperButton
-                            aria-describedby="random-id-3"
+                            aria-describedby="random-id-16"
                             aria-expanded={false}
                             aria-haspopup={true}
                             aria-label="Open"
@@ -434,7 +434,7 @@ exports[`Storyshots Tooltip Tooltip 1`] = `
                             size="medium"
                           >
                             <button
-                              aria-describedby="random-id-3"
+                              aria-describedby="random-id-16"
                               aria-expanded={false}
                               aria-haspopup={true}
                               aria-label="Open"
@@ -463,7 +463,7 @@ exports[`Storyshots Tooltip Tooltip 1`] = `
                         positionFixed={false}
                         referenceElement={
                           <button
-                            aria-describedby="random-id-3"
+                            aria-describedby="random-id-16"
                             aria-expanded="false"
                             aria-haspopup="true"
                             aria-label="Open"
@@ -475,7 +475,7 @@ exports[`Storyshots Tooltip Tooltip 1`] = `
                       >
                         <Styled(Box)
                           className=" nds-popper-pop-up"
-                          id="random-id-3"
+                          id="random-id-16"
                           maxWidth="24em"
                           onBlur={[Function]}
                           onFocus={[Function]}
@@ -581,7 +581,7 @@ exports[`Storyshots Tooltip Tooltip 1`] = `
                         >
                           <div
                             className="Box-sc-1qu1edy-0 sc-fzXfNh kAYrkP  nds-popper-pop-up"
-                            id="random-id-3"
+                            id="random-id-16"
                             onBlur={[Function]}
                             onFocus={[Function]}
                             onMouseEnter={[Function]}
@@ -904,7 +904,7 @@ exports[`Storyshots Tooltip open by default 1`] = `
             <ForwardRef
               defaultOpen={true}
               hideDelay="350"
-              id="random-id-27"
+              id="random-id-40"
               modifiers={null}
               openOnClick={false}
               openOnHover={true}
@@ -930,7 +930,7 @@ exports[`Storyshots Tooltip open by default 1`] = `
                     setReferenceNode={[Function]}
                   >
                     <ForwardRef
-                      aria-describedby="random-id-27"
+                      aria-describedby="random-id-40"
                       aria-expanded={true}
                       aria-haspopup={true}
                       aria-label="Close"
@@ -946,7 +946,7 @@ exports[`Storyshots Tooltip open by default 1`] = `
                       size="medium"
                     >
                       <Button__WrapperButton
-                        aria-describedby="random-id-27"
+                        aria-describedby="random-id-40"
                         aria-expanded={true}
                         aria-haspopup={true}
                         aria-label="Close"
@@ -959,7 +959,7 @@ exports[`Storyshots Tooltip open by default 1`] = `
                         size="medium"
                       >
                         <button
-                          aria-describedby="random-id-27"
+                          aria-describedby="random-id-40"
                           aria-expanded={true}
                           aria-haspopup={true}
                           aria-label="Close"
@@ -988,7 +988,7 @@ exports[`Storyshots Tooltip open by default 1`] = `
                     positionFixed={false}
                     referenceElement={
                       <button
-                        aria-describedby="random-id-27"
+                        aria-describedby="random-id-40"
                         aria-expanded="true"
                         aria-haspopup="true"
                         aria-label="Close"
@@ -1000,7 +1000,7 @@ exports[`Storyshots Tooltip open by default 1`] = `
                   >
                     <Styled(Box)
                       className=" nds-popper-pop-up"
-                      id="random-id-27"
+                      id="random-id-40"
                       maxWidth="24em"
                       onBlur={[Function]}
                       onFocus={[Function]}
@@ -1106,7 +1106,7 @@ exports[`Storyshots Tooltip open by default 1`] = `
                     >
                       <div
                         className="Box-sc-1qu1edy-0 sc-fzXfNh qNuDP  nds-popper-pop-up"
-                        id="random-id-27"
+                        id="random-id-40"
                         onBlur={[Function]}
                         onFocus={[Function]}
                         onMouseEnter={[Function]}
@@ -1439,7 +1439,7 @@ exports[`Storyshots Tooltip with Button passed in 1`] = `
             <ForwardRef
               defaultOpen={false}
               hideDelay="350"
-              id="random-id-19"
+              id="random-id-32"
               modifiers={null}
               openOnClick={false}
               openOnHover={true}
@@ -1465,7 +1465,7 @@ exports[`Storyshots Tooltip with Button passed in 1`] = `
                     setReferenceNode={[Function]}
                   >
                     <ForwardRef
-                      aria-describedby="random-id-19"
+                      aria-describedby="random-id-32"
                       aria-expanded={false}
                       aria-haspopup={true}
                       aria-label="Open"
@@ -1481,7 +1481,7 @@ exports[`Storyshots Tooltip with Button passed in 1`] = `
                       size="medium"
                     >
                       <Button__WrapperButton
-                        aria-describedby="random-id-19"
+                        aria-describedby="random-id-32"
                         aria-expanded={false}
                         aria-haspopup={true}
                         aria-label="Open"
@@ -1494,7 +1494,7 @@ exports[`Storyshots Tooltip with Button passed in 1`] = `
                         size="medium"
                       >
                         <button
-                          aria-describedby="random-id-19"
+                          aria-describedby="random-id-32"
                           aria-expanded={false}
                           aria-haspopup={true}
                           aria-label="Open"
@@ -1523,7 +1523,7 @@ exports[`Storyshots Tooltip with Button passed in 1`] = `
                     positionFixed={false}
                     referenceElement={
                       <button
-                        aria-describedby="random-id-19"
+                        aria-describedby="random-id-32"
                         aria-expanded="false"
                         aria-haspopup="true"
                         aria-label="Open"
@@ -1535,7 +1535,7 @@ exports[`Storyshots Tooltip with Button passed in 1`] = `
                   >
                     <Styled(Box)
                       className=" nds-popper-pop-up"
-                      id="random-id-19"
+                      id="random-id-32"
                       maxWidth="24em"
                       onBlur={[Function]}
                       onFocus={[Function]}
@@ -1641,7 +1641,7 @@ exports[`Storyshots Tooltip with Button passed in 1`] = `
                     >
                       <div
                         className="Box-sc-1qu1edy-0 sc-fzXfNh kAYrkP  nds-popper-pop-up"
-                        id="random-id-19"
+                        id="random-id-32"
                         onBlur={[Function]}
                         onFocus={[Function]}
                         onMouseEnter={[Function]}
@@ -2080,7 +2080,7 @@ exports[`Storyshots Tooltip with Link passed in 1`] = `
             <ForwardRef
               defaultOpen={false}
               hideDelay="350"
-              id="random-id-18"
+              id="random-id-31"
               modifiers={null}
               openOnClick={false}
               openOnHover={true}
@@ -2106,7 +2106,7 @@ exports[`Storyshots Tooltip with Link passed in 1`] = `
                     setReferenceNode={[Function]}
                   >
                     <ForwardRef
-                      aria-describedby="random-id-18"
+                      aria-describedby="random-id-31"
                       aria-expanded={false}
                       aria-haspopup={true}
                       aria-label="Open"
@@ -2122,7 +2122,7 @@ exports[`Storyshots Tooltip with Link passed in 1`] = `
                       size="medium"
                     >
                       <Button__WrapperButton
-                        aria-describedby="random-id-18"
+                        aria-describedby="random-id-31"
                         aria-expanded={false}
                         aria-haspopup={true}
                         aria-label="Open"
@@ -2135,7 +2135,7 @@ exports[`Storyshots Tooltip with Link passed in 1`] = `
                         size="medium"
                       >
                         <button
-                          aria-describedby="random-id-18"
+                          aria-describedby="random-id-31"
                           aria-expanded={false}
                           aria-haspopup={true}
                           aria-label="Open"
@@ -2164,7 +2164,7 @@ exports[`Storyshots Tooltip with Link passed in 1`] = `
                     positionFixed={false}
                     referenceElement={
                       <button
-                        aria-describedby="random-id-18"
+                        aria-describedby="random-id-31"
                         aria-expanded="false"
                         aria-haspopup="true"
                         aria-label="Open"
@@ -2176,7 +2176,7 @@ exports[`Storyshots Tooltip with Link passed in 1`] = `
                   >
                     <Styled(Box)
                       className=" nds-popper-pop-up"
-                      id="random-id-18"
+                      id="random-id-31"
                       maxWidth="24em"
                       onBlur={[Function]}
                       onFocus={[Function]}
@@ -2282,7 +2282,7 @@ exports[`Storyshots Tooltip with Link passed in 1`] = `
                     >
                       <div
                         className="Box-sc-1qu1edy-0 sc-fzXfNh kAYrkP  nds-popper-pop-up"
-                        id="random-id-18"
+                        id="random-id-31"
                         onBlur={[Function]}
                         onFocus={[Function]}
                         onMouseEnter={[Function]}
@@ -2701,7 +2701,7 @@ exports[`Storyshots Tooltip with custom hideDelay 1`] = `
             <ForwardRef
               defaultOpen={false}
               hideDelay="1000"
-              id="random-id-21"
+              id="random-id-34"
               modifiers={null}
               openOnClick={false}
               openOnHover={true}
@@ -2727,7 +2727,7 @@ exports[`Storyshots Tooltip with custom hideDelay 1`] = `
                     setReferenceNode={[Function]}
                   >
                     <ForwardRef
-                      aria-describedby="random-id-21"
+                      aria-describedby="random-id-34"
                       aria-expanded={false}
                       aria-haspopup={true}
                       aria-label="Open"
@@ -2743,7 +2743,7 @@ exports[`Storyshots Tooltip with custom hideDelay 1`] = `
                       size="medium"
                     >
                       <Button__WrapperButton
-                        aria-describedby="random-id-21"
+                        aria-describedby="random-id-34"
                         aria-expanded={false}
                         aria-haspopup={true}
                         aria-label="Open"
@@ -2756,7 +2756,7 @@ exports[`Storyshots Tooltip with custom hideDelay 1`] = `
                         size="medium"
                       >
                         <button
-                          aria-describedby="random-id-21"
+                          aria-describedby="random-id-34"
                           aria-expanded={false}
                           aria-haspopup={true}
                           aria-label="Open"
@@ -2785,7 +2785,7 @@ exports[`Storyshots Tooltip with custom hideDelay 1`] = `
                     positionFixed={false}
                     referenceElement={
                       <button
-                        aria-describedby="random-id-21"
+                        aria-describedby="random-id-34"
                         aria-expanded="false"
                         aria-haspopup="true"
                         aria-label="Open"
@@ -2797,7 +2797,7 @@ exports[`Storyshots Tooltip with custom hideDelay 1`] = `
                   >
                     <Styled(Box)
                       className=" nds-popper-pop-up"
-                      id="random-id-21"
+                      id="random-id-34"
                       maxWidth="24em"
                       onBlur={[Function]}
                       onFocus={[Function]}
@@ -2903,7 +2903,7 @@ exports[`Storyshots Tooltip with custom hideDelay 1`] = `
                     >
                       <div
                         className="Box-sc-1qu1edy-0 sc-fzXfNh kAYrkP  nds-popper-pop-up"
-                        id="random-id-21"
+                        id="random-id-34"
                         onBlur={[Function]}
                         onFocus={[Function]}
                         onMouseEnter={[Function]}
@@ -3316,7 +3316,7 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                 <ForwardRef
                   defaultOpen={true}
                   hideDelay="350"
-                  id="random-id-5"
+                  id="random-id-18"
                   modifiers={null}
                   openOnClick={false}
                   openOnHover={true}
@@ -3342,7 +3342,7 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                         setReferenceNode={[Function]}
                       >
                         <ForwardRef
-                          aria-describedby="random-id-5"
+                          aria-describedby="random-id-18"
                           aria-expanded={true}
                           aria-haspopup={true}
                           aria-label="Close"
@@ -3358,7 +3358,7 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                           size="medium"
                         >
                           <Button__WrapperButton
-                            aria-describedby="random-id-5"
+                            aria-describedby="random-id-18"
                             aria-expanded={true}
                             aria-haspopup={true}
                             aria-label="Close"
@@ -3371,7 +3371,7 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                             size="medium"
                           >
                             <button
-                              aria-describedby="random-id-5"
+                              aria-describedby="random-id-18"
                               aria-expanded={true}
                               aria-haspopup={true}
                               aria-label="Close"
@@ -3400,7 +3400,7 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                         positionFixed={false}
                         referenceElement={
                           <button
-                            aria-describedby="random-id-5"
+                            aria-describedby="random-id-18"
                             aria-expanded="true"
                             aria-haspopup="true"
                             aria-label="Close"
@@ -3412,7 +3412,7 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                       >
                         <Styled(Box)
                           className=" nds-popper-pop-up"
-                          id="random-id-5"
+                          id="random-id-18"
                           maxWidth="128px"
                           onBlur={[Function]}
                           onFocus={[Function]}
@@ -3518,7 +3518,7 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
                         >
                           <div
                             className="Box-sc-1qu1edy-0 sc-fzXfNh fIA-DHu  nds-popper-pop-up"
-                            id="random-id-5"
+                            id="random-id-18"
                             onBlur={[Function]}
                             onFocus={[Function]}
                             onMouseEnter={[Function]}
@@ -3841,7 +3841,7 @@ exports[`Storyshots Tooltip with custom showDelay 1`] = `
             <ForwardRef
               defaultOpen={false}
               hideDelay="350"
-              id="random-id-20"
+              id="random-id-33"
               modifiers={null}
               openOnClick={false}
               openOnHover={true}
@@ -3867,7 +3867,7 @@ exports[`Storyshots Tooltip with custom showDelay 1`] = `
                     setReferenceNode={[Function]}
                   >
                     <ForwardRef
-                      aria-describedby="random-id-20"
+                      aria-describedby="random-id-33"
                       aria-expanded={false}
                       aria-haspopup={true}
                       aria-label="Open"
@@ -3883,7 +3883,7 @@ exports[`Storyshots Tooltip with custom showDelay 1`] = `
                       size="medium"
                     >
                       <Button__WrapperButton
-                        aria-describedby="random-id-20"
+                        aria-describedby="random-id-33"
                         aria-expanded={false}
                         aria-haspopup={true}
                         aria-label="Open"
@@ -3896,7 +3896,7 @@ exports[`Storyshots Tooltip with custom showDelay 1`] = `
                         size="medium"
                       >
                         <button
-                          aria-describedby="random-id-20"
+                          aria-describedby="random-id-33"
                           aria-expanded={false}
                           aria-haspopup={true}
                           aria-label="Open"
@@ -3925,7 +3925,7 @@ exports[`Storyshots Tooltip with custom showDelay 1`] = `
                     positionFixed={false}
                     referenceElement={
                       <button
-                        aria-describedby="random-id-20"
+                        aria-describedby="random-id-33"
                         aria-expanded="false"
                         aria-haspopup="true"
                         aria-label="Open"
@@ -3937,7 +3937,7 @@ exports[`Storyshots Tooltip with custom showDelay 1`] = `
                   >
                     <Styled(Box)
                       className=" nds-popper-pop-up"
-                      id="random-id-20"
+                      id="random-id-33"
                       maxWidth="24em"
                       onBlur={[Function]}
                       onFocus={[Function]}
@@ -4043,7 +4043,7 @@ exports[`Storyshots Tooltip with custom showDelay 1`] = `
                     >
                       <div
                         className="Box-sc-1qu1edy-0 sc-fzXfNh kAYrkP  nds-popper-pop-up"
-                        id="random-id-20"
+                        id="random-id-33"
                         onBlur={[Function]}
                         onFocus={[Function]}
                         onMouseEnter={[Function]}
@@ -4364,7 +4364,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
             <ForwardRef
               defaultOpen={false}
               hideDelay="350"
-              id="random-id-22"
+              id="random-id-35"
               modifiers={null}
               openOnClick={false}
               openOnHover={true}
@@ -4390,7 +4390,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                     setReferenceNode={[Function]}
                   >
                     <ForwardRef
-                      aria-describedby="random-id-22"
+                      aria-describedby="random-id-35"
                       aria-expanded={false}
                       aria-haspopup={true}
                       aria-label="Open"
@@ -4406,7 +4406,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                       size="medium"
                     >
                       <Button__WrapperButton
-                        aria-describedby="random-id-22"
+                        aria-describedby="random-id-35"
                         aria-expanded={false}
                         aria-haspopup={true}
                         aria-label="Open"
@@ -4419,7 +4419,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                         size="medium"
                       >
                         <button
-                          aria-describedby="random-id-22"
+                          aria-describedby="random-id-35"
                           aria-expanded={false}
                           aria-haspopup={true}
                           aria-label="Open"
@@ -4448,7 +4448,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                     positionFixed={false}
                     referenceElement={
                       <button
-                        aria-describedby="random-id-22"
+                        aria-describedby="random-id-35"
                         aria-expanded="false"
                         aria-haspopup="true"
                         aria-label="Open"
@@ -4460,7 +4460,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                   >
                     <Styled(Box)
                       className=" nds-popper-pop-up"
-                      id="random-id-22"
+                      id="random-id-35"
                       maxWidth="24em"
                       onBlur={[Function]}
                       onFocus={[Function]}
@@ -4566,7 +4566,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                     >
                       <div
                         className="Box-sc-1qu1edy-0 sc-fzXfNh kAYrkP  nds-popper-pop-up"
-                        id="random-id-22"
+                        id="random-id-35"
                         onBlur={[Function]}
                         onFocus={[Function]}
                         onMouseEnter={[Function]}
@@ -4604,7 +4604,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
             <ForwardRef
               defaultOpen={false}
               hideDelay="350"
-              id="random-id-23"
+              id="random-id-36"
               modifiers={null}
               openOnClick={false}
               openOnHover={true}
@@ -4713,7 +4713,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                     setReferenceNode={[Function]}
                   >
                     <Link
-                      aria-describedby="random-id-23"
+                      aria-describedby="random-id-36"
                       aria-expanded={false}
                       aria-haspopup={true}
                       aria-label="Open"
@@ -4812,7 +4812,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                       underline={true}
                     >
                       <a
-                        aria-describedby="random-id-23"
+                        aria-describedby="random-id-36"
                         aria-expanded={false}
                         aria-haspopup={true}
                         aria-label="Open"
@@ -4840,7 +4840,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                     positionFixed={false}
                     referenceElement={
                       <a
-                        aria-describedby="random-id-23"
+                        aria-describedby="random-id-36"
                         aria-expanded="false"
                         aria-haspopup="true"
                         aria-label="Open"
@@ -4854,7 +4854,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                   >
                     <Styled(Box)
                       className=" nds-popper-pop-up"
-                      id="random-id-23"
+                      id="random-id-36"
                       maxWidth="24em"
                       onBlur={[Function]}
                       onFocus={[Function]}
@@ -4960,7 +4960,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                     >
                       <div
                         className="Box-sc-1qu1edy-0 sc-fzXfNh kAYrkP  nds-popper-pop-up"
-                        id="random-id-23"
+                        id="random-id-36"
                         onBlur={[Function]}
                         onFocus={[Function]}
                         onMouseEnter={[Function]}
@@ -4998,7 +4998,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
             <ForwardRef
               defaultOpen={false}
               hideDelay="350"
-              id="random-id-24"
+              id="random-id-37"
               modifiers={null}
               openOnClick={false}
               openOnHover={true}
@@ -5027,7 +5027,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                     setReferenceNode={[Function]}
                   >
                     <styled.p
-                      aria-describedby="random-id-24"
+                      aria-describedby="random-id-37"
                       aria-expanded={false}
                       aria-haspopup={true}
                       aria-label="Open"
@@ -5046,7 +5046,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                       onMouseLeave={[Function]}
                     >
                       <span
-                        aria-describedby="random-id-24"
+                        aria-describedby="random-id-37"
                         aria-expanded={false}
                         aria-haspopup={true}
                         aria-label="Open"
@@ -5075,7 +5075,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                     positionFixed={false}
                     referenceElement={
                       <span
-                        aria-describedby="random-id-24"
+                        aria-describedby="random-id-37"
                         aria-expanded="false"
                         aria-haspopup="true"
                         aria-label="Open"
@@ -5089,7 +5089,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                   >
                     <Styled(Box)
                       className=" nds-popper-pop-up"
-                      id="random-id-24"
+                      id="random-id-37"
                       maxWidth="24em"
                       onBlur={[Function]}
                       onFocus={[Function]}
@@ -5195,7 +5195,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                     >
                       <div
                         className="Box-sc-1qu1edy-0 sc-fzXfNh kAYrkP  nds-popper-pop-up"
-                        id="random-id-24"
+                        id="random-id-37"
                         onBlur={[Function]}
                         onFocus={[Function]}
                         onMouseEnter={[Function]}
@@ -5233,7 +5233,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
             <ForwardRef
               defaultOpen={false}
               hideDelay="350"
-              id="random-id-25"
+              id="random-id-38"
               modifiers={null}
               openOnClick={false}
               openOnHover={true}
@@ -5341,7 +5341,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                     setReferenceNode={[Function]}
                   >
                     <Box
-                      aria-describedby="random-id-25"
+                      aria-describedby="random-id-38"
                       aria-expanded={false}
                       aria-haspopup={true}
                       aria-label="Open"
@@ -5439,7 +5439,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                       width="200px"
                     >
                       <div
-                        aria-describedby="random-id-25"
+                        aria-describedby="random-id-38"
                         aria-expanded={false}
                         aria-haspopup={true}
                         aria-label="Open"
@@ -5466,7 +5466,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                     positionFixed={false}
                     referenceElement={
                       <div
-                        aria-describedby="random-id-25"
+                        aria-describedby="random-id-38"
                         aria-expanded="false"
                         aria-haspopup="true"
                         aria-label="Open"
@@ -5479,7 +5479,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                   >
                     <Styled(Box)
                       className=" nds-popper-pop-up"
-                      id="random-id-25"
+                      id="random-id-38"
                       maxWidth="24em"
                       onBlur={[Function]}
                       onFocus={[Function]}
@@ -5585,7 +5585,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                     >
                       <div
                         className="Box-sc-1qu1edy-0 sc-fzXfNh kAYrkP  nds-popper-pop-up"
-                        id="random-id-25"
+                        id="random-id-38"
                         onBlur={[Function]}
                         onFocus={[Function]}
                         onMouseEnter={[Function]}
@@ -5623,7 +5623,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
             <ForwardRef
               defaultOpen={false}
               hideDelay="350"
-              id="random-id-26"
+              id="random-id-39"
               modifiers={null}
               openOnClick={false}
               openOnHover={true}
@@ -5730,7 +5730,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                     setReferenceNode={[Function]}
                   >
                     <Box
-                      aria-describedby="random-id-26"
+                      aria-describedby="random-id-39"
                       aria-expanded={false}
                       aria-haspopup={true}
                       aria-label="Open"
@@ -5827,7 +5827,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                       }
                     >
                       <div
-                        aria-describedby="random-id-26"
+                        aria-describedby="random-id-39"
                         aria-expanded={false}
                         aria-haspopup={true}
                         aria-label="Open"
@@ -5853,7 +5853,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                     positionFixed={false}
                     referenceElement={
                       <div
-                        aria-describedby="random-id-26"
+                        aria-describedby="random-id-39"
                         aria-expanded="false"
                         aria-haspopup="true"
                         aria-label="Open"
@@ -5865,7 +5865,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                   >
                     <Styled(Box)
                       className=" nds-popper-pop-up"
-                      id="random-id-26"
+                      id="random-id-39"
                       maxWidth="24em"
                       onBlur={[Function]}
                       onFocus={[Function]}
@@ -5971,7 +5971,7 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
                     >
                       <div
                         className="Box-sc-1qu1edy-0 sc-fzXfNh kAYrkP  nds-popper-pop-up"
-                        id="random-id-26"
+                        id="random-id-39"
                         onBlur={[Function]}
                         onFocus={[Function]}
                         onMouseEnter={[Function]}
@@ -6386,7 +6386,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                 <ForwardRef
                   defaultOpen={true}
                   hideDelay="350"
-                  id="random-id-6"
+                  id="random-id-19"
                   modifiers={null}
                   openOnClick={false}
                   openOnHover={true}
@@ -6412,7 +6412,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         setReferenceNode={[Function]}
                       >
                         <ForwardRef
-                          aria-describedby="random-id-6"
+                          aria-describedby="random-id-19"
                           aria-expanded={true}
                           aria-haspopup={true}
                           aria-label="Close"
@@ -6428,7 +6428,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                           size="medium"
                         >
                           <Button__WrapperButton
-                            aria-describedby="random-id-6"
+                            aria-describedby="random-id-19"
                             aria-expanded={true}
                             aria-haspopup={true}
                             aria-label="Close"
@@ -6441,7 +6441,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                             size="medium"
                           >
                             <button
-                              aria-describedby="random-id-6"
+                              aria-describedby="random-id-19"
                               aria-expanded={true}
                               aria-haspopup={true}
                               aria-label="Close"
@@ -6470,7 +6470,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         positionFixed={false}
                         referenceElement={
                           <button
-                            aria-describedby="random-id-6"
+                            aria-describedby="random-id-19"
                             aria-expanded="true"
                             aria-haspopup="true"
                             aria-label="Close"
@@ -6482,7 +6482,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                       >
                         <Styled(Box)
                           className=" nds-popper-pop-up"
-                          id="random-id-6"
+                          id="random-id-19"
                           maxWidth="24em"
                           onBlur={[Function]}
                           onFocus={[Function]}
@@ -6588,7 +6588,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         >
                           <div
                             className="Box-sc-1qu1edy-0 sc-fzXfNh qNuDP  nds-popper-pop-up"
-                            id="random-id-6"
+                            id="random-id-19"
                             onBlur={[Function]}
                             onFocus={[Function]}
                             onMouseEnter={[Function]}
@@ -6626,7 +6626,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                 <ForwardRef
                   defaultOpen={true}
                   hideDelay="350"
-                  id="random-id-7"
+                  id="random-id-20"
                   modifiers={null}
                   openOnClick={false}
                   openOnHover={true}
@@ -6652,7 +6652,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         setReferenceNode={[Function]}
                       >
                         <ForwardRef
-                          aria-describedby="random-id-7"
+                          aria-describedby="random-id-20"
                           aria-expanded={true}
                           aria-haspopup={true}
                           aria-label="Close"
@@ -6668,7 +6668,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                           size="medium"
                         >
                           <Button__WrapperButton
-                            aria-describedby="random-id-7"
+                            aria-describedby="random-id-20"
                             aria-expanded={true}
                             aria-haspopup={true}
                             aria-label="Close"
@@ -6681,7 +6681,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                             size="medium"
                           >
                             <button
-                              aria-describedby="random-id-7"
+                              aria-describedby="random-id-20"
                               aria-expanded={true}
                               aria-haspopup={true}
                               aria-label="Close"
@@ -6710,7 +6710,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         positionFixed={false}
                         referenceElement={
                           <button
-                            aria-describedby="random-id-7"
+                            aria-describedby="random-id-20"
                             aria-expanded="true"
                             aria-haspopup="true"
                             aria-label="Close"
@@ -6722,7 +6722,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                       >
                         <Styled(Box)
                           className=" nds-popper-pop-up"
-                          id="random-id-7"
+                          id="random-id-20"
                           maxWidth="24em"
                           onBlur={[Function]}
                           onFocus={[Function]}
@@ -6828,7 +6828,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         >
                           <div
                             className="Box-sc-1qu1edy-0 sc-fzXfNh qNuDP  nds-popper-pop-up"
-                            id="random-id-7"
+                            id="random-id-20"
                             onBlur={[Function]}
                             onFocus={[Function]}
                             onMouseEnter={[Function]}
@@ -6866,7 +6866,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                 <ForwardRef
                   defaultOpen={true}
                   hideDelay="350"
-                  id="random-id-8"
+                  id="random-id-21"
                   modifiers={null}
                   openOnClick={false}
                   openOnHover={true}
@@ -6892,7 +6892,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         setReferenceNode={[Function]}
                       >
                         <ForwardRef
-                          aria-describedby="random-id-8"
+                          aria-describedby="random-id-21"
                           aria-expanded={true}
                           aria-haspopup={true}
                           aria-label="Close"
@@ -6908,7 +6908,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                           size="medium"
                         >
                           <Button__WrapperButton
-                            aria-describedby="random-id-8"
+                            aria-describedby="random-id-21"
                             aria-expanded={true}
                             aria-haspopup={true}
                             aria-label="Close"
@@ -6921,7 +6921,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                             size="medium"
                           >
                             <button
-                              aria-describedby="random-id-8"
+                              aria-describedby="random-id-21"
                               aria-expanded={true}
                               aria-haspopup={true}
                               aria-label="Close"
@@ -6950,7 +6950,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         positionFixed={false}
                         referenceElement={
                           <button
-                            aria-describedby="random-id-8"
+                            aria-describedby="random-id-21"
                             aria-expanded="true"
                             aria-haspopup="true"
                             aria-label="Close"
@@ -6962,7 +6962,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                       >
                         <Styled(Box)
                           className=" nds-popper-pop-up"
-                          id="random-id-8"
+                          id="random-id-21"
                           maxWidth="24em"
                           onBlur={[Function]}
                           onFocus={[Function]}
@@ -7068,7 +7068,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         >
                           <div
                             className="Box-sc-1qu1edy-0 sc-fzXfNh qNuDP  nds-popper-pop-up"
-                            id="random-id-8"
+                            id="random-id-21"
                             onBlur={[Function]}
                             onFocus={[Function]}
                             onMouseEnter={[Function]}
@@ -7202,7 +7202,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                 <ForwardRef
                   defaultOpen={true}
                   hideDelay="350"
-                  id="random-id-9"
+                  id="random-id-22"
                   modifiers={null}
                   openOnClick={false}
                   openOnHover={true}
@@ -7228,7 +7228,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         setReferenceNode={[Function]}
                       >
                         <ForwardRef
-                          aria-describedby="random-id-9"
+                          aria-describedby="random-id-22"
                           aria-expanded={true}
                           aria-haspopup={true}
                           aria-label="Close"
@@ -7244,7 +7244,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                           size="medium"
                         >
                           <Button__WrapperButton
-                            aria-describedby="random-id-9"
+                            aria-describedby="random-id-22"
                             aria-expanded={true}
                             aria-haspopup={true}
                             aria-label="Close"
@@ -7257,7 +7257,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                             size="medium"
                           >
                             <button
-                              aria-describedby="random-id-9"
+                              aria-describedby="random-id-22"
                               aria-expanded={true}
                               aria-haspopup={true}
                               aria-label="Close"
@@ -7286,7 +7286,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         positionFixed={false}
                         referenceElement={
                           <button
-                            aria-describedby="random-id-9"
+                            aria-describedby="random-id-22"
                             aria-expanded="true"
                             aria-haspopup="true"
                             aria-label="Close"
@@ -7298,7 +7298,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                       >
                         <Styled(Box)
                           className=" nds-popper-pop-up"
-                          id="random-id-9"
+                          id="random-id-22"
                           maxWidth="24em"
                           onBlur={[Function]}
                           onFocus={[Function]}
@@ -7404,7 +7404,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         >
                           <div
                             className="Box-sc-1qu1edy-0 sc-fzXfNh qNuDP  nds-popper-pop-up"
-                            id="random-id-9"
+                            id="random-id-22"
                             onBlur={[Function]}
                             onFocus={[Function]}
                             onMouseEnter={[Function]}
@@ -7442,7 +7442,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                 <ForwardRef
                   defaultOpen={true}
                   hideDelay="350"
-                  id="random-id-10"
+                  id="random-id-23"
                   modifiers={null}
                   openOnClick={false}
                   openOnHover={true}
@@ -7468,7 +7468,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         setReferenceNode={[Function]}
                       >
                         <ForwardRef
-                          aria-describedby="random-id-10"
+                          aria-describedby="random-id-23"
                           aria-expanded={true}
                           aria-haspopup={true}
                           aria-label="Close"
@@ -7484,7 +7484,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                           size="medium"
                         >
                           <Button__WrapperButton
-                            aria-describedby="random-id-10"
+                            aria-describedby="random-id-23"
                             aria-expanded={true}
                             aria-haspopup={true}
                             aria-label="Close"
@@ -7497,7 +7497,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                             size="medium"
                           >
                             <button
-                              aria-describedby="random-id-10"
+                              aria-describedby="random-id-23"
                               aria-expanded={true}
                               aria-haspopup={true}
                               aria-label="Close"
@@ -7526,7 +7526,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         positionFixed={false}
                         referenceElement={
                           <button
-                            aria-describedby="random-id-10"
+                            aria-describedby="random-id-23"
                             aria-expanded="true"
                             aria-haspopup="true"
                             aria-label="Close"
@@ -7538,7 +7538,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                       >
                         <Styled(Box)
                           className=" nds-popper-pop-up"
-                          id="random-id-10"
+                          id="random-id-23"
                           maxWidth="24em"
                           onBlur={[Function]}
                           onFocus={[Function]}
@@ -7644,7 +7644,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         >
                           <div
                             className="Box-sc-1qu1edy-0 sc-fzXfNh qNuDP  nds-popper-pop-up"
-                            id="random-id-10"
+                            id="random-id-23"
                             onBlur={[Function]}
                             onFocus={[Function]}
                             onMouseEnter={[Function]}
@@ -7682,7 +7682,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                 <ForwardRef
                   defaultOpen={true}
                   hideDelay="350"
-                  id="random-id-11"
+                  id="random-id-24"
                   modifiers={null}
                   openOnClick={false}
                   openOnHover={true}
@@ -7708,7 +7708,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         setReferenceNode={[Function]}
                       >
                         <ForwardRef
-                          aria-describedby="random-id-11"
+                          aria-describedby="random-id-24"
                           aria-expanded={true}
                           aria-haspopup={true}
                           aria-label="Close"
@@ -7724,7 +7724,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                           size="medium"
                         >
                           <Button__WrapperButton
-                            aria-describedby="random-id-11"
+                            aria-describedby="random-id-24"
                             aria-expanded={true}
                             aria-haspopup={true}
                             aria-label="Close"
@@ -7737,7 +7737,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                             size="medium"
                           >
                             <button
-                              aria-describedby="random-id-11"
+                              aria-describedby="random-id-24"
                               aria-expanded={true}
                               aria-haspopup={true}
                               aria-label="Close"
@@ -7766,7 +7766,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         positionFixed={false}
                         referenceElement={
                           <button
-                            aria-describedby="random-id-11"
+                            aria-describedby="random-id-24"
                             aria-expanded="true"
                             aria-haspopup="true"
                             aria-label="Close"
@@ -7778,7 +7778,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                       >
                         <Styled(Box)
                           className=" nds-popper-pop-up"
-                          id="random-id-11"
+                          id="random-id-24"
                           maxWidth="24em"
                           onBlur={[Function]}
                           onFocus={[Function]}
@@ -7884,7 +7884,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         >
                           <div
                             className="Box-sc-1qu1edy-0 sc-fzXfNh qNuDP  nds-popper-pop-up"
-                            id="random-id-11"
+                            id="random-id-24"
                             onBlur={[Function]}
                             onFocus={[Function]}
                             onMouseEnter={[Function]}
@@ -8018,7 +8018,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                 <ForwardRef
                   defaultOpen={true}
                   hideDelay="350"
-                  id="random-id-12"
+                  id="random-id-25"
                   modifiers={null}
                   openOnClick={false}
                   openOnHover={true}
@@ -8044,7 +8044,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         setReferenceNode={[Function]}
                       >
                         <ForwardRef
-                          aria-describedby="random-id-12"
+                          aria-describedby="random-id-25"
                           aria-expanded={true}
                           aria-haspopup={true}
                           aria-label="Close"
@@ -8060,7 +8060,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                           size="medium"
                         >
                           <Button__WrapperButton
-                            aria-describedby="random-id-12"
+                            aria-describedby="random-id-25"
                             aria-expanded={true}
                             aria-haspopup={true}
                             aria-label="Close"
@@ -8073,7 +8073,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                             size="medium"
                           >
                             <button
-                              aria-describedby="random-id-12"
+                              aria-describedby="random-id-25"
                               aria-expanded={true}
                               aria-haspopup={true}
                               aria-label="Close"
@@ -8102,7 +8102,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         positionFixed={false}
                         referenceElement={
                           <button
-                            aria-describedby="random-id-12"
+                            aria-describedby="random-id-25"
                             aria-expanded="true"
                             aria-haspopup="true"
                             aria-label="Close"
@@ -8114,7 +8114,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                       >
                         <Styled(Box)
                           className=" nds-popper-pop-up"
-                          id="random-id-12"
+                          id="random-id-25"
                           maxWidth="24em"
                           onBlur={[Function]}
                           onFocus={[Function]}
@@ -8220,7 +8220,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         >
                           <div
                             className="Box-sc-1qu1edy-0 sc-fzXfNh qNuDP  nds-popper-pop-up"
-                            id="random-id-12"
+                            id="random-id-25"
                             onBlur={[Function]}
                             onFocus={[Function]}
                             onMouseEnter={[Function]}
@@ -8258,7 +8258,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                 <ForwardRef
                   defaultOpen={true}
                   hideDelay="350"
-                  id="random-id-13"
+                  id="random-id-26"
                   modifiers={null}
                   openOnClick={false}
                   openOnHover={true}
@@ -8284,7 +8284,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         setReferenceNode={[Function]}
                       >
                         <ForwardRef
-                          aria-describedby="random-id-13"
+                          aria-describedby="random-id-26"
                           aria-expanded={true}
                           aria-haspopup={true}
                           aria-label="Close"
@@ -8300,7 +8300,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                           size="medium"
                         >
                           <Button__WrapperButton
-                            aria-describedby="random-id-13"
+                            aria-describedby="random-id-26"
                             aria-expanded={true}
                             aria-haspopup={true}
                             aria-label="Close"
@@ -8313,7 +8313,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                             size="medium"
                           >
                             <button
-                              aria-describedby="random-id-13"
+                              aria-describedby="random-id-26"
                               aria-expanded={true}
                               aria-haspopup={true}
                               aria-label="Close"
@@ -8342,7 +8342,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         positionFixed={false}
                         referenceElement={
                           <button
-                            aria-describedby="random-id-13"
+                            aria-describedby="random-id-26"
                             aria-expanded="true"
                             aria-haspopup="true"
                             aria-label="Close"
@@ -8354,7 +8354,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                       >
                         <Styled(Box)
                           className=" nds-popper-pop-up"
-                          id="random-id-13"
+                          id="random-id-26"
                           maxWidth="24em"
                           onBlur={[Function]}
                           onFocus={[Function]}
@@ -8460,7 +8460,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         >
                           <div
                             className="Box-sc-1qu1edy-0 sc-fzXfNh qNuDP  nds-popper-pop-up"
-                            id="random-id-13"
+                            id="random-id-26"
                             onBlur={[Function]}
                             onFocus={[Function]}
                             onMouseEnter={[Function]}
@@ -8498,7 +8498,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                 <ForwardRef
                   defaultOpen={true}
                   hideDelay="350"
-                  id="random-id-14"
+                  id="random-id-27"
                   modifiers={null}
                   openOnClick={false}
                   openOnHover={true}
@@ -8524,7 +8524,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         setReferenceNode={[Function]}
                       >
                         <ForwardRef
-                          aria-describedby="random-id-14"
+                          aria-describedby="random-id-27"
                           aria-expanded={true}
                           aria-haspopup={true}
                           aria-label="Close"
@@ -8540,7 +8540,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                           size="medium"
                         >
                           <Button__WrapperButton
-                            aria-describedby="random-id-14"
+                            aria-describedby="random-id-27"
                             aria-expanded={true}
                             aria-haspopup={true}
                             aria-label="Close"
@@ -8553,7 +8553,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                             size="medium"
                           >
                             <button
-                              aria-describedby="random-id-14"
+                              aria-describedby="random-id-27"
                               aria-expanded={true}
                               aria-haspopup={true}
                               aria-label="Close"
@@ -8582,7 +8582,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         positionFixed={false}
                         referenceElement={
                           <button
-                            aria-describedby="random-id-14"
+                            aria-describedby="random-id-27"
                             aria-expanded="true"
                             aria-haspopup="true"
                             aria-label="Close"
@@ -8594,7 +8594,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                       >
                         <Styled(Box)
                           className=" nds-popper-pop-up"
-                          id="random-id-14"
+                          id="random-id-27"
                           maxWidth="24em"
                           onBlur={[Function]}
                           onFocus={[Function]}
@@ -8700,7 +8700,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         >
                           <div
                             className="Box-sc-1qu1edy-0 sc-fzXfNh qNuDP  nds-popper-pop-up"
-                            id="random-id-14"
+                            id="random-id-27"
                             onBlur={[Function]}
                             onFocus={[Function]}
                             onMouseEnter={[Function]}
@@ -8834,7 +8834,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                 <ForwardRef
                   defaultOpen={true}
                   hideDelay="350"
-                  id="random-id-15"
+                  id="random-id-28"
                   modifiers={null}
                   openOnClick={false}
                   openOnHover={true}
@@ -8860,7 +8860,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         setReferenceNode={[Function]}
                       >
                         <ForwardRef
-                          aria-describedby="random-id-15"
+                          aria-describedby="random-id-28"
                           aria-expanded={true}
                           aria-haspopup={true}
                           aria-label="Close"
@@ -8876,7 +8876,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                           size="medium"
                         >
                           <Button__WrapperButton
-                            aria-describedby="random-id-15"
+                            aria-describedby="random-id-28"
                             aria-expanded={true}
                             aria-haspopup={true}
                             aria-label="Close"
@@ -8889,7 +8889,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                             size="medium"
                           >
                             <button
-                              aria-describedby="random-id-15"
+                              aria-describedby="random-id-28"
                               aria-expanded={true}
                               aria-haspopup={true}
                               aria-label="Close"
@@ -8918,7 +8918,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         positionFixed={false}
                         referenceElement={
                           <button
-                            aria-describedby="random-id-15"
+                            aria-describedby="random-id-28"
                             aria-expanded="true"
                             aria-haspopup="true"
                             aria-label="Close"
@@ -8930,7 +8930,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                       >
                         <Styled(Box)
                           className=" nds-popper-pop-up"
-                          id="random-id-15"
+                          id="random-id-28"
                           maxWidth="24em"
                           onBlur={[Function]}
                           onFocus={[Function]}
@@ -9036,7 +9036,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         >
                           <div
                             className="Box-sc-1qu1edy-0 sc-fzXfNh qNuDP  nds-popper-pop-up"
-                            id="random-id-15"
+                            id="random-id-28"
                             onBlur={[Function]}
                             onFocus={[Function]}
                             onMouseEnter={[Function]}
@@ -9074,7 +9074,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                 <ForwardRef
                   defaultOpen={true}
                   hideDelay="350"
-                  id="random-id-16"
+                  id="random-id-29"
                   modifiers={null}
                   openOnClick={false}
                   openOnHover={true}
@@ -9100,7 +9100,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         setReferenceNode={[Function]}
                       >
                         <ForwardRef
-                          aria-describedby="random-id-16"
+                          aria-describedby="random-id-29"
                           aria-expanded={true}
                           aria-haspopup={true}
                           aria-label="Close"
@@ -9116,7 +9116,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                           size="medium"
                         >
                           <Button__WrapperButton
-                            aria-describedby="random-id-16"
+                            aria-describedby="random-id-29"
                             aria-expanded={true}
                             aria-haspopup={true}
                             aria-label="Close"
@@ -9129,7 +9129,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                             size="medium"
                           >
                             <button
-                              aria-describedby="random-id-16"
+                              aria-describedby="random-id-29"
                               aria-expanded={true}
                               aria-haspopup={true}
                               aria-label="Close"
@@ -9158,7 +9158,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         positionFixed={false}
                         referenceElement={
                           <button
-                            aria-describedby="random-id-16"
+                            aria-describedby="random-id-29"
                             aria-expanded="true"
                             aria-haspopup="true"
                             aria-label="Close"
@@ -9170,7 +9170,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                       >
                         <Styled(Box)
                           className=" nds-popper-pop-up"
-                          id="random-id-16"
+                          id="random-id-29"
                           maxWidth="24em"
                           onBlur={[Function]}
                           onFocus={[Function]}
@@ -9276,7 +9276,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         >
                           <div
                             className="Box-sc-1qu1edy-0 sc-fzXfNh qNuDP  nds-popper-pop-up"
-                            id="random-id-16"
+                            id="random-id-29"
                             onBlur={[Function]}
                             onFocus={[Function]}
                             onMouseEnter={[Function]}
@@ -9314,7 +9314,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                 <ForwardRef
                   defaultOpen={true}
                   hideDelay="350"
-                  id="random-id-17"
+                  id="random-id-30"
                   modifiers={null}
                   openOnClick={false}
                   openOnHover={true}
@@ -9340,7 +9340,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         setReferenceNode={[Function]}
                       >
                         <ForwardRef
-                          aria-describedby="random-id-17"
+                          aria-describedby="random-id-30"
                           aria-expanded={true}
                           aria-haspopup={true}
                           aria-label="Close"
@@ -9356,7 +9356,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                           size="medium"
                         >
                           <Button__WrapperButton
-                            aria-describedby="random-id-17"
+                            aria-describedby="random-id-30"
                             aria-expanded={true}
                             aria-haspopup={true}
                             aria-label="Close"
@@ -9369,7 +9369,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                             size="medium"
                           >
                             <button
-                              aria-describedby="random-id-17"
+                              aria-describedby="random-id-30"
                               aria-expanded={true}
                               aria-haspopup={true}
                               aria-label="Close"
@@ -9398,7 +9398,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         positionFixed={false}
                         referenceElement={
                           <button
-                            aria-describedby="random-id-17"
+                            aria-describedby="random-id-30"
                             aria-expanded="true"
                             aria-haspopup="true"
                             aria-label="Close"
@@ -9410,7 +9410,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                       >
                         <Styled(Box)
                           className=" nds-popper-pop-up"
-                          id="random-id-17"
+                          id="random-id-30"
                           maxWidth="24em"
                           onBlur={[Function]}
                           onFocus={[Function]}
@@ -9516,7 +9516,7 @@ exports[`Storyshots Tooltip with placement 1`] = `
                         >
                           <div
                             className="Box-sc-1qu1edy-0 sc-fzXfNh qNuDP  nds-popper-pop-up"
-                            id="random-id-17"
+                            id="random-id-30"
                             onBlur={[Function]}
                             onFocus={[Function]}
                             onMouseEnter={[Function]}
@@ -9931,7 +9931,7 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                 <ForwardRef
                   defaultOpen={true}
                   hideDelay="350"
-                  id="random-id-4"
+                  id="random-id-17"
                   modifiers={null}
                   openOnClick={false}
                   openOnHover={true}
@@ -9957,7 +9957,7 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                         setReferenceNode={[Function]}
                       >
                         <ForwardRef
-                          aria-describedby="random-id-4"
+                          aria-describedby="random-id-17"
                           aria-expanded={true}
                           aria-haspopup={true}
                           aria-label="Close"
@@ -9973,7 +9973,7 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                           size="medium"
                         >
                           <Button__WrapperButton
-                            aria-describedby="random-id-4"
+                            aria-describedby="random-id-17"
                             aria-expanded={true}
                             aria-haspopup={true}
                             aria-label="Close"
@@ -9986,7 +9986,7 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                             size="medium"
                           >
                             <button
-                              aria-describedby="random-id-4"
+                              aria-describedby="random-id-17"
                               aria-expanded={true}
                               aria-haspopup={true}
                               aria-label="Close"
@@ -10015,7 +10015,7 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                         positionFixed={false}
                         referenceElement={
                           <button
-                            aria-describedby="random-id-4"
+                            aria-describedby="random-id-17"
                             aria-expanded="true"
                             aria-haspopup="true"
                             aria-label="Close"
@@ -10027,7 +10027,7 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                       >
                         <Styled(Box)
                           className=" nds-popper-pop-up"
-                          id="random-id-4"
+                          id="random-id-17"
                           maxWidth="24em"
                           onBlur={[Function]}
                           onFocus={[Function]}
@@ -10133,7 +10133,7 @@ exports[`Storyshots Tooltip with wrapped text 1`] = `
                         >
                           <div
                             className="Box-sc-1qu1edy-0 sc-fzXfNh qNuDP  nds-popper-pop-up"
-                            id="random-id-4"
+                            id="random-id-17"
                             onBlur={[Function]}
                             onFocus={[Function]}
                             onMouseEnter={[Function]}


### PR DESCRIPTION
## Description

Add animated LoadingIcon component using loading svg from: https://github.com/SamHerbert/SVG-Loaders
maintains external api (<Icon icon="loading" />) and all other props normally used with Icon can be used (ie: color, size, focusable, className, spacing)

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [x] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
