### PR TITLE
fix: windowed select should allow overflow to view text longer than t…

### DIFF
--- a/components/src/Select/Select.js
+++ b/components/src/Select/Select.js
@@ -8,8 +8,6 @@ import customStyles from "./customReactSelectStyles";
 import { SelectPropTypes, SelectDefaultProps } from "./Select.type";
 import SelectOption from "./SelectOption";
 
-const WINDOW_THRESHOLD = 100; // number of options beyond which the menu will be windowed
-
 const Control = props => {
   // eslint-disable-next-line react/prop-types
   const { isFocused } = props;
@@ -114,7 +112,8 @@ const ReactSelect = ({
   onMenuClose,
   onInputChange,
   components,
-  "aria-label": ariaLabel
+  "aria-label": ariaLabel,
+  windowThreshold
 }) => {
   const { t } = useTranslation();
   return (
@@ -127,8 +126,8 @@ const ReactSelect = ({
           placeholder={placeholder || t("select ...")}
           options={options}
           labelText={labelText}
-          windowThreshold={WINDOW_THRESHOLD}
-          styles={customStyles({ error, maxHeight, windowed: options.length > WINDOW_THRESHOLD })}
+          windowThreshold={windowThreshold}
+          styles={customStyles({ error, maxHeight, windowed: options.length > windowThreshold })}
           isDisabled={disabled}
           isSearchable={autocomplete}
           aria-required={required}

--- a/components/src/Select/Select.story.js
+++ b/components/src/Select/Select.story.js
@@ -364,8 +364,8 @@ storiesOf("Select", module)
     </>
   ))
   .add("with many options (SkipStoryshot)", () => (
-    <>
+    <Box style={{ width: "300px" }}>
       <SelectWithManyOptions labelText="Select from many options:" />
       <SelectWithManyOptions multiselect labelText="Multiselect many options:" />
-    </>
+    </Box>
   ));

--- a/components/src/Select/Select.type.js
+++ b/components/src/Select/Select.type.js
@@ -36,7 +36,8 @@ export const SelectPropTypes = {
   onMenuOpen: PropTypes.func,
   onMenuClose: PropTypes.func,
   onInputChange: PropTypes.func,
-  components: PropTypes.object
+  components: PropTypes.object,
+  windowThreshold: PropTypes.number
 };
 
 export const SelectDefaultProps = {
@@ -67,5 +68,6 @@ export const SelectDefaultProps = {
   onMenuOpen: undefined,
   onMenuClose: undefined,
   onInputChange: undefined,
-  components: undefined
+  components: undefined,
+  windowThreshold: 300
 };

--- a/components/src/Select/SelectOption.js
+++ b/components/src/Select/SelectOption.js
@@ -15,10 +15,11 @@ const StyledOption = styled.div(({ isSelected, isFocused }) => ({
     fontWeight: isSelected ? theme.fontWeights.medium : theme.fontWeights.normal,
     background: isFocused ? theme.colors.lightBlue : null,
     minHeight: theme.space.x4,
-    cursor: "pointer",
+    minWidth: "max-content",
+    whiteSpace: "100%",
     "&:hover": {
       background: theme.colors.lightBlue,
-      minHeight: theme.space.x4
+      cursor: "pointer"
     }
   }
 }));

--- a/components/src/Select/__snapshots__/Select.story.storyshot
+++ b/components/src/Select/__snapshots__/Select.story.storyshot
@@ -216,7 +216,7 @@ exports[`Storyshots Select With wrapping text 1`] = `
                   class=" css-famnlw-MenuList"
                 >
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Onelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstring"
@@ -232,7 +232,7 @@ exports[`Storyshots Select With wrapping text 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Many words many words many words many words many words many words many words many words many words many words many words many words many words"
@@ -1748,7 +1748,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                   class=" css-famnlw-MenuList"
                 >
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 cOCUoo"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 kICoIv"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Accepted"
@@ -1764,7 +1764,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Assigned to a line"
@@ -1780,7 +1780,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
                     data="[object Object]"
                     data-testid="select-option"
                     label="On hold"
@@ -1796,7 +1796,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Rejected"
@@ -1812,7 +1812,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Open"
@@ -1828,7 +1828,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
                     data="[object Object]"
                     data-testid="select-option"
                     label="In progress"
@@ -1844,7 +1844,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
                     data="[object Object]"
                     data-testid="select-option"
                     label="In quarantine"
@@ -2225,7 +2225,7 @@ exports[`Storyshots Select with error list 1`] = `
                 class=" css-famnlw-MenuList"
               >
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
                   data="[object Object]"
                   data-testid="select-option"
                   label="Accepted"
@@ -2241,7 +2241,7 @@ exports[`Storyshots Select with error list 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
                   data="[object Object]"
                   data-testid="select-option"
                   label="Assigned to a line"
@@ -2257,7 +2257,7 @@ exports[`Storyshots Select with error list 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
                   data="[object Object]"
                   data-testid="select-option"
                   label="On hold"
@@ -2273,7 +2273,7 @@ exports[`Storyshots Select with error list 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
                   data="[object Object]"
                   data-testid="select-option"
                   label="Rejected"
@@ -2289,7 +2289,7 @@ exports[`Storyshots Select with error list 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
                   data="[object Object]"
                   data-testid="select-option"
                   label="Open"
@@ -2305,7 +2305,7 @@ exports[`Storyshots Select with error list 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
                   data="[object Object]"
                   data-testid="select-option"
                   label="In progress"
@@ -2321,7 +2321,7 @@ exports[`Storyshots Select with error list 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
                   data="[object Object]"
                   data-testid="select-option"
                   label="In quarantine"
@@ -2619,7 +2619,7 @@ exports[`Storyshots Select with error message 1`] = `
                 class=" css-famnlw-MenuList"
               >
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
                   data="[object Object]"
                   data-testid="select-option"
                   label="Accepted"
@@ -2635,7 +2635,7 @@ exports[`Storyshots Select with error message 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
                   data="[object Object]"
                   data-testid="select-option"
                   label="Assigned to a line"
@@ -2651,7 +2651,7 @@ exports[`Storyshots Select with error message 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
                   data="[object Object]"
                   data-testid="select-option"
                   label="On hold"
@@ -2667,7 +2667,7 @@ exports[`Storyshots Select with error message 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
                   data="[object Object]"
                   data-testid="select-option"
                   label="Rejected"
@@ -2683,7 +2683,7 @@ exports[`Storyshots Select with error message 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
                   data="[object Object]"
                   data-testid="select-option"
                   label="Open"
@@ -2699,7 +2699,7 @@ exports[`Storyshots Select with error message 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
                   data="[object Object]"
                   data-testid="select-option"
                   label="In progress"
@@ -2715,7 +2715,7 @@ exports[`Storyshots Select with error message 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
                   data="[object Object]"
                   data-testid="select-option"
                   label="In quarantine"
@@ -3288,7 +3288,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                   class=" css-1hz449x-MenuList"
                 >
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 cOCUoo"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 kICoIv"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Accepted"
@@ -3304,7 +3304,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Assigned to a line"
@@ -3320,7 +3320,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
                     data="[object Object]"
                     data-testid="select-option"
                     label="On hold"
@@ -3336,7 +3336,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Rejected"
@@ -3352,7 +3352,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Open"
@@ -3368,7 +3368,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
                     data="[object Object]"
                     data-testid="select-option"
                     label="In progress"
@@ -3384,7 +3384,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 dnDQzZ"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
                     data="[object Object]"
                     data-testid="select-option"
                     label="In quarantine"

--- a/docs/src/shared/selectProps.js
+++ b/docs/src/shared/selectProps.js
@@ -69,6 +69,13 @@ const selectProps = [
     defaultValue: "absolute",
     description: "The CSS position value of the menu. ex: 'fixed'"
   },
+  {
+    name: "windowThreshold",
+    type: "number",
+    defaultValue: "300",
+    description:
+      "The number of option at which to use virtualization to improve performance of the select"
+  },
   ...inputProps
 ];
 


### PR DESCRIPTION
## Description

Allows horizontal overflow in select to show overflowed text. Since windowing using absolute positioning and fixed heights we can't support wrapping text.
Adds a window threshold prop so that developers can change when windowing takes effect to suit their own needs. 

A visual bug in the windowed select where the hover does not span the full width of the container remains.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
