### PR TITLE
feat: add truncated text component

### DIFF
--- a/components-e2e/cypress/integration/components/TruncatedText.spec.js
+++ b/components-e2e/cypress/integration/components/TruncatedText.spec.js
@@ -1,0 +1,68 @@
+describe("TruncatedText", () => {
+  const assertNoTooltip = () => cy.get('[role="tooltip"]').should("not.exist");
+  const assertText = text => {
+    cy.get("p").should("be.visible");
+    cy.get("p").contains(text);
+  };
+  const assertTooltip = text => {
+    cy.get('[aria-haspopup="true"]').trigger("mouseover");
+    cy.get('[role="tooltip"]').should("be.visible");
+    cy.isInViewport('[role="tooltip"]');
+    cy.get('[role="tooltip"]').contains(text);
+  };
+  describe("default", () => {
+    beforeEach(() => {
+      cy.renderFromStorybook("truncatedtext--truncatedtext");
+    });
+    it("shows the truncated text", () => {
+      assertText("Special instructions...");
+    });
+    it("shows a tooltip with full content on hover", () => {
+      assertTooltip("Special instructions are provided for the shipment");
+    });
+  });
+  describe("without tooltip", () => {
+    beforeEach(() => {
+      cy.renderFromStorybook("truncatedtext--without-tooltip");
+    });
+    it("shows the truncated text", () => {
+      assertText("Special instructions...");
+    });
+    it("does not show a tooltip", () => {
+      assertNoTooltip();
+    });
+  });
+  describe("under max characters", () => {
+    beforeEach(() => {
+      cy.renderFromStorybook("truncatedtext--under-max-characters");
+    });
+    it("shows the full text", () => {
+      assertText("Item is available");
+    });
+    it("does not show a tooltip", () => {
+      assertNoTooltip();
+    });
+  });
+  describe("with max characters 10", () => {
+    beforeEach(() => {
+      cy.renderFromStorybook("truncatedtext--with-max-characters-10");
+    });
+    it("shows the truncated text", () => {
+      assertText("Item is av...");
+    });
+    it("does not show a tooltip", () => {
+      assertNoTooltip();
+    });
+  });
+  describe("default", () => {
+    beforeEach(() => {
+      cy.renderFromStorybook("truncatedtext--with-custom-truncation-indicator");
+    });
+    it("shows the truncated text", () => {
+      assertText("Special instructions + 2...");
+    });
+    it("shows a tooltip with full content on hover", () => {
+      assertTooltip("Special instructions are provided for the shipment");
+    });
+  });
+});

