### PR TITLE
fix: overlap issue with multiple stacked datepickers

### DIFF
--- a/components/src/DatePicker/DatePicker.js
+++ b/components/src/DatePicker/DatePicker.js
@@ -85,7 +85,7 @@ class DatePicker extends Component {
   };
 
   render() {
-    const { dateFormat, errorMessage, errorList, inputProps, minDate, maxDate, highlightDates } = this.props;
+    const { dateFormat, errorMessage, errorList, inputProps, minDate, maxDate, highlightDates, className } = this.props;
     const { selectedDate } = this.state;
     const customInputProps = {
       ...inputProps,
@@ -106,7 +106,7 @@ class DatePicker extends Component {
     );
 
     return (
-      <Field className="nds-date-picker">
+      <Field className={`${className} nds-date-picker`}>
         <DatePickerStyles />
         <LocaleContext.Consumer>
           {({ locale }) => (
@@ -145,7 +145,8 @@ DatePicker.propTypes = {
   errorList: PropTypes.arrayOf(PropTypes.string),
   minDate: PropTypes.instanceOf(Date),
   maxDate: PropTypes.instanceOf(Date),
-  highlightDates: PropTypes.arrayOf(PropTypes.shape({}))
+  highlightDates: PropTypes.arrayOf(PropTypes.shape({})),
+  className: PropTypes.string
 };
 
 DatePicker.defaultProps = {
@@ -158,7 +159,8 @@ DatePicker.defaultProps = {
   errorList: undefined,
   minDate: undefined,
   maxDate: undefined,
-  highlightDates: undefined
+  highlightDates: undefined,
+  className: undefined
 };
 
 export default DatePicker;

--- a/components/src/DatePicker/DatePicker.js
+++ b/components/src/DatePicker/DatePicker.js
@@ -160,7 +160,7 @@ DatePicker.defaultProps = {
   minDate: undefined,
   maxDate: undefined,
   highlightDates: undefined,
-  className: undefined
+  className: ""
 };
 
 export default DatePicker;

--- a/components/src/DatePicker/DatePickerStyles.js
+++ b/components/src/DatePicker/DatePickerStyles.js
@@ -18,6 +18,9 @@ export const DatePickerStyles = createGlobalStyle({
     ".react-datepicker__triangle": {
       display: "none"
     },
+    ".react-datepicker-popper": {
+      zIndex: 1
+    },
     ".react-datepicker-popper[data-placement^='bottom']": {
       marginTop: "0"
     },

--- a/components/src/DatePicker/__snapshots__/DatePicker.story.storyshot
+++ b/components/src/DatePicker/__snapshots__/DatePicker.story.storyshot
@@ -8,7 +8,7 @@ exports[`Storyshots DatePicker default 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-date-picker"
+      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
     >
       <div
         class="react-datepicker-wrapper"
@@ -79,7 +79,7 @@ exports[`Storyshots DatePicker with custom date format 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-date-picker"
+      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
     >
       <div
         class="react-datepicker-wrapper"
@@ -150,7 +150,7 @@ exports[`Storyshots DatePicker with custom locale 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-date-picker"
+      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
     >
       <div
         class="react-datepicker-wrapper"
@@ -221,7 +221,7 @@ exports[`Storyshots DatePicker with custom placeholder 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-date-picker"
+      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
     >
       <div
         class="react-datepicker-wrapper"
@@ -292,7 +292,7 @@ exports[`Storyshots DatePicker with error state 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-date-picker"
+      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
     >
       <div
         class="react-datepicker-wrapper"
@@ -395,7 +395,7 @@ exports[`Storyshots DatePicker with min and max date 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-date-picker"
+      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
     >
       <div
         class="react-datepicker-wrapper"

--- a/components/src/DatePicker/__snapshots__/DatePicker.story.storyshot
+++ b/components/src/DatePicker/__snapshots__/DatePicker.story.storyshot
@@ -8,7 +8,7 @@ exports[`Storyshots DatePicker default 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
+      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
     >
       <div
         class="react-datepicker-wrapper"
@@ -79,7 +79,7 @@ exports[`Storyshots DatePicker with custom date format 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
+      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
     >
       <div
         class="react-datepicker-wrapper"
@@ -150,7 +150,7 @@ exports[`Storyshots DatePicker with custom locale 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
+      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
     >
       <div
         class="react-datepicker-wrapper"
@@ -221,7 +221,7 @@ exports[`Storyshots DatePicker with custom placeholder 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
+      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
     >
       <div
         class="react-datepicker-wrapper"
@@ -292,7 +292,7 @@ exports[`Storyshots DatePicker with error state 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
+      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
     >
       <div
         class="react-datepicker-wrapper"
@@ -395,7 +395,7 @@ exports[`Storyshots DatePicker with min and max date 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
+      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
     >
       <div
         class="react-datepicker-wrapper"

--- a/components/src/DateRange/__snapshots__/DateRange.story.storyshot
+++ b/components/src/DateRange/__snapshots__/DateRange.story.storyshot
@@ -28,7 +28,7 @@ exports[`Storyshots DateRange customizing input props 1`] = `
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -83,7 +83,7 @@ exports[`Storyshots DateRange customizing input props 1`] = `
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -159,7 +159,7 @@ exports[`Storyshots DateRange default 1`] = `
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -214,7 +214,7 @@ exports[`Storyshots DateRange default 1`] = `
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -290,7 +290,7 @@ exports[`Storyshots DateRange default start and end date 1`] = `
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -345,7 +345,7 @@ exports[`Storyshots DateRange default start and end date 1`] = `
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -421,7 +421,7 @@ exports[`Storyshots DateRange disabled range validation 1`] = `
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -476,7 +476,7 @@ exports[`Storyshots DateRange disabled range validation 1`] = `
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -552,7 +552,7 @@ exports[`Storyshots DateRange individual input error 1`] = `
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -640,7 +640,7 @@ exports[`Storyshots DateRange individual input error 1`] = `
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -716,7 +716,7 @@ exports[`Storyshots DateRange with custom error 1`] = `
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -771,7 +771,7 @@ exports[`Storyshots DateRange with custom error 1`] = `
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -879,7 +879,7 @@ exports[`Storyshots DateRange with default start and end times 1`] = `
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -1104,7 +1104,7 @@ exports[`Storyshots DateRange with default start and end times 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -1180,7 +1180,7 @@ exports[`Storyshots DateRange with time error 1`] = `
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -1405,7 +1405,7 @@ exports[`Storyshots DateRange with time error 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -1481,7 +1481,7 @@ exports[`Storyshots DateRange with times 1`] = `
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -1706,7 +1706,7 @@ exports[`Storyshots DateRange with times 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"

--- a/components/src/DateRange/__snapshots__/DateRange.story.storyshot
+++ b/components/src/DateRange/__snapshots__/DateRange.story.storyshot
@@ -28,7 +28,7 @@ exports[`Storyshots DateRange customizing input props 1`] = `
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -83,7 +83,7 @@ exports[`Storyshots DateRange customizing input props 1`] = `
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -159,7 +159,7 @@ exports[`Storyshots DateRange default 1`] = `
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -214,7 +214,7 @@ exports[`Storyshots DateRange default 1`] = `
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -290,7 +290,7 @@ exports[`Storyshots DateRange default start and end date 1`] = `
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -345,7 +345,7 @@ exports[`Storyshots DateRange default start and end date 1`] = `
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -421,7 +421,7 @@ exports[`Storyshots DateRange disabled range validation 1`] = `
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -476,7 +476,7 @@ exports[`Storyshots DateRange disabled range validation 1`] = `
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -552,7 +552,7 @@ exports[`Storyshots DateRange individual input error 1`] = `
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -640,7 +640,7 @@ exports[`Storyshots DateRange individual input error 1`] = `
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -716,7 +716,7 @@ exports[`Storyshots DateRange with custom error 1`] = `
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -771,7 +771,7 @@ exports[`Storyshots DateRange with custom error 1`] = `
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -879,7 +879,7 @@ exports[`Storyshots DateRange with default start and end times 1`] = `
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -1104,7 +1104,7 @@ exports[`Storyshots DateRange with default start and end times 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -1180,7 +1180,7 @@ exports[`Storyshots DateRange with time error 1`] = `
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -1405,7 +1405,7 @@ exports[`Storyshots DateRange with time error 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -1481,7 +1481,7 @@ exports[`Storyshots DateRange with times 1`] = `
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"
@@ -1706,7 +1706,7 @@ exports[`Storyshots DateRange with times 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-date-picker"
+        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB undefined nds-date-picker"
       >
         <div
           class="react-datepicker-wrapper"

--- a/docs/src/pages/components/date-picker.js
+++ b/docs/src/pages/components/date-picker.js
@@ -55,6 +55,11 @@ const propsRows = [
     type: "Date",
     defaultValue: "undefined",
     description: "The latest date that can be selected"
+  },
+  {
+    name: "className",
+    type: "string",
+    defaultValue: "undefined"
   }
 ];
 


### PR DESCRIPTION
## Description
fixes input showing through the calendar when inputs are stacked.

https://nu.slack.com/archives/CBAFQ4X7X/p1588615938071800

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
