### PR TITLE
feat: Select supports thousands of options without major performance issues

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -107,7 +107,7 @@
     "react-modal": "^3.10.1",
     "react-popper": "^1.3.3",
     "react-resize-detector": "^4.2.0",
-    "react-select": "^3.0.4",
+    "react-windowed-select": "^2.0.2",
     "smoothscroll-polyfill": "^0.4.4",
     "styled-components": "^5.0.0",
     "styled-system": "^5.1.4",

--- a/components/src/LoadingAnimation/LoadingAnimation.story.js
+++ b/components/src/LoadingAnimation/LoadingAnimation.story.js
@@ -20,10 +20,8 @@ storiesOf("LoadingAnimation", module)
         </Text>
       </Flex>
       <Flex justifyContent="center" mb="x1">
-        <ControlIcon icon="refresh" disabled mr="x1">
-          Retry
-        </ControlIcon>
-        <ControlIcon icon="close">Abort</ControlIcon>
+        <ControlIcon icon="refresh" disabled mr="x1" label="Retry" />
+        <ControlIcon icon="close" label="Abort" />
       </Flex>
     </Overlay>
   ))
@@ -44,10 +42,8 @@ storiesOf("LoadingAnimation", module)
         This action takes longer than expected. Try again...
       </Alert>
       <Flex justifyContent="center" mb="x1">
-        <ControlIcon icon="refresh" mr="x1">
-          Retry
-        </ControlIcon>
-        <ControlIcon icon="close">Abort</ControlIcon>
+        <ControlIcon icon="refresh" mr="x1" label="Retry" />
+        <ControlIcon icon="close" label="Abort" />
       </Flex>
     </Overlay>
   ));

--- a/components/src/LoadingAnimation/__snapshots__/LoadingAnimation.story.storyshot
+++ b/components/src/LoadingAnimation/__snapshots__/LoadingAnimation.story.storyshot
@@ -500,6 +500,7 @@ exports[`Storyshots LoadingAnimation Page example - active 1`] = `
         class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 eRyacc"
       >
         <button
+          aria-label="Retry"
           class="ControlIcon__StyledButton-sc-1h83lvi-0 jupSnY"
           disabled=""
         >
@@ -520,6 +521,7 @@ exports[`Storyshots LoadingAnimation Page example - active 1`] = `
           </svg>
         </button>
         <button
+          aria-label="Abort"
           class="ControlIcon__StyledButton-sc-1h83lvi-0 cCdEvo"
         >
           <svg
@@ -738,6 +740,7 @@ exports[`Storyshots LoadingAnimation Page example - inactive 1`] = `
         class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 eRyacc"
       >
         <button
+          aria-label="Retry"
           class="ControlIcon__StyledButton-sc-1h83lvi-0 jlPgHC"
         >
           <svg
@@ -757,6 +760,7 @@ exports[`Storyshots LoadingAnimation Page example - inactive 1`] = `
           </svg>
         </button>
         <button
+          aria-label="Abort"
           class="ControlIcon__StyledButton-sc-1h83lvi-0 cCdEvo"
         >
           <svg

--- a/components/src/Select/Select.js
+++ b/components/src/Select/Select.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Select, { components as selectComponents } from "react-select";
+import WindowedSelect, { components as selectComponents } from "react-windowed-select";
 import { useTranslation } from "react-i18next";
 import { Field } from "../Form";
 import { MaybeFieldLabel } from "../FieldLabel";
@@ -7,6 +7,8 @@ import { InlineValidation } from "../Validation";
 import customStyles from "./customReactSelectStyles";
 import { SelectPropTypes, SelectDefaultProps } from "./Select.type";
 import SelectOption from "./SelectOption";