--- a/components-e2e/cypress/integration/components/TruncatedText.spec.js
+++ b/components-e2e/cypress/integration/components/TruncatedText.spec.js
@@ -1,8 +1,8 @@
 describe("TruncatedText", () => {
   const assertNoTooltip = () => cy.get('[role="tooltip"]').should("not.exist");
-  const assertText = text => {
-    cy.get("p").should("be.visible");
-    cy.get("p").contains(text);
+  const assertText = (text, el = "p") => {
+    cy.get(el).should("be.visible");
+    cy.get(el).contains(text);
   };
   const assertTooltip = text => {
     cy.get('[aria-haspopup="true"]').trigger("mouseover");
@@ -54,7 +54,7 @@ describe("TruncatedText", () => {
       assertNoTooltip();
     });
   });
-  describe("default", () => {
+  describe("with custom truncation indicator", () => {
     beforeEach(() => {
       cy.renderFromStorybook("truncatedtext--with-custom-truncation-indicator");
     });
@@ -63,6 +63,14 @@ describe("TruncatedText", () => {
     });
     it("shows a tooltip with full content on hover", () => {
       assertTooltip("Special instructions are provided for the shipment");
+    });
+  });
+  describe("as title", () => {
+    beforeEach(() => {
+      cy.renderFromStorybook("truncatedtext--as-title");
+    });
+    it("shows the truncated text", () => {
+      assertText("Special instructions...", "h1");
     });
   });
 });

--- a/components/src/TruncatedText/TruncatedText.js
+++ b/components/src/TruncatedText/TruncatedText.js
@@ -1,0 +1,55 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import { Tooltip } from "../Tooltip";
+import { Text } from "../Type";
+
+const StyledTruncatedText = styled(Text)(({ hoverable }) => ({
+  width: "fit-content",
+  cursor: hoverable ? "pointer" : "default"
+}));
+
+const MaybeTooltip = ({ children, showTooltip, ...props }) => {
+  return showTooltip ? <Tooltip {...props}>{children}</Tooltip> : children;
+};
+
+MaybeTooltip.propTypes = {
+  children: PropTypes.node,
+  showTooltip: PropTypes.bool
+};
+
+MaybeTooltip.defaultProps = {
+  children: undefined,
+  showTooltip: true
+};
+
+const TruncatedText = ({ children, indicator, maxCharacters, showTooltip, tooltipProps, ...props }) => {
+  const requiresTruncation = children.length > maxCharacters;
+  const truncatedText = requiresTruncation ? children.slice(0, maxCharacters) + indicator : children;
+  const hasTooltip = showTooltip && requiresTruncation;
+  return (
+    <MaybeTooltip showTooltip={hasTooltip} tooltip={children} {...tooltipProps}>
+      <StyledTruncatedText hoverable={hasTooltip} {...props}>
+        {truncatedText}
+      </StyledTruncatedText>
+    </MaybeTooltip>
+  );
+};
+
+TruncatedText.propTypes = {
+  children: PropTypes.string,
+  indicator: PropTypes.string,
+  maxCharacters: PropTypes.number,
+  showTooltip: PropTypes.bool,
+  tooltipProps: PropTypes.shape({})
+};
+
+TruncatedText.defaultProps = {
+  children: undefined,
+  indicator: "...",
+  maxCharacters: 20,
+  showTooltip: true,
+  tooltipProps: undefined
+};
+
+export default TruncatedText;

--- a/components/src/TruncatedText/TruncatedText.js
+++ b/components/src/TruncatedText/TruncatedText.js
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import { Tooltip } from "../Tooltip";
 import { Text } from "../Type";
 
-const StyledTruncatedText = styled(Text)(({ hoverable }) => ({
+const StyledWrapper = styled("div")(({ hoverable }) => ({
   width: "fit-content",
   cursor: hoverable ? "pointer" : "default"
 }));
@@ -23,15 +23,16 @@ MaybeTooltip.defaultProps = {
   showTooltip: true
 };
 
-const TruncatedText = ({ children, indicator, maxCharacters, showTooltip, tooltipProps, ...props }) => {
-  const requiresTruncation = children.length > maxCharacters;
-  const truncatedText = requiresTruncation ? children.slice(0, maxCharacters) + indicator : children;
+const TruncatedText = ({ children, element, indicator, maxCharacters, showTooltip, tooltipProps }) => {
+  const innerText = children;
+  const requiresTruncation = innerText.length > maxCharacters;
+  const truncatedText = requiresTruncation ? innerText.slice(0, maxCharacters) + indicator : children;
   const hasTooltip = showTooltip && requiresTruncation;
   return (
-    <MaybeTooltip showTooltip={hasTooltip} tooltip={children} {...tooltipProps}>
-      <StyledTruncatedText hoverable={hasTooltip} {...props}>
+    <MaybeTooltip showTooltip={hasTooltip} tooltip={innerText} {...tooltipProps}>
+      <StyledWrapper as={element.type} hoverable={hasTooltip} {...element.props}>
         {truncatedText}
-      </StyledTruncatedText>
+      </StyledWrapper>
     </MaybeTooltip>
   );
 };
@@ -39,6 +40,7 @@ const TruncatedText = ({ children, indicator, maxCharacters, showTooltip, toolti
 TruncatedText.propTypes = {
   children: PropTypes.string,
   indicator: PropTypes.string,
+  element: PropTypes.node,
   maxCharacters: PropTypes.number,
   showTooltip: PropTypes.bool,
   tooltipProps: PropTypes.shape({})
@@ -47,6 +49,7 @@ TruncatedText.propTypes = {
 TruncatedText.defaultProps = {
   children: undefined,
   indicator: "...",
+  element: <Text />,
   maxCharacters: 20,
   showTooltip: true,
   tooltipProps: undefined

--- a/components/src/TruncatedText/TruncatedText.story.js
+++ b/components/src/TruncatedText/TruncatedText.story.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
+import { Title } from "../Type";
 import { TruncatedText } from ".";
 
 storiesOf("TruncatedText", module)
@@ -11,4 +12,7 @@ storiesOf("TruncatedText", module)
   .add("with max characters 10", () => <TruncatedText maxCharacters={10}>Item is available</TruncatedText>)
   .add("with custom truncation indicator", () => (
     <TruncatedText indicator=" + 2...">Special instructions are provided for the shipment</TruncatedText>
+  ))
+  .add("as title", () => (
+    <TruncatedText element={<Title />}>Special instructions are provided for the shipment</TruncatedText>
   ));

--- a/components/src/TruncatedText/TruncatedText.story.js
+++ b/components/src/TruncatedText/TruncatedText.story.js
@@ -1,0 +1,14 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import { TruncatedText } from ".";
+
+storiesOf("TruncatedText", module)
+  .add("TruncatedText", () => <TruncatedText>Special instructions are provided for the shipment</TruncatedText>)
+  .add("without tooltip", () => (
+    <TruncatedText showTooltip={false}>Special instructions are provided for the shipment</TruncatedText>
+  ))
+  .add("under max characters", () => <TruncatedText>Item is available</TruncatedText>)
+  .add("with max characters 10", () => <TruncatedText maxCharacters={10}>Item is available</TruncatedText>)
+  .add("with custom truncation indicator", () => (
+    <TruncatedText indicator=" + 2...">Special instructions are provided for the shipment</TruncatedText>
+  ));

--- a/components/src/TruncatedText/__snapshots__/TruncatedText.story.storyshot
+++ b/components/src/TruncatedText/__snapshots__/TruncatedText.story.storyshot
@@ -1,0 +1,103 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots TruncatedText TruncatedText 1`] = `
+<div
+  style="padding:24px"
+>
+  <div
+    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+  >
+    <p
+      aria-describedby="random-id-38"
+      aria-expanded="false"
+      aria-haspopup="true"
+      aria-label="Open"
+      class="sc-AxhCb sc-fzqAbL ewHLcq"
+      color="currentColor"
+      font-size="16px"
+    >
+      Special instructions...
+    </p>
+  </div>
+</div>
+`;
+
+exports[`Storyshots TruncatedText under max characters 1`] = `
+<div
+  style="padding:24px"
+>
+  <div
+    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+  >
+    <p
+      class="sc-AxhCb sc-fzqAbL lbdOSO"
+      color="currentColor"
+      font-size="16px"
+    >
+      Item is available
+    </p>
+  </div>
+</div>
+`;
+
+exports[`Storyshots TruncatedText with custom truncation indicator 1`] = `
+<div
+  style="padding:24px"
+>
+  <div
+    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+  >
+    <p
+      aria-describedby="random-id-40"
+      aria-expanded="false"
+      aria-haspopup="true"
+      aria-label="Open"
+      class="sc-AxhCb sc-fzqAbL ewHLcq"
+      color="currentColor"
+      font-size="16px"
+    >
+      Special instructions + 2...
+    </p>
+  </div>
+</div>
+`;
+
+exports[`Storyshots TruncatedText with max characters 10 1`] = `
+<div
+  style="padding:24px"
+>
+  <div
+    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+  >
+    <p
+      aria-describedby="random-id-39"
+      aria-expanded="false"
+      aria-haspopup="true"
+      aria-label="Open"
+      class="sc-AxhCb sc-fzqAbL ewHLcq"
+      color="currentColor"
+      font-size="16px"
+    >
+      Item is av...
+    </p>
+  </div>
+</div>
+`;
+
+exports[`Storyshots TruncatedText without tooltip 1`] = `
+<div
+  style="padding:24px"
+>
+  <div
+    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+  >
+    <p
+      class="sc-AxhCb sc-fzqAbL lbdOSO"
+      color="currentColor"
+      font-size="16px"
+    >
+      Special instructions...
+    </p>
+  </div>
+</div>
+`;

--- a/components/src/TruncatedText/__snapshots__/TruncatedText.story.storyshot
+++ b/components/src/TruncatedText/__snapshots__/TruncatedText.story.storyshot
@@ -12,12 +12,34 @@ exports[`Storyshots TruncatedText TruncatedText 1`] = `
       aria-expanded="false"
       aria-haspopup="true"
       aria-label="Open"
-      class="sc-AxhCb sc-fzqAbL ewHLcq"
+      class="sc-AxhCb hpmHVQ sc-fzqAbL kjPEQA"
       color="currentColor"
       font-size="16px"
     >
       Special instructions...
     </p>
+  </div>
+</div>
+`;
+
+exports[`Storyshots TruncatedText as title 1`] = `
+<div
+  style="padding:24px"
+>
+  <div
+    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+  >
+    <h1
+      aria-describedby="random-id-41"
+      aria-expanded="false"
+      aria-haspopup="true"
+      aria-label="Open"
+      class="sc-AxhUy jXBjWt sc-fzqAbL kjPEQA"
+      font-size="46px"
+      font-weight="300"
+    >
+      Special instructions...
+    </h1>
   </div>
 </div>
 `;
@@ -30,7 +52,7 @@ exports[`Storyshots TruncatedText under max characters 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <p
-      class="sc-AxhCb sc-fzqAbL lbdOSO"
+      class="sc-AxhCb hpmHVQ sc-fzqAbL zrxPo"
       color="currentColor"
       font-size="16px"
     >
@@ -52,7 +74,7 @@ exports[`Storyshots TruncatedText with custom truncation indicator 1`] = `
       aria-expanded="false"
       aria-haspopup="true"
       aria-label="Open"
-      class="sc-AxhCb sc-fzqAbL ewHLcq"
+      class="sc-AxhCb hpmHVQ sc-fzqAbL kjPEQA"
       color="currentColor"
       font-size="16px"
     >
@@ -74,7 +96,7 @@ exports[`Storyshots TruncatedText with max characters 10 1`] = `
       aria-expanded="false"
       aria-haspopup="true"
       aria-label="Open"
-      class="sc-AxhCb sc-fzqAbL ewHLcq"
+      class="sc-AxhCb hpmHVQ sc-fzqAbL kjPEQA"
       color="currentColor"
       font-size="16px"
     >
@@ -92,7 +114,7 @@ exports[`Storyshots TruncatedText without tooltip 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <p
-      class="sc-AxhCb sc-fzqAbL lbdOSO"
+      class="sc-AxhCb hpmHVQ sc-fzqAbL zrxPo"
       color="currentColor"
       font-size="16px"
     >

--- a/components/src/TruncatedText/index.js
+++ b/components/src/TruncatedText/index.js
@@ -1,0 +1,1 @@
+export { default as TruncatedText } from "./TruncatedText";

--- a/components/src/index.js
+++ b/components/src/index.js
@@ -44,3 +44,4 @@ export { Overlay } from "./Overlay";
 export { LoadingAnimation } from "./LoadingAnimation";
 
 export { ALL_NDS_LOCALES } from "./locales.const";
+export { TruncatedText } from "./TruncatedText";

--- a/docs/src/pages/components/truncated-text.js
+++ b/docs/src/pages/components/truncated-text.js
@@ -1,0 +1,166 @@
+/* eslint-disable no-unused-vars, quotes, react/self-closing-comp */
+
+import React from "react";
+import { Helmet } from "react-helmet";
+import Highlight from "react-highlight";
+import {
+  SectionTitle,
+  Title,
+  Link,
+  ListItem,
+  List,
+  Text,
+  TruncatedText
+} from "@nulogy/components";
+import {
+  Layout,
+  Intro,
+  IntroText,
+  DocSection,
+  PropsTable
+} from "../../components";
+
+const propsRows = [
+  {
+    name: "children",
+    type: "string",
+    defaultValue: "Required",
+    description: "The content to be truncated"
+  },
+  {
+    name: "indicator",
+    type: "string",
+    defaultValue: "...",
+    description: "The text to display after content that is truncated"
+  },
+  {
+    name: "maxCharacters",
+    type: "number",
+    defaultValue: "20",
+    description: "The number of characters to display"
+  },
+  {
+    name: "showTooltip",
+    type: "boolean",
+    defaultValue: "true",
+    description: "Displays a tooltip with the full content"
+  },
+  {
+    name: "tooltipProps",
+    type: "object",
+    description: "Additional options for the tooltip, see Tooltip Props table"
+  }
+];
+
+const tooltipPropsRows = [
+  {
+    name: "tooltip",
+    type: "node",
+    defaultValue: "Required",
+    description: "The content to display inside of the tooltip."
+  },
+  {
+    name: "children",
+    type: "element",
+    defaultValue: "Required",
+    description: "Single child of tooltip must be able to accept a ref."
+  },
+  {
+    name: "maxWidth",
+    type: "string",
+    defaultValue: "24em",
+    description: "Width of the tooltip."
+  },
+  {
+    name: "placement",
+    type: "string",
+    defaultValue: "bottom",
+    description:
+      "The position of the tooltip relative to its trigger. Accepts top, top-start, top-end, bottom, bottom-end, left, left-start, left-end, right, right-start and right-end."
+  },
+  {
+    name: "showDelay",
+    type: "number|string",
+    defaultValue: "100",
+    description: "Time in seconds before the tooltip appears."
+  },
+  {
+    name: "hideDelay",
+    type: "number|string",
+    defaultValue: "350",
+    description: "Time in seconds before the tooltip disappears."
+  },
+  {
+    name: "className",
+    type: "String",
+    defaultValue: "undefined",
+    description: "className passed to the tooltip container element."
+  },
+  {
+    name: "defaultOpen",
+    type: "boolean",
+    defaultValue: "false",
+    description: "when set to true the tooltip will be open by default"
+  }
+];
+
+export default () => (
+  <Layout>
+    <Helmet>
+      <title>Truncated Text</title>
+    </Helmet>
+    <Intro>
+      <Title>Truncated Text</Title>
+      <IntroText>
+        Displays text that is truncated if it is longer than the maximum number
+        of characters. Optionally displays the full content within a tooltip
+        when the user hovers over the text.
+      </IntroText>
+    </Intro>
+
+    <DocSection>
+      <TruncatedText>
+        Special instructions are provided for the shipment
+      </TruncatedText>
+      <Highlight className="js">
+        {`<TruncatedText>Special instructions are provided for the shipment</TruncatedText>
+`}
+      </Highlight>
+    </DocSection>
+
+    <DocSection>
+      <SectionTitle>Props</SectionTitle>
+      <Text>
+        In addition to the props in the table below, props from the{" "}
+        <Link href="/components/text">Text</Link> component can also be passed
+        to TruncatedText.
+      </Text>
+      <PropsTable propsRows={propsRows} />
+    </DocSection>
+    <DocSection>
+      <SectionTitle>Tooltip Props</SectionTitle>
+      <PropsTable propsRows={tooltipPropsRows} />
+    </DocSection>
+
+    <DocSection>
+      <SectionTitle>Related components</SectionTitle>
+      <List>
+        <ListItem>
+          <Link href="/components/text">Text</Link>
+        </ListItem>
+        <ListItem>
+          <Link href="/components/tooltip">Tooltip</Link>
+        </ListItem>
+      </List>
+    </DocSection>
+
+    <DocSection>
+      <SectionTitle>Resources</SectionTitle>
+      <ListItem>
+        <Link href="https://storybook.nulogy.design/?path=/story/truncatedtext--truncatedtext">
+          View in Storybook
+        </Link>
+      </ListItem>
+    </DocSection>
+  </Layout>
+);

--- a/docs/src/pages/components/truncated-text.js
+++ b/docs/src/pages/components/truncated-text.js
@@ -55,7 +55,7 @@ const propsRows = [
   {
     name: "tooltipProps",
     type: "object",
-    description: "Additional options for the tooltip, see Tooltip Props table"
+    description: "Additional options for to be passed to the tooltip"
   }
 ];
 

--- a/docs/src/pages/components/truncated-text.js
+++ b/docs/src/pages/components/truncated-text.js
@@ -28,6 +28,13 @@ const propsRows = [
     description: "The content to be truncated"
   },
   {
+    name: "element",
+    type: "node",
+    defaultValue: "<Text />",
+    description:
+      "The element to use to wrap the truncated text. Props can be passed to this element as usual."
+  },
+  {
     name: "indicator",
     type: "string",
     defaultValue: "...",
@@ -49,58 +56,6 @@ const propsRows = [
     name: "tooltipProps",
     type: "object",
     description: "Additional options for the tooltip, see Tooltip Props table"
-  }
-];
-
-const tooltipPropsRows = [
-  {
-    name: "tooltip",
-    type: "node",
-    defaultValue: "Required",
-    description: "The content to display inside of the tooltip."
-  },
-  {
-    name: "children",
-    type: "element",
-    defaultValue: "Required",
-    description: "Single child of tooltip must be able to accept a ref."
-  },
-  {
-    name: "maxWidth",
-    type: "string",
-    defaultValue: "24em",
-    description: "Width of the tooltip."
-  },
-  {
-    name: "placement",
-    type: "string",
-    defaultValue: "bottom",
-    description:
-      "The position of the tooltip relative to its trigger. Accepts top, top-start, top-end, bottom, bottom-end, left, left-start, left-end, right, right-start and right-end."
-  },
-  {
-    name: "showDelay",
-    type: "number|string",
-    defaultValue: "100",
-    description: "Time in seconds before the tooltip appears."
-  },
-  {
-    name: "hideDelay",
-    type: "number|string",
-    defaultValue: "350",
-    description: "Time in seconds before the tooltip disappears."
-  },
-  {
-    name: "className",
-    type: "String",
-    defaultValue: "undefined",
-    description: "className passed to the tooltip container element."
-  },
-  {
-    name: "defaultOpen",
-    type: "boolean",
-    defaultValue: "false",
-    description: "when set to true the tooltip will be open by default"
   }
 ];
 
@@ -130,16 +85,14 @@ export default () => (
 
     <DocSection>
       <SectionTitle>Props</SectionTitle>
-      <Text>
-        In addition to the props in the table below, props from the{" "}
-        <Link href="/components/text">Text</Link> component can also be passed
-        to TruncatedText.
-      </Text>
       <PropsTable propsRows={propsRows} />
     </DocSection>
     <DocSection>
       <SectionTitle>Tooltip Props</SectionTitle>
-      <PropsTable propsRows={tooltipPropsRows} />
+      <Text>
+        Props from the <Link href="/components/tooltip">Tooltip</Link> component
+        can also be passed throught the tooltipProps object.
+      </Text>
     </DocSection>
 
     <DocSection>

--- a/docs/src/shared/menuData.js
+++ b/docs/src/shared/menuData.js
@@ -182,6 +182,10 @@ export const menuData = [
       {
         name: "Tooltip",
         href: "/components/tooltip"
+      },
+      {
+        name: "Truncated Text",
+        href: "/components/truncated-text"
       }
     ]
   },


### PR DESCRIPTION
## Description

Adds a TruncatedText component which truncates text when the text is longer than maxCharacters. Optionally displays a tooltip with the full text on hover. 

Currently only supports strings without nested dom nodes within it. For example, supports "some text to be truncated" but not "some text to be` <i>truncated</i>`"

<img width="340" alt="Screen Shot 2020-03-17 at 12 09 52 PM" src="https://user-images.githubusercontent.com/8175052/76876420-4a32d200-6848-11ea-974c-3d07568bc06d.png">

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [x] Storybook updated with examples of new functionality
- [x] Storybook uses variable and realistic data (ex: short and long text)
- [x] Docs updated with correct props and examples
- [x] Updated and reviewed changes to storyshots
- [x] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
  - no additional pieces to capture outside of e2e tests

- [x] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
