### PR TITLE
chore!: readme change to bump to v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,6 @@ Designers can use the Nulogy Design System in Sketch by downloading the [Sketch 
 - [@nulogy/css on npm](https://www.npmjs.com/package/@nulogy/css)
 - [@nulogy/tokens on npm](https://www.npmjs.com/package/@nulogy/tokens)
 
-## Requests
-
-If you would like to request a specific component please fill out the trello card template on the [Component Request Board](https://trello.com/b/t2zYuzI7/nds-component-requests)
-
 ## Contributing
 
 - [CONTRIBUTING.md](https://github.com/nulogy/design-system/blob/master/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Designers can use the Nulogy Design System in Sketch by downloading the [Sketch 
 
 ## Requests
 
-- https://trello.com/b/t2zYuzI7/nds-component-requests
+If you would like to request a specific component please fill out the trello card template on the [Component Request Board](https://trello.com/b/t2zYuzI7/nds-component-requests)
 
 ## Contributing
 


### PR DESCRIPTION
Adding a change to the readme simply to bump to a major version.
"breaking change" in the body  of the commit is required to bump to the v1.0 according to https://www.conventionalcommits.org/en/v1.0.0-beta.4/

`BREAKING CHANGE: update package versions to major version`

## Description

**Include what change you're making, why, and link to any relevant JIRA issues**

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only
- [x] Version bump only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
