### PR TITLE
feat: create a checkbox that describes some options are checked but not all

### DIFF
--- a/components/src/Checkbox/Checkbox.js
+++ b/components/src/Checkbox/Checkbox.js
@@ -7,6 +7,7 @@ import { Box } from "../Box";
 import { Text } from "../Type";
 import theme from "../theme";
 import { ClickInputLabel } from "../utils";
+import { conditionallyRequiredProp } from "../utils/conditionallyRequiredProp";
 
 const checkboxStyle = {
   checked: {
@@ -48,14 +49,25 @@ const getCheckboxStyle = (props, checked) => {
   }
   return checkboxStyle[checked].default;
 };
+const checkedStyles = {
+  borderRadius: "1px",
+  borderWidth: "0 3px 3px 0",
+  transform: "rotate(45deg)"
+};
 
-const VisualCheckbox = styled.div({
+const indeterminateStyles = {
+  borderWidth: "0 3px 0 0",
+  transform: "rotate(90deg) translateX(1px)",
+  borderRadius: 0
+};
+const VisualCheckbox = styled.div(({ indeterminate }) => ({
   minWidth: theme.space.x2,
   height: theme.space.x2,
   borderRadius: theme.radii.small,
   border: "solid 1px",
   position: "relative",
   alignSelf: "center",
+  // checkmark
   "&:before": {
     content: "''",
     display: "none",
@@ -64,11 +76,9 @@ const VisualCheckbox = styled.div({
     width: "3px",
     height: "9px",
     border: `solid ${theme.colors.white}`,
-    borderWidth: "0 3px 3px 0",
-    borderRadius: "1px",
-    transform: "rotate(45deg)"
+    ...(indeterminate ? indeterminateStyles : checkedStyles)
   }
-});
+}));
 
 const CheckboxInput = styled.input(props => ({
   position: "absolute",
@@ -90,38 +100,18 @@ const CheckboxInput = styled.input(props => ({
 }));
 
 const BaseCheckbox = props => {
-  const { className, labelText, disabled, checked, required, error } = props;
+  // disabled react prop types as they are defined in Checkbox
+  // eslint-disable-next-line react/prop-types
+  const { className, labelText, disabled, checked, required, error, indeterminate } = props;
   return (
     <Box className={className}>
       <ClickInputLabel disabled={disabled}>
         <CheckboxInput type="checkbox" required={required} aria-required={required} aria-invalid={error} {...props} />
-        <VisualCheckbox disabled={disabled} checked={checked} />
+        <VisualCheckbox disabled={disabled} checked={checked} indeterminate={indeterminate} />
         {labelText && <Text disabled={disabled}>{labelText}</Text>}
       </ClickInputLabel>
     </Box>
   );
-};
-
-BaseCheckbox.propTypes = {
-  labelText: PropTypes.string,
-  checked: PropTypes.bool,
-  defaultChecked: PropTypes.bool,
-  disabled: PropTypes.bool,
-  error: PropTypes.bool,
-  id: PropTypes.string,
-  className: PropTypes.string,
-  required: PropTypes.bool
-};
-
-BaseCheckbox.defaultProps = {
-  labelText: undefined,
-  checked: undefined,
-  defaultChecked: undefined,
-  disabled: false,
-  error: false,
-  id: null,
-  className: undefined,
-  required: false
 };
 
 const Checkbox = styled(BaseCheckbox)(
@@ -137,7 +127,28 @@ const Checkbox = styled(BaseCheckbox)(
 );
 
 Checkbox.propTypes = {
+  labelText: PropTypes.string,
+  checked: conditionallyRequiredProp(PropTypes.bool, "indeterminate"),
+  defaultChecked: PropTypes.bool,
+  disabled: PropTypes.bool,
+  error: PropTypes.bool,
+  id: PropTypes.string,
+  className: PropTypes.string,
+  required: PropTypes.bool,
+  indeterminate: PropTypes.bool,
   ...propTypes.space
+};
+
+Checkbox.defaultProps = {
+  labelText: undefined,
+  checked: undefined,
+  defaultChecked: undefined,
+  disabled: false,
+  error: false,
+  id: null,
+  className: undefined,
+  required: false,
+  indeterminate: undefined
 };
 
 export default Checkbox;

--- a/components/src/Checkbox/Checkbox.js
+++ b/components/src/Checkbox/Checkbox.js
@@ -106,7 +106,14 @@ const BaseCheckbox = props => {
   return (
     <Box className={className}>
       <ClickInputLabel disabled={disabled}>
-        <CheckboxInput type="checkbox" required={required} aria-required={required} aria-invalid={error} {...props} />
+        <CheckboxInput
+          type="checkbox"
+          required={required}
+          aria-required={required}
+          aria-invalid={error}
+          indeterminate={indeterminate}
+          {...props}
+        />
         <VisualCheckbox disabled={disabled} checked={checked} indeterminate={indeterminate} />
         {labelText && <Text disabled={disabled}>{labelText}</Text>}
       </ClickInputLabel>

--- a/components/src/Checkbox/Checkbox.story.js
+++ b/components/src/Checkbox/Checkbox.story.js
@@ -74,7 +74,7 @@ storiesOf("Checkbox", module)
       />
       <Checkbox
         id="checkbox"
-        labelText="I am an inderterminate checkbox with an error"
+        labelText="I am an indeterminate checkbox with an error"
         readOnly
         checked
         indeterminate

--- a/components/src/Checkbox/Checkbox.story.js
+++ b/components/src/Checkbox/Checkbox.story.js
@@ -62,8 +62,32 @@ storiesOf("Checkbox", module)
       <Checkbox id="checkbox" labelText="I am a checkbox" required />
     </>
   ))
-  .add("With state", () => (
+  .add("indeterminate", () => (
     <>
-      <CheckboxWithState />
+      <Checkbox id="checkbox" labelText="I am an indeterminate checkbox" readOnly checked indeterminate />
+      <Checkbox
+        id="checkbox"
+        labelText="I am a unchecked indeterminate checkbox"
+        readOnly
+        checked={false}
+        indeterminate
+      />
+      <Checkbox
+        id="checkbox"
+        labelText="I am an inderterminate checkbox with an error"
+        readOnly
+        checked
+        indeterminate
+        error
+      />
+      <Checkbox
+        id="checkbox"
+        labelText="I am a disabled indeterminate checkbox"
+        readOnly
+        checked
+        indeterminate
+        disabled
+      />
     </>
-  ));
+  ))
+  .add("With state", () => <CheckboxWithState />);

--- a/components/src/Checkbox/__snapshots__/Checkbox.story.storyshot
+++ b/components/src/Checkbox/__snapshots__/Checkbox.story.storyshot
@@ -277,8 +277,11 @@ exports[`Storyshots Checkbox Checkbox 1`] = `
           }
         >
           <Styled(BaseCheckbox)
+            disabled={false}
+            error={false}
             id="checkbox"
             labelText="I am a checkbox"
+            required={false}
           >
             <BaseCheckbox
               className="sc-fzXfNc bSPfCk"
@@ -412,7 +415,7 @@ exports[`Storyshots Checkbox Checkbox 1`] = `
                         disabled={false}
                       >
                         <div
-                          className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                          className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                           disabled={false}
                         />
                       </Checkbox__VisualCheckbox>
@@ -723,7 +726,12 @@ exports[`Storyshots Checkbox Checkbox with no label 1`] = `
             }
           }
         >
-          <Styled(BaseCheckbox)>
+          <Styled(BaseCheckbox)
+            disabled={false}
+            error={false}
+            id={null}
+            required={false}
+          >
             <BaseCheckbox
               className="sc-fzXfNc bSPfCk"
               disabled={false}
@@ -854,7 +862,7 @@ exports[`Storyshots Checkbox Checkbox with no label 1`] = `
                         disabled={false}
                       >
                         <div
-                          className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                          className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                           disabled={false}
                         />
                       </Checkbox__VisualCheckbox>
@@ -1149,8 +1157,11 @@ exports[`Storyshots Checkbox Set to defaultChecked 1`] = `
         >
           <Styled(BaseCheckbox)
             defaultChecked={true}
+            disabled={false}
+            error={false}
             id="checkbox"
             labelText="I am checked by default"
+            required={false}
           >
             <BaseCheckbox
               className="sc-fzXfNc bSPfCk"
@@ -1287,7 +1298,7 @@ exports[`Storyshots Checkbox Set to defaultChecked 1`] = `
                         disabled={false}
                       >
                         <div
-                          className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                          className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                           disabled={false}
                         />
                       </Checkbox__VisualCheckbox>
@@ -1600,8 +1611,10 @@ exports[`Storyshots Checkbox Set to disabled 1`] = `
         >
           <Styled(BaseCheckbox)
             disabled={true}
+            error={false}
             id="checkbox-1"
             labelText="I am disabled"
+            required={false}
           >
             <BaseCheckbox
               className="sc-fzXfNc bSPfCk"
@@ -1735,7 +1748,7 @@ exports[`Storyshots Checkbox Set to disabled 1`] = `
                         disabled={true}
                       >
                         <div
-                          className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                          className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                           disabled={true}
                         />
                       </Checkbox__VisualCheckbox>
@@ -1766,8 +1779,10 @@ exports[`Storyshots Checkbox Set to disabled 1`] = `
           <Styled(BaseCheckbox)
             checked={true}
             disabled={true}
+            error={false}
             id="checkbox-2"
             labelText="I am disabled"
+            required={false}
           >
             <BaseCheckbox
               checked={true}
@@ -1906,7 +1921,7 @@ exports[`Storyshots Checkbox Set to disabled 1`] = `
                       >
                         <div
                           checked={true}
-                          className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                          className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                           disabled={true}
                         />
                       </Checkbox__VisualCheckbox>
@@ -2218,9 +2233,11 @@ exports[`Storyshots Checkbox Set to error 1`] = `
           }
         >
           <Styled(BaseCheckbox)
+            disabled={false}
             error={true}
             id="checkbox"
             labelText="I am error"
+            required={false}
           >
             <BaseCheckbox
               className="sc-fzXfNc bSPfCk"
@@ -2354,7 +2371,7 @@ exports[`Storyshots Checkbox Set to error 1`] = `
                         disabled={false}
                       >
                         <div
-                          className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                          className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                           disabled={false}
                         />
                       </Checkbox__VisualCheckbox>
@@ -2384,9 +2401,11 @@ exports[`Storyshots Checkbox Set to error 1`] = `
           </Styled(BaseCheckbox)>
           <Styled(BaseCheckbox)
             defaultChecked={true}
+            disabled={false}
             error={true}
             id="checkbox"
             labelText="I am error"
+            required={false}
           >
             <BaseCheckbox
               className="sc-fzXfNc bSPfCk"
@@ -2523,7 +2542,7 @@ exports[`Storyshots Checkbox Set to error 1`] = `
                         disabled={false}
                       >
                         <div
-                          className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                          className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                           disabled={false}
                         />
                       </Checkbox__VisualCheckbox>
@@ -2835,6 +2854,8 @@ exports[`Storyshots Checkbox Set to required 1`] = `
           }
         >
           <Styled(BaseCheckbox)
+            disabled={false}
+            error={false}
             id="checkbox"
             labelText="I am a checkbox"
             required={true}
@@ -2971,7 +2992,7 @@ exports[`Storyshots Checkbox Set to required 1`] = `
                         disabled={false}
                       >
                         <div
-                          className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                          className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                           disabled={false}
                         />
                       </Checkbox__VisualCheckbox>
@@ -3285,9 +3306,12 @@ exports[`Storyshots Checkbox With state 1`] = `
           <CheckboxWithState>
             <Styled(BaseCheckbox)
               checked={false}
+              disabled={false}
+              error={false}
               id="checkbox-1"
               labelText="I am controlled and checked"
               onChange={[Function]}
+              required={false}
             >
               <BaseCheckbox
                 checked={false}
@@ -3429,7 +3453,7 @@ exports[`Storyshots Checkbox With state 1`] = `
                         >
                           <div
                             checked={false}
-                            className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                            className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                             disabled={false}
                           />
                         </Checkbox__VisualCheckbox>
@@ -3459,9 +3483,12 @@ exports[`Storyshots Checkbox With state 1`] = `
             </Styled(BaseCheckbox)>
             <Styled(BaseCheckbox)
               checked={false}
+              disabled={false}
+              error={false}
               id="checkbox-2"
               labelText="I am controlled and unchecked"
               onChange={[Function]}
+              required={false}
             >
               <BaseCheckbox
                 checked={false}
@@ -3603,7 +3630,7 @@ exports[`Storyshots Checkbox With state 1`] = `
                         >
                           <div
                             checked={false}
-                            className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                            className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                             disabled={false}
                           />
                         </Checkbox__VisualCheckbox>
@@ -3632,6 +3659,1013 @@ exports[`Storyshots Checkbox With state 1`] = `
               </BaseCheckbox>
             </Styled(BaseCheckbox)>
           </CheckboxWithState>
+        </ThemeProvider>
+      </div>
+    </NDSProvider__GlobalStyles>
+  </NDSProvider>
+</div>
+`;
+
+exports[`Storyshots Checkbox indeterminate 1`] = `
+<div
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
+>
+  <NDSProvider
+    theme={
+      Object {
+        "borders": Array [],
+        "breakpoints": Object {
+          "extraLarge": "1920px",
+          "extraSmall": "0px",
+          "large": "1360px",
+          "medium": "1024px",
+          "small": "768px",
+        },
+        "colors": Object {
+          "black": "#011e38",
+          "blackBlue": "#122b47",
+          "blue": "#216beb",
+          "darkBlue": "#00438f",
+          "darkGrey": "#434d59",
+          "green": "#008059",
+          "grey": "#c0c8d1",
+          "lightBlue": "#e1ebfa",
+          "lightGreen": "#e9f7f2",
+          "lightGrey": "#e4e7eb",
+          "lightRed": "#fae6ea",
+          "lightYellow": "#fcf5e3",
+          "red": "#cc1439",
+          "white": "#ffffff",
+          "whiteGrey": "#f0f2f5",
+          "yellow": "#ffbb00",
+        },
+        "fontSizes": Object {
+          "large": "20px",
+          "larger": "26px",
+          "largest": "46px",
+          "medium": "16px",
+          "small": "14px",
+          "smaller": "12px",
+        },
+        "fontWeights": Object {
+          "bold": "600",
+          "light": "300",
+          "medium": "500",
+          "normal": "400",
+        },
+        "fonts": Object {
+          "base": "'IBM Plex Sans', sans-serif",
+          "mono": "'IBM Plex Mono', monospace",
+        },
+        "lineHeights": Object {
+          "base": "1.5",
+          "sectionTitle": "1.23076923",
+          "smallTextBase": "1.71428571",
+          "smallTextCompressed": "1.14285714",
+          "smallerText": "1.33333333",
+          "subsectionTitle": "1.2",
+          "title": "1.04347826",
+        },
+        "radii": Object {
+          "circle": "50%",
+          "medium": "4px",
+          "small": "2px",
+        },
+        "shadows": Object {
+          "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+          "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+          "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+          "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+          "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+        },
+        "space": Object {
+          "half": "4px",
+          "none": "0px",
+          "x1": "8px",
+          "x2": "16px",
+          "x3": "24px",
+          "x4": "32px",
+          "x5": "40px",
+          "x6": "48px",
+          "x8": "64px",
+        },
+        "zIndex": Object {
+          "content": 100,
+          "overlay": 1000,
+          "tabsBar": 210,
+          "tabsScollIndicator": 200,
+        },
+      }
+    }
+  >
+    <Memo(GlobalStyleComponent) />
+    <NDSProvider__GlobalStyles
+      theme={
+        Object {
+          "borders": Array [],
+          "breakpoints": Object {
+            "extraLarge": "1920px",
+            "extraSmall": "0px",
+            "large": "1360px",
+            "medium": "1024px",
+            "small": "768px",
+          },
+          "colors": Object {
+            "black": "#011e38",
+            "blackBlue": "#122b47",
+            "blue": "#216beb",
+            "darkBlue": "#00438f",
+            "darkGrey": "#434d59",
+            "green": "#008059",
+            "grey": "#c0c8d1",
+            "lightBlue": "#e1ebfa",
+            "lightGreen": "#e9f7f2",
+            "lightGrey": "#e4e7eb",
+            "lightRed": "#fae6ea",
+            "lightYellow": "#fcf5e3",
+            "red": "#cc1439",
+            "white": "#ffffff",
+            "whiteGrey": "#f0f2f5",
+            "yellow": "#ffbb00",
+          },
+          "fontSizes": Object {
+            "large": "20px",
+            "larger": "26px",
+            "largest": "46px",
+            "medium": "16px",
+            "small": "14px",
+            "smaller": "12px",
+          },
+          "fontWeights": Object {
+            "bold": "600",
+            "light": "300",
+            "medium": "500",
+            "normal": "400",
+          },
+          "fonts": Object {
+            "base": "'IBM Plex Sans', sans-serif",
+            "mono": "'IBM Plex Mono', monospace",
+          },
+          "lineHeights": Object {
+            "base": "1.5",
+            "sectionTitle": "1.23076923",
+            "smallTextBase": "1.71428571",
+            "smallTextCompressed": "1.14285714",
+            "smallerText": "1.33333333",
+            "subsectionTitle": "1.2",
+            "title": "1.04347826",
+          },
+          "radii": Object {
+            "circle": "50%",
+            "medium": "4px",
+            "small": "2px",
+          },
+          "shadows": Object {
+            "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+            "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+            "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+            "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+            "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+          },
+          "space": Object {
+            "half": "4px",
+            "none": "0px",
+            "x1": "8px",
+            "x2": "16px",
+            "x3": "24px",
+            "x4": "32px",
+            "x5": "40px",
+            "x6": "48px",
+            "x8": "64px",
+          },
+          "zIndex": Object {
+            "content": 100,
+            "overlay": 1000,
+            "tabsBar": 210,
+            "tabsScollIndicator": 200,
+          },
+        }
+      }
+    >
+      <div
+        className="NDSProvider__GlobalStyles-f28eoq-0 edIMFr"
+      >
+        <ThemeProvider
+          theme={
+            Object {
+              "borders": Array [],
+              "breakpoints": Object {
+                "extraLarge": "1920px",
+                "extraSmall": "0px",
+                "large": "1360px",
+                "medium": "1024px",
+                "small": "768px",
+              },
+              "colors": Object {
+                "black": "#011e38",
+                "blackBlue": "#122b47",
+                "blue": "#216beb",
+                "darkBlue": "#00438f",
+                "darkGrey": "#434d59",
+                "green": "#008059",
+                "grey": "#c0c8d1",
+                "lightBlue": "#e1ebfa",
+                "lightGreen": "#e9f7f2",
+                "lightGrey": "#e4e7eb",
+                "lightRed": "#fae6ea",
+                "lightYellow": "#fcf5e3",
+                "red": "#cc1439",
+                "white": "#ffffff",
+                "whiteGrey": "#f0f2f5",
+                "yellow": "#ffbb00",
+              },
+              "fontSizes": Object {
+                "large": "20px",
+                "larger": "26px",
+                "largest": "46px",
+                "medium": "16px",
+                "small": "14px",
+                "smaller": "12px",
+              },
+              "fontWeights": Object {
+                "bold": "600",
+                "light": "300",
+                "medium": "500",
+                "normal": "400",
+              },
+              "fonts": Object {
+                "base": "'IBM Plex Sans', sans-serif",
+                "mono": "'IBM Plex Mono', monospace",
+              },
+              "lineHeights": Object {
+                "base": "1.5",
+                "sectionTitle": "1.23076923",
+                "smallTextBase": "1.71428571",
+                "smallTextCompressed": "1.14285714",
+                "smallerText": "1.33333333",
+                "subsectionTitle": "1.2",
+                "title": "1.04347826",
+              },
+              "radii": Object {
+                "circle": "50%",
+                "medium": "4px",
+                "small": "2px",
+              },
+              "shadows": Object {
+                "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+              },
+              "space": Object {
+                "half": "4px",
+                "none": "0px",
+                "x1": "8px",
+                "x2": "16px",
+                "x3": "24px",
+                "x4": "32px",
+                "x5": "40px",
+                "x6": "48px",
+                "x8": "64px",
+              },
+              "zIndex": Object {
+                "content": 100,
+                "overlay": 1000,
+                "tabsBar": 210,
+                "tabsScollIndicator": 200,
+              },
+            }
+          }
+        >
+          <Styled(BaseCheckbox)
+            checked={true}
+            disabled={false}
+            error={false}
+            id="checkbox"
+            indeterminate={true}
+            labelText="I am an indeterminate checkbox"
+            readOnly={true}
+            required={false}
+          >
+            <BaseCheckbox
+              checked={true}
+              className="sc-fzXfNc bSPfCk"
+              disabled={false}
+              error={false}
+              id="checkbox"
+              indeterminate={true}
+              labelText="I am an indeterminate checkbox"
+              readOnly={true}
+              required={false}
+            >
+              <Box
+                className="sc-fzXfNc bSPfCk"
+                theme={
+                  Object {
+                    "borders": Array [],
+                    "breakpoints": Object {
+                      "extraLarge": "1920px",
+                      "extraSmall": "0px",
+                      "large": "1360px",
+                      "medium": "1024px",
+                      "small": "768px",
+                    },
+                    "colors": Object {
+                      "black": "#011e38",
+                      "blackBlue": "#122b47",
+                      "blue": "#216beb",
+                      "darkBlue": "#00438f",
+                      "darkGrey": "#434d59",
+                      "green": "#008059",
+                      "grey": "#c0c8d1",
+                      "lightBlue": "#e1ebfa",
+                      "lightGreen": "#e9f7f2",
+                      "lightGrey": "#e4e7eb",
+                      "lightRed": "#fae6ea",
+                      "lightYellow": "#fcf5e3",
+                      "red": "#cc1439",
+                      "white": "#ffffff",
+                      "whiteGrey": "#f0f2f5",
+                      "yellow": "#ffbb00",
+                    },
+                    "fontSizes": Object {
+                      "large": "20px",
+                      "larger": "26px",
+                      "largest": "46px",
+                      "medium": "16px",
+                      "small": "14px",
+                      "smaller": "12px",
+                    },
+                    "fontWeights": Object {
+                      "bold": "600",
+                      "light": "300",
+                      "medium": "500",
+                      "normal": "400",
+                    },
+                    "fonts": Object {
+                      "base": "'IBM Plex Sans', sans-serif",
+                      "mono": "'IBM Plex Mono', monospace",
+                    },
+                    "lineHeights": Object {
+                      "base": "1.5",
+                      "sectionTitle": "1.23076923",
+                      "smallTextBase": "1.71428571",
+                      "smallTextCompressed": "1.14285714",
+                      "smallerText": "1.33333333",
+                      "subsectionTitle": "1.2",
+                      "title": "1.04347826",
+                    },
+                    "radii": Object {
+                      "circle": "50%",
+                      "medium": "4px",
+                      "small": "2px",
+                    },
+                    "shadows": Object {
+                      "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                      "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                      "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                      "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                      "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                    },
+                    "space": Object {
+                      "half": "4px",
+                      "none": "0px",
+                      "x1": "8px",
+                      "x2": "16px",
+                      "x3": "24px",
+                      "x4": "32px",
+                      "x5": "40px",
+                      "x6": "48px",
+                      "x8": "64px",
+                    },
+                    "zIndex": Object {
+                      "content": 100,
+                      "overlay": 1000,
+                      "tabsBar": 210,
+                      "tabsScollIndicator": 200,
+                    },
+                  }
+                }
+              >
+                <div
+                  className="Box-sc-1qu1edy-0 jgHxgc sc-fzXfNc bSPfCk"
+                >
+                  <ClickInputLabel
+                    disabled={false}
+                  >
+                    <label
+                      className="ClickInputLabel-j2axnv-0 hdKIjC"
+                      disabled={false}
+                    >
+                      <Checkbox__CheckboxInput
+                        aria-invalid={false}
+                        aria-required={false}
+                        checked={true}
+                        className="sc-fzXfNc bSPfCk"
+                        disabled={false}
+                        error={false}
+                        id="checkbox"
+                        indeterminate={true}
+                        labelText="I am an indeterminate checkbox"
+                        readOnly={true}
+                        required={false}
+                        type="checkbox"
+                      >
+                        <input
+                          aria-invalid={false}
+                          aria-required={false}
+                          checked={true}
+                          className="Checkbox__CheckboxInput-sc-1nm58f1-1 bJQgsS sc-fzXfNc bSPfCk"
+                          disabled={false}
+                          id="checkbox"
+                          readOnly={true}
+                          required={false}
+                          type="checkbox"
+                        />
+                      </Checkbox__CheckboxInput>
+                      <Checkbox__VisualCheckbox
+                        checked={true}
+                        disabled={false}
+                        indeterminate={true}
+                      >
+                        <div
+                          checked={true}
+                          className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eUjqVh"
+                          disabled={false}
+                        />
+                      </Checkbox__VisualCheckbox>
+                      <styled.p
+                        color="currentColor"
+                        disabled={false}
+                        fontSize="16px"
+                        inline={false}
+                        lineHeight="1.5"
+                        mb={0}
+                        mt={0}
+                      >
+                        <p
+                          className="sc-AykKF jKbmDj"
+                          color="currentColor"
+                          disabled={false}
+                          fontSize="16px"
+                        >
+                          I am an indeterminate checkbox
+                        </p>
+                      </styled.p>
+                    </label>
+                  </ClickInputLabel>
+                </div>
+              </Box>
+            </BaseCheckbox>
+          </Styled(BaseCheckbox)>
+          <Styled(BaseCheckbox)
+            checked={false}
+            disabled={false}
+            error={false}
+            id="checkbox"
+            indeterminate={true}
+            labelText="I am a unchecked indeterminate checkbox"
+            readOnly={true}
+            required={false}
+          >
+            <BaseCheckbox
+              checked={false}
+              className="sc-fzXfNc bSPfCk"
+              disabled={false}
+              error={false}
+              id="checkbox"
+              indeterminate={true}
+              labelText="I am a unchecked indeterminate checkbox"
+              readOnly={true}
+              required={false}
+            >
+              <Box
+                className="sc-fzXfNc bSPfCk"
+                theme={
+                  Object {
+                    "borders": Array [],
+                    "breakpoints": Object {
+                      "extraLarge": "1920px",
+                      "extraSmall": "0px",
+                      "large": "1360px",
+                      "medium": "1024px",
+                      "small": "768px",
+                    },
+                    "colors": Object {
+                      "black": "#011e38",
+                      "blackBlue": "#122b47",
+                      "blue": "#216beb",
+                      "darkBlue": "#00438f",
+                      "darkGrey": "#434d59",
+                      "green": "#008059",
+                      "grey": "#c0c8d1",
+                      "lightBlue": "#e1ebfa",
+                      "lightGreen": "#e9f7f2",
+                      "lightGrey": "#e4e7eb",
+                      "lightRed": "#fae6ea",
+                      "lightYellow": "#fcf5e3",
+                      "red": "#cc1439",
+                      "white": "#ffffff",
+                      "whiteGrey": "#f0f2f5",
+                      "yellow": "#ffbb00",
+                    },
+                    "fontSizes": Object {
+                      "large": "20px",
+                      "larger": "26px",
+                      "largest": "46px",
+                      "medium": "16px",
+                      "small": "14px",
+                      "smaller": "12px",
+                    },
+                    "fontWeights": Object {
+                      "bold": "600",
+                      "light": "300",
+                      "medium": "500",
+                      "normal": "400",
+                    },
+                    "fonts": Object {
+                      "base": "'IBM Plex Sans', sans-serif",
+                      "mono": "'IBM Plex Mono', monospace",
+                    },
+                    "lineHeights": Object {
+                      "base": "1.5",
+                      "sectionTitle": "1.23076923",
+                      "smallTextBase": "1.71428571",
+                      "smallTextCompressed": "1.14285714",
+                      "smallerText": "1.33333333",
+                      "subsectionTitle": "1.2",
+                      "title": "1.04347826",
+                    },
+                    "radii": Object {
+                      "circle": "50%",
+                      "medium": "4px",
+                      "small": "2px",
+                    },
+                    "shadows": Object {
+                      "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                      "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                      "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                      "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                      "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                    },
+                    "space": Object {
+                      "half": "4px",
+                      "none": "0px",
+                      "x1": "8px",
+                      "x2": "16px",
+                      "x3": "24px",
+                      "x4": "32px",
+                      "x5": "40px",
+                      "x6": "48px",
+                      "x8": "64px",
+                    },
+                    "zIndex": Object {
+                      "content": 100,
+                      "overlay": 1000,
+                      "tabsBar": 210,
+                      "tabsScollIndicator": 200,
+                    },
+                  }
+                }
+              >
+                <div
+                  className="Box-sc-1qu1edy-0 jgHxgc sc-fzXfNc bSPfCk"
+                >
+                  <ClickInputLabel
+                    disabled={false}
+                  >
+                    <label
+                      className="ClickInputLabel-j2axnv-0 hdKIjC"
+                      disabled={false}
+                    >
+                      <Checkbox__CheckboxInput
+                        aria-invalid={false}
+                        aria-required={false}
+                        checked={false}
+                        className="sc-fzXfNc bSPfCk"
+                        disabled={false}
+                        error={false}
+                        id="checkbox"
+                        indeterminate={true}
+                        labelText="I am a unchecked indeterminate checkbox"
+                        readOnly={true}
+                        required={false}
+                        type="checkbox"
+                      >
+                        <input
+                          aria-invalid={false}
+                          aria-required={false}
+                          checked={false}
+                          className="Checkbox__CheckboxInput-sc-1nm58f1-1 bJQgsS sc-fzXfNc bSPfCk"
+                          disabled={false}
+                          id="checkbox"
+                          readOnly={true}
+                          required={false}
+                          type="checkbox"
+                        />
+                      </Checkbox__CheckboxInput>
+                      <Checkbox__VisualCheckbox
+                        checked={false}
+                        disabled={false}
+                        indeterminate={true}
+                      >
+                        <div
+                          checked={false}
+                          className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eUjqVh"
+                          disabled={false}
+                        />
+                      </Checkbox__VisualCheckbox>
+                      <styled.p
+                        color="currentColor"
+                        disabled={false}
+                        fontSize="16px"
+                        inline={false}
+                        lineHeight="1.5"
+                        mb={0}
+                        mt={0}
+                      >
+                        <p
+                          className="sc-AykKF jKbmDj"
+                          color="currentColor"
+                          disabled={false}
+                          fontSize="16px"
+                        >
+                          I am a unchecked indeterminate checkbox
+                        </p>
+                      </styled.p>
+                    </label>
+                  </ClickInputLabel>
+                </div>
+              </Box>
+            </BaseCheckbox>
+          </Styled(BaseCheckbox)>
+          <Styled(BaseCheckbox)
+            checked={true}
+            disabled={false}
+            error={true}
+            id="checkbox"
+            indeterminate={true}
+            labelText="I am an inderterminate checkbox with an error"
+            readOnly={true}
+            required={false}
+          >
+            <BaseCheckbox
+              checked={true}
+              className="sc-fzXfNc bSPfCk"
+              disabled={false}
+              error={true}
+              id="checkbox"
+              indeterminate={true}
+              labelText="I am an inderterminate checkbox with an error"
+              readOnly={true}
+              required={false}
+            >
+              <Box
+                className="sc-fzXfNc bSPfCk"
+                theme={
+                  Object {
+                    "borders": Array [],
+                    "breakpoints": Object {
+                      "extraLarge": "1920px",
+                      "extraSmall": "0px",
+                      "large": "1360px",
+                      "medium": "1024px",
+                      "small": "768px",
+                    },
+                    "colors": Object {
+                      "black": "#011e38",
+                      "blackBlue": "#122b47",
+                      "blue": "#216beb",
+                      "darkBlue": "#00438f",
+                      "darkGrey": "#434d59",
+                      "green": "#008059",
+                      "grey": "#c0c8d1",
+                      "lightBlue": "#e1ebfa",
+                      "lightGreen": "#e9f7f2",
+                      "lightGrey": "#e4e7eb",
+                      "lightRed": "#fae6ea",
+                      "lightYellow": "#fcf5e3",
+                      "red": "#cc1439",
+                      "white": "#ffffff",
+                      "whiteGrey": "#f0f2f5",
+                      "yellow": "#ffbb00",
+                    },
+                    "fontSizes": Object {
+                      "large": "20px",
+                      "larger": "26px",
+                      "largest": "46px",
+                      "medium": "16px",
+                      "small": "14px",
+                      "smaller": "12px",
+                    },
+                    "fontWeights": Object {
+                      "bold": "600",
+                      "light": "300",
+                      "medium": "500",
+                      "normal": "400",
+                    },
+                    "fonts": Object {
+                      "base": "'IBM Plex Sans', sans-serif",
+                      "mono": "'IBM Plex Mono', monospace",
+                    },
+                    "lineHeights": Object {
+                      "base": "1.5",
+                      "sectionTitle": "1.23076923",
+                      "smallTextBase": "1.71428571",
+                      "smallTextCompressed": "1.14285714",
+                      "smallerText": "1.33333333",
+                      "subsectionTitle": "1.2",
+                      "title": "1.04347826",
+                    },
+                    "radii": Object {
+                      "circle": "50%",
+                      "medium": "4px",
+                      "small": "2px",
+                    },
+                    "shadows": Object {
+                      "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                      "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                      "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                      "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                      "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                    },
+                    "space": Object {
+                      "half": "4px",
+                      "none": "0px",
+                      "x1": "8px",
+                      "x2": "16px",
+                      "x3": "24px",
+                      "x4": "32px",
+                      "x5": "40px",
+                      "x6": "48px",
+                      "x8": "64px",
+                    },
+                    "zIndex": Object {
+                      "content": 100,
+                      "overlay": 1000,
+                      "tabsBar": 210,
+                      "tabsScollIndicator": 200,
+                    },
+                  }
+                }
+              >
+                <div
+                  className="Box-sc-1qu1edy-0 jgHxgc sc-fzXfNc bSPfCk"
+                >
+                  <ClickInputLabel
+                    disabled={false}
+                  >
+                    <label
+                      className="ClickInputLabel-j2axnv-0 hdKIjC"
+                      disabled={false}
+                    >
+                      <Checkbox__CheckboxInput
+                        aria-invalid={true}
+                        aria-required={false}
+                        checked={true}
+                        className="sc-fzXfNc bSPfCk"
+                        disabled={false}
+                        error={true}
+                        id="checkbox"
+                        indeterminate={true}
+                        labelText="I am an inderterminate checkbox with an error"
+                        readOnly={true}
+                        required={false}
+                        type="checkbox"
+                      >
+                        <input
+                          aria-invalid={true}
+                          aria-required={false}
+                          checked={true}
+                          className="Checkbox__CheckboxInput-sc-1nm58f1-1 djfPeS sc-fzXfNc bSPfCk"
+                          disabled={false}
+                          id="checkbox"
+                          readOnly={true}
+                          required={false}
+                          type="checkbox"
+                        />
+                      </Checkbox__CheckboxInput>
+                      <Checkbox__VisualCheckbox
+                        checked={true}
+                        disabled={false}
+                        indeterminate={true}
+                      >
+                        <div
+                          checked={true}
+                          className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eUjqVh"
+                          disabled={false}
+                        />
+                      </Checkbox__VisualCheckbox>
+                      <styled.p
+                        color="currentColor"
+                        disabled={false}
+                        fontSize="16px"
+                        inline={false}
+                        lineHeight="1.5"
+                        mb={0}
+                        mt={0}
+                      >
+                        <p
+                          className="sc-AykKF jKbmDj"
+                          color="currentColor"
+                          disabled={false}
+                          fontSize="16px"
+                        >
+                          I am an inderterminate checkbox with an error
+                        </p>
+                      </styled.p>
+                    </label>
+                  </ClickInputLabel>
+                </div>
+              </Box>
+            </BaseCheckbox>
+          </Styled(BaseCheckbox)>
+          <Styled(BaseCheckbox)
+            checked={true}
+            disabled={true}
+            error={false}
+            id="checkbox"
+            indeterminate={true}
+            labelText="I am a disabled indeterminate checkbox"
+            readOnly={true}
+            required={false}
+          >
+            <BaseCheckbox
+              checked={true}
+              className="sc-fzXfNc bSPfCk"
+              disabled={true}
+              error={false}
+              id="checkbox"
+              indeterminate={true}
+              labelText="I am a disabled indeterminate checkbox"
+              readOnly={true}
+              required={false}
+            >
+              <Box
+                className="sc-fzXfNc bSPfCk"
+                theme={
+                  Object {
+                    "borders": Array [],
+                    "breakpoints": Object {
+                      "extraLarge": "1920px",
+                      "extraSmall": "0px",
+                      "large": "1360px",
+                      "medium": "1024px",
+                      "small": "768px",
+                    },
+                    "colors": Object {
+                      "black": "#011e38",
+                      "blackBlue": "#122b47",
+                      "blue": "#216beb",
+                      "darkBlue": "#00438f",
+                      "darkGrey": "#434d59",
+                      "green": "#008059",
+                      "grey": "#c0c8d1",
+                      "lightBlue": "#e1ebfa",
+                      "lightGreen": "#e9f7f2",
+                      "lightGrey": "#e4e7eb",
+                      "lightRed": "#fae6ea",
+                      "lightYellow": "#fcf5e3",
+                      "red": "#cc1439",
+                      "white": "#ffffff",
+                      "whiteGrey": "#f0f2f5",
+                      "yellow": "#ffbb00",
+                    },
+                    "fontSizes": Object {
+                      "large": "20px",
+                      "larger": "26px",
+                      "largest": "46px",
+                      "medium": "16px",
+                      "small": "14px",
+                      "smaller": "12px",
+                    },
+                    "fontWeights": Object {
+                      "bold": "600",
+                      "light": "300",
+                      "medium": "500",
+                      "normal": "400",
+                    },
+                    "fonts": Object {
+                      "base": "'IBM Plex Sans', sans-serif",
+                      "mono": "'IBM Plex Mono', monospace",
+                    },
+                    "lineHeights": Object {
+                      "base": "1.5",
+                      "sectionTitle": "1.23076923",
+                      "smallTextBase": "1.71428571",
+                      "smallTextCompressed": "1.14285714",
+                      "smallerText": "1.33333333",
+                      "subsectionTitle": "1.2",
+                      "title": "1.04347826",
+                    },
+                    "radii": Object {
+                      "circle": "50%",
+                      "medium": "4px",
+                      "small": "2px",
+                    },
+                    "shadows": Object {
+                      "error": "0px 0px 5px 0px rgba(204, 20, 57, .9)",
+                      "focus": "0px 0px 5px 0px rgba(33, 107, 235, .9)",
+                      "large": "0px 3px 5px 0px rgba(1, 30, 56, 0.1)",
+                      "medium": "0px 1px 4px 0px rgba(1, 30, 56, 0.15)",
+                      "small": "0px 0px 3px 0px rgba(1, 30, 56, 0.2)",
+                    },
+                    "space": Object {
+                      "half": "4px",
+                      "none": "0px",
+                      "x1": "8px",
+                      "x2": "16px",
+                      "x3": "24px",
+                      "x4": "32px",
+                      "x5": "40px",
+                      "x6": "48px",
+                      "x8": "64px",
+                    },
+                    "zIndex": Object {
+                      "content": 100,
+                      "overlay": 1000,
+                      "tabsBar": 210,
+                      "tabsScollIndicator": 200,
+                    },
+                  }
+                }
+              >
+                <div
+                  className="Box-sc-1qu1edy-0 jgHxgc sc-fzXfNc bSPfCk"
+                >
+                  <ClickInputLabel
+                    disabled={true}
+                  >
+                    <label
+                      className="ClickInputLabel-j2axnv-0 jxKJCC"
+                      disabled={true}
+                    >
+                      <Checkbox__CheckboxInput
+                        aria-invalid={false}
+                        aria-required={false}
+                        checked={true}
+                        className="sc-fzXfNc bSPfCk"
+                        disabled={true}
+                        error={false}
+                        id="checkbox"
+                        indeterminate={true}
+                        labelText="I am a disabled indeterminate checkbox"
+                        readOnly={true}
+                        required={false}
+                        type="checkbox"
+                      >
+                        <input
+                          aria-invalid={false}
+                          aria-required={false}
+                          checked={true}
+                          className="Checkbox__CheckboxInput-sc-1nm58f1-1 gYNwWa sc-fzXfNc bSPfCk"
+                          disabled={true}
+                          id="checkbox"
+                          readOnly={true}
+                          required={false}
+                          type="checkbox"
+                        />
+                      </Checkbox__CheckboxInput>
+                      <Checkbox__VisualCheckbox
+                        checked={true}
+                        disabled={true}
+                        indeterminate={true}
+                      >
+                        <div
+                          checked={true}
+                          className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eUjqVh"
+                          disabled={true}
+                        />
+                      </Checkbox__VisualCheckbox>
+                      <styled.p
+                        color="currentColor"
+                        disabled={true}
+                        fontSize="16px"
+                        inline={false}
+                        lineHeight="1.5"
+                        mb={0}
+                        mt={0}
+                      >
+                        <p
+                          className="sc-AykKF gRcVjH"
+                          color="currentColor"
+                          disabled={true}
+                          fontSize="16px"
+                        >
+                          I am a disabled indeterminate checkbox
+                        </p>
+                      </styled.p>
+                    </label>
+                  </ClickInputLabel>
+                </div>
+              </Box>
+            </BaseCheckbox>
+          </Styled(BaseCheckbox)>
         </ThemeProvider>
       </div>
     </NDSProvider__GlobalStyles>

--- a/components/src/Checkbox/__snapshots__/Checkbox.story.storyshot
+++ b/components/src/Checkbox/__snapshots__/Checkbox.story.storyshot
@@ -4310,7 +4310,7 @@ exports[`Storyshots Checkbox indeterminate 1`] = `
             error={true}
             id="checkbox"
             indeterminate={true}
-            labelText="I am an inderterminate checkbox with an error"
+            labelText="I am an indeterminate checkbox with an error"
             readOnly={true}
             required={false}
           >
@@ -4321,7 +4321,7 @@ exports[`Storyshots Checkbox indeterminate 1`] = `
               error={true}
               id="checkbox"
               indeterminate={true}
-              labelText="I am an inderterminate checkbox with an error"
+              labelText="I am an indeterminate checkbox with an error"
               readOnly={true}
               required={false}
             >
@@ -4433,7 +4433,7 @@ exports[`Storyshots Checkbox indeterminate 1`] = `
                         error={true}
                         id="checkbox"
                         indeterminate={true}
-                        labelText="I am an inderterminate checkbox with an error"
+                        labelText="I am an indeterminate checkbox with an error"
                         readOnly={true}
                         required={false}
                         type="checkbox"
@@ -4476,7 +4476,7 @@ exports[`Storyshots Checkbox indeterminate 1`] = `
                           disabled={false}
                           fontSize="16px"
                         >
-                          I am an inderterminate checkbox with an error
+                          I am an indeterminate checkbox with an error
                         </p>
                       </styled.p>
                     </label>

--- a/components/src/Checkbox/__snapshots__/CheckboxGroup.story.storyshot
+++ b/components/src/Checkbox/__snapshots__/CheckboxGroup.story.storyshot
@@ -316,10 +316,13 @@ exports[`Storyshots CheckboxGroup CheckboxGroup 1`] = `
                     </span>
                   </legend>
                   <Styled(BaseCheckbox)
+                    disabled={false}
                     error={false}
+                    id={null}
                     key=".0"
                     labelText="Option A"
                     name="settingSelection"
+                    required={false}
                     value="a"
                   >
                     <BaseCheckbox
@@ -460,7 +463,7 @@ exports[`Storyshots CheckboxGroup CheckboxGroup 1`] = `
                                 disabled={false}
                               >
                                 <div
-                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                   disabled={false}
                                 />
                               </Checkbox__VisualCheckbox>
@@ -489,10 +492,13 @@ exports[`Storyshots CheckboxGroup CheckboxGroup 1`] = `
                     </BaseCheckbox>
                   </Styled(BaseCheckbox)>
                   <Styled(BaseCheckbox)
+                    disabled={false}
                     error={false}
+                    id={null}
                     key=".1"
                     labelText="Option B"
                     name="settingSelection"
+                    required={false}
                     value="b"
                   >
                     <BaseCheckbox
@@ -633,7 +639,7 @@ exports[`Storyshots CheckboxGroup CheckboxGroup 1`] = `
                                 disabled={false}
                               >
                                 <div
-                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                   disabled={false}
                                 />
                               </Checkbox__VisualCheckbox>
@@ -662,10 +668,13 @@ exports[`Storyshots CheckboxGroup CheckboxGroup 1`] = `
                     </BaseCheckbox>
                   </Styled(BaseCheckbox)>
                   <Styled(BaseCheckbox)
+                    disabled={false}
                     error={false}
+                    id={null}
                     key=".2"
                     labelText="Option C"
                     name="settingSelection"
+                    required={false}
                     value="c"
                   >
                     <BaseCheckbox
@@ -806,7 +815,7 @@ exports[`Storyshots CheckboxGroup CheckboxGroup 1`] = `
                                 disabled={false}
                               >
                                 <div
-                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                   disabled={false}
                                 />
                               </Checkbox__VisualCheckbox>
@@ -1222,7 +1231,9 @@ exports[`Storyshots CheckboxGroup CheckboxGroup with all props 1`] = `
                   </HelpText>
                   <Styled(BaseCheckbox)
                     defaultChecked={true}
+                    disabled={false}
                     error={false}
+                    id={null}
                     key=".0"
                     labelText="Option A"
                     name="settingSelection"
@@ -1370,7 +1381,7 @@ exports[`Storyshots CheckboxGroup CheckboxGroup with all props 1`] = `
                                 disabled={false}
                               >
                                 <div
-                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                   disabled={false}
                                 />
                               </Checkbox__VisualCheckbox>
@@ -1400,7 +1411,9 @@ exports[`Storyshots CheckboxGroup CheckboxGroup with all props 1`] = `
                   </Styled(BaseCheckbox)>
                   <Styled(BaseCheckbox)
                     defaultChecked={false}
+                    disabled={false}
                     error={false}
+                    id={null}
                     key=".1"
                     labelText="Option B"
                     name="settingSelection"
@@ -1548,7 +1561,7 @@ exports[`Storyshots CheckboxGroup CheckboxGroup with all props 1`] = `
                                 disabled={false}
                               >
                                 <div
-                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                   disabled={false}
                                 />
                               </Checkbox__VisualCheckbox>
@@ -1578,7 +1591,9 @@ exports[`Storyshots CheckboxGroup CheckboxGroup with all props 1`] = `
                   </Styled(BaseCheckbox)>
                   <Styled(BaseCheckbox)
                     defaultChecked={false}
+                    disabled={false}
                     error={false}
+                    id={null}
                     key=".2"
                     labelText="Option C"
                     name="settingSelection"
@@ -1726,7 +1741,7 @@ exports[`Storyshots CheckboxGroup CheckboxGroup with all props 1`] = `
                                 disabled={false}
                               >
                                 <div
-                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                   disabled={false}
                                 />
                               </Checkbox__VisualCheckbox>
@@ -2099,11 +2114,14 @@ exports[`Storyshots CheckboxGroup Controlled 1`] = `
                   </legend>
                   <Styled(BaseCheckbox)
                     checked={true}
+                    disabled={false}
                     error={false}
+                    id={null}
                     key=".0"
                     labelText="Option A"
                     name="settingSelection"
                     onChange={[Function]}
+                    required={false}
                     value="a"
                   >
                     <BaseCheckbox
@@ -2252,7 +2270,7 @@ exports[`Storyshots CheckboxGroup Controlled 1`] = `
                               >
                                 <div
                                   checked={true}
-                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                   disabled={false}
                                 />
                               </Checkbox__VisualCheckbox>
@@ -2282,11 +2300,14 @@ exports[`Storyshots CheckboxGroup Controlled 1`] = `
                   </Styled(BaseCheckbox)>
                   <Styled(BaseCheckbox)
                     checked={false}
+                    disabled={false}
                     error={false}
+                    id={null}
                     key=".1"
                     labelText="Option B"
                     name="settingSelection"
                     onChange={[Function]}
+                    required={false}
                     value="b"
                   >
                     <BaseCheckbox
@@ -2435,7 +2456,7 @@ exports[`Storyshots CheckboxGroup Controlled 1`] = `
                               >
                                 <div
                                   checked={false}
-                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                   disabled={false}
                                 />
                               </Checkbox__VisualCheckbox>
@@ -2465,11 +2486,14 @@ exports[`Storyshots CheckboxGroup Controlled 1`] = `
                   </Styled(BaseCheckbox)>
                   <Styled(BaseCheckbox)
                     checked={false}
+                    disabled={false}
                     error={false}
+                    id={null}
                     key=".2"
                     labelText="Option C"
                     name="settingSelection"
                     onChange={[Function]}
+                    required={false}
                     value="c"
                   >
                     <BaseCheckbox
@@ -2618,7 +2642,7 @@ exports[`Storyshots CheckboxGroup Controlled 1`] = `
                               >
                                 <div
                                   checked={false}
-                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                   disabled={false}
                                 />
                               </Checkbox__VisualCheckbox>
@@ -2993,9 +3017,11 @@ exports[`Storyshots CheckboxGroup Set to disabled 1`] = `
                     defaultChecked={true}
                     disabled={true}
                     error={false}
+                    id={null}
                     key=".0"
                     labelText="Option A"
                     name="settingSelection"
+                    required={false}
                     value="a"
                   >
                     <BaseCheckbox
@@ -3139,7 +3165,7 @@ exports[`Storyshots CheckboxGroup Set to disabled 1`] = `
                                 disabled={true}
                               >
                                 <div
-                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                   disabled={true}
                                 />
                               </Checkbox__VisualCheckbox>
@@ -3171,9 +3197,11 @@ exports[`Storyshots CheckboxGroup Set to disabled 1`] = `
                     defaultChecked={false}
                     disabled={true}
                     error={false}
+                    id={null}
                     key=".1"
                     labelText="Option B"
                     name="settingSelection"
+                    required={false}
                     value="b"
                   >
                     <BaseCheckbox
@@ -3317,7 +3345,7 @@ exports[`Storyshots CheckboxGroup Set to disabled 1`] = `
                                 disabled={true}
                               >
                                 <div
-                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                   disabled={true}
                                 />
                               </Checkbox__VisualCheckbox>
@@ -3349,9 +3377,11 @@ exports[`Storyshots CheckboxGroup Set to disabled 1`] = `
                     defaultChecked={false}
                     disabled={true}
                     error={false}
+                    id={null}
                     key=".2"
                     labelText="Option C"
                     name="settingSelection"
+                    required={false}
                     value="c"
                   >
                     <BaseCheckbox
@@ -3495,7 +3525,7 @@ exports[`Storyshots CheckboxGroup Set to disabled 1`] = `
                                 disabled={true}
                               >
                                 <div
-                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                   disabled={true}
                                 />
                               </Checkbox__VisualCheckbox>
@@ -3878,10 +3908,13 @@ exports[`Storyshots CheckboxGroup with error list 1`] = `
                   </legend>
                   <Styled(BaseCheckbox)
                     defaultChecked={true}
+                    disabled={false}
                     error={true}
+                    id={null}
                     key=".0"
                     labelText="Option A"
                     name="settingSelection"
+                    required={false}
                     value="a"
                   >
                     <BaseCheckbox
@@ -4025,7 +4058,7 @@ exports[`Storyshots CheckboxGroup with error list 1`] = `
                                 disabled={false}
                               >
                                 <div
-                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                   disabled={false}
                                 />
                               </Checkbox__VisualCheckbox>
@@ -4055,10 +4088,13 @@ exports[`Storyshots CheckboxGroup with error list 1`] = `
                   </Styled(BaseCheckbox)>
                   <Styled(BaseCheckbox)
                     defaultChecked={false}
+                    disabled={false}
                     error={true}
+                    id={null}
                     key=".1"
                     labelText="Option B"
                     name="settingSelection"
+                    required={false}
                     value="b"
                   >
                     <BaseCheckbox
@@ -4202,7 +4238,7 @@ exports[`Storyshots CheckboxGroup with error list 1`] = `
                                 disabled={false}
                               >
                                 <div
-                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                   disabled={false}
                                 />
                               </Checkbox__VisualCheckbox>
@@ -4232,10 +4268,13 @@ exports[`Storyshots CheckboxGroup with error list 1`] = `
                   </Styled(BaseCheckbox)>
                   <Styled(BaseCheckbox)
                     defaultChecked={false}
+                    disabled={false}
                     error={true}
+                    id={null}
                     key=".2"
                     labelText="Option C"
                     name="settingSelection"
+                    required={false}
                     value="c"
                   >
                     <BaseCheckbox
@@ -4379,7 +4418,7 @@ exports[`Storyshots CheckboxGroup with error list 1`] = `
                                 disabled={false}
                               >
                                 <div
-                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                   disabled={false}
                                 />
                               </Checkbox__VisualCheckbox>
@@ -4949,10 +4988,13 @@ exports[`Storyshots CheckboxGroup with error message 1`] = `
                   </legend>
                   <Styled(BaseCheckbox)
                     defaultChecked={true}
+                    disabled={false}
                     error={true}
+                    id={null}
                     key=".0"
                     labelText="Option A"
                     name="settingSelection"
+                    required={false}
                     value="a"
                   >
                     <BaseCheckbox
@@ -5096,7 +5138,7 @@ exports[`Storyshots CheckboxGroup with error message 1`] = `
                                 disabled={false}
                               >
                                 <div
-                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                   disabled={false}
                                 />
                               </Checkbox__VisualCheckbox>
@@ -5126,10 +5168,13 @@ exports[`Storyshots CheckboxGroup with error message 1`] = `
                   </Styled(BaseCheckbox)>
                   <Styled(BaseCheckbox)
                     defaultChecked={false}
+                    disabled={false}
                     error={true}
+                    id={null}
                     key=".1"
                     labelText="Option B"
                     name="settingSelection"
+                    required={false}
                     value="b"
                   >
                     <BaseCheckbox
@@ -5273,7 +5318,7 @@ exports[`Storyshots CheckboxGroup with error message 1`] = `
                                 disabled={false}
                               >
                                 <div
-                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                   disabled={false}
                                 />
                               </Checkbox__VisualCheckbox>
@@ -5303,10 +5348,13 @@ exports[`Storyshots CheckboxGroup with error message 1`] = `
                   </Styled(BaseCheckbox)>
                   <Styled(BaseCheckbox)
                     defaultChecked={false}
+                    disabled={false}
                     error={true}
+                    id={null}
                     key=".2"
                     labelText="Option C"
                     name="settingSelection"
+                    required={false}
                     value="c"
                   >
                     <BaseCheckbox
@@ -5450,7 +5498,7 @@ exports[`Storyshots CheckboxGroup with error message 1`] = `
                                 disabled={false}
                               >
                                 <div
-                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                  className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                   disabled={false}
                                 />
                               </Checkbox__VisualCheckbox>

--- a/components/src/Form/__snapshots__/Form.story.storyshot
+++ b/components/src/Form/__snapshots__/Form.story.storyshot
@@ -6496,10 +6496,13 @@ exports[`Storyshots Form Demo form 1`] = `
                                 </RequirementText>
                               </legend>
                               <Styled(BaseCheckbox)
+                                disabled={false}
                                 error={false}
+                                id={null}
                                 key=".0"
                                 labelText="Christiaan Oostenbrug"
                                 name="linelead"
+                                required={false}
                                 value="christiaan"
                               >
                                 <BaseCheckbox
@@ -6640,7 +6643,7 @@ exports[`Storyshots Form Demo form 1`] = `
                                             disabled={false}
                                           >
                                             <div
-                                              className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                              className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                               disabled={false}
                                             />
                                           </Checkbox__VisualCheckbox>
@@ -6669,10 +6672,13 @@ exports[`Storyshots Form Demo form 1`] = `
                                 </BaseCheckbox>
                               </Styled(BaseCheckbox)>
                               <Styled(BaseCheckbox)
+                                disabled={false}
                                 error={false}
+                                id={null}
                                 key=".1"
                                 labelText="Matt Dunn"
                                 name="linelead"
+                                required={false}
                                 value="matt"
                               >
                                 <BaseCheckbox
@@ -6813,7 +6819,7 @@ exports[`Storyshots Form Demo form 1`] = `
                                             disabled={false}
                                           >
                                             <div
-                                              className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                              className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                               disabled={false}
                                             />
                                           </Checkbox__VisualCheckbox>
@@ -6844,9 +6850,11 @@ exports[`Storyshots Form Demo form 1`] = `
                               <Styled(BaseCheckbox)
                                 disabled={true}
                                 error={false}
+                                id={null}
                                 key=".2"
                                 labelText="Clemens Park"
                                 name="linelead"
+                                required={false}
                                 value="clemens"
                               >
                                 <BaseCheckbox
@@ -6987,7 +6995,7 @@ exports[`Storyshots Form Demo form 1`] = `
                                             disabled={true}
                                           >
                                             <div
-                                              className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                              className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                               disabled={true}
                                             />
                                           </Checkbox__VisualCheckbox>
@@ -7018,9 +7026,11 @@ exports[`Storyshots Form Demo form 1`] = `
                               <Styled(BaseCheckbox)
                                 disabled={true}
                                 error={false}
+                                id={null}
                                 key=".3"
                                 labelText="Nikola Pejcic"
                                 name="linelead"
+                                required={false}
                                 value="nikola"
                               >
                                 <BaseCheckbox
@@ -7161,7 +7171,7 @@ exports[`Storyshots Form Demo form 1`] = `
                                             disabled={true}
                                           >
                                             <div
-                                              className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                              className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                               disabled={true}
                                             />
                                           </Checkbox__VisualCheckbox>

--- a/components/src/Table/__snapshots__/Table.story.storyshot
+++ b/components/src/Table/__snapshots__/Table.story.storyshot
@@ -719,7 +719,11 @@ exports[`Storyshots Table with everything 1`] = `
                                 <Styled(BaseCheckbox)
                                   aria-label="toggle all row selections"
                                   checked={false}
+                                  disabled={false}
+                                  error={false}
+                                  id={null}
                                   onChange={[Function]}
+                                  required={false}
                                 >
                                   <BaseCheckbox
                                     aria-label="toggle all row selections"
@@ -862,7 +866,7 @@ exports[`Storyshots Table with everything 1`] = `
                                             >
                                               <div
                                                 checked={false}
-                                                className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                                className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                                 disabled={false}
                                               />
                                             </Checkbox__VisualCheckbox>
@@ -1377,7 +1381,11 @@ exports[`Storyshots Table with everything 1`] = `
                                       <Styled(BaseCheckbox)
                                         aria-label="toggle row selection"
                                         checked={false}
+                                        disabled={false}
+                                        error={false}
+                                        id={null}
                                         onChange={[Function]}
+                                        required={false}
                                       >
                                         <BaseCheckbox
                                           aria-label="toggle row selection"
@@ -1520,7 +1528,7 @@ exports[`Storyshots Table with everything 1`] = `
                                                   >
                                                     <div
                                                       checked={false}
-                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                                       disabled={false}
                                                     />
                                                   </Checkbox__VisualCheckbox>
@@ -2441,7 +2449,11 @@ exports[`Storyshots Table with everything 1`] = `
                                       <Styled(BaseCheckbox)
                                         aria-label="toggle row selection"
                                         checked={false}
+                                        disabled={false}
+                                        error={false}
+                                        id={null}
                                         onChange={[Function]}
+                                        required={false}
                                       >
                                         <BaseCheckbox
                                           aria-label="toggle row selection"
@@ -2584,7 +2596,7 @@ exports[`Storyshots Table with everything 1`] = `
                                                   >
                                                     <div
                                                       checked={false}
-                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                                       disabled={false}
                                                     />
                                                   </Checkbox__VisualCheckbox>
@@ -3440,7 +3452,11 @@ exports[`Storyshots Table with everything 1`] = `
                                       <Styled(BaseCheckbox)
                                         aria-label="toggle row selection"
                                         checked={false}
+                                        disabled={false}
+                                        error={false}
+                                        id={null}
                                         onChange={[Function]}
+                                        required={false}
                                       >
                                         <BaseCheckbox
                                           aria-label="toggle row selection"
@@ -3583,7 +3599,7 @@ exports[`Storyshots Table with everything 1`] = `
                                                   >
                                                     <div
                                                       checked={false}
-                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                                       disabled={false}
                                                     />
                                                   </Checkbox__VisualCheckbox>
@@ -4442,7 +4458,11 @@ exports[`Storyshots Table with everything 1`] = `
                                       <Styled(BaseCheckbox)
                                         aria-label="toggle row selection"
                                         checked={false}
+                                        disabled={false}
+                                        error={false}
+                                        id={null}
                                         onChange={[Function]}
+                                        required={false}
                                       >
                                         <BaseCheckbox
                                           aria-label="toggle row selection"
@@ -4585,7 +4605,7 @@ exports[`Storyshots Table with everything 1`] = `
                                                   >
                                                     <div
                                                       checked={false}
-                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                                       disabled={false}
                                                     />
                                                   </Checkbox__VisualCheckbox>

--- a/components/src/Table/__snapshots__/TableWithSelectableRows.story.storyshot
+++ b/components/src/Table/__snapshots__/TableWithSelectableRows.story.storyshot
@@ -595,7 +595,11 @@ exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
                                 <Styled(BaseCheckbox)
                                   aria-label="toggle all row selections"
                                   checked={false}
+                                  disabled={false}
+                                  error={false}
+                                  id={null}
                                   onChange={[Function]}
+                                  required={false}
                                 >
                                   <BaseCheckbox
                                     aria-label="toggle all row selections"
@@ -738,7 +742,7 @@ exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
                                             >
                                               <div
                                                 checked={false}
-                                                className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                                className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                                 disabled={false}
                                               />
                                             </Checkbox__VisualCheckbox>
@@ -976,7 +980,11 @@ exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
                                       <Styled(BaseCheckbox)
                                         aria-label="toggle row selection"
                                         checked={true}
+                                        disabled={false}
+                                        error={false}
+                                        id={null}
                                         onChange={[Function]}
+                                        required={false}
                                       >
                                         <BaseCheckbox
                                           aria-label="toggle row selection"
@@ -1119,7 +1127,7 @@ exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
                                                   >
                                                     <div
                                                       checked={true}
-                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                                       disabled={false}
                                                     />
                                                   </Checkbox__VisualCheckbox>
@@ -1325,7 +1333,11 @@ exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
                                       <Styled(BaseCheckbox)
                                         aria-label="toggle row selection"
                                         checked={false}
+                                        disabled={false}
+                                        error={false}
+                                        id={null}
                                         onChange={[Function]}
+                                        required={false}
                                       >
                                         <BaseCheckbox
                                           aria-label="toggle row selection"
@@ -1468,7 +1480,7 @@ exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
                                                   >
                                                     <div
                                                       checked={false}
-                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                                       disabled={false}
                                                     />
                                                   </Checkbox__VisualCheckbox>
@@ -1674,7 +1686,11 @@ exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
                                       <Styled(BaseCheckbox)
                                         aria-label="toggle row selection"
                                         checked={false}
+                                        disabled={false}
+                                        error={false}
+                                        id={null}
                                         onChange={[Function]}
+                                        required={false}
                                       >
                                         <BaseCheckbox
                                           aria-label="toggle row selection"
@@ -1817,7 +1833,7 @@ exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
                                                   >
                                                     <div
                                                       checked={false}
-                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                                       disabled={false}
                                                     />
                                                   </Checkbox__VisualCheckbox>
@@ -2023,7 +2039,11 @@ exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
                                       <Styled(BaseCheckbox)
                                         aria-label="toggle row selection"
                                         checked={false}
+                                        disabled={false}
+                                        error={false}
+                                        id={null}
                                         onChange={[Function]}
+                                        required={false}
                                       >
                                         <BaseCheckbox
                                           aria-label="toggle row selection"
@@ -2166,7 +2186,7 @@ exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
                                                   >
                                                     <div
                                                       checked={false}
-                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                                       disabled={false}
                                                     />
                                                   </Checkbox__VisualCheckbox>
@@ -2372,7 +2392,11 @@ exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
                                       <Styled(BaseCheckbox)
                                         aria-label="toggle row selection"
                                         checked={false}
+                                        disabled={false}
+                                        error={false}
+                                        id={null}
                                         onChange={[Function]}
+                                        required={false}
                                       >
                                         <BaseCheckbox
                                           aria-label="toggle row selection"
@@ -2515,7 +2539,7 @@ exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
                                                   >
                                                     <div
                                                       checked={false}
-                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                                       disabled={false}
                                                     />
                                                   </Checkbox__VisualCheckbox>
@@ -2721,7 +2745,11 @@ exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
                                       <Styled(BaseCheckbox)
                                         aria-label="toggle row selection"
                                         checked={false}
+                                        disabled={false}
+                                        error={false}
+                                        id={null}
                                         onChange={[Function]}
+                                        required={false}
                                       >
                                         <BaseCheckbox
                                           aria-label="toggle row selection"
@@ -2864,7 +2892,7 @@ exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
                                                   >
                                                     <div
                                                       checked={false}
-                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                                       disabled={false}
                                                     />
                                                   </Checkbox__VisualCheckbox>
@@ -3070,7 +3098,11 @@ exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
                                       <Styled(BaseCheckbox)
                                         aria-label="toggle row selection"
                                         checked={false}
+                                        disabled={false}
+                                        error={false}
+                                        id={null}
                                         onChange={[Function]}
+                                        required={false}
                                       >
                                         <BaseCheckbox
                                           aria-label="toggle row selection"
@@ -3213,7 +3245,7 @@ exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
                                                   >
                                                     <div
                                                       checked={false}
-                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                                       disabled={false}
                                                     />
                                                   </Checkbox__VisualCheckbox>
@@ -3419,7 +3451,11 @@ exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
                                       <Styled(BaseCheckbox)
                                         aria-label="toggle row selection"
                                         checked={false}
+                                        disabled={false}
+                                        error={false}
+                                        id={null}
                                         onChange={[Function]}
+                                        required={false}
                                       >
                                         <BaseCheckbox
                                           aria-label="toggle row selection"
@@ -3562,7 +3598,7 @@ exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
                                                   >
                                                     <div
                                                       checked={false}
-                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                                       disabled={false}
                                                     />
                                                   </Checkbox__VisualCheckbox>
@@ -4298,7 +4334,11 @@ exports[`Storyshots Table/with selectable rows with selectable rows 1`] = `
                                 <Styled(BaseCheckbox)
                                   aria-label="toggle all row selections"
                                   checked={false}
+                                  disabled={false}
+                                  error={false}
+                                  id={null}
                                   onChange={[Function]}
+                                  required={false}
                                 >
                                   <BaseCheckbox
                                     aria-label="toggle all row selections"
@@ -4441,7 +4481,7 @@ exports[`Storyshots Table/with selectable rows with selectable rows 1`] = `
                                             >
                                               <div
                                                 checked={false}
-                                                className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                                className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                                 disabled={false}
                                               />
                                             </Checkbox__VisualCheckbox>
@@ -4679,7 +4719,11 @@ exports[`Storyshots Table/with selectable rows with selectable rows 1`] = `
                                       <Styled(BaseCheckbox)
                                         aria-label="toggle row selection"
                                         checked={false}
+                                        disabled={false}
+                                        error={false}
+                                        id={null}
                                         onChange={[Function]}
+                                        required={false}
                                       >
                                         <BaseCheckbox
                                           aria-label="toggle row selection"
@@ -4822,7 +4866,7 @@ exports[`Storyshots Table/with selectable rows with selectable rows 1`] = `
                                                   >
                                                     <div
                                                       checked={false}
-                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                                       disabled={false}
                                                     />
                                                   </Checkbox__VisualCheckbox>
@@ -5028,7 +5072,11 @@ exports[`Storyshots Table/with selectable rows with selectable rows 1`] = `
                                       <Styled(BaseCheckbox)
                                         aria-label="toggle row selection"
                                         checked={false}
+                                        disabled={false}
+                                        error={false}
+                                        id={null}
                                         onChange={[Function]}
+                                        required={false}
                                       >
                                         <BaseCheckbox
                                           aria-label="toggle row selection"
@@ -5171,7 +5219,7 @@ exports[`Storyshots Table/with selectable rows with selectable rows 1`] = `
                                                   >
                                                     <div
                                                       checked={false}
-                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                                       disabled={false}
                                                     />
                                                   </Checkbox__VisualCheckbox>
@@ -5377,7 +5425,11 @@ exports[`Storyshots Table/with selectable rows with selectable rows 1`] = `
                                       <Styled(BaseCheckbox)
                                         aria-label="toggle row selection"
                                         checked={false}
+                                        disabled={false}
+                                        error={false}
+                                        id={null}
                                         onChange={[Function]}
+                                        required={false}
                                       >
                                         <BaseCheckbox
                                           aria-label="toggle row selection"
@@ -5520,7 +5572,7 @@ exports[`Storyshots Table/with selectable rows with selectable rows 1`] = `
                                                   >
                                                     <div
                                                       checked={false}
-                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                                       disabled={false}
                                                     />
                                                   </Checkbox__VisualCheckbox>
@@ -5726,7 +5778,11 @@ exports[`Storyshots Table/with selectable rows with selectable rows 1`] = `
                                       <Styled(BaseCheckbox)
                                         aria-label="toggle row selection"
                                         checked={false}
+                                        disabled={false}
+                                        error={false}
+                                        id={null}
                                         onChange={[Function]}
+                                        required={false}
                                       >
                                         <BaseCheckbox
                                           aria-label="toggle row selection"
@@ -5869,7 +5925,7 @@ exports[`Storyshots Table/with selectable rows with selectable rows 1`] = `
                                                   >
                                                     <div
                                                       checked={false}
-                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                                       disabled={false}
                                                     />
                                                   </Checkbox__VisualCheckbox>
@@ -6075,7 +6131,11 @@ exports[`Storyshots Table/with selectable rows with selectable rows 1`] = `
                                       <Styled(BaseCheckbox)
                                         aria-label="toggle row selection"
                                         checked={false}
+                                        disabled={false}
+                                        error={false}
+                                        id={null}
                                         onChange={[Function]}
+                                        required={false}
                                       >
                                         <BaseCheckbox
                                           aria-label="toggle row selection"
@@ -6218,7 +6278,7 @@ exports[`Storyshots Table/with selectable rows with selectable rows 1`] = `
                                                   >
                                                     <div
                                                       checked={false}
-                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                                       disabled={false}
                                                     />
                                                   </Checkbox__VisualCheckbox>
@@ -6424,7 +6484,11 @@ exports[`Storyshots Table/with selectable rows with selectable rows 1`] = `
                                       <Styled(BaseCheckbox)
                                         aria-label="toggle row selection"
                                         checked={false}
+                                        disabled={false}
+                                        error={false}
+                                        id={null}
                                         onChange={[Function]}
+                                        required={false}
                                       >
                                         <BaseCheckbox
                                           aria-label="toggle row selection"
@@ -6567,7 +6631,7 @@ exports[`Storyshots Table/with selectable rows with selectable rows 1`] = `
                                                   >
                                                     <div
                                                       checked={false}
-                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                                       disabled={false}
                                                     />
                                                   </Checkbox__VisualCheckbox>
@@ -6773,7 +6837,11 @@ exports[`Storyshots Table/with selectable rows with selectable rows 1`] = `
                                       <Styled(BaseCheckbox)
                                         aria-label="toggle row selection"
                                         checked={false}
+                                        disabled={false}
+                                        error={false}
+                                        id={null}
                                         onChange={[Function]}
+                                        required={false}
                                       >
                                         <BaseCheckbox
                                           aria-label="toggle row selection"
@@ -6916,7 +6984,7 @@ exports[`Storyshots Table/with selectable rows with selectable rows 1`] = `
                                                   >
                                                     <div
                                                       checked={false}
-                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                                       disabled={false}
                                                     />
                                                   </Checkbox__VisualCheckbox>
@@ -7122,7 +7190,11 @@ exports[`Storyshots Table/with selectable rows with selectable rows 1`] = `
                                       <Styled(BaseCheckbox)
                                         aria-label="toggle row selection"
                                         checked={false}
+                                        disabled={false}
+                                        error={false}
+                                        id={null}
                                         onChange={[Function]}
+                                        required={false}
                                       >
                                         <BaseCheckbox
                                           aria-label="toggle row selection"
@@ -7265,7 +7337,7 @@ exports[`Storyshots Table/with selectable rows with selectable rows 1`] = `
                                                   >
                                                     <div
                                                       checked={false}
-                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                                      className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                                       disabled={false}
                                                     />
                                                   </Checkbox__VisualCheckbox>

--- a/components/src/pages/__snapshots__/Details.story.storyshot
+++ b/components/src/pages/__snapshots__/Details.story.storyshot
@@ -26860,10 +26860,13 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                                             </RequirementText>
                                           </legend>
                                           <Styled(BaseCheckbox)
+                                            disabled={false}
                                             error={false}
+                                            id={null}
                                             key=".0"
                                             labelText="Christiaan Oostenbrug"
                                             name="linelead"
+                                            required={false}
                                             value="christiaan"
                                           >
                                             <BaseCheckbox
@@ -27004,7 +27007,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                                                         disabled={false}
                                                       >
                                                         <div
-                                                          className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                                          className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                                           disabled={false}
                                                         />
                                                       </Checkbox__VisualCheckbox>
@@ -27033,10 +27036,13 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                                             </BaseCheckbox>
                                           </Styled(BaseCheckbox)>
                                           <Styled(BaseCheckbox)
+                                            disabled={false}
                                             error={false}
+                                            id={null}
                                             key=".1"
                                             labelText="Matt Dunn"
                                             name="linelead"
+                                            required={false}
                                             value="matt"
                                           >
                                             <BaseCheckbox
@@ -27177,7 +27183,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                                                         disabled={false}
                                                       >
                                                         <div
-                                                          className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                                          className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                                           disabled={false}
                                                         />
                                                       </Checkbox__VisualCheckbox>
@@ -27208,9 +27214,11 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                                           <Styled(BaseCheckbox)
                                             disabled={true}
                                             error={false}
+                                            id={null}
                                             key=".2"
                                             labelText="Clemens Park"
                                             name="linelead"
+                                            required={false}
                                             value="clemens"
                                           >
                                             <BaseCheckbox
@@ -27351,7 +27359,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                                                         disabled={true}
                                                       >
                                                         <div
-                                                          className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                                          className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                                           disabled={true}
                                                         />
                                                       </Checkbox__VisualCheckbox>
@@ -27382,9 +27390,11 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                                           <Styled(BaseCheckbox)
                                             disabled={true}
                                             error={false}
+                                            id={null}
                                             key=".3"
                                             labelText="Nikola Pejcic"
                                             name="linelead"
+                                            required={false}
                                             value="nikola"
                                           >
                                             <BaseCheckbox
@@ -27525,7 +27535,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                                                         disabled={true}
                                                       >
                                                         <div
-                                                          className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                                          className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                                           disabled={true}
                                                         />
                                                       </Checkbox__VisualCheckbox>

--- a/components/src/pages/__snapshots__/LoginPage.story.storyshot
+++ b/components/src/pages/__snapshots__/LoginPage.story.storyshot
@@ -10725,8 +10725,12 @@ exports[`Storyshots Pages/LoginPage with remember me 1`] = `
                           </Styled(Box)>
                         </ForwardRef>
                         <Styled(BaseCheckbox)
+                          disabled={false}
+                          error={false}
+                          id={null}
                           labelText="Remember me"
                           mb="x3"
+                          required={false}
                         >
                           <BaseCheckbox
                             className="sc-fzXfNc dmqVOD"
@@ -10862,7 +10866,7 @@ exports[`Storyshots Pages/LoginPage with remember me 1`] = `
                                       disabled={false}
                                     >
                                       <div
-                                        className="Checkbox__VisualCheckbox-sc-1nm58f1-0 hqCscW"
+                                        className="Checkbox__VisualCheckbox-sc-1nm58f1-0 eVpbJR"
                                         disabled={false}
                                       />
                                     </Checkbox__VisualCheckbox>

--- a/components/src/utils/conditionallyRequiredProp.js
+++ b/components/src/utils/conditionallyRequiredProp.js
@@ -1,0 +1,11 @@
+/* eslint-disable no-console */
+export const conditionallyRequiredProp = (propType, dependsOnPropName) => {
+  return (props, propName, componentName, ...rest) => {
+    if (props[propName] === undefined && props[dependsOnPropName] !== undefined) {
+      const message = `NDS Warning: "${propName}" prop of "${componentName}" is required when ${dependsOnPropName} prop is set`;
+      console.error(message);
+    }
+
+    return propType(props, propName, componentName, ...rest);
+  };
+};

--- a/docs/src/pages/components/checkbox.js
+++ b/docs/src/pages/components/checkbox.js
@@ -20,6 +20,17 @@ import {
 } from "../../components";
 import radioProps from "../../shared/radioProps";
 
+const checkboxProps = [
+  ...radioProps,
+  {
+    name: "indeterminate",
+    type: "boolean",
+    defaultValue: "undefined",
+    description:
+      "Displays the checkbox in an indeterminate state if checked. You must use the checkbox as a controlled input (give the checked prop a value) when using this prop"
+  }
+];
+
 export default () => (
   <Layout>
     <Helmet>
@@ -70,6 +81,16 @@ export default () => (
           }
         </Highlight>
       </Box>
+
+      <Box>
+        <SubsectionTitle>indeterminate</SubsectionTitle>
+        <Checkbox labelText="I am a checkbox" defaultChecked="true" />
+        <Highlight className="js">
+          {
+            '<Checkbox id="disabled-checkbox" labelText="I am a checkbox" defaultChecked="true"/>'
+          }
+        </Highlight>
+      </Box>
     </DocSection>
 
     <DocSection>
@@ -87,7 +108,7 @@ export default () => (
 
     <DocSection>
       <SectionTitle>Props</SectionTitle>
-      <PropsTable propsRows={radioProps} />
+      <PropsTable propsRows={checkboxProps} />
     </DocSection>
 
     <DocSection>

--- a/docs/src/pages/components/checkbox.js
+++ b/docs/src/pages/components/checkbox.js
@@ -72,7 +72,7 @@ export default () => (
         </Highlight>
       </Box>
 
-      <Box>
+      <Box mb="x6">
         <SubsectionTitle>Default Checked</SubsectionTitle>
         <Checkbox labelText="I am a checkbox" defaultChecked="true" />
         <Highlight className="js">
@@ -81,13 +81,17 @@ export default () => (
           }
         </Highlight>
       </Box>
-
-      <Box>
-        <SubsectionTitle>indeterminate</SubsectionTitle>
-        <Checkbox labelText="I am a checkbox" defaultChecked="true" />
+      <Box mb="x6">
+        <SubsectionTitle>Indeterminate</SubsectionTitle>
+        <Checkbox
+          labelText="I am an indeterminate checkbox"
+          checked
+          indeterminate
+          readOnly
+        />
         <Highlight className="js">
           {
-            '<Checkbox id="disabled-checkbox" labelText="I am a checkbox" defaultChecked="true"/>'
+            '<Checkbox labelText="I am an indeterminate checkbox" checked indeterminate />'
           }
         </Highlight>
       </Box>


### PR DESCRIPTION
## Description

Adds an indeterminate state for the checkbox.

- Setting the <checkbox indeterminate checked/> shows [-]
- when the indeterminate prop is used, the checked prop becomes required (developer must use it as a controlled component and provide whether the checkbox is checked or not and turn off the indeterminate state when it is not supposed to be displayed)
- a conditional prop-type check was added to guide the developer to set the checked value whenever using the indeterminate prop

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [x] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [x] Docs updated with correct props and examples
- [x] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
