### PR TITLE
fix: Toggle not responding to toggle prop value

### DIFF
--- a/components/src/Form/__snapshots__/Form.story.storyshot
+++ b/components/src/Form/__snapshots__/Form.story.storyshot
@@ -747,7 +747,7 @@ exports[`Storyshots Form Demo form 1`] = `
           </div>
         </fieldset>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle-sc-1oqd206-0 lmHrFj"
+          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle__StyledToggle-sc-1oqd206-0 dyORCK"
         >
           <div
             id="Job Visibility-label"
@@ -768,6 +768,7 @@ exports[`Storyshots Form Demo form 1`] = `
                 class="ToggleButton__Switch-asgrb8-1 irhlNv"
               >
                 <input
+                  aria-invalid="false"
                   aria-labelledby="Job Visibility-label"
                   aria-required="false"
                   class="ToggleButton__ToggleInput-asgrb8-2 lcDvtB"
@@ -902,7 +903,7 @@ exports[`Storyshots Form Demo form 1`] = `
           </label>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle-sc-1oqd206-0 lmHrFj"
+          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle__StyledToggle-sc-1oqd206-0 dyORCK"
         >
           <div
             id="Reject visibility-label"
@@ -924,6 +925,7 @@ exports[`Storyshots Form Demo form 1`] = `
                 class="ToggleButton__Switch-asgrb8-1 irhlNv"
               >
                 <input
+                  aria-invalid="false"
                   aria-labelledby="Reject visibility-label"
                   aria-required="false"
                   class="ToggleButton__ToggleInput-asgrb8-2 gajnWZ"

--- a/components/src/Toggle/Toggle.js
+++ b/components/src/Toggle/Toggle.js
@@ -6,7 +6,7 @@ import { HelpText, RequirementText } from "../FieldLabel";
 import { Field } from "../Form";
 import { Text } from "../Type";
 import theme from "../theme";
