### PR TITLE
feat: add responsive utility classes

### DIFF
--- a/css/readme.md
+++ b/css/readme.md
@@ -1,18 +1,29 @@
 ![npm (scoped)](https://img.shields.io/npm/v/@nulogy/css.svg?color=blue)
 
 # @nulogy/css
-Sass variables and atomic classes for writing CSS using Nulogy design tokens. These variables can be used to create CSS versions of our React components and the atomic classes can be 
 
-## Installation 
+Sass variables and atomic classes for writing CSS using Nulogy design tokens. These variables can be used to create CSS versions of our React components and the atomic classes can be
+
+## Installation
+
 `npm install @nulogy/css --save`
 
 ## Usage
-1. Include the CSS 
-`<link rel="stylesheet" href="/node_modules/@nulogy/tokens/dist/nds.css" />`
+
+1. Include the CSS
+   `<link rel="stylesheet" href="/node_modules/@nulogy/tokens/dist/nds.css" />`
 
 2. Use the utility classes as needed in your HTML
-`<p class='text--grey'>Grey text</p>`
+   `<p class='nds-text--grey'>Grey text</p>`
 
-If you'd prefer to create your own classes using Scss variables, see [@nulogy/tokens](https://www.npmjs.com/package/@nulogy/tokens). 
+If you'd prefer to create your own classes using Scss variables, see [@nulogy/tokens](https://www.npmjs.com/package/@nulogy/tokens).
 
+### Responsive
 
+All utilitity classes are available responsively by adding a breakpoint prefix to the beginning of the class, e.g:
+
+.nds-font-size--large (for any screen size)
+.nds@sm-font-size--large (768px and up)
+.nds@md-font-size--large (1024px and up)
+.nds@lg-font-size--large (1360px and up)
+.nds@xl-font-size--large (1920px and up)

--- a/css/src/scss/_mixins.scss
+++ b/css/src/scss/_mixins.scss
@@ -28,7 +28,7 @@ $breakpoints: (
     // otherwise, add all the breakpoints
     @else {
       @include breakpoint($breakpoint-name) {
-        .nds-#{$breakpoint-name}- {
+        .nds\@#{$breakpoint-name}- {
           @content;
         }
       }

--- a/css/src/scss/_mixins.scss
+++ b/css/src/scss/_mixins.scss
@@ -1,0 +1,37 @@
+// Modified from https://raw.githubusercontent.com/buzzfeed/solid/master/_lib/solid-helpers/_mixins.scss
+
+$breakpoints: (
+  xs: null,
+  sm: $size-breakpoint-small,
+  md: $size-breakpoint-medium,
+  lg: $size-breakpoint-large,
+  xl: $size-breakpoint-extra-large
+);
+
+// returns the apropriate media query for the given breakpoint name
+@mixin breakpoint($breakpoint) {
+  @media (min-width: #{map-get($breakpoints, $breakpoint)}) {
+    @content;
+  }
+}
+
+// nest content inside breakpoint prefix classes in the appropriate media query block
+@mixin generate-breakpoint-prefixes {
+  // generate nds prefixed and responsive suffixed classes
+  @each $breakpoint-name, $breakpoint-value in $breakpoints {
+    // for xs, don't prefix anything
+    @if $breakpoint-name == "xs" {
+      .nds- {
+        @content;
+      }
+    }
+    // otherwise, add all the breakpoints
+    @else {
+      @include breakpoint($breakpoint-name) {
+        .nds-#{$breakpoint-name}- {
+          @content;
+        }
+      }
+    }
+  }
+}

--- a/css/src/scss/nds.scss
+++ b/css/src/scss/nds.scss
@@ -1,9 +1,8 @@
-$namespace: ".nds-";
-
 @import url("https://fonts.googleapis.com/css?family=IBM+Plex+Sans");
 
 @import "../tokens/dist/_variables";
 
+@import "mixins";
 @import "defaults";
 
 @import "utilities/borders";

--- a/css/src/scss/utilities/_borders.scss
+++ b/css/src/scss/utilities/_borders.scss
@@ -1,4 +1,4 @@
-#{$namespace} {
+@include generate-breakpoint-prefixes {
   &rounded-corners {
     border-radius: $radius-border-medium !important;
   }

--- a/css/src/scss/utilities/_colors.scss
+++ b/css/src/scss/utilities/_colors.scss
@@ -27,7 +27,7 @@ $colors: (
   .background--light-green {color: background-green;)
 */
 
-#{$namespace} {
+@include generate-breakpoint-prefixes {
   &text {
     @include color-modifiers($attribute: "color");
   }

--- a/css/src/scss/utilities/_helpers.scss
+++ b/css/src/scss/utilities/_helpers.scss
@@ -1,4 +1,4 @@
-#{$namespace} {
+@include generate-breakpoint-prefixes {
   &clearfix:after {
     content: "";
     display: table;

--- a/css/src/scss/utilities/_layout.scss
+++ b/css/src/scss/utilities/_layout.scss
@@ -1,4 +1,4 @@
-#{$namespace} {
+@include generate-breakpoint-prefixes {
   &float-left {
     float: left !important;
   }

--- a/css/src/scss/utilities/_shadows.scss
+++ b/css/src/scss/utilities/_shadows.scss
@@ -1,4 +1,4 @@
-#{$namespace} {
+@include generate-breakpoint-prefixes {
   &shadow--small {
     box-shadow: $shadow-box-small !important;
   }

--- a/css/src/scss/utilities/_space.scss
+++ b/css/src/scss/utilities/_space.scss
@@ -15,7 +15,7 @@ $directions: [ "top", "right", "bottom", "left" ];
 
 @each $name, $value in $scale {
   @each $property in $properties {
-    #{$namespace} {
+    @include generate-breakpoint-prefixes {
       &#{$property}--#{$name} {
         #{$property}: $value !important;
       } // all

--- a/css/src/scss/utilities/_type.scss
+++ b/css/src/scss/utilities/_type.scss
@@ -26,22 +26,22 @@
   }
 
   &font-weight--normal {
-    font-weight: $weight-font-normal;
+    font-weight: $weight-font-normal !important;
   }
   &font-weight--medium {
-    font-weight: $weight-font-medium;
+    font-weight: $weight-font-medium !important;
   }
   &font-weight--bold {
-    font-weight: $weight-font-bold;
+    font-weight: $weight-font-bold !important;
   }
 
   &text-align--left {
-    text-align: left;
+    text-align: left !important;
   }
   &text-align--center {
-    text-align: center;
+    text-align: center !important;
   }
   &text-align--right {
-    text-align: right;
+    text-align: right !important;
   }
 }

--- a/css/src/scss/utilities/_type.scss
+++ b/css/src/scss/utilities/_type.scss
@@ -1,4 +1,4 @@
-#{$namespace} {
+@include generate-breakpoint-prefixes {
   &font-size--smaller {
     font-size: $size-font-smaller !important;
   }
@@ -26,22 +26,22 @@
   }
 
   &font-weight--normal {
-    font-weight: $weight-font-normal !important;
+    font-weight: $weight-font-normal;
   }
   &font-weight--medium {
-    font-weight: $weight-font-medium !important;
+    font-weight: $weight-font-medium;
   }
   &font-weight--bold {
-    font-weight: $weight-font-bold !important;
+    font-weight: $weight-font-bold;
   }
 
   &text-align--left {
-    text-align: left !important;
+    text-align: left;
   }
   &text-align--center {
-    text-align: center !important;
+    text-align: center;
   }
   &text-align--right {
-    text-align: right !important;
+    text-align: right;
   }
 }


### PR DESCRIPTION
## Description

All utilitity classes are now available responsively by adding a breakpoint prefix to the beginning of the class, e.g:

```
.nds-font-size--large (for any screen size)
.nds@sm-font-size--large (768px and up)
.nds@md-font-size--large (1024px and up)
.nds@lg-font-size--large (1360px and up)
.nds@xl-font-size--large (1920px and up)
```

The naming convention is up for discussion.
