### PR TITLE
fix: StatusIndicator spacing and flexbox bug

### DIFF
--- a/components/src/StatusIndicator/StatusIndicator.js
+++ b/components/src/StatusIndicator/StatusIndicator.js
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import { space } from "styled-system";
+import { space, typography, flexbox } from "styled-system";
 import propTypes from "@styled-system/prop-types";
 import theme from "../theme";
 
@@ -44,27 +44,37 @@ const getStatusIndicatorColours = type => {
 const StatusIndicator = styled.p(
   {
     display: "inline-block",
-    fontSize: theme.fontSizes.smaller,
-    lineHeight: theme.lineHeights.smallerText,
     fontWeight: theme.fontWeights.bold,
     textTransform: "uppercase",
     letterSpacing: ".05em",
-    padding: `0 ${theme.space.x1}`,
-    borderRadius: theme.space.x1,
-    position: "relative",
-    top: "-2px"
+    borderRadius: theme.space.x1
   },
   space,
+  typography,
+  flexbox,
   ({ type }) => getStatusIndicatorColours(type)
 );
 
 StatusIndicator.propTypes = {
   type: PropTypes.oneOf(["neutral", "danger", "informative", "success", "warning", "quiet"]),
-  ...propTypes.space
+  ...propTypes.space,
+  ...propTypes.typography,
+  ...propTypes.flexbox
 };
 
 StatusIndicator.defaultProps = {
-  type: "neutral"
+  type: "neutral",
+  mt: "0",
+  mr: "0",
+  mb: "0",
+  ml: "0",
+  pt: "0",
+  pr: "x1",
+  pb: "0",
+  pl: "x1",
+  fontSize: "smaller",
+  lineHeight: "smallerText",
+  alignSelf: "center"
 };
 
 export default StatusIndicator;

--- a/components/src/StatusIndicator/StatusIndicator.story.js
+++ b/components/src/StatusIndicator/StatusIndicator.story.js
@@ -3,6 +3,7 @@ import { storiesOf } from "@storybook/react";
 import { StatusIndicator } from ".";
 import { Text, SectionTitle, SubsectionTitle } from "../Type";
 import { Box } from "../Box";
+import { Flex } from "../Flex";
 
 storiesOf("StatusIndicator", module)
   .add("All", () => (
@@ -36,35 +37,78 @@ storiesOf("StatusIndicator", module)
   .add("Danger", () => <StatusIndicator type="danger">Danger</StatusIndicator>)
   .add("Following text", () => (
     <>
-      <Box m="x3">
+      <Box mb="x3">
         <SectionTitle inline mr="x1">
           Label
         </SectionTitle>
         <StatusIndicator>Status</StatusIndicator>
       </Box>
-      <Box m="x3">
+      <Box mb="x3">
         <SubsectionTitle inline mr="x1">
           Label
         </SubsectionTitle>
         <StatusIndicator>Status</StatusIndicator>
       </Box>
-      <Box m="x3">
+      <Box mb="x3">
         <Text inline mr="x1">
           Label
         </Text>
         <StatusIndicator>Status</StatusIndicator>
       </Box>
-      <Box m="x3">
-        <Text fontSize="small" inline mr="x1">
+      <Box mb="x3">
+        <Text fontSize="small" lineHeight="smallTextBase" inline mr="x1">
           Label
         </Text>
         <StatusIndicator>Status</StatusIndicator>
       </Box>
-      <Box m="x3">
-        <Text fontSize="smaller" inline mr="x1">
+      <Box mb="x3">
+        <Text fontSize="smaller" lineHeight="smallerText" inline mr="x1">
           Label
         </Text>
         <StatusIndicator>Status</StatusIndicator>
       </Box>
+      <Box mb="x3">
+        <Text inline mr="x1">
+          Long label Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus in eleifend metus, in tempus
+          sapien. Morbi eget felis est. Nunc facilisis vel nisi nec ornare. Ut blandit ullamcorper enim sed fringilla.
+          Quisque malesuada pharetra tincidunt. Mauris mauris tortor, maximus vitae tempor ac, tincidunt pharetra augue.
+          In eget suscipit est. Suspendisse feugiat risus urna
+        </Text>
+        <StatusIndicator>Status</StatusIndicator>
+      </Box>
+    </>
+  ))
+  .add("Inside flex", () => (
+    <>
+      <Flex mb="x3">
+        <SectionTitle inline mr="x1" mb="0">
+          Label
+        </SectionTitle>
+        <StatusIndicator>Status</StatusIndicator>
+      </Flex>
+      <Flex mb="x3">
+        <SubsectionTitle inline mr="x1" mb="0">
+          Label
+        </SubsectionTitle>
+        <StatusIndicator>Status</StatusIndicator>
+      </Flex>
+      <Flex mb="x3">
+        <Text inline mr="x1" mb="0">
+          Label
+        </Text>
+        <StatusIndicator>Status</StatusIndicator>
+      </Flex>
+      <Flex mb="x3">
+        <Text fontSize="small" lineHeight="smallTextBase" inline mr="x1" mb="0">
+          Label
+        </Text>
+        <StatusIndicator>Status</StatusIndicator>
+      </Flex>
+      <Flex mb="x3">
+        <Text fontSize="smaller" lineHeight="smallerText" inline mr="x1" mb="0">
+          Label
+        </Text>
+        <StatusIndicator>Status</StatusIndicator>
+      </Flex>
     </>
   ));

--- a/components/src/StatusIndicator/__snapshots__/StatusIndicator.story.storyshot
+++ b/components/src/StatusIndicator/__snapshots__/StatusIndicator.story.storyshot
@@ -177,6 +177,107 @@ exports[`Storyshots StatusIndicator Informative 1`] = `
 </div>
 `;
 
+exports[`Storyshots StatusIndicator Inside flex 1`] = `
+<div
+  style="padding:24px"
+>
+  <div
+    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+  >
+    <div
+      class="Box-sc-1qu1edy-0 sc-AxjAm iVQrfK"
+    >
+      <span
+        class="sc-AxgMl fyyuUF"
+        font-size="26px"
+        font-weight="500"
+      >
+        Label
+      </span>
+      <p
+        class="StatusIndicator-t1vtrp-0 cIlGSI"
+        font-size="smaller"
+        type="neutral"
+      >
+        Status
+      </p>
+    </div>
+    <div
+      class="Box-sc-1qu1edy-0 sc-AxjAm iVQrfK"
+    >
+      <span
+        class="sc-AxheI sc-Axmtr iRBWoo"
+        font-size="20px"
+        font-weight="500"
+      >
+        Label
+      </span>
+      <p
+        class="StatusIndicator-t1vtrp-0 cIlGSI"
+        font-size="smaller"
+        type="neutral"
+      >
+        Status
+      </p>
+    </div>
+    <div
+      class="Box-sc-1qu1edy-0 sc-AxjAm iVQrfK"
+    >
+      <span
+        class="sc-AxhCb laTFNi"
+        color="currentColor"
+        font-size="16px"
+      >
+        Label
+      </span>
+      <p
+        class="StatusIndicator-t1vtrp-0 cIlGSI"
+        font-size="smaller"
+        type="neutral"
+      >
+        Status
+      </p>
+    </div>
+    <div
+      class="Box-sc-1qu1edy-0 sc-AxjAm iVQrfK"
+    >
+      <span
+        class="sc-AxhCb chBKUG"
+        color="currentColor"
+        font-size="small"
+      >
+        Label
+      </span>
+      <p
+        class="StatusIndicator-t1vtrp-0 cIlGSI"
+        font-size="smaller"
+        type="neutral"
+      >
+        Status
+      </p>
+    </div>
+    <div
+      class="Box-sc-1qu1edy-0 sc-AxjAm iVQrfK"
+    >
+      <span
+        class="sc-AxhCb hlgKbb"
+        color="currentColor"
+        font-size="smaller"
+      >
+        Label
+      </span>
+      <p
+        class="StatusIndicator-t1vtrp-0 cIlGSI"
+        font-size="smaller"
+        type="neutral"
+      >
+        Status
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots StatusIndicator Neutral 1`] = `
 <div
   style="padding:24px"

--- a/components/src/StatusIndicator/__snapshots__/StatusIndicator.story.storyshot
+++ b/components/src/StatusIndicator/__snapshots__/StatusIndicator.story.storyshot
@@ -8,37 +8,43 @@ exports[`Storyshots StatusIndicator All 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <p
-      class="StatusIndicator-t1vtrp-0 ogdeZ"
+      class="StatusIndicator-t1vtrp-0 bAmZds"
+      font-size="smaller"
       type="neutral"
     >
       Neutral
     </p>
     <p
-      class="StatusIndicator-t1vtrp-0 bpXEKd"
+      class="StatusIndicator-t1vtrp-0 dfEhGU"
+      font-size="smaller"
       type="quiet"
     >
       Quiet
     </p>
     <p
-      class="StatusIndicator-t1vtrp-0 vdLbK"
+      class="StatusIndicator-t1vtrp-0 HGpwD"
+      font-size="smaller"
       type="informative"
     >
       Informative
     </p>
     <p
-      class="StatusIndicator-t1vtrp-0 gBtuFC"
+      class="StatusIndicator-t1vtrp-0 hFgyBj"
+      font-size="smaller"
       type="success"
     >
       Success
     </p>
     <p
-      class="StatusIndicator-t1vtrp-0 jYbbBN"
+      class="StatusIndicator-t1vtrp-0 eUxftY"
+      font-size="smaller"
       type="warning"
     >
       Warning
     </p>
     <p
-      class="StatusIndicator-t1vtrp-0 eptaEq"
+      class="StatusIndicator-t1vtrp-0 eYOOcD"
+      font-size="smaller"
       type="danger"
     >
       Danger
@@ -55,7 +61,8 @@ exports[`Storyshots StatusIndicator Danger 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <p
-      class="StatusIndicator-t1vtrp-0 kEBduM"
+      class="StatusIndicator-t1vtrp-0 gbtKcH"
+      font-size="smaller"
       type="danger"
     >
       Danger
@@ -72,7 +79,7 @@ exports[`Storyshots StatusIndicator Following text 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <div
-      class="Box-sc-1qu1edy-0 bPFBWy"
+      class="Box-sc-1qu1edy-0 dgqwRo"
     >
       <span
         class="sc-AxgMl irYLZC"
@@ -82,14 +89,15 @@ exports[`Storyshots StatusIndicator Following text 1`] = `
         Label
       </span>
       <p
-        class="StatusIndicator-t1vtrp-0 ewmDkL"
+        class="StatusIndicator-t1vtrp-0 cIlGSI"
+        font-size="smaller"
         type="neutral"
       >
         Status
       </p>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 bPFBWy"
+      class="Box-sc-1qu1edy-0 dgqwRo"
     >
       <span
         class="sc-AxheI sc-Axmtr jGoQwU"
@@ -99,14 +107,15 @@ exports[`Storyshots StatusIndicator Following text 1`] = `
         Label
       </span>
       <p
-        class="StatusIndicator-t1vtrp-0 ewmDkL"
+        class="StatusIndicator-t1vtrp-0 cIlGSI"
+        font-size="smaller"
         type="neutral"
       >
         Status
       </p>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 bPFBWy"
+      class="Box-sc-1qu1edy-0 dgqwRo"
     >
       <span
         class="sc-AxhCb czaJmK"
@@ -116,41 +125,62 @@ exports[`Storyshots StatusIndicator Following text 1`] = `
         Label
       </span>
       <p
-        class="StatusIndicator-t1vtrp-0 ewmDkL"
+        class="StatusIndicator-t1vtrp-0 cIlGSI"
+        font-size="smaller"
         type="neutral"
       >
         Status
       </p>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 bPFBWy"
+      class="Box-sc-1qu1edy-0 dgqwRo"
     >
       <span
-        class="sc-AxhCb gGqpvs"
+        class="sc-AxhCb dfJiXK"
         color="currentColor"
         font-size="small"
       >
         Label
       </span>
       <p
-        class="StatusIndicator-t1vtrp-0 ewmDkL"
+        class="StatusIndicator-t1vtrp-0 cIlGSI"
+        font-size="smaller"
         type="neutral"
       >
         Status
       </p>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 bPFBWy"
+      class="Box-sc-1qu1edy-0 dgqwRo"
     >
       <span
-        class="sc-AxhCb eHrDLS"
+        class="sc-AxhCb gttWcT"
         color="currentColor"
         font-size="smaller"
       >
         Label
       </span>
       <p
-        class="StatusIndicator-t1vtrp-0 ewmDkL"
+        class="StatusIndicator-t1vtrp-0 cIlGSI"
+        font-size="smaller"
+        type="neutral"
+      >
+        Status
+      </p>
+    </div>
+    <div
+      class="Box-sc-1qu1edy-0 dgqwRo"
+    >
+      <span
+        class="sc-AxhCb czaJmK"
+        color="currentColor"
+        font-size="16px"
+      >
+        Long label Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus in eleifend metus, in tempus sapien. Morbi eget felis est. Nunc facilisis vel nisi nec ornare. Ut blandit ullamcorper enim sed fringilla. Quisque malesuada pharetra tincidunt. Mauris mauris tortor, maximus vitae tempor ac, tincidunt pharetra augue. In eget suscipit est. Suspendisse feugiat risus urna
+      </span>
+      <p
+        class="StatusIndicator-t1vtrp-0 cIlGSI"
+        font-size="smaller"
         type="neutral"
       >
         Status
@@ -168,7 +198,8 @@ exports[`Storyshots StatusIndicator Informative 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <p
-      class="StatusIndicator-t1vtrp-0 dyxeGM"
+      class="StatusIndicator-t1vtrp-0 hnuXoH"
+      font-size="smaller"
       type="informative"
     >
       Informative
@@ -286,7 +317,8 @@ exports[`Storyshots StatusIndicator Neutral 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <p
-      class="StatusIndicator-t1vtrp-0 ewmDkL"
+      class="StatusIndicator-t1vtrp-0 cIlGSI"
+      font-size="smaller"
       type="neutral"
     >
       Neutral
@@ -303,7 +335,8 @@ exports[`Storyshots StatusIndicator Quiet 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <p
-      class="StatusIndicator-t1vtrp-0 jiQOiD"
+      class="StatusIndicator-t1vtrp-0 fvoNSY"
+      font-size="smaller"
       type="quiet"
     >
       Quiet
@@ -320,7 +353,8 @@ exports[`Storyshots StatusIndicator Success 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <p
-      class="StatusIndicator-t1vtrp-0 isWGuw"
+      class="StatusIndicator-t1vtrp-0 dXWjDv"
+      font-size="smaller"
       type="success"
     >
       Success
@@ -337,7 +371,8 @@ exports[`Storyshots StatusIndicator Warning 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <p
-      class="StatusIndicator-t1vtrp-0 kuIqEL"
+      class="StatusIndicator-t1vtrp-0 hgaihM"
+      font-size="smaller"
       type="warning"
     >
       Warning

--- a/docs/src/pages/components/status-indicator.js
+++ b/docs/src/pages/components/status-indicator.js
@@ -170,7 +170,8 @@ export default () => (
       <PropsTable propsRows={propsRows} />
       <Text mt="x3">
         The StatusIndicator component has access to{" "}
-        <InlineCode>space</InlineCode> style props. See the{" "}
+        <InlineCode>space</InlineCode>, <InlineCode>typography</InlineCode>, and{" "}
+        <InlineCode>flexbox</InlineCode> style props. See the{" "}
         <Link href="/guides/style-props">style prop documentation</Link> for a
         full list of available props.
       </Text>


### PR DESCRIPTION
- The default margin was eliminated by adding default margin props
- Typography and flexbox style props were added
- StatusIndicator was made more resilient in flexbox
- Documentation was updated

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [x] Storybook updated with examples of new functionality
- [x] Storybook uses variable and realistic data (ex: short and long text)
- [x] Docs updated with correct props and examples
- [x] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [x] Tested storybook deployment preview
- [x] Tested docs deployment preview
