### PR TITLE
fix: support numeric select values

### DIFF
--- a/components/src/Select/Select.type.js
+++ b/components/src/Select/Select.type.js
@@ -1,5 +1,12 @@
 import PropTypes from "prop-types";
 
+const valueType = PropTypes.oneOfType([
+  PropTypes.string,
+  PropTypes.number,
+  PropTypes.arrayOf(PropTypes.string),
+  PropTypes.arrayOf(PropTypes.number)
+]);
+
 export const SelectPropTypes = {
   autocomplete: PropTypes.bool,
   options: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
@@ -21,8 +28,8 @@ export const SelectPropTypes = {
   onChange: PropTypes.func,
   placeholder: PropTypes.string,
   required: PropTypes.bool,
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
-  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
+  value: valueType,
+  defaultValue: valueType,
   className: PropTypes.string,
   classNamePrefix: PropTypes.string,
   menuIsOpen: PropTypes.bool,


### PR DESCRIPTION
## Description

Nulogy Connections has been using numeric values in their Select components for months without issues. Even though it is unclear if react-select supports more than just string values, I would like to be able to continue using working software against this Select component without PropType error.

Therefore, I propose that we allow numbers to be valid values for Select options. This is implemented just as a prop type update.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
