### PR TITLE
fix: Update DatePicker when selected date prop updates

### DIFF
--- a/components/src/DatePicker/DatePicker.js
+++ b/components/src/DatePicker/DatePicker.js
@@ -22,6 +22,13 @@ class DatePicker extends Component {
     registerDatePickerLocales();
   }
 
+  componentDidUpdate(prevProps) {
+    const { selected } = this.props;
+    if (prevProps.selected !== selected) {
+      this.setSelectedDate(selected);
+    }
+  }
+
   setSelectedDate = date => {
     this.setState({
       selectedDate: date

--- a/components/src/DatePicker/DatePicker.story.js
+++ b/components/src/DatePicker/DatePicker.story.js
@@ -6,11 +6,17 @@ import { withKnobs, select } from "@storybook/addon-knobs";
 import { DatePicker } from ".";
 import { supportedDateLocales } from "../utils/datePickerLocales";
 
+const selectedDateExamples = [
+  new Date("2019-01-01T05:00:00.000Z"),
+  new Date("2019-02-05T05:00:00.000Z"),
+  new Date("2019-03-07T05:00:00.000Z")
+];
+
 storiesOf("DatePicker", module)
   .addDecorator(withKnobs)
   .add("default", () => (
     <DatePicker
-      selected={new Date("2019-01-01T05:00:00.000Z")}
+      selected={select("selected", selectedDateExamples, selectedDateExamples[0], "selected")}
       onChange={action("date changed")}
       onInputChange={action("input changed")}
       inputProps={{ labelText: "Expiry Date" }}
@@ -18,7 +24,7 @@ storiesOf("DatePicker", module)
   ))
   .add("with custom date format", () => (
     <DatePicker
-      selected={new Date("2019-01-01T05:00:00.000Z")}
+      selected={select("selected", selectedDateExamples, selectedDateExamples[0], "selected")}
       dateFormat="MMMM d, yyyy"
       onChange={action("date changed")}
       onInputChange={action("input changed")}


### PR DESCRIPTION
## Description

Allow the state of the datepicker to be updated through propers after initial render

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
