### PR TITLE
feat: add iconic button component

### DIFF
--- a/css/.storybook/preview.js
+++ b/css/.storybook/preview.js
@@ -11,5 +11,8 @@ addParameters({
 });
 
 addDecorator(
-  story => `<div class="nds" style="padding: 16px;">${story()}</div>`
+  story => `
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      rel="stylesheet">
+  <div class="nds" style="padding: 16px;">${story()}</div>`
 );

--- a/css/src/scss/_defaults.scss
+++ b/css/src/scss/_defaults.scss
@@ -13,6 +13,10 @@
     box-sizing: border-box;
   }
 
+  button {
+    font-family: $font-family-base;
+  }
+
   code {
     font-family: $font-family-mono;
   }

--- a/css/src/scss/components/_iconic-button.scss
+++ b/css/src/scss/components/_iconic-button.scss
@@ -1,0 +1,36 @@
+/* -----------------------------------------
+    ## Iconic Button
+----------------------------------------- */
+
+.IconicButton {
+  display: inline-flex;
+  border: none;
+  justify-content: center;
+  align-items: center;
+  outline: none;
+  cursor: pointer;
+  &:focus i {
+    box-shadow: $shadow-focus;
+  }
+  &:hover i {
+    background: $color-base-light-blue;
+  }
+  &:active i {
+    transform: scale(0.875);
+    transition: 0.2s ease-in;
+  }
+  i {
+    width: 32px;
+    height: 32px;
+    transition: 0.2s;
+    border-radius: 50%;
+    color: $color-base-dark-blue;
+    padding: $size-base-half 0;
+  }
+  &__text {
+    color: $color-base-dark-blue;
+    font-size: $size-font-base;
+    font-weight: $weight-font-medium;
+    margin: 0 $size-base-half;
+  }
+}

--- a/css/src/scss/components/_iconic-button.scss
+++ b/css/src/scss/components/_iconic-button.scss
@@ -9,17 +9,17 @@
   align-items: center;
   outline: none;
   cursor: pointer;
-  &:focus i {
+  &:focus &__icon {
     box-shadow: $shadow-focus;
   }
-  &:hover i {
+  &:hover &__icon {
     background: $color-base-light-blue;
   }
-  &:active i {
+  &:active &__icon {
     transform: scale(0.875);
     transition: 0.2s ease-in;
   }
-  i {
+  &__icon {
     width: 32px;
     height: 32px;
     transition: 0.2s;

--- a/css/src/scss/components/_iconic-button.story.js
+++ b/css/src/scss/components/_iconic-button.story.js
@@ -5,11 +5,11 @@ storiesOf("Components|Iconic Button", module).add(
   "Iconic Button",
   () => `
     <button class="IconicButton">
-      <i class="material-icons">delete</i>
+      <i class="IconicButton__icon material-icons">delete</i>
     </button>
     <br/>
     <button class="IconicButton">
-      <i class="material-icons">delete</i>
+      <i class="IconicButton__icon material-icons">delete</i>
       <p class="IconicButton__text">Delete</p>
     </button>
 `

--- a/css/src/scss/components/_iconic-button.story.js
+++ b/css/src/scss/components/_iconic-button.story.js
@@ -1,0 +1,16 @@
+/* global document */
+import { storiesOf } from "@storybook/html";
+
+storiesOf("Components|Iconic Button", module).add(
+  "Iconic Button",
+  () => `
+    <button class="IconicButton">
+      <i class="material-icons">delete</i>
+    </button>
+    <br/>
+    <button class="IconicButton">
+      <i class="material-icons">delete</i>
+      <p class="IconicButton__text">Delete</p>
+    </button>
+`
+);

--- a/css/src/scss/nds.scss
+++ b/css/src/scss/nds.scss
@@ -20,6 +20,7 @@ $namespace: ".nds-";
 @import "components/card";
 @import "components/checkbox";
 @import "components/form";
+@import "components/iconic-button";
 @import "components/link";
 @import "components/list";
 @import "components/pagination";


### PR DESCRIPTION
## Description

Add iconic button. For the story examples, the material icon font is loaded instead of svg's to avoid needing to set up an assets folder.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
