### PR TITLE
feat: adds box-sizing modifier 

### DIFF
--- a/css/src/scss/_defaults.scss
+++ b/css/src/scss/_defaults.scss
@@ -20,12 +20,6 @@
   code {
     font-family: $font-family-mono;
   }
-
-  img {
-    max-width: 100%;
-    height: auto;
-    display: block;
-  }
 }
 
 .nds--content-box {

--- a/css/src/scss/_defaults.scss
+++ b/css/src/scss/_defaults.scss
@@ -27,3 +27,9 @@
     display: block;
   }
 }
+
+.nds--content-box {
+  * {
+    box-sizing: content-box;
+  }
+}


### PR DESCRIPTION
## Description

This allows adding `.nds--content-box` to the wrapper to use `* {box-sizing: content-box}` instead to provide compatibility with PackManager. This required adding box-sizing directly to our inputs as we still want them to be sized with border-box regardless. I also removed the default img styles which weren't required or in-use but could cause issues with PackManager form and table images. 

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