+
+const WINDOW_THRESHOLD = 100; // number of options beyond which the menu will be windowed
 
 const Control = props => {
   // eslint-disable-next-line react/prop-types
@@ -118,20 +120,20 @@ const ReactSelect = ({
   return (
     <Field>
       <MaybeFieldLabel labelText={labelText} requirementText={requirementText} helpText={helpText}>
-        <Select
+        <WindowedSelect
           className={className}
           classNamePrefix={classNamePrefix}
           noOptionsMessage={noOptionsMessage}
           placeholder={placeholder || t("select ...")}
           options={options}
           labelText={labelText}
-          styles={customStyles(error)}
+          windowThreshold={WINDOW_THRESHOLD}
+          styles={customStyles({ error, maxHeight, windowed: options.length > WINDOW_THRESHOLD })}
           isDisabled={disabled}
           isSearchable={autocomplete}
           aria-required={required}
           aria-invalid={error}
           defaultMenuIsOpen={initialIsOpen}
-          maxMenuHeight={maxHeight}
           inputId={id}
           onBlur={onBlur}
           onChange={onChange && (option => onChange(extractValue(option, multiselect)))}

--- a/components/src/Select/Select.story.js
+++ b/components/src/Select/Select.story.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { useEffect, useState } from "react";
 import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
@@ -39,10 +40,10 @@ const wrappingOptions = [
   }
 ];
 
-const SelectWithManyOptions = () => {
+const SelectWithManyOptions = ({ multiselect, labelText }) => {
   const [photoList, setPhotoList] = useState([]);
-  const [selectedValue, setSelectedValue] = useState(undefined);
   const getPhotos = async () => {
+    // returns 5000 items
     const data = await fetch("https://jsonplaceholder.typicode.com/photos");
     const json = await data.json();
     const results = json.map(({ title, id }) => ({
@@ -55,15 +56,10 @@ const SelectWithManyOptions = () => {
     const result = await getPhotos();
     setPhotoList(result);
   };
-  const handleChange = value => {
-    setSelectedValue(value);
-  };
   useEffect(() => {
     setOptions();
   }, []);
-  return (
-    <Select options={photoList} onChange={handleChange} value={selectedValue} labelText="Select from many options:" />
-  );
+  return <Select multiselect={multiselect} options={photoList} labelText={labelText} />;
 };
 
 class SelectWithState extends React.Component {
@@ -367,4 +363,9 @@ storiesOf("Select", module)
       </Box>
     </>
   ))
-  .add("with many options (SkipStoryshot)", () => <SelectWithManyOptions />);
+  .add("with many options (SkipStoryshot)", () => (
+    <>
+      <SelectWithManyOptions labelText="Select from many options:" />
+      <SelectWithManyOptions multiselect labelText="Multiselect many options:" />
+    </>
+  ));

--- a/components/src/Select/Select.story.js
+++ b/components/src/Select/Select.story.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import { Button, Input, PrimaryButton, Select } from "../index";
@@ -38,6 +38,33 @@ const wrappingOptions = [
       "Many words many words many words many words many words many words many words many words many words many words many words many words many words"
   }
 ];
+
+const SelectWithManyOptions = () => {
+  const [photoList, setPhotoList] = useState([]);
+  const [selectedValue, setSelectedValue] = useState(undefined);
+  const getPhotos = async () => {
+    const data = await fetch("https://jsonplaceholder.typicode.com/photos");
+    const json = await data.json();
+    const results = json.map(({ title, id }) => ({
+      label: title,
+      value: id
+    }));
+    return results;
+  };
+  const setOptions = async () => {
+    const result = await getPhotos();
+    setPhotoList(result);
+  };
+  const handleChange = value => {
+    setSelectedValue(value);
+  };
+  useEffect(() => {
+    setOptions();
+  }, []);
+  return (
+    <Select options={photoList} onChange={handleChange} value={selectedValue} labelText="Select from many options:" />
+  );
+};
 
 class SelectWithState extends React.Component {
   constructor(props) {
@@ -339,4 +366,5 @@ storiesOf("Select", module)
         />
       </Box>
     </>
-  ));
+  ))
+  .add("with many options (SkipStoryshot)", () => <SelectWithManyOptions />);

--- a/components/src/Select/SelectOption.js
+++ b/components/src/Select/SelectOption.js
@@ -1,6 +1,6 @@
 import React from "react";
 import styled from "styled-components";
-import { components } from "react-select";
+import { components } from "react-windowed-select";
 
 import theme from "../theme";
 import { subPx } from "../utils";

--- a/components/src/Select/__snapshots__/Select.story.storyshot
+++ b/components/src/Select/__snapshots__/Select.story.storyshot
@@ -213,7 +213,7 @@ exports[`Storyshots Select With wrapping text 1`] = `
                 class=" css-1l502d3-Menu"
               >
                 <div
-                  class=" css-fthyjs-MenuList"
+                  class=" css-famnlw-MenuList"
                 >
                   <div
                     class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
@@ -224,7 +224,7 @@ exports[`Storyshots Select With wrapping text 1`] = `
                     value="onestring"
                   >
                     <div
-                      class=" css-o8533i-Option"
+                      class=" css-5aymxm-Option"
                       id="react-select-24-option-0"
                       tabindex="-1"
                     >
@@ -240,7 +240,7 @@ exports[`Storyshots Select With wrapping text 1`] = `
                     value="manywords"
                   >
                     <div
-                      class=" css-o8533i-Option"
+                      class=" css-5aymxm-Option"
                       id="react-select-24-option-1"
                       tabindex="-1"
                     >
@@ -1745,7 +1745,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                 class=" css-1l502d3-Menu"
               >
                 <div
-                  class=" css-fthyjs-MenuList"
+                  class=" css-famnlw-MenuList"
                 >
                   <div
                     class="SelectOption__StyledOption-sc-3ujurn-0 cOCUoo"
@@ -1756,7 +1756,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                     value="accepted"
                   >
                     <div
-                      class=" css-o8533i-Option"
+                      class=" css-5aymxm-Option"
                       id="react-select-13-option-0"
                       tabindex="-1"
                     >
@@ -1772,7 +1772,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                     value="assigned"
                   >
                     <div
-                      class=" css-o8533i-Option"
+                      class=" css-5aymxm-Option"
                       id="react-select-13-option-1"
                       tabindex="-1"
                     >
@@ -1788,7 +1788,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                     value="hold"
                   >
                     <div
-                      class=" css-o8533i-Option"
+                      class=" css-5aymxm-Option"
                       id="react-select-13-option-2"
                       tabindex="-1"
                     >
@@ -1804,7 +1804,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                     value="rejected"
                   >
                     <div
-                      class=" css-o8533i-Option"
+                      class=" css-5aymxm-Option"
                       id="react-select-13-option-3"
                       tabindex="-1"
                     >
@@ -1820,7 +1820,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                     value="open"
                   >
                     <div
-                      class=" css-o8533i-Option"
+                      class=" css-5aymxm-Option"
                       id="react-select-13-option-4"
                       tabindex="-1"
                     >
@@ -1836,7 +1836,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                     value="progress"
                   >
                     <div
-                      class=" css-o8533i-Option"
+                      class=" css-5aymxm-Option"
                       id="react-select-13-option-5"
                       tabindex="-1"
                     >
@@ -1852,7 +1852,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                     value="quarantine"
                   >
                     <div
-                      class=" css-o8533i-Option"
+                      class=" css-5aymxm-Option"
                       id="react-select-13-option-6"
                       tabindex="-1"
                     >
@@ -2222,7 +2222,7 @@ exports[`Storyshots Select with error list 1`] = `
               class=" css-6mfljk-Menu"
             >
               <div
-                class=" css-fthyjs-MenuList"
+                class=" css-famnlw-MenuList"
               >
                 <div
                   class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
@@ -2233,7 +2233,7 @@ exports[`Storyshots Select with error list 1`] = `
                   value="accepted"
                 >
                   <div
-                    class=" css-o8533i-Option"
+                    class=" css-5aymxm-Option"
                     id="react-select-19-option-0"
                     tabindex="-1"
                   >
@@ -2249,7 +2249,7 @@ exports[`Storyshots Select with error list 1`] = `
                   value="assigned"
                 >
                   <div
-                    class=" css-o8533i-Option"
+                    class=" css-5aymxm-Option"
                     id="react-select-19-option-1"
                     tabindex="-1"
                   >
@@ -2265,7 +2265,7 @@ exports[`Storyshots Select with error list 1`] = `
                   value="hold"
                 >
                   <div
-                    class=" css-o8533i-Option"
+                    class=" css-5aymxm-Option"
                     id="react-select-19-option-2"
                     tabindex="-1"
                   >
@@ -2281,7 +2281,7 @@ exports[`Storyshots Select with error list 1`] = `
                   value="rejected"
                 >
                   <div
-                    class=" css-o8533i-Option"
+                    class=" css-5aymxm-Option"
                     id="react-select-19-option-3"
                     tabindex="-1"
                   >
@@ -2297,7 +2297,7 @@ exports[`Storyshots Select with error list 1`] = `
                   value="open"
                 >
                   <div
-                    class=" css-o8533i-Option"
+                    class=" css-5aymxm-Option"
                     id="react-select-19-option-4"
                     tabindex="-1"
                   >
@@ -2313,7 +2313,7 @@ exports[`Storyshots Select with error list 1`] = `
                   value="progress"
                 >
                   <div
-                    class=" css-o8533i-Option"
+                    class=" css-5aymxm-Option"
                     id="react-select-19-option-5"
                     tabindex="-1"
                   >
@@ -2329,7 +2329,7 @@ exports[`Storyshots Select with error list 1`] = `
                   value="quarantine"
                 >
                   <div
-                    class=" css-o8533i-Option"
+                    class=" css-5aymxm-Option"
                     id="react-select-19-option-6"
                     tabindex="-1"
                   >
@@ -2616,7 +2616,7 @@ exports[`Storyshots Select with error message 1`] = `
               class=" css-6mfljk-Menu"
             >
               <div
-                class=" css-fthyjs-MenuList"
+                class=" css-famnlw-MenuList"
               >
                 <div
                   class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
@@ -2627,7 +2627,7 @@ exports[`Storyshots Select with error message 1`] = `
                   value="accepted"
                 >
                   <div
-                    class=" css-o8533i-Option"
+                    class=" css-5aymxm-Option"
                     id="react-select-17-option-0"
                     tabindex="-1"
                   >
@@ -2643,7 +2643,7 @@ exports[`Storyshots Select with error message 1`] = `
                   value="assigned"
                 >
                   <div
-                    class=" css-o8533i-Option"
+                    class=" css-5aymxm-Option"
                     id="react-select-17-option-1"
                     tabindex="-1"
                   >
@@ -2659,7 +2659,7 @@ exports[`Storyshots Select with error message 1`] = `
                   value="hold"
                 >
                   <div
-                    class=" css-o8533i-Option"
+                    class=" css-5aymxm-Option"
                     id="react-select-17-option-2"
                     tabindex="-1"
                   >
@@ -2675,7 +2675,7 @@ exports[`Storyshots Select with error message 1`] = `
                   value="rejected"
                 >
                   <div
-                    class=" css-o8533i-Option"
+                    class=" css-5aymxm-Option"
                     id="react-select-17-option-3"
                     tabindex="-1"
                   >
@@ -2691,7 +2691,7 @@ exports[`Storyshots Select with error message 1`] = `
                   value="open"
                 >
                   <div
-                    class=" css-o8533i-Option"
+                    class=" css-5aymxm-Option"
                     id="react-select-17-option-4"
                     tabindex="-1"
                   >
@@ -2707,7 +2707,7 @@ exports[`Storyshots Select with error message 1`] = `
                   value="progress"
                 >
                   <div
-                    class=" css-o8533i-Option"
+                    class=" css-5aymxm-Option"
                     id="react-select-17-option-5"
                     tabindex="-1"
                   >
@@ -2723,7 +2723,7 @@ exports[`Storyshots Select with error message 1`] = `
                   value="quarantine"
                 >
                   <div
-                    class=" css-o8533i-Option"
+                    class=" css-5aymxm-Option"
                     id="react-select-17-option-6"
                     tabindex="-1"
                   >
@@ -3285,7 +3285,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                 class=" css-1l502d3-Menu"
               >
                 <div
-                  class=" css-ktzzr0-MenuList"
+                  class=" css-1hz449x-MenuList"
                 >
                   <div
                     class="SelectOption__StyledOption-sc-3ujurn-0 cOCUoo"
@@ -3296,7 +3296,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                     value="accepted"
                   >
                     <div
-                      class=" css-o8533i-Option"
+                      class=" css-5aymxm-Option"
                       id="react-select-23-option-0"
                       tabindex="-1"
                     >
@@ -3312,7 +3312,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                     value="assigned"
                   >
                     <div
-                      class=" css-o8533i-Option"
+                      class=" css-5aymxm-Option"
                       id="react-select-23-option-1"
                       tabindex="-1"
                     >
@@ -3328,7 +3328,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                     value="hold"
                   >
                     <div
-                      class=" css-o8533i-Option"
+                      class=" css-5aymxm-Option"
                       id="react-select-23-option-2"
                       tabindex="-1"
                     >
@@ -3344,7 +3344,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                     value="rejected"
                   >
                     <div
-                      class=" css-o8533i-Option"
+                      class=" css-5aymxm-Option"
                       id="react-select-23-option-3"
                       tabindex="-1"
                     >
@@ -3360,7 +3360,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                     value="open"
                   >
                     <div
-                      class=" css-o8533i-Option"
+                      class=" css-5aymxm-Option"
                       id="react-select-23-option-4"
                       tabindex="-1"
                     >
@@ -3376,7 +3376,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                     value="progress"
                   >
                     <div
-                      class=" css-o8533i-Option"
+                      class=" css-5aymxm-Option"
                       id="react-select-23-option-5"
                       tabindex="-1"
                     >
@@ -3392,7 +3392,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                     value="quarantine"
                   >
                     <div
-                      class=" css-o8533i-Option"
+                      class=" css-5aymxm-Option"
                       id="react-select-23-option-6"
                       tabindex="-1"
                     >

--- a/components/src/Select/customReactSelectStyles.js
+++ b/components/src/Select/customReactSelectStyles.js
@@ -23,9 +23,11 @@ const getShadow = ({ errored, isOpen }) => {
   }
 };
 
-const customStyles = error => {
+const customStyles = ({ error, maxHeight, windowed }) => {
   return {
-    option: () => null,
+    option: () => ({
+      height: 38
+    }),
     control: (provided, state) => ({
       display: "flex",
       minHeight: theme.space.x5,
@@ -92,7 +94,10 @@ const customStyles = error => {
       ...provided,
       minWidth: "fit-content",
       padding: 0,
-      borderRadius: theme.radii.medium
+      maxHeight: parseInt(maxHeight, 10),
+      borderRadius: theme.radii.medium,
+      marginTop: windowed ? "-4px" : 0,
+      marginBottom: windowed ? "-4px" : 0
     }),
     multiValue: provided => ({
       ...provided,

--- a/components/src/TimePicker/TimePicker.js
+++ b/components/src/TimePicker/TimePicker.js
@@ -2,7 +2,7 @@ import React from "react";
 import { setMinutes } from "date-fns";
 import styled from "styled-components";
 import PropTypes from "prop-types";
-import { components } from "react-select";
+import { components } from "react-windowed-select";
 import { useTranslation } from "react-i18next";
 
 import theme from "../theme";

--- a/yarn.lock
+++ b/yarn.lock
@@ -14155,7 +14155,7 @@ mem@^4.0.0:
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
 
-memoize-one@^5.0.0:
+"memoize-one@>=3.1.1 <6", memoize-one@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
   integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
@@ -17529,7 +17529,7 @@ react-resize-detector@^4.2.0:
     raf-schd "^4.0.2"
     resize-observer-polyfill "^1.5.1"
 
-react-select@^3.0.4, react-select@^3.0.8:
+react-select@3.0.8, react-select@^3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.0.8.tgz#06ff764e29db843bcec439ef13e196865242e0c1"
   integrity sha512-v9LpOhckLlRmXN5A6/mGGEft4FMrfaBFTGAnuPHcUgVId7Je42kTq9y0Z+Ye5z8/j0XDT3zUqza8gaRaI1PZIg==
@@ -17598,6 +17598,23 @@ react-transition-group@^2.2.1:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
+
+react-window@1.8.5:
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.8.5.tgz#a56b39307e79979721021f5d06a67742ecca52d1"
+  integrity sha512-HeTwlNa37AFa8MDZFZOKcNEkuF2YflA0hpGPiTT9vR7OawEt+GZbfM6wqkBahD3D3pUjIabQYzsnY/BSJbgq6Q==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    memoize-one ">=3.1.1 <6"
+
+react-windowed-select@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/react-windowed-select/-/react-windowed-select-2.0.2.tgz#1563fd5ee844414ca063324dbfee808df614005b"
+  integrity sha512-f3ISbVQYcl17EvABkG4IDPeDsrsPoD93/1+sW5xYh3g44F7HO8qnS+9QThDwSrXQaSTKOwgK21eDXN9lSECsDA==
+  dependencies:
+    prop-types "15.7.2"
+    react-select "3.0.8"
+    react-window "1.8.5"
 
 react@16.12.0:
   version "16.12.0"


### PR DESCRIPTION
## Description

Uses react-windowed-select which is a wrapper around react-select that improves all the performance issues with react-select when options are in the thousands.

The windowing feature only comes into effect when there are more than 100 options (this value can be set but i kept the default from the library).

Some update to the customStyles had to be made and the window library assumes the default styles from react-select which we do not use much. There should be no visual difference compared to what we currently have though. 


## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [x] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
