### PR TITLE
fix: accept only className as other props cause warnings

### DIFF
--- a/components/src/Table/BaseTable.js
+++ b/components/src/Table/BaseTable.js
@@ -23,9 +23,9 @@ const BaseTable = ({
   footerRows,
   rowHovers,
   compact,
-  ...props
+  className
 }) => (
-  <StyledTable id={id} {...props}>
+  <StyledTable id={id} className={className}>
     <TableHead columns={columns} compact={compact} />
     <TableBody
       columns={columns}
@@ -49,7 +49,8 @@ BaseTable.propTypes = {
   loading: PropTypes.bool,
   footerRows: rowsPropType,
   rowHovers: PropTypes.bool,
-  compact: PropTypes.bool
+  compact: PropTypes.bool,
+  className: PropTypes.string
 };
 
 BaseTable.defaultProps = {
@@ -59,7 +60,8 @@ BaseTable.defaultProps = {
   loading: false,
   footerRows: [],
   rowHovers: true,
-  compact: false
+  compact: false,
+  className: undefined
 };
 
 export default BaseTable;

--- a/components/src/Table/BaseTable.story.js
+++ b/components/src/Table/BaseTable.story.js
@@ -123,6 +123,7 @@ storiesOf("Table", module)
       rowHovers={boolean("Show row hovers", true)}
       compact={boolean("Show with compact styling", false)}
       loading={boolean("Show loading state", false)}
+      className="Table"
     />
   ))
   .add("with no data", () => (

--- a/components/src/Table/Table.story.js
+++ b/components/src/Table/Table.story.js
@@ -111,5 +111,6 @@ storiesOf("Table", module)
       hasSelectableRows={boolean("Selectable", true)}
       onRowSelectionChange={action("row selection changed")}
       onPageChange={action("page changed")}
+      className="Table"
     />
   ));

--- a/components/src/Table/__snapshots__/BaseTable.story.storyshot
+++ b/components/src/Table/__snapshots__/BaseTable.story.storyshot
@@ -8,7 +8,7 @@ exports[`Storyshots Table  with data 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub Table"
     >
       <thead>
         <tr

--- a/components/src/Table/__snapshots__/Table.story.storyshot
+++ b/components/src/Table/__snapshots__/Table.story.storyshot
@@ -8,7 +8,7 @@ exports[`Storyshots Table with everything 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub Table"
     >
       <thead>
         <tr


### PR DESCRIPTION
## Description

Testing with QCloud surfaced this issue. They hold of on deploymengt if any console warnings are shown so i've chose to just add the prop we need rather than spreading all props to add className to the table.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
