### PR TITLE
fix: firefox issue with double scroll bars

### DIFF
--- a/components/src/Select/SelectOption.js
+++ b/components/src/Select/SelectOption.js
@@ -16,7 +16,7 @@ const StyledOption = styled.div(({ isSelected, isFocused }) => ({
     background: isFocused ? theme.colors.lightBlue : null,
     minHeight: theme.space.x4,
     minWidth: "max-content",
-    whiteSpace: "100%",
+    whiteSpace: "nowrap",
     "&:hover": {
       background: theme.colors.lightBlue,
       cursor: "pointer"

--- a/components/src/Select/__snapshots__/Select.story.storyshot
+++ b/components/src/Select/__snapshots__/Select.story.storyshot
@@ -218,7 +218,7 @@ exports[`Storyshots Select With wrapping text 1`] = `
                   class=" css-famnlw-MenuList"
                 >
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 cNpvsf"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Onelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstring"
@@ -234,7 +234,7 @@ exports[`Storyshots Select With wrapping text 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 cNpvsf"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Many words many words many words many words many words many words many words many words many words many words many words many words many words"
@@ -1759,7 +1759,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                   class=" css-famnlw-MenuList"
                 >
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 kICoIv"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 lncjJW"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Accepted"
@@ -1775,7 +1775,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 cNpvsf"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Assigned to a line"
@@ -1791,7 +1791,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 cNpvsf"
                     data="[object Object]"
                     data-testid="select-option"
                     label="On hold"
@@ -1807,7 +1807,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 cNpvsf"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Rejected"
@@ -1823,7 +1823,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 cNpvsf"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Open"
@@ -1839,7 +1839,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 cNpvsf"
                     data="[object Object]"
                     data-testid="select-option"
                     label="In progress"
@@ -1855,7 +1855,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 cNpvsf"
                     data="[object Object]"
                     data-testid="select-option"
                     label="In quarantine"
@@ -2238,7 +2238,7 @@ exports[`Storyshots Select with error list 1`] = `
                 class=" css-famnlw-MenuList"
               >
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 cNpvsf"
                   data="[object Object]"
                   data-testid="select-option"
                   label="Accepted"
@@ -2254,7 +2254,7 @@ exports[`Storyshots Select with error list 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 cNpvsf"
                   data="[object Object]"
                   data-testid="select-option"
                   label="Assigned to a line"
@@ -2270,7 +2270,7 @@ exports[`Storyshots Select with error list 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 cNpvsf"
                   data="[object Object]"
                   data-testid="select-option"
                   label="On hold"
@@ -2286,7 +2286,7 @@ exports[`Storyshots Select with error list 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 cNpvsf"
                   data="[object Object]"
                   data-testid="select-option"
                   label="Rejected"
@@ -2302,7 +2302,7 @@ exports[`Storyshots Select with error list 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 cNpvsf"
                   data="[object Object]"
                   data-testid="select-option"
                   label="Open"
@@ -2318,7 +2318,7 @@ exports[`Storyshots Select with error list 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 cNpvsf"
                   data="[object Object]"
                   data-testid="select-option"
                   label="In progress"
@@ -2334,7 +2334,7 @@ exports[`Storyshots Select with error list 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 cNpvsf"
                   data="[object Object]"
                   data-testid="select-option"
                   label="In quarantine"
@@ -2633,7 +2633,7 @@ exports[`Storyshots Select with error message 1`] = `
                 class=" css-famnlw-MenuList"
               >
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 cNpvsf"
                   data="[object Object]"
                   data-testid="select-option"
                   label="Accepted"
@@ -2649,7 +2649,7 @@ exports[`Storyshots Select with error message 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 cNpvsf"
                   data="[object Object]"
                   data-testid="select-option"
                   label="Assigned to a line"
@@ -2665,7 +2665,7 @@ exports[`Storyshots Select with error message 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 cNpvsf"
                   data="[object Object]"
                   data-testid="select-option"
                   label="On hold"
@@ -2681,7 +2681,7 @@ exports[`Storyshots Select with error message 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 cNpvsf"
                   data="[object Object]"
                   data-testid="select-option"
                   label="Rejected"
@@ -2697,7 +2697,7 @@ exports[`Storyshots Select with error message 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 cNpvsf"
                   data="[object Object]"
                   data-testid="select-option"
                   label="Open"
@@ -2713,7 +2713,7 @@ exports[`Storyshots Select with error message 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 cNpvsf"
                   data="[object Object]"
                   data-testid="select-option"
                   label="In progress"
@@ -2729,7 +2729,7 @@ exports[`Storyshots Select with error message 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 cNpvsf"
                   data="[object Object]"
                   data-testid="select-option"
                   label="In quarantine"
@@ -3306,7 +3306,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                   class=" css-1hz449x-MenuList"
                 >
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 kICoIv"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 lncjJW"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Accepted"
@@ -3322,7 +3322,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 cNpvsf"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Assigned to a line"
@@ -3338,7 +3338,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 cNpvsf"
                     data="[object Object]"
                     data-testid="select-option"
                     label="On hold"
@@ -3354,7 +3354,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 cNpvsf"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Rejected"
@@ -3370,7 +3370,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 cNpvsf"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Open"
@@ -3386,7 +3386,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 cNpvsf"
                     data="[object Object]"
                     data-testid="select-option"
                     label="In progress"
@@ -3402,7 +3402,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 kYNuXi"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 cNpvsf"
                     data="[object Object]"
                     data-testid="select-option"
                     label="In quarantine"


### PR DESCRIPTION
## Description

Previously there were double horizontal scrollbars which can be seen on the story with many options.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
