### PR TITLE
fix: adds data-testid attribute to FieldLabel component

### DIFF
--- a/components/src/DatePicker/__snapshots__/DatePicker.story.storyshot
+++ b/components/src/DatePicker/__snapshots__/DatePicker.story.storyshot
@@ -23,6 +23,7 @@ exports[`Storyshots DatePicker default 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -93,6 +94,7 @@ exports[`Storyshots DatePicker with custom date format 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -163,6 +165,7 @@ exports[`Storyshots DatePicker with custom locale 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -233,6 +236,7 @@ exports[`Storyshots DatePicker with custom placeholder 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -303,6 +307,7 @@ exports[`Storyshots DatePicker with error state 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -405,6 +410,7 @@ exports[`Storyshots DatePicker with min and max date 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"

--- a/components/src/DateRange/__snapshots__/DateRange.story.storyshot
+++ b/components/src/DateRange/__snapshots__/DateRange.story.storyshot
@@ -14,6 +14,7 @@ exports[`Storyshots DateRange customizing input props 1`] = `
     >
       <div
         class="Box-sc-1qu1edy-0 jlPsmj"
+        data-testid="field-label"
       >
         <span
           style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -144,6 +145,7 @@ exports[`Storyshots DateRange default 1`] = `
     >
       <div
         class="Box-sc-1qu1edy-0 jlPsmj"
+        data-testid="field-label"
       >
         <span
           style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -274,6 +276,7 @@ exports[`Storyshots DateRange default start and end date 1`] = `
     >
       <div
         class="Box-sc-1qu1edy-0 jlPsmj"
+        data-testid="field-label"
       >
         <span
           style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -404,6 +407,7 @@ exports[`Storyshots DateRange disabled range validation 1`] = `
     >
       <div
         class="Box-sc-1qu1edy-0 jlPsmj"
+        data-testid="field-label"
       >
         <span
           style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -534,6 +538,7 @@ exports[`Storyshots DateRange individual input error 1`] = `
     >
       <div
         class="Box-sc-1qu1edy-0 jlPsmj"
+        data-testid="field-label"
       >
         <span
           style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -697,6 +702,7 @@ exports[`Storyshots DateRange with custom error 1`] = `
     >
       <div
         class="Box-sc-1qu1edy-0 jlPsmj"
+        data-testid="field-label"
       >
         <span
           style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -859,6 +865,7 @@ exports[`Storyshots DateRange with default start and end times 1`] = `
     >
       <div
         class="Box-sc-1qu1edy-0 jlPsmj"
+        data-testid="field-label"
       >
         <span
           style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -1159,6 +1166,7 @@ exports[`Storyshots DateRange with time error 1`] = `
     >
       <div
         class="Box-sc-1qu1edy-0 jlPsmj"
+        data-testid="field-label"
       >
         <span
           style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -1459,6 +1467,7 @@ exports[`Storyshots DateRange with times 1`] = `
     >
       <div
         class="Box-sc-1qu1edy-0 jlPsmj"
+        data-testid="field-label"
       >
         <span
           style="font-size:14px;font-weight:600;line-height:1.71428571"

--- a/components/src/FieldLabel/FieldLabel.js
+++ b/components/src/FieldLabel/FieldLabel.js
@@ -29,7 +29,7 @@ Label.defaultProps = {
 
 const BaseFieldLabel = ({ labelText, requirementText, helpText, children, ...props }) => (
   <Label style={{ display: "block" }} {...props}>
-    <Box mb={children && "x1"}>
+    <Box mb={children && "x1"} data-testid="field-label">
       <span style={labelTextStyles}>{labelText}</span>
       {requirementText && <RequirementText>{requirementText}</RequirementText>}
       {helpText && <HelpText>{helpText}</HelpText>}

--- a/components/src/FieldLabel/__snapshots__/FieldLabel.story.storyshot
+++ b/components/src/FieldLabel/__snapshots__/FieldLabel.story.storyshot
@@ -14,6 +14,7 @@ exports[`Storyshots FieldLabel FieldLabel 1`] = `
     >
       <div
         class="Box-sc-1qu1edy-0 jlPsmj"
+        data-testid="field-label"
       >
         <span
           style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -40,6 +41,7 @@ exports[`Storyshots FieldLabel with HelpText 1`] = `
     >
       <div
         class="Box-sc-1qu1edy-0 jlPsmj"
+        data-testid="field-label"
       >
         <span
           style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -81,6 +83,7 @@ exports[`Storyshots FieldLabel with RequirementText 1`] = `
     >
       <div
         class="Box-sc-1qu1edy-0 jlPsmj"
+        data-testid="field-label"
       >
         <span
           style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -114,6 +117,7 @@ exports[`Storyshots FieldLabel with all additional text 1`] = `
     >
       <div
         class="Box-sc-1qu1edy-0 jlPsmj"
+        data-testid="field-label"
       >
         <span
           style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -154,6 +158,7 @@ exports[`Storyshots FieldLabel with associated custom input component 1`] = `
     >
       <div
         class="Box-sc-1qu1edy-0 ilQgHG"
+        data-testid="field-label"
       >
         <span
           style="font-size:14px;font-weight:600;line-height:1.71428571"

--- a/components/src/Form/__snapshots__/Form.story.storyshot
+++ b/components/src/Form/__snapshots__/Form.story.storyshot
@@ -104,6 +104,7 @@ exports[`Storyshots Form Demo form 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -139,6 +140,7 @@ exports[`Storyshots Form Demo form 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -187,6 +189,7 @@ exports[`Storyshots Form Demo form 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -283,6 +286,7 @@ exports[`Storyshots Form Demo form 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -350,6 +354,7 @@ exports[`Storyshots Form Demo form 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -385,6 +390,7 @@ exports[`Storyshots Form Demo form 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -421,6 +427,7 @@ exports[`Storyshots Form Demo form 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -456,6 +463,7 @@ exports[`Storyshots Form Demo form 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -811,6 +819,7 @@ exports[`Storyshots Form Demo form 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -878,6 +887,7 @@ exports[`Storyshots Form Demo form 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -983,6 +993,7 @@ exports[`Storyshots Form Form 1`] = `
         >
           <div
             class="Box-sc-1qu1edy-0 ilQgHG"
+            data-testid="field-label"
           >
             <span
               style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -1017,6 +1028,7 @@ exports[`Storyshots Form Form 1`] = `
         >
           <div
             class="Box-sc-1qu1edy-0 ilQgHG"
+            data-testid="field-label"
           >
             <span
               style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -1066,6 +1078,7 @@ exports[`Storyshots Form Form 1`] = `
         >
           <div
             class="Box-sc-1qu1edy-0 ilQgHG"
+            data-testid="field-label"
           >
             <span
               style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -1139,6 +1152,7 @@ exports[`Storyshots Form With form sections 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -1173,6 +1187,7 @@ exports[`Storyshots Form With form sections 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -1222,6 +1237,7 @@ exports[`Storyshots Form With form sections 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -1274,6 +1290,7 @@ exports[`Storyshots Form With form sections 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -1308,6 +1325,7 @@ exports[`Storyshots Form With form sections 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -1368,6 +1386,7 @@ exports[`Storyshots Form With form sections without titles 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -1402,6 +1421,7 @@ exports[`Storyshots Form With form sections without titles 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -1451,6 +1471,7 @@ exports[`Storyshots Form With form sections without titles 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -1496,6 +1517,7 @@ exports[`Storyshots Form With form sections without titles 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -1530,6 +1552,7 @@ exports[`Storyshots Form With form sections without titles 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -1580,6 +1603,7 @@ exports[`Storyshots Form Without title 1`] = `
         >
           <div
             class="Box-sc-1qu1edy-0 ilQgHG"
+            data-testid="field-label"
           >
             <span
               style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -1614,6 +1638,7 @@ exports[`Storyshots Form Without title 1`] = `
         >
           <div
             class="Box-sc-1qu1edy-0 ilQgHG"
+            data-testid="field-label"
           >
             <span
               style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -1663,6 +1688,7 @@ exports[`Storyshots Form Without title 1`] = `
         >
           <div
             class="Box-sc-1qu1edy-0 ilQgHG"
+            data-testid="field-label"
           >
             <span
               style="font-size:14px;font-weight:600;line-height:1.71428571"

--- a/components/src/Input/__snapshots__/Input.story.storyshot
+++ b/components/src/Input/__snapshots__/Input.story.storyshot
@@ -17,6 +17,7 @@ exports[`Storyshots Input Input 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -61,6 +62,7 @@ exports[`Storyshots Input set to disabled 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -116,6 +118,7 @@ exports[`Storyshots Input set to required 1`] = `
         >
           <div
             class="Box-sc-1qu1edy-0 ilQgHG"
+            data-testid="field-label"
           >
             <span
               style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -591,6 +594,7 @@ exports[`Storyshots Input with all props 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -651,6 +655,7 @@ exports[`Storyshots Input with custom ID 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -696,6 +701,7 @@ exports[`Storyshots Input with error list  1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -789,6 +795,7 @@ exports[`Storyshots Input with error message 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"

--- a/components/src/MonthPicker/__snapshots__/MonthPicker.story.storyshot
+++ b/components/src/MonthPicker/__snapshots__/MonthPicker.story.storyshot
@@ -24,6 +24,7 @@ exports[`Storyshots MonthPicker default 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -95,6 +96,7 @@ exports[`Storyshots MonthPicker with a min and max date 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -166,6 +168,7 @@ exports[`Storyshots MonthPicker with custom placeholder 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -237,6 +240,7 @@ exports[`Storyshots MonthPicker with error state 1`] = `
           >
             <div
               class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
             >
               <span
                 style="font-size:14px;font-weight:600;line-height:1.71428571"

--- a/components/src/MonthRange/__snapshots__/MonthRange.story.storyshot
+++ b/components/src/MonthRange/__snapshots__/MonthRange.story.storyshot
@@ -14,6 +14,7 @@ exports[`Storyshots MonthRange customizing input props 1`] = `
     >
       <div
         class="Box-sc-1qu1edy-0 jlPsmj"
+        data-testid="field-label"
       >
         <span
           style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -146,6 +147,7 @@ exports[`Storyshots MonthRange default 1`] = `
     >
       <div
         class="Box-sc-1qu1edy-0 jlPsmj"
+        data-testid="field-label"
       >
         <span
           style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -278,6 +280,7 @@ exports[`Storyshots MonthRange default start and end date 1`] = `
     >
       <div
         class="Box-sc-1qu1edy-0 jlPsmj"
+        data-testid="field-label"
       >
         <span
           style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -410,6 +413,7 @@ exports[`Storyshots MonthRange disabled range validation 1`] = `
     >
       <div
         class="Box-sc-1qu1edy-0 jlPsmj"
+        data-testid="field-label"
       >
         <span
           style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -542,6 +546,7 @@ exports[`Storyshots MonthRange individual input error 1`] = `
     >
       <div
         class="Box-sc-1qu1edy-0 jlPsmj"
+        data-testid="field-label"
       >
         <span
           style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -707,6 +712,7 @@ exports[`Storyshots MonthRange with custom error 1`] = `
     >
       <div
         class="Box-sc-1qu1edy-0 jlPsmj"
+        data-testid="field-label"
       >
         <span
           style="font-size:14px;font-weight:600;line-height:1.71428571"

--- a/components/src/RangeContainer/__snapshots__/RangeContainer.story.storyshot
+++ b/components/src/RangeContainer/__snapshots__/RangeContainer.story.storyshot
@@ -14,6 +14,7 @@ exports[`Storyshots RangeContainer RangeContainer 1`] = `
     >
       <div
         class="Box-sc-1qu1edy-0 ilQgHG"
+        data-testid="field-label"
       >
         <span
           style="font-size:14px;font-weight:600;line-height:1.71428571"

--- a/components/src/Select/__snapshots__/Select.story.storyshot
+++ b/components/src/Select/__snapshots__/Select.story.storyshot
@@ -17,6 +17,7 @@ exports[`Storyshots Select Select 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -124,6 +125,7 @@ exports[`Storyshots Select With wrapping text 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -275,6 +277,7 @@ exports[`Storyshots Select set to disabled 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -403,6 +406,7 @@ exports[`Storyshots Select set to required 1`] = `
         >
           <div
             class="Box-sc-1qu1edy-0 ilQgHG"
+            data-testid="field-label"
           >
             <span
               style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -524,6 +528,7 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -698,6 +703,7 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
         >
           <div
             class="Box-sc-1qu1edy-0 ilQgHG"
+            data-testid="field-label"
           >
             <span
               style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -1018,6 +1024,7 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
         >
           <div
             class="Box-sc-1qu1edy-0 ilQgHG"
+            data-testid="field-label"
           >
             <span
               style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -1345,6 +1352,7 @@ exports[`Storyshots Select with a blank value 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -1452,6 +1460,7 @@ exports[`Storyshots Select with a defaultValue 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -1559,6 +1568,7 @@ exports[`Storyshots Select with an option selected 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -1656,6 +1666,7 @@ exports[`Storyshots Select with an option selected 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -1887,6 +1898,7 @@ exports[`Storyshots Select with custom id 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -2001,6 +2013,7 @@ exports[`Storyshots Select with error list 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -2412,6 +2425,7 @@ exports[`Storyshots Select with error message 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -2793,6 +2807,7 @@ exports[`Storyshots Select with fixed positioning 1`] = `
         >
           <div
             class="Box-sc-1qu1edy-0 ilQgHG"
+            data-testid="field-label"
           >
             <span
               style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -2901,6 +2916,7 @@ exports[`Storyshots Select with helpText 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -3015,6 +3031,7 @@ exports[`Storyshots Select with multiselect 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -3196,6 +3213,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -3427,6 +3445,7 @@ exports[`Storyshots Select with state 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"

--- a/components/src/Textarea/__snapshots__/Textarea.story.storyshot
+++ b/components/src/Textarea/__snapshots__/Textarea.story.storyshot
@@ -17,6 +17,7 @@ exports[`Storyshots Textarea Set to disabled 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -54,6 +55,7 @@ exports[`Storyshots Textarea Textarea 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -90,6 +92,7 @@ exports[`Storyshots Textarea Textarea with all props 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -142,6 +145,7 @@ exports[`Storyshots Textarea With custom id 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -179,6 +183,7 @@ exports[`Storyshots Textarea With custom number of rows 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -225,6 +230,7 @@ exports[`Storyshots Textarea set to required 1`] = `
         >
           <div
             class="Box-sc-1qu1edy-0 ilQgHG"
+            data-testid="field-label"
           >
             <span
               style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -268,6 +274,7 @@ exports[`Storyshots Textarea with error list 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -353,6 +360,7 @@ exports[`Storyshots Textarea with error message 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"

--- a/components/src/TimePicker/__snapshots__/TimePicker.story.storyshot
+++ b/components/src/TimePicker/__snapshots__/TimePicker.story.storyshot
@@ -17,6 +17,7 @@ exports[`Storyshots TimePicker default 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -128,6 +129,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -239,6 +241,7 @@ exports[`Storyshots TimePicker with custom time format 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -350,6 +353,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -493,6 +497,7 @@ exports[`Storyshots TimePicker with min and max time 1`] = `
       >
         <div
           class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
         >
           <span
             style="font-size:14px;font-weight:600;line-height:1.71428571"

--- a/components/src/TimeRange/__snapshots__/TimeRange.story.storyshot
+++ b/components/src/TimeRange/__snapshots__/TimeRange.story.storyshot
@@ -14,6 +14,7 @@ exports[`Storyshots TimeRange default 1`] = `
     >
       <div
         class="Box-sc-1qu1edy-0 jlPsmj"
+        data-testid="field-label"
       >
         <span
           style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -226,6 +227,7 @@ exports[`Storyshots TimeRange default selections 1`] = `
     >
       <div
         class="Box-sc-1qu1edy-0 jlPsmj"
+        data-testid="field-label"
       >
         <span
           style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -438,6 +440,7 @@ exports[`Storyshots TimeRange with min and max time range 1`] = `
     >
       <div
         class="Box-sc-1qu1edy-0 jlPsmj"
+        data-testid="field-label"
       >
         <span
           style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -650,6 +653,7 @@ exports[`Storyshots TimeRange with range validation 1`] = `
     >
       <div
         class="Box-sc-1qu1edy-0 jlPsmj"
+        data-testid="field-label"
       >
         <span
           style="font-size:14px;font-weight:600;line-height:1.71428571"

--- a/components/src/pages/__snapshots__/Details.story.storyshot
+++ b/components/src/pages/__snapshots__/Details.story.storyshot
@@ -2466,6 +2466,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 >
                   <div
                     class="Box-sc-1qu1edy-0 ilQgHG"
+                    data-testid="field-label"
                   >
                     <span
                       style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -2501,6 +2502,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 >
                   <div
                     class="Box-sc-1qu1edy-0 ilQgHG"
+                    data-testid="field-label"
                   >
                     <span
                       style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -2549,6 +2551,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 >
                   <div
                     class="Box-sc-1qu1edy-0 ilQgHG"
+                    data-testid="field-label"
                   >
                     <span
                       style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -2645,6 +2648,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 >
                   <div
                     class="Box-sc-1qu1edy-0 ilQgHG"
+                    data-testid="field-label"
                   >
                     <span
                       style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -2712,6 +2716,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 >
                   <div
                     class="Box-sc-1qu1edy-0 ilQgHG"
+                    data-testid="field-label"
                   >
                     <span
                       style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -2747,6 +2752,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 >
                   <div
                     class="Box-sc-1qu1edy-0 ilQgHG"
+                    data-testid="field-label"
                   >
                     <span
                       style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -2783,6 +2789,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 >
                   <div
                     class="Box-sc-1qu1edy-0 ilQgHG"
+                    data-testid="field-label"
                   >
                     <span
                       style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -2818,6 +2825,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 >
                   <div
                     class="Box-sc-1qu1edy-0 ilQgHG"
+                    data-testid="field-label"
                   >
                     <span
                       style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -3173,6 +3181,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 >
                   <div
                     class="Box-sc-1qu1edy-0 ilQgHG"
+                    data-testid="field-label"
                   >
                     <span
                       style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -3240,6 +3249,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 >
                   <div
                     class="Box-sc-1qu1edy-0 ilQgHG"
+                    data-testid="field-label"
                   >
                     <span
                       style="font-size:14px;font-weight:600;line-height:1.71428571"

--- a/components/src/pages/__snapshots__/LoginPage.story.storyshot
+++ b/components/src/pages/__snapshots__/LoginPage.story.storyshot
@@ -98,6 +98,7 @@ exports[`Storyshots Pages/LoginPage Base 1`] = `
               >
                 <div
                   class="Box-sc-1qu1edy-0 ilQgHG"
+                  data-testid="field-label"
                 >
                   <span
                     style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -131,6 +132,7 @@ exports[`Storyshots Pages/LoginPage Base 1`] = `
               >
                 <div
                   class="Box-sc-1qu1edy-0 ilQgHG"
+                  data-testid="field-label"
                 >
                   <span
                     style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -306,6 +308,7 @@ exports[`Storyshots Pages/LoginPage with error 1`] = `
               >
                 <div
                   class="Box-sc-1qu1edy-0 ilQgHG"
+                  data-testid="field-label"
                 >
                   <span
                     style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -339,6 +342,7 @@ exports[`Storyshots Pages/LoginPage with error 1`] = `
               >
                 <div
                   class="Box-sc-1qu1edy-0 ilQgHG"
+                  data-testid="field-label"
                 >
                   <span
                     style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -507,6 +511,7 @@ exports[`Storyshots Pages/LoginPage with error and no additional text 1`] = `
               >
                 <div
                   class="Box-sc-1qu1edy-0 ilQgHG"
+                  data-testid="field-label"
                 >
                   <span
                     style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -540,6 +545,7 @@ exports[`Storyshots Pages/LoginPage with error and no additional text 1`] = `
               >
                 <div
                   class="Box-sc-1qu1edy-0 ilQgHG"
+                  data-testid="field-label"
                 >
                   <span
                     style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -688,6 +694,7 @@ exports[`Storyshots Pages/LoginPage with forgot password link 1`] = `
               >
                 <div
                   class="Box-sc-1qu1edy-0 ilQgHG"
+                  data-testid="field-label"
                 >
                   <span
                     style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -721,6 +728,7 @@ exports[`Storyshots Pages/LoginPage with forgot password link 1`] = `
               >
                 <div
                   class="Box-sc-1qu1edy-0 ilQgHG"
+                  data-testid="field-label"
                 >
                   <span
                     style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -879,6 +887,7 @@ exports[`Storyshots Pages/LoginPage with remember me 1`] = `
               >
                 <div
                   class="Box-sc-1qu1edy-0 ilQgHG"
+                  data-testid="field-label"
                 >
                   <span
                     style="font-size:14px;font-weight:600;line-height:1.71428571"
@@ -912,6 +921,7 @@ exports[`Storyshots Pages/LoginPage with remember me 1`] = `
               >
                 <div
                   class="Box-sc-1qu1edy-0 ilQgHG"
+                  data-testid="field-label"
                 >
                   <span
                     style="font-size:14px;font-weight:600;line-height:1.71428571"


### PR DESCRIPTION
## Description

This change was motivated by CN1-1345.

In our Capybara tests, we prefer to select NDS input elements, such as checkboxes and selects, by _label text_. We currently do this with some hacky xpath. However, we would prefer to follow the `data-testid` pattern used elsewhere in NDS.

This PR adds a `data-testid` to the `<Box>` that surrounds a label. It's important that this `data-testid` attribute is on the box's `<div>` as opposed to the child `<span>` because it is easier to then select a sibling input element in the test, instead of an ancestor's sibling.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [x] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