-import { ClickInputLabel, omit } from "../utils";
+import { ClickInputLabel } from "../utils";
 import ToggleButton from "./ToggleButton";
 
 const labelTextStyles = {

--- a/components/src/Toggle/Toggle.js
+++ b/components/src/Toggle/Toggle.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { Box } from "../Box";
@@ -44,23 +44,15 @@ MaybeToggleTitle.defaultProps = {
 };
 
 class BaseToggle extends React.Component {
-  constructor(props) {
+  constructor() {
     super();
-    this.state = {
-      toggled: !!(props.toggled || props.defaultToggled)
-    };
-    this.handleClick = this.handleClick.bind(this);
     this.inputRef = React.createRef();
   }
 
-  handleClick(e) {
-    const { toggled } = this.props;
-    if (toggled === undefined) {
-      this.setState({
-        toggled: e.target.checked
-      });
-    }
-  }
+  handleClick = e => {
+    const { onClick } = this.props;
+    onClick(e);
+  };
 
   render() {
     const {
@@ -75,9 +67,9 @@ class BaseToggle extends React.Component {
       labelText,
       requirementText,
       helpText,
+      toggled,
       ...props
-    } = omit(this.props, "defaultToggled");
-    const { toggled } = this.state;
+    } = this.props;
     return (
       <Field className={className}>
         <MaybeToggleTitle
@@ -123,7 +115,6 @@ class BaseToggle extends React.Component {
 BaseToggle.propTypes = {
   onChange: PropTypes.func,
   toggled: PropTypes.bool,
-  defaultToggled: PropTypes.bool,
   disabled: PropTypes.bool,
   onText: PropTypes.string,
   offText: PropTypes.string,
@@ -133,13 +124,14 @@ BaseToggle.propTypes = {
   required: PropTypes.bool,
   helpText: PropTypes.node,
   labelText: PropTypes.string,
-  requirementText: PropTypes.string
+  requirementText: PropTypes.string,
+  error: PropTypes.bool,
+  onClick: PropTypes.func
 };
 
 BaseToggle.defaultProps = {
   onChange: () => {},
   toggled: undefined,
-  defaultToggled: undefined,
   disabled: false,
   onText: null,
   offText: null,
@@ -149,12 +141,48 @@ BaseToggle.defaultProps = {
   required: false,
   helpText: null,
   labelText: null,
-  requirementText: null
+  requirementText: null,
+  error: false,
+  onClick: () => {}
 };
 
-const Toggle = styled(BaseToggle)({
+const StyledToggle = styled(BaseToggle)({
   padding: `${theme.space.half} 0`,
   alignItems: "flex-start"
 });
+
+const StatefulToggle = ({ defaultToggled, onClick, ...props }) => {
+  const [toggled, setToggled] = useState(defaultToggled);
+
+  const handleClick = e => {
+    setToggled(!toggled);
+    onClick(e);
+  };
+
+  return <StyledToggle toggled={toggled} onClick={handleClick} {...props} />;
+};
+
+StatefulToggle.propTypes = {
+  defaultToggled: PropTypes.bool,
+  onClick: PropTypes.func
+};
+
+StatefulToggle.defaultProps = {
+  defaultToggled: undefined,
+  onClick: () => {}
+};
+
+const Toggle = ({ toggled, ...props }) =>
+  toggled === undefined ? <StatefulToggle {...props} /> : <StyledToggle toggled={toggled} {...props} />;
+
+Toggle.propTypes = {
+  ...StatefulToggle.propTypes,
+  ...BaseToggle.propTypes
+};
+
+Toggle.defaultProps = {
+  ...StatefulToggle.defaultProps,
+  ...BaseToggle.defaultProps
+};
 
 export default Toggle;

--- a/components/src/Toggle/Toggle.story.js
+++ b/components/src/Toggle/Toggle.story.js
@@ -1,10 +1,11 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
+import { boolean } from "@storybook/addon-knobs";
 import { Toggle } from "../index";
 
 storiesOf("Toggle", module)
-  .add("Toggle", () => <Toggle onChange={action("on change")} />)
+  .add("Toggle", () => <Toggle />)
   .add("Toggle with all props", () => (
     <Toggle
       labelText="Toggle"
@@ -48,8 +49,11 @@ storiesOf("Toggle", module)
     />
   ))
   .add("Controlled Toggle", () => (
-    <>
-      <Toggle labelText="Toggle" toggled onText="on" offText="off" onChange={action("on change")} />
-      <Toggle labelText="Toggle" toggled={false} onText="on" offText="off" onChange={action("on change")} />
-    </>
+    <Toggle
+      labelText="Controlled Toggle"
+      toggled={boolean("Toggled", false)}
+      onText="on"
+      offText="off"
+      onChange={action("on change")}
+    />
   ));

--- a/components/src/Toggle/__snapshots__/Toggle.story.storyshot
+++ b/components/src/Toggle/__snapshots__/Toggle.story.storyshot
@@ -8,10 +8,10 @@ exports[`Storyshots Toggle Controlled Toggle 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle-sc-1oqd206-0 lmHrFj"
+      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle__StyledToggle-sc-1oqd206-0 dyORCK"
     >
       <div
-        id="Toggle-label"
+        id="Controlled Toggle-label"
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
@@ -19,7 +19,7 @@ exports[`Storyshots Toggle Controlled Toggle 1`] = `
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
           >
-            Toggle
+            Controlled Toggle
           </span>
         </div>
         <div
@@ -29,50 +29,8 @@ exports[`Storyshots Toggle Controlled Toggle 1`] = `
             class="ToggleButton__Switch-asgrb8-1 irhlNv"
           >
             <input
-              aria-labelledby="Toggle-label"
-              aria-required="false"
-              checked=""
-              class="ToggleButton__ToggleInput-asgrb8-2 lcDvtB"
-              type="checkbox"
-              value="on"
-            />
-            <span
-              class="ToggleButton__Slider-asgrb8-0 bLvWmF"
-            />
-          </div>
-          <p
-            class="Text-sc-1wu7vpu-0 cOGezP"
-            color="currentColor"
-            font-size="16px"
-          >
-            on
-          </p>
-        </div>
-      </div>
-    </div>
-    <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle-sc-1oqd206-0 lmHrFj"
-    >
-      <div
-        id="Toggle-label"
-      >
-        <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
-        >
-          <span
-            style="font-size:14px;font-weight:600;line-height:1.71428571"
-          >
-            Toggle
-          </span>
-        </div>
-        <div
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
-        >
-          <div
-            class="ToggleButton__Switch-asgrb8-1 irhlNv"
-          >
-            <input
-              aria-labelledby="Toggle-label"
+              aria-invalid="false"
+              aria-labelledby="Controlled Toggle-label"
               aria-required="false"
               class="ToggleButton__ToggleInput-asgrb8-2 lcDvtB"
               type="checkbox"
@@ -104,7 +62,7 @@ exports[`Storyshots Toggle Toggle 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle-sc-1oqd206-0 lmHrFj"
+      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle__StyledToggle-sc-1oqd206-0 dyORCK"
     >
       <div
         class="ClickInputLabel-j2axnv-0 kemUmZ"
@@ -113,6 +71,7 @@ exports[`Storyshots Toggle Toggle 1`] = `
           class="ToggleButton__Switch-asgrb8-1 irhlNv"
         >
           <input
+            aria-invalid="false"
             aria-required="false"
             class="ToggleButton__ToggleInput-asgrb8-2 lcDvtB"
             type="checkbox"
@@ -136,7 +95,7 @@ exports[`Storyshots Toggle Toggle set to defaultToggled 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle-sc-1oqd206-0 lmHrFj"
+      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle__StyledToggle-sc-1oqd206-0 dyORCK"
     >
       <div
         id="Toggle-label"
@@ -157,6 +116,7 @@ exports[`Storyshots Toggle Toggle set to defaultToggled 1`] = `
             class="ToggleButton__Switch-asgrb8-1 irhlNv"
           >
             <input
+              aria-invalid="false"
               aria-labelledby="Toggle-label"
               aria-required="false"
               checked=""
@@ -183,7 +143,7 @@ exports[`Storyshots Toggle Toggle set to disabled 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle-sc-1oqd206-0 lmHrFj"
+      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle__StyledToggle-sc-1oqd206-0 dyORCK"
     >
       <div
         id="Toggle-label"
@@ -205,6 +165,7 @@ exports[`Storyshots Toggle Toggle set to disabled 1`] = `
             class="ToggleButton__Switch-asgrb8-1 irhlNv"
           >
             <input
+              aria-invalid="false"
               aria-labelledby="Toggle-label"
               aria-required="false"
               class="ToggleButton__ToggleInput-asgrb8-2 gajnWZ"
@@ -229,7 +190,7 @@ exports[`Storyshots Toggle Toggle set to disabled 1`] = `
       </div>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle-sc-1oqd206-0 lmHrFj"
+      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle__StyledToggle-sc-1oqd206-0 dyORCK"
     >
       <div
         id="Toggle-label"
@@ -251,6 +212,7 @@ exports[`Storyshots Toggle Toggle set to disabled 1`] = `
             class="ToggleButton__Switch-asgrb8-1 irhlNv"
           >
             <input
+              aria-invalid="false"
               aria-labelledby="Toggle-label"
               aria-required="false"
               checked=""
@@ -288,7 +250,7 @@ exports[`Storyshots Toggle Toggle with all props 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle-sc-1oqd206-0 lmHrFj"
+      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle__StyledToggle-sc-1oqd206-0 dyORCK"
     >
       <div
         id="Toggle-label"
@@ -323,6 +285,7 @@ exports[`Storyshots Toggle Toggle with all props 1`] = `
             class="ToggleButton__Switch-asgrb8-1 irhlNv"
           >
             <input
+              aria-invalid="false"
               aria-labelledby="Toggle-label"
               aria-required="true"
               checked=""
@@ -357,7 +320,7 @@ exports[`Storyshots Toggle With custom id 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle-sc-1oqd206-0 lmHrFj"
+      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle__StyledToggle-sc-1oqd206-0 dyORCK"
     >
       <div
         id="Toggle-label"
@@ -378,6 +341,7 @@ exports[`Storyshots Toggle With custom id 1`] = `
             class="ToggleButton__Switch-asgrb8-1 irhlNv"
           >
             <input
+              aria-invalid="false"
               aria-labelledby="Toggle-label"
               aria-required="false"
               class="ToggleButton__ToggleInput-asgrb8-2 lcDvtB"
@@ -411,7 +375,7 @@ exports[`Storyshots Toggle With long text 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle-sc-1oqd206-0 lmHrFj"
+      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle__StyledToggle-sc-1oqd206-0 dyORCK"
     >
       <div
         id="Toggle-label"
@@ -432,6 +396,7 @@ exports[`Storyshots Toggle With long text 1`] = `
             class="ToggleButton__Switch-asgrb8-1 irhlNv"
           >
             <input
+              aria-invalid="false"
               aria-labelledby="Toggle-label"
               aria-required="false"
               checked=""
@@ -465,7 +430,7 @@ exports[`Storyshots Toggle With text 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle-sc-1oqd206-0 lmHrFj"
+      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle__StyledToggle-sc-1oqd206-0 dyORCK"
     >
       <div
         id="Toggle-label"
@@ -486,6 +451,7 @@ exports[`Storyshots Toggle With text 1`] = `
             class="ToggleButton__Switch-asgrb8-1 irhlNv"
           >
             <input
+              aria-invalid="false"
               aria-labelledby="Toggle-label"
               aria-required="false"
               class="ToggleButton__ToggleInput-asgrb8-2 lcDvtB"

--- a/components/src/pages/__snapshots__/Details.story.storyshot
+++ b/components/src/pages/__snapshots__/Details.story.storyshot
@@ -3109,7 +3109,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 </div>
               </fieldset>
               <div
-                class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle-sc-1oqd206-0 lmHrFj"
+                class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle__StyledToggle-sc-1oqd206-0 dyORCK"
               >
                 <div
                   id="Job Visibility-label"
@@ -3130,6 +3130,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                       class="ToggleButton__Switch-asgrb8-1 irhlNv"
                     >
                       <input
+                        aria-invalid="false"
                         aria-labelledby="Job Visibility-label"
                         aria-required="false"
                         class="ToggleButton__ToggleInput-asgrb8-2 lcDvtB"
@@ -3264,7 +3265,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 </label>
               </div>
               <div
-                class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle-sc-1oqd206-0 lmHrFj"
+                class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle__StyledToggle-sc-1oqd206-0 dyORCK"
               >
                 <div
                   id="Reject visibility-label"
@@ -3286,6 +3287,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                       class="ToggleButton__Switch-asgrb8-1 irhlNv"
                     >
                       <input
+                        aria-invalid="false"
                         aria-labelledby="Reject visibility-label"
                         aria-required="false"
                         class="ToggleButton__ToggleInput-asgrb8-2 gajnWZ"

--- a/docs/src/pages/components/toggle.js
+++ b/docs/src/pages/components/toggle.js
@@ -73,14 +73,14 @@ const togglePropsRows = [
     name: "toggled",
     type: "Boolean",
     defaultValue: "undefined",
-    description: "State of the toggle, use to control the toggle component."
+    description: "The value of the toggle when using as a controlled component."
   },
   {
     name: "onChange",
     type: "Function",
     defaultValue: "null",
     description:
-      "Function that triggers when toggle is clicked, used to control component."
+      "Function that triggers when toggle is clicked, use with the toggled prop for a controlled component."
   },
   {
     name: "required",


### PR DESCRIPTION
## Description

Toggle component did not respond to toggle prop value changes due to them being overridden by the internal state of the component.
This fixes that issue and simplifies the implementation by separating the stateful uncontrolled version of the component from the controlled component. If the toggled prop is provided the consumer gets a simple controlled version of the component without any internal state.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [x] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
