### PR TITLE
fix: remove max width from Alert to match React component

### DIFF
--- a/css/src/scss/components/_alert.scss
+++ b/css/src/scss/components/_alert.scss
@@ -19,7 +19,6 @@
 
 .Alert {
   @include alert($color-base-blue, $color-base-light-blue);
-  display: flex;
 }
 
 .Alert__title {

--- a/css/src/scss/components/_alert.scss
+++ b/css/src/scss/components/_alert.scss
@@ -20,7 +20,6 @@
 .Alert {
   @include alert($color-base-blue, $color-base-light-blue);
   display: flex;
-  max-width: 432px;
 }
 
 .Alert__title {

--- a/css/src/scss/components/_alert.story.js
+++ b/css/src/scss/components/_alert.story.js
@@ -6,17 +6,15 @@ storiesOf("Components|Alerts", module)
     "Alert",
     () => `
     <div class="Alert">
-      <div class="Alert__content">
-        <p class="Alert__title">Important information</p>
-        <p class="Alert__message">Details about important information</p>
-      </div>
+      <p class="Alert__title">Important information</p>
+      <p class="Alert__message">Details about important information</p>
     </div>
 `
   )
   .add(
     "Alert--danger",
     () => `
-  <div class="Alert Alert--danger">
+  <div class="Alert Alert--danger nds-flex"">
     <div class="Alert--danger__icon">
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0z"/><path d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"/></svg>
     </div>
@@ -31,17 +29,15 @@ storiesOf("Components|Alerts", module)
     "Alert--warning",
     () => `
   <div class="Alert Alert--warning">
-    <div class="Alert__content">
-      <p class="Alert__title">Important information</p>
-      <p class="Alert__message">Details about important information</p>
-    </div>
+    <p class="Alert__title">Important information</p>
+    <p class="Alert__message">Details about important information</p>
   </div>
   `
   )
   .add(
     "Alert--success",
     () => `
-  <div class="Alert Alert--success">
+  <div class="Alert Alert--success nds-flex"">
     <svg class="Alert--success__icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>
     <div class="Alert__content">
       <p class="Alert__title">Important information</p>


### PR DESCRIPTION
## Description

Just noticed bw our css alert  isn't full width like the react component. 

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
