### PR TITLE
store npm token in npmrc to pass npm auth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ addons:
   apt:
     packages:
       - libgconf-2-4
+before_deploy:
+  # create npmrc to store the token to pass npm auth
+  - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> $HOME/.npmrc 2> /dev/null
 deploy:
   provider: script
   script: yarn lerna publish --yes


### PR DESCRIPTION
## Description

NPM authentication is failing on the master builds when attempting to publish to npm. According to the demo repo, I need to add a step to store the npm token: https://github.com/geut/lerna-travis-demo

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
