### PR TITLE
feat: Add shape type option to Table rows

### DIFF
--- a/components/src/Table/Table.story.js
+++ b/components/src/Table/Table.story.js
@@ -80,7 +80,8 @@ const rowDataWithEverything = [
   { date: "2019-10-22", expectedQuantity: "1,725 eaches", actualQuantity: "-", id: "r7" },
   { heading: "And Another Company", cellRenderer: sectionRow, id: "r8" },
   { date: "2019-10-23", expectedQuantity: "2,475 eaches", actualQuantity: "-", id: "r9", expandedContent },
-  { date: "2019-10-24", expectedQuantity: "2,475 eaches", actualQuantity: "-", id: "r10" }
+  { date: "2019-10-24", expectedQuantity: "2,475 eaches", actualQuantity: "-", id: "r10" },
+  { date: "2020-01-24", expectedQuantity: { value: 2475, unit: "eaches" }, id: "r11" }
 ];
 
 const footerRowData = [

--- a/components/src/Table/Table.types.js
+++ b/components/src/Table/Table.types.js
@@ -11,7 +11,7 @@ export const columnPropType = PropTypes.shape({
 });
 
 export const rowPropType = PropTypes.objectOf(
-  PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.bool, PropTypes.func])
+  PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.bool, PropTypes.func, PropTypes.shape])
 );
 
 export const columnsPropType = PropTypes.arrayOf(columnPropType);

--- a/components/src/Table/__snapshots__/Table.story.storyshot
+++ b/components/src/Table/__snapshots__/Table.story.storyshot
@@ -398,6 +398,14 @@ exports[`Storyshots Table with everything 1`] = `
                   "expectedQuantity": "2,475 eaches",
                   "id": "r10",
                 },
+                Object {
+                  "date": "2020-01-24",
+                  "expectedQuantity": Object {
+                    "unit": "eaches",
+                    "value": 2475,
+                  },
+                  "id": "r11",
+                },
               ]
             }
             rowsPerPage={5}
@@ -524,6 +532,14 @@ exports[`Storyshots Table with everything 1`] = `
                     "date": "2019-10-24",
                     "expectedQuantity": "2,475 eaches",
                     "id": "r10",
+                  },
+                  Object {
+                    "date": "2020-01-24",
+                    "expectedQuantity": Object {
+                      "unit": "eaches",
+                      "value": 2475,
+                    },
+                    "id": "r11",
                   },
                 ]
               }
@@ -5158,7 +5174,7 @@ exports[`Storyshots Table with everything 1`] = `
                 onPrevious={[Function]}
                 onSelectPage={[Function]}
                 pt="x2"
-                totalPages={2}
+                totalPages={3}
               >
                 <Styled(Box)
                   aria-label="Pagination navigation"
@@ -5344,6 +5360,24 @@ exports[`Storyshots Table with everything 1`] = `
                         onClick={[Function]}
                       >
                         2
+                      </button>
+                    </Styled(Pagination__PaginationButton)>
+                    <Styled(Pagination__PaginationButton)
+                      aria-current={false}
+                      aria-label="Go to page 3"
+                      currentPage={false}
+                      disabled={false}
+                      key="3"
+                      onClick={[Function]}
+                    >
+                      <button
+                        aria-current={false}
+                        aria-label="Go to page 3"
+                        className="Pagination__PaginationButton-sc-1fsx1pp-0 sc-fzXfNL fHUOFU"
+                        disabled={false}
+                        onClick={[Function]}
+                      >
+                        3
                       </button>
                     </Styled(Pagination__PaginationButton)>
                     <NextButton


### PR DESCRIPTION
## Description

I added 'shape' as one of the propTypes available for Table rows because when using custom cell renderer we might want a complex object in order to have more flexibility.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [x] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [x] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
