### PR TITLE
fix: select hover bug when text overflows select due to long words

### DIFF
--- a/components/src/Select/__snapshots__/Select.story.storyshot
+++ b/components/src/Select/__snapshots__/Select.story.storyshot
@@ -184,10 +184,10 @@ exports[`Storyshots Select With wrapping text 1`] = `
             </div>
           </div>
           <div
-            class=" css-1b2mvq3-Menu"
+            class=" css-1l502d3-Menu"
           >
             <div
-              class=" css-1fewbap-MenuList"
+              class=" css-fthyjs-MenuList"
             >
               <div
                 class="SelectOption__StyledOption-sc-3ujurn-0 QKDUh"
@@ -1526,10 +1526,10 @@ exports[`Storyshots Select with an option selected 1`] = `
             </div>
           </div>
           <div
-            class=" css-1b2mvq3-Menu"
+            class=" css-1l502d3-Menu"
           >
             <div
-              class=" css-1fewbap-MenuList"
+              class=" css-fthyjs-MenuList"
             >
               <div
                 class="SelectOption__StyledOption-sc-3ujurn-0 fsUZLC"
@@ -1956,10 +1956,10 @@ exports[`Storyshots Select with error list 1`] = `
           </div>
         </div>
         <div
-          class=" css-hlqse3-Menu"
+          class=" css-6mfljk-Menu"
         >
           <div
-            class=" css-1fewbap-MenuList"
+            class=" css-fthyjs-MenuList"
           >
             <div
               class="SelectOption__StyledOption-sc-3ujurn-0 QKDUh"
@@ -2315,10 +2315,10 @@ exports[`Storyshots Select with error message 1`] = `
           </div>
         </div>
         <div
-          class=" css-hlqse3-Menu"
+          class=" css-6mfljk-Menu"
         >
           <div
-            class=" css-1fewbap-MenuList"
+            class=" css-fthyjs-MenuList"
           >
             <div
               class="SelectOption__StyledOption-sc-3ujurn-0 QKDUh"
@@ -2913,10 +2913,10 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
             </div>
           </div>
           <div
-            class=" css-1b2mvq3-Menu"
+            class=" css-1l502d3-Menu"
           >
             <div
-              class=" css-1pxmkj-MenuList"
+              class=" css-ktzzr0-MenuList"
             >
               <div
                 class="SelectOption__StyledOption-sc-3ujurn-0 fsUZLC"

--- a/components/src/Select/customReactSelectStyles.js
+++ b/components/src/Select/customReactSelectStyles.js
@@ -71,6 +71,7 @@ const customStyles = error => {
     menu: (provided, state) => ({
       marginTop: 0,
       position: "absolute",
+      overflowX: "auto",
       zIndex: "100",
       width: "100%",
       background: theme.colors.white,
@@ -89,6 +90,7 @@ const customStyles = error => {
     }),
     menuList: provided => ({
       ...provided,
+      minWidth: "fit-content",
       padding: 0,
       borderRadius: theme.radii.medium
     }),


### PR DESCRIPTION
## Description

Fixes issues documented in the comments of NDS-1344
(https://nulogy-go.atlassian.net/browse/NDS-1344)

To replicate update a Select story option with a very long word in the option label, that causes the text to overflow.

Before:
<img width="400" alt="rename" src="https://user-images.githubusercontent.com/8175052/75908795-d391df80-5e18-11ea-888c-cbee0a56bca1.png">

Padding is correct:
<img width="313" alt="padding" src="https://user-images.githubusercontent.com/8175052/75908824-e1dffb80-5e18-11ea-854a-479cbe784c50.png">

After:
<img width="297" alt="after" src="https://user-images.githubusercontent.com/8175052/75908856-ec9a9080-5e18-11ea-9321-bf5a52225648.png">




## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
