### PR TITLE
fix: update build status badge after migrating from travis-ci.org to .com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,38 @@
 [![Netlify Status](https://api.netlify.com/api/v1/badges/29a91f95-431b-4c72-ac07-f01f2f2d8b1b/deploy-status)](https://app.netlify.com/sites/nulogy-design-system/deploys)
-[![Build Status](https://travis-ci.org/nulogy/design-system.svg?branch=master)](https://travis-ci.org/nulogy/design-system)
+[![Build Status](https://travis-ci.com/nulogy/design-system.svg?branch=master)](https://travis-ci.com/nulogy/design-system)
 
-# Nulogy Design System 
+# Nulogy Design System
+
 The Nulogy Design System is a collection of Visual Guidelines and UI Components that will allow designers and developers to quickly create consistent experiences for our customers using established best practices.
 
-## Components 
+## Components
+
 The primary way to interface with the system is by using our React components. They can be found in a package called [@nulogy/components](https://github.com/nulogy/design-system/tree/master/components).
 
-## CSS 
+## CSS
+
 If your application can't use React components we also provide atomic CSS classes and Sass variables to build your own interface in Nulogy's style. These can be found in a package called [@nulogy/css](https://github.com/nulogy/design-system/tree/master/css).
 
 ## Tokens
-Design tokens are stored in their own package called [@nulogy/tokens](https://github.com/nulogy/design-system/tree/master/tokens). These are mostly used to build our Components and CSS packages above, but can also be imported directly into your application if needed. 
+
+Design tokens are stored in their own package called [@nulogy/tokens](https://github.com/nulogy/design-system/tree/master/tokens). These are mostly used to build our Components and CSS packages above, but can also be imported directly into your application if needed.
 
 ## UI Kit
+
 Designers can use the Nulogy Design System in Sketch by downloading the [Sketch UI Kit](https://share.goabstract.com/73221fd2-6626-43c8-b95c-e4bec74741ab)
 
 ## Resources
-* [Documentation](http://nulogy.design)
-* [Component Storybook](http://storybook.nulogy.design)
-* [@nulogy/components on npm](https://www.npmjs.com/package/@nulogy/components)
-* [@nulogy/css on npm](https://www.npmjs.com/package/@nulogy/css)
-* [@nulogy/tokens on npm](https://www.npmjs.com/package/@nulogy/tokens)
+
+- [Documentation](http://nulogy.design)
+- [Component Storybook](http://storybook.nulogy.design)
+- [@nulogy/components on npm](https://www.npmjs.com/package/@nulogy/components)
+- [@nulogy/css on npm](https://www.npmjs.com/package/@nulogy/css)
+- [@nulogy/tokens on npm](https://www.npmjs.com/package/@nulogy/tokens)
 
 ## Requests
-* https://trello.com/b/t2zYuzI7/nds-component-requests
+
+- https://trello.com/b/t2zYuzI7/nds-component-requests
 
 ## Contributing
-* [CONTRIBUTING.md](https://github.com/nulogy/design-system/blob/master/CONTRIBUTING.md)
+
+- [CONTRIBUTING.md](https://github.com/nulogy/design-system/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
## Description

In the midst of trying to figure out the permission issues we migrated from travis-ci.org to the newer travis-ci.com

This updates the badge so it should display the right status and link.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
