### PR TITLE
fix: datepicker clears on space key

### DIFF
--- a/components-e2e/cypress/integration/components/DatePicker.spec.js
+++ b/components-e2e/cypress/integration/components/DatePicker.spec.js
@@ -37,11 +37,6 @@ describe("Datepicker", () => {
         closesOnKeyPress("{enter}");
       });
 
-      it("can close a calendar on space", () => {
-        getDateInputComponent().click();
-        closesOnKeyPress(" ");
-      });
-
       it("displays the selected date in the calendar", () => {
         getDateInputComponent().click();
         cy.get(

--- a/components/src/DatePicker/DatePicker.js
+++ b/components/src/DatePicker/DatePicker.js
@@ -76,10 +76,6 @@ class DatePicker extends Component {
     this.datepickerRef.setOpen(!isOpen);
   };
 
-  handleSpaceKey = () => {
-    this.datepickerRef.setOpen(false);
-  };
-
   renderHeader = ({ locale }) => {
     return props => <DatePickerHeader locale={locale} {...props} />;
   };
@@ -101,7 +97,6 @@ class DatePicker extends Component {
         onUpKeyPress={this.handleUpKey}
         onDownKeyPress={this.handleDownKey}
         onEnterKeyPress={this.handleEnterKey}
-        onSpaceKeyPress={this.handleSpaceKey}
       />
     );
 

--- a/components/src/DatePicker/DatePickerInput.js
+++ b/components/src/DatePicker/DatePickerInput.js
@@ -15,7 +15,6 @@ const DatePickerInput = forwardRef(
       onUpKeyPress,
       onDownKeyPress,
       onEnterKeyPress,
-      onSpaceKeyPress,
       "aria-label": ariaLabel
     },
     ref

--- a/components/src/DatePicker/DatePickerInput.js
+++ b/components/src/DatePicker/DatePickerInput.js
@@ -32,7 +32,7 @@ const DatePickerInput = forwardRef(
         onDownKeyPress(event);
       } else if (event.keyCode === 13) {
         onEnterKeyPress(event);
-      } else if (event.keyCode === 32) {
+      } else if (event.keyCode === 32 && onSpaceKeyPress) {
         onSpaceKeyPress(event);
       }
     };

--- a/components/src/DatePicker/DatePickerInput.js
+++ b/components/src/DatePicker/DatePickerInput.js
@@ -32,8 +32,6 @@ const DatePickerInput = forwardRef(
         onDownKeyPress(event);
       } else if (event.keyCode === 13) {
         onEnterKeyPress(event);
-      } else if (event.keyCode === 32 && onSpaceKeyPress) {
-        onSpaceKeyPress(event);
       }
     };
     const { t } = useTranslation();


### PR DESCRIPTION
## Description

Datepicker closes on space key but the datepicker.setOpen function  also clears the input if its not a valid date making it impossible to type a full date! 

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
