### PR TITLE
feat: adds data-testid attribute to TableBody rows

### DIFF
--- a/components/src/Table/TableBody.js
+++ b/components/src/Table/TableBody.js
@@ -49,7 +49,7 @@ const TableBodyRow = ({ row, columns, rowHovers, compact }) => {
         )}
       </StyledTr>
       {row.expandedContent && row.expanded && (
-        <tr data-testid="table-row">
+        <tr data-testid="expanded-table-row">
           <td colSpan={columns.length}>{row.expandedContent({ row })}</td>
         </tr>
       )}

--- a/components/src/Table/TableBody.js
+++ b/components/src/Table/TableBody.js
@@ -41,7 +41,7 @@ const TableBodyRow = ({ row, columns, rowHovers, compact }) => {
     ));
   return (
     <>
-      <StyledTr rowHovers={rowHovers}>
+      <StyledTr rowHovers={rowHovers} data-testid="table-row">
         {row.heading ? (
           <TableCell row={row} colSpan={columns.length} cellData={row.heading} compact={compact} />
         ) : (
@@ -49,7 +49,7 @@ const TableBodyRow = ({ row, columns, rowHovers, compact }) => {
         )}
       </StyledTr>
       {row.expandedContent && row.expanded && (
-        <tr>
+        <tr data-testid="table-row">
           <td colSpan={columns.length}>{row.expandedContent({ row })}</td>
         </tr>
       )}
@@ -65,7 +65,7 @@ TableBodyRow.propTypes = {
 };
 
 const TableMessageContainer = ({ colSpan, children }) => (
-  <tr>
+  <tr data-testid="table-message-container">
     <td colSpan={colSpan}>
       <StyledMessageContainer>{children}</StyledMessageContainer>
     </td>

--- a/components/src/Table/__snapshots__/BaseTable.story.storyshot
+++ b/components/src/Table/__snapshots__/BaseTable.story.storyshot
@@ -42,6 +42,7 @@ exports[`Storyshots Table  with data 1`] = `
       >
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -61,6 +62,7 @@ exports[`Storyshots Table  with data 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -80,6 +82,7 @@ exports[`Storyshots Table  with data 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -99,6 +102,7 @@ exports[`Storyshots Table  with data 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -118,6 +122,7 @@ exports[`Storyshots Table  with data 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -137,6 +142,7 @@ exports[`Storyshots Table  with data 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -156,6 +162,7 @@ exports[`Storyshots Table  with data 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -175,6 +182,7 @@ exports[`Storyshots Table  with data 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -241,6 +249,7 @@ exports[`Storyshots Table with a cell formatter 1`] = `
       >
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -260,6 +269,7 @@ exports[`Storyshots Table with a cell formatter 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -279,6 +289,7 @@ exports[`Storyshots Table with a cell formatter 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -298,6 +309,7 @@ exports[`Storyshots Table with a cell formatter 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -317,6 +329,7 @@ exports[`Storyshots Table with a cell formatter 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -336,6 +349,7 @@ exports[`Storyshots Table with a cell formatter 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -355,6 +369,7 @@ exports[`Storyshots Table with a cell formatter 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -374,6 +389,7 @@ exports[`Storyshots Table with a cell formatter 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -438,6 +454,7 @@ exports[`Storyshots Table with a custom cell component 1`] = `
       >
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -482,6 +499,7 @@ exports[`Storyshots Table with a custom cell component 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -526,6 +544,7 @@ exports[`Storyshots Table with a custom cell component 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -570,6 +589,7 @@ exports[`Storyshots Table with a custom cell component 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -614,6 +634,7 @@ exports[`Storyshots Table with a custom cell component 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -658,6 +679,7 @@ exports[`Storyshots Table with a custom cell component 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -702,6 +724,7 @@ exports[`Storyshots Table with a custom cell component 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -746,6 +769,7 @@ exports[`Storyshots Table with a custom cell component 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -848,6 +872,7 @@ exports[`Storyshots Table with a custom column label component 1`] = `
       >
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -870,6 +895,7 @@ exports[`Storyshots Table with a custom column label component 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -892,6 +918,7 @@ exports[`Storyshots Table with a custom column label component 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -914,6 +941,7 @@ exports[`Storyshots Table with a custom column label component 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -936,6 +964,7 @@ exports[`Storyshots Table with a custom column label component 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -958,6 +987,7 @@ exports[`Storyshots Table with a custom column label component 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -980,6 +1010,7 @@ exports[`Storyshots Table with a custom column label component 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1002,6 +1033,7 @@ exports[`Storyshots Table with a custom column label component 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1071,6 +1103,7 @@ exports[`Storyshots Table with a footer 1`] = `
       >
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1090,6 +1123,7 @@ exports[`Storyshots Table with a footer 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1109,6 +1143,7 @@ exports[`Storyshots Table with a footer 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1128,6 +1163,7 @@ exports[`Storyshots Table with a footer 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1147,6 +1183,7 @@ exports[`Storyshots Table with a footer 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1166,6 +1203,7 @@ exports[`Storyshots Table with a footer 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1185,6 +1223,7 @@ exports[`Storyshots Table with a footer 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1204,6 +1243,7 @@ exports[`Storyshots Table with a footer 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1311,6 +1351,7 @@ exports[`Storyshots Table with cell alignment 1`] = `
       >
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1330,6 +1371,7 @@ exports[`Storyshots Table with cell alignment 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1349,6 +1391,7 @@ exports[`Storyshots Table with cell alignment 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1368,6 +1411,7 @@ exports[`Storyshots Table with cell alignment 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1387,6 +1431,7 @@ exports[`Storyshots Table with cell alignment 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1406,6 +1451,7 @@ exports[`Storyshots Table with cell alignment 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1425,6 +1471,7 @@ exports[`Storyshots Table with cell alignment 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1444,6 +1491,7 @@ exports[`Storyshots Table with cell alignment 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1518,6 +1566,7 @@ exports[`Storyshots Table with custom column widths 1`] = `
       >
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1540,6 +1589,7 @@ exports[`Storyshots Table with custom column widths 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1562,6 +1612,7 @@ exports[`Storyshots Table with custom column widths 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1584,6 +1635,7 @@ exports[`Storyshots Table with custom column widths 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1608,6 +1660,7 @@ exports[`Storyshots Table with custom column widths 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1630,6 +1683,7 @@ exports[`Storyshots Table with custom column widths 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1652,6 +1706,7 @@ exports[`Storyshots Table with custom column widths 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1674,6 +1729,7 @@ exports[`Storyshots Table with custom column widths 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1743,6 +1799,7 @@ exports[`Storyshots Table with full width section 1`] = `
       >
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1762,6 +1819,7 @@ exports[`Storyshots Table with full width section 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1781,6 +1839,7 @@ exports[`Storyshots Table with full width section 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1800,6 +1859,7 @@ exports[`Storyshots Table with full width section 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1819,6 +1879,7 @@ exports[`Storyshots Table with full width section 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             colspan="3"
@@ -1839,6 +1900,7 @@ exports[`Storyshots Table with full width section 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1858,6 +1920,7 @@ exports[`Storyshots Table with full width section 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1877,6 +1940,7 @@ exports[`Storyshots Table with full width section 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -2095,6 +2159,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
       >
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -2227,6 +2292,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -2359,6 +2425,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -2491,6 +2558,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -2623,6 +2691,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -2755,6 +2824,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -2887,6 +2957,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -3019,6 +3090,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -3151,6 +3223,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -3283,6 +3356,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -3415,6 +3489,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -3547,6 +3622,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -3679,6 +3755,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -3811,6 +3888,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -3943,6 +4021,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -4075,6 +4154,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -4207,6 +4287,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -4339,6 +4420,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -4471,6 +4553,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -4603,6 +4686,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -4735,6 +4819,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -4867,6 +4952,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -4999,6 +5085,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -5131,6 +5218,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -5263,6 +5351,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -5395,6 +5484,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -5527,6 +5617,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -5659,6 +5750,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -5791,6 +5883,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -5923,6 +6016,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -6055,6 +6149,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -6187,6 +6282,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -6319,6 +6415,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -6451,6 +6548,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -6583,6 +6681,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -6715,6 +6814,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -6847,6 +6947,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -6979,6 +7080,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -7111,6 +7213,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -7243,6 +7346,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -7375,6 +7479,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -7507,6 +7612,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -7639,6 +7745,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -7771,6 +7878,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -7903,6 +8011,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -8035,6 +8144,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -8167,6 +8277,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -8299,6 +8410,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -8431,6 +8543,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -8563,6 +8676,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -8740,7 +8854,9 @@ exports[`Storyshots Table with no data 1`] = `
       <tbody
         data-testid="table-body"
       >
-        <tr>
+        <tr
+          data-testid="table-message-container"
+        >
           <td
             colspan="2"
           >

--- a/components/src/Table/__snapshots__/Table.story.storyshot
+++ b/components/src/Table/__snapshots__/Table.story.storyshot
@@ -91,6 +91,7 @@ exports[`Storyshots Table with everything 1`] = `
       >
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             colspan="7"
@@ -111,6 +112,7 @@ exports[`Storyshots Table with everything 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -210,6 +212,7 @@ exports[`Storyshots Table with everything 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -288,6 +291,7 @@ exports[`Storyshots Table with everything 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -366,6 +370,7 @@ exports[`Storyshots Table with everything 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -617,6 +622,7 @@ exports[`Storyshots Table with pagination 1`] = `
       >
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"

--- a/components/src/Table/__snapshots__/TableWithExpandableRows.story.storyshot
+++ b/components/src/Table/__snapshots__/TableWithExpandableRows.story.storyshot
@@ -48,6 +48,7 @@ exports[`Storyshots Table/with expandable rows with expandable rows 1`] = `
       >
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -70,6 +71,7 @@ exports[`Storyshots Table/with expandable rows with expandable rows 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -113,6 +115,7 @@ exports[`Storyshots Table/with expandable rows with expandable rows 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -135,6 +138,7 @@ exports[`Storyshots Table/with expandable rows with expandable rows 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -178,6 +182,7 @@ exports[`Storyshots Table/with expandable rows with expandable rows 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -200,6 +205,7 @@ exports[`Storyshots Table/with expandable rows with expandable rows 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -243,6 +249,7 @@ exports[`Storyshots Table/with expandable rows with expandable rows 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -265,6 +272,7 @@ exports[`Storyshots Table/with expandable rows with expandable rows 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -340,6 +348,7 @@ exports[`Storyshots Table/with expandable rows with rows expanded by default 1`]
       >
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -362,6 +371,7 @@ exports[`Storyshots Table/with expandable rows with rows expanded by default 1`]
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -405,6 +415,7 @@ exports[`Storyshots Table/with expandable rows with rows expanded by default 1`]
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -427,6 +438,7 @@ exports[`Storyshots Table/with expandable rows with rows expanded by default 1`]
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -468,7 +480,9 @@ exports[`Storyshots Table/with expandable rows with rows expanded by default 1`]
             675 eaches
           </td>
         </tr>
-        <tr>
+        <tr
+          data-testid="table-row"
+        >
           <td
             colspan="4"
           >
@@ -488,6 +502,7 @@ exports[`Storyshots Table/with expandable rows with rows expanded by default 1`]
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -510,6 +525,7 @@ exports[`Storyshots Table/with expandable rows with rows expanded by default 1`]
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -551,7 +567,9 @@ exports[`Storyshots Table/with expandable rows with rows expanded by default 1`]
             -
           </td>
         </tr>
-        <tr>
+        <tr
+          data-testid="table-row"
+        >
           <td
             colspan="4"
           >
@@ -571,6 +589,7 @@ exports[`Storyshots Table/with expandable rows with rows expanded by default 1`]
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -593,6 +612,7 @@ exports[`Storyshots Table/with expandable rows with rows expanded by default 1`]
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"

--- a/components/src/Table/__snapshots__/TableWithExpandableRows.story.storyshot
+++ b/components/src/Table/__snapshots__/TableWithExpandableRows.story.storyshot
@@ -481,7 +481,7 @@ exports[`Storyshots Table/with expandable rows with rows expanded by default 1`]
           </td>
         </tr>
         <tr
-          data-testid="table-row"
+          data-testid="expanded-table-row"
         >
           <td
             colspan="4"
@@ -568,7 +568,7 @@ exports[`Storyshots Table/with expandable rows with rows expanded by default 1`]
           </td>
         </tr>
         <tr
-          data-testid="table-row"
+          data-testid="expanded-table-row"
         >
           <td
             colspan="4"

--- a/components/src/Table/__snapshots__/TableWithSelectableRows.story.storyshot
+++ b/components/src/Table/__snapshots__/TableWithSelectableRows.story.storyshot
@@ -68,6 +68,7 @@ exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
       >
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -112,6 +113,7 @@ exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -154,6 +156,7 @@ exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -196,6 +199,7 @@ exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -238,6 +242,7 @@ exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -280,6 +285,7 @@ exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -322,6 +328,7 @@ exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -364,6 +371,7 @@ exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -479,6 +487,7 @@ exports[`Storyshots Table/with selectable rows with selectable rows 1`] = `
       >
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -521,6 +530,7 @@ exports[`Storyshots Table/with selectable rows with selectable rows 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -563,6 +573,7 @@ exports[`Storyshots Table/with selectable rows with selectable rows 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -605,6 +616,7 @@ exports[`Storyshots Table/with selectable rows with selectable rows 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -647,6 +659,7 @@ exports[`Storyshots Table/with selectable rows with selectable rows 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -689,6 +702,7 @@ exports[`Storyshots Table/with selectable rows with selectable rows 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -731,6 +745,7 @@ exports[`Storyshots Table/with selectable rows with selectable rows 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -773,6 +788,7 @@ exports[`Storyshots Table/with selectable rows with selectable rows 1`] = `
         </tr>
         <tr
           class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
         >
           <td
             class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"

--- a/components/src/pages/__snapshots__/Details.story.storyshot
+++ b/components/src/pages/__snapshots__/Details.story.storyshot
@@ -395,6 +395,7 @@ exports[`Storyshots Pages/Details page Default 1`] = `
                 >
                   <tr
                     class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    data-testid="table-row"
                   >
                     <td
                       class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -443,6 +444,7 @@ exports[`Storyshots Pages/Details page Default 1`] = `
                   </tr>
                   <tr
                     class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    data-testid="table-row"
                   >
                     <td
                       class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -491,6 +493,7 @@ exports[`Storyshots Pages/Details page Default 1`] = `
                   </tr>
                   <tr
                     class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    data-testid="table-row"
                   >
                     <td
                       class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -539,6 +542,7 @@ exports[`Storyshots Pages/Details page Default 1`] = `
                   </tr>
                   <tr
                     class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    data-testid="table-row"
                   >
                     <td
                       class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -639,6 +643,7 @@ exports[`Storyshots Pages/Details page Default 1`] = `
                 >
                   <tr
                     class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    data-testid="table-row"
                   >
                     <td
                       class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -658,6 +663,7 @@ exports[`Storyshots Pages/Details page Default 1`] = `
                   </tr>
                   <tr
                     class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    data-testid="table-row"
                   >
                     <td
                       class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -677,6 +683,7 @@ exports[`Storyshots Pages/Details page Default 1`] = `
                   </tr>
                   <tr
                     class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    data-testid="table-row"
                   >
                     <td
                       class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -696,6 +703,7 @@ exports[`Storyshots Pages/Details page Default 1`] = `
                   </tr>
                   <tr
                     class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    data-testid="table-row"
                   >
                     <td
                       class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1236,6 +1244,7 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                 >
                   <tr
                     class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    data-testid="table-row"
                   >
                     <td
                       class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1284,6 +1293,7 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                   </tr>
                   <tr
                     class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    data-testid="table-row"
                   >
                     <td
                       class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1332,6 +1342,7 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                   </tr>
                   <tr
                     class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    data-testid="table-row"
                   >
                     <td
                       class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1380,6 +1391,7 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                   </tr>
                   <tr
                     class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    data-testid="table-row"
                   >
                     <td
                       class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1480,6 +1492,7 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                 >
                   <tr
                     class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    data-testid="table-row"
                   >
                     <td
                       class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1499,6 +1512,7 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                   </tr>
                   <tr
                     class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    data-testid="table-row"
                   >
                     <td
                       class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1518,6 +1532,7 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                   </tr>
                   <tr
                     class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    data-testid="table-row"
                   >
                     <td
                       class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -1537,6 +1552,7 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                   </tr>
                   <tr
                     class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    data-testid="table-row"
                   >
                     <td
                       class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -2044,6 +2060,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 >
                   <tr
                     class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    data-testid="table-row"
                   >
                     <td
                       class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -2092,6 +2109,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                   </tr>
                   <tr
                     class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    data-testid="table-row"
                   >
                     <td
                       class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -2140,6 +2158,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                   </tr>
                   <tr
                     class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    data-testid="table-row"
                   >
                     <td
                       class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -2188,6 +2207,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                   </tr>
                   <tr
                     class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    data-testid="table-row"
                   >
                     <td
                       class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -2288,6 +2308,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 >
                   <tr
                     class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    data-testid="table-row"
                   >
                     <td
                       class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -2307,6 +2328,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                   </tr>
                   <tr
                     class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    data-testid="table-row"
                   >
                     <td
                       class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -2326,6 +2348,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                   </tr>
                   <tr
                     class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    data-testid="table-row"
                   >
                     <td
                       class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
@@ -2345,6 +2368,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                   </tr>
                   <tr
                     class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    data-testid="table-row"
                   >
                     <td
                       class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"


### PR DESCRIPTION
## Description

This change was motivated by CN1-1349.

To test our tables on the front end using the React-testing-library we aren't able to select a specific row to test without a hacky workaround to select tags. We would prefer to follow the data-testid pattern used elsewhere in NDS.

This PR adds a data-testid to each < tr > row.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [x] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
