### PR TITLE
fix: set button type on ControlIcon so it doesn't submit forms

### DIFF
--- a/components/src/Button/ControlIcon.js
+++ b/components/src/Button/ControlIcon.js
@@ -39,7 +39,7 @@ const StyledButton = styled.button(
 );
 
 const ControlIcon = React.forwardRef(({ icon, toggled, disabled, label, size, ...props }, ref) => (
-  <StyledButton aria-label={label} ref={ref} disabled={disabled} toggled={toggled} {...props}>
+  <StyledButton aria-label={label} ref={ref} disabled={disabled} toggled={toggled} type="button" {...props}>
     <Icon size={size} icon={icon} />
   </StyledButton>
 ));
@@ -51,6 +51,7 @@ ControlIcon.propTypes = {
   toggled: PropTypes.bool,
   disabled: PropTypes.bool,
   size: PropTypes.string,
+  type: PropTypes.string,
   ...propTypes.space
 };
 
@@ -58,6 +59,7 @@ ControlIcon.defaultProps = {
   onClick: null,
   toggled: false,
   disabled: false,
-  size: theme.space.x4
+  size: theme.space.x4,
+  type: "button"
 };
 export default ControlIcon;

--- a/components/src/Button/ControlIcon.js
+++ b/components/src/Button/ControlIcon.js
@@ -38,8 +38,8 @@ const StyledButton = styled.button(
   space
 );
 
-const ControlIcon = React.forwardRef(({ icon, toggled, disabled, label, size, ...props }, ref) => (
-  <StyledButton aria-label={label} ref={ref} disabled={disabled} toggled={toggled} type="button" {...props}>
+const ControlIcon = React.forwardRef(({ icon, toggled, disabled, label, size, type, ...props }, ref) => (
+  <StyledButton aria-label={label} ref={ref} disabled={disabled} toggled={toggled} type={type} {...props}>
     <Icon size={size} icon={icon} />
   </StyledButton>
 ));

--- a/components/src/Button/__snapshots__/ControlIcon.story.storyshot
+++ b/components/src/Button/__snapshots__/ControlIcon.story.storyshot
@@ -10,6 +10,7 @@ exports[`Storyshots ControlIcon Control Icon 1`] = `
     <button
       aria-label="close"
       class="ControlIcon__StyledButton-sc-1h83lvi-0 cCdEvo"
+      type="button"
     >
       <svg
         aria-hidden="true"
@@ -42,6 +43,7 @@ exports[`Storyshots ControlIcon Disabled 1`] = `
       aria-label="close"
       class="ControlIcon__StyledButton-sc-1h83lvi-0 lkZGcS"
       disabled=""
+      type="button"
     >
       <svg
         aria-hidden="true"
@@ -73,6 +75,7 @@ exports[`Storyshots ControlIcon Toggled 1`] = `
     <button
       aria-label="close"
       class="ControlIcon__StyledButton-sc-1h83lvi-0 jjnZya"
+      type="button"
     >
       <svg
         aria-hidden="true"

--- a/components/src/LoadingAnimation/__snapshots__/LoadingAnimation.story.storyshot
+++ b/components/src/LoadingAnimation/__snapshots__/LoadingAnimation.story.storyshot
@@ -503,6 +503,7 @@ exports[`Storyshots LoadingAnimation Page example - active 1`] = `
           aria-label="Retry"
           class="ControlIcon__StyledButton-sc-1h83lvi-0 jupSnY"
           disabled=""
+          type="button"
         >
           <svg
             aria-hidden="true"
@@ -523,6 +524,7 @@ exports[`Storyshots LoadingAnimation Page example - active 1`] = `
         <button
           aria-label="Abort"
           class="ControlIcon__StyledButton-sc-1h83lvi-0 cCdEvo"
+          type="button"
         >
           <svg
             aria-hidden="true"
@@ -742,6 +744,7 @@ exports[`Storyshots LoadingAnimation Page example - inactive 1`] = `
         <button
           aria-label="Retry"
           class="ControlIcon__StyledButton-sc-1h83lvi-0 jlPgHC"
+          type="button"
         >
           <svg
             aria-hidden="true"
@@ -762,6 +765,7 @@ exports[`Storyshots LoadingAnimation Page example - inactive 1`] = `
         <button
           aria-label="Abort"
           class="ControlIcon__StyledButton-sc-1h83lvi-0 cCdEvo"
+          type="button"
         >
           <svg
             aria-hidden="true"

--- a/components/src/Table/__snapshots__/SortingColumnHeader.story.storyshot
+++ b/components/src/Table/__snapshots__/SortingColumnHeader.story.storyshot
@@ -20,6 +20,7 @@ exports[`Storyshots Table.Headers Sorting Header 1`] = `
       <button
         aria-label="Sort ascending"
         class="ControlIcon__StyledButton-sc-1h83lvi-0 cCdEvo"
+        type="button"
       >
         <svg
           aria-hidden="true"

--- a/components/src/Table/__snapshots__/Table.story.storyshot
+++ b/components/src/Table/__snapshots__/Table.story.storyshot
@@ -143,6 +143,7 @@ exports[`Storyshots Table with everything 1`] = `
             <button
               aria-label="Expand row"
               class="ControlIcon__StyledButton-sc-1h83lvi-0 cCdEvo"
+              type="button"
             >
               <svg
                 aria-hidden="true"

--- a/components/src/Table/__snapshots__/TableWithExpandableRows.story.storyshot
+++ b/components/src/Table/__snapshots__/TableWithExpandableRows.story.storyshot
@@ -79,6 +79,7 @@ exports[`Storyshots Table/with expandable rows with expandable rows 1`] = `
             <button
               aria-label="Expand row"
               class="ControlIcon__StyledButton-sc-1h83lvi-0 cCdEvo"
+              type="button"
             >
               <svg
                 aria-hidden="true"
@@ -146,6 +147,7 @@ exports[`Storyshots Table/with expandable rows with expandable rows 1`] = `
             <button
               aria-label="Expand row"
               class="ControlIcon__StyledButton-sc-1h83lvi-0 cCdEvo"
+              type="button"
             >
               <svg
                 aria-hidden="true"
@@ -213,6 +215,7 @@ exports[`Storyshots Table/with expandable rows with expandable rows 1`] = `
             <button
               aria-label="Expand row"
               class="ControlIcon__StyledButton-sc-1h83lvi-0 cCdEvo"
+              type="button"
             >
               <svg
                 aria-hidden="true"
@@ -379,6 +382,7 @@ exports[`Storyshots Table/with expandable rows with rows expanded by default 1`]
             <button
               aria-label="Expand row"
               class="ControlIcon__StyledButton-sc-1h83lvi-0 cCdEvo"
+              type="button"
             >
               <svg
                 aria-hidden="true"
@@ -446,6 +450,7 @@ exports[`Storyshots Table/with expandable rows with rows expanded by default 1`]
             <button
               aria-label="Collapse row"
               class="ControlIcon__StyledButton-sc-1h83lvi-0 cCdEvo"
+              type="button"
             >
               <svg
                 aria-hidden="true"
@@ -533,6 +538,7 @@ exports[`Storyshots Table/with expandable rows with rows expanded by default 1`]
             <button
               aria-label="Collapse row"
               class="ControlIcon__StyledButton-sc-1h83lvi-0 cCdEvo"
+              type="button"
             >
               <svg
                 aria-hidden="true"


### PR DESCRIPTION
## Description

HTML button is submit by default causing onSubmit to be called when pressed.
This sets the type to button to fix unexpected submits

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
