### PR TITLE
feat!: scope css body classes to a container

### DIFF
--- a/css/.storybook/preview.js
+++ b/css/.storybook/preview.js
@@ -10,4 +10,6 @@ addParameters({
   }
 });
 
-addDecorator(story => `<div style="padding:24px;">${story()}</div>`);
+addDecorator(
+  story => `<div class="nds" style="padding: 16px;">${story()}</div>`
+);

--- a/css/src/nds.css
+++ b/css/src/nds.css
@@ -2,27 +2,19 @@
 /* -----------------------------------------
     ## Default styles
 ----------------------------------------- */
-html,
-body {
-  margin: 0;
+.nds {
   -webkit-font-smoothing: antialiased;
-}
-
-* {
-  box-sizing: border-box;
-}
-
-body {
   color: #011e38;
   font-family: "IBM Plex Sans", sans-serif;
   line-height: 1.5;
 }
-
-code {
+.nds * {
+  box-sizing: border-box;
+}
+.nds code {
   font-family: "IBM Plex Mono", monospace;
 }
-
-img {
+.nds img {
   max-width: 100%;
   height: auto;
   display: block;

--- a/css/src/pages/error.css
+++ b/css/src/pages/error.css
@@ -2,27 +2,19 @@
 /* -----------------------------------------
     ## Default styles
 ----------------------------------------- */
-html,
-body {
-  margin: 0;
+.nds {
   -webkit-font-smoothing: antialiased;
-}
-
-* {
-  box-sizing: border-box;
-}
-
-body {
   color: #011e38;
   font-family: "IBM Plex Sans", sans-serif;
   line-height: 1.5;
 }
-
-code {
+.nds * {
+  box-sizing: border-box;
+}
+.nds code {
   font-family: "IBM Plex Mono", monospace;
 }
-
-img {
+.nds img {
   max-width: 100%;
   height: auto;
   display: block;

--- a/css/src/scss/_defaults.scss
+++ b/css/src/scss/_defaults.scss
@@ -2,28 +2,24 @@
     ## Default styles
 ----------------------------------------- */
 
-html,
-body {
-  margin: 0;
+.nds {
   -webkit-font-smoothing: antialiased;
-}
 
-* {
-  box-sizing: border-box;
-}
-
-body {
   color: $color-base-black;
   font-family: $font-family-base;
   line-height: $line-height-base;
-}
 
-code {
-  font-family: $font-family-mono;
-}
+  * {
+    box-sizing: border-box;
+  }
 
-img {
-  max-width: 100%;
-  height: auto;
-  display: block;
+  code {
+    font-family: $font-family-mono;
+  }
+
+  img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+  }
 }


### PR DESCRIPTION
## Description

This moves default classes into a class called `.nds` to prevent style collisions when used on a page with mixed styles. It also removes the body margin reset, and reduces the padding on our storybook to compensate. 

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
