### PR TITLE
fix: allow object as row value

### DIFF
--- a/components/src/Table/Table.types.js
+++ b/components/src/Table/Table.types.js
@@ -11,7 +11,7 @@ export const columnPropType = PropTypes.shape({
 });
 
 export const rowPropType = PropTypes.objectOf(
-  PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.bool, PropTypes.func])
+  PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.bool, PropTypes.func, PropTypes.shape({})])
 );
 
 export const columnsPropType = PropTypes.arrayOf(columnPropType);


### PR DESCRIPTION
## Description

Allows an object to be passed as a row key value in response to the issue posted here: https://nu.slack.com/archives/CBAFQ4X7X/p1582560911003800

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
