### PR TITLE
feat: accept node as navbar menu name and add aria-label option

### DIFF
--- a/components/src/NavBar/DesktopMenu.js
+++ b/components/src/NavBar/DesktopMenu.js
@@ -76,7 +76,7 @@ const Nav = styled.nav({
 
 const renderMenuTrigger = (menuItem, themeColorObject) => (
   <div key={menuItem.name}>
-    <MenuTrigger name={menuItem.name} menuData={menuItem.items} {...themeColorObject} />
+    <MenuTrigger name={menuItem.name} aria-label={menuItem.ariaLabel} menuData={menuItem.items} {...themeColorObject} />
   </div>
 );
 

--- a/components/src/NavBar/MenuTrigger.js
+++ b/components/src/NavBar/MenuTrigger.js
@@ -61,7 +61,7 @@ const MenuTriggerButton = React.forwardRef(({ name, color, hoverColor, hoverBack
 ));
 
 MenuTriggerButton.propTypes = {
-  name: PropTypes.string.isRequired,
+  name: PropTypes.node.isRequired,
   color: PropTypes.string,
   hoverColor: PropTypes.string,
   hoverBackground: PropTypes.string
@@ -74,7 +74,7 @@ MenuTriggerButton.defaultProps = {
 };
 
 const MenuTrigger = props => {
-  const { menuData, name, color, hoverColor, hoverBackground, ...otherProps } = props;
+  const { menuData, name, color, hoverColor, hoverBackground, "aria-label": ariaLabel, ...otherProps } = props;
   let dropdownMinWidth = "auto";
   const setDropdownMinWidth = popperData => {
     // Popper.js throws an error if popperData is not returned from this fn
@@ -94,7 +94,13 @@ const MenuTrigger = props => {
         preventOverflow: { enabled: true, padding: 8, boundariesElement: "viewport" }
       }}
       trigger={() => (
-        <MenuTriggerButton color={color} hoverColor={hoverColor} hoverBackground={hoverBackground} name={name} />
+        <MenuTriggerButton
+          color={color}
+          hoverColor={hoverColor}
+          hoverBackground={hoverBackground}
+          name={name}
+          aria-label={ariaLabel}
+        />
       )}
     >
       {({ closeMenu }) => (
@@ -114,7 +120,8 @@ const MenuTrigger = props => {
 };
 
 MenuTrigger.propTypes = {
-  name: PropTypes.string.isRequired,
+  name: PropTypes.node.isRequired,
+  "aria-label": PropTypes.string,
   menuData: PropTypes.arrayOf(PropTypes.shape({})),
   color: PropTypes.string,
   hoverColor: PropTypes.string,
@@ -123,6 +130,7 @@ MenuTrigger.propTypes = {
 
 MenuTrigger.defaultProps = {
   menuData: null,
+  "aria-label": undefined,
   color: theme.colors.white,
   hoverColor: theme.colors.lightBlue,
   hoverBackground: theme.colors.black

--- a/components/src/NavBar/MenuTrigger.js
+++ b/components/src/NavBar/MenuTrigger.js
@@ -9,13 +9,13 @@ import SubMenuTrigger from "./SubMenuTrigger";
 import renderSubMenuItems from "./renderSubMenuItems";
 
 const StyledButton = styled.button(({ color, hoverColor, hoverBackground }) => ({
-  display: "block",
+  display: "flex",
+  alignItems: "center",
   position: "relative",
   color: themeGet(`colors.${color}`, color)(color),
   border: "none",
   backgroundColor: "transparent",
   textDecoration: "none",
-  verticalAlign: "middle",
   lineHeight: theme.lineHeights.base,
   transition: "background-color .2s",
   fontSize: `${theme.fontSizes.medium}`,
@@ -51,7 +51,7 @@ const MenuTriggerButton = React.forwardRef(({ name, color, hoverColor, hoverBack
   <StyledButton color={color} hoverColor={hoverColor} hoverBackground={hoverBackground} ref={ref} {...props}>
     {name}
     <Icon
-      style={{ position: "absolute", top: "11px" }}
+      style={{ position: "absolute", top: "11px", right: "8px" }}
       icon="downArrow"
       color={themeGet(`colors.${color}`, color)(color)}
       size="20px"

--- a/components/src/NavBar/NavBar.story.js
+++ b/components/src/NavBar/NavBar.story.js
@@ -2,6 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import { storiesOf } from "@storybook/react";
 import { NavBar as NDSNavBar } from "../index";
+import { Icon } from "../Icon";
 
 const ResetStorybookView = styled.div({
   position: "absolute",
@@ -151,6 +152,18 @@ const secondaryMenu = [
   }
 ];
 
+const secondaryMenuCustomLinks = [
+  {
+    name: "User@Nulogy.com",
+    items: [{ name: "Profile", href: "/" }, { name: "Preferences", href: "/" }, { name: "Logout", href: "/" }]
+  },
+  {
+    name: <Icon icon="settings" />,
+    ariaLabel: "Settings",
+    items: [{ name: "Permissions", href: "/" }, { name: "Manage account", href: "/" }]
+  }
+];
+
 const search = {
   onSubmit: () => {}
 };
@@ -162,7 +175,9 @@ storiesOf("NavBar", module)
   .add("Without search and secondary menu", () => <NavBar menuData={{ primaryMenu }} />)
   .add("Without search and primary menu", () => <NavBar menuData={{ secondaryMenu }} />)
   .add("With branding only", () => <NavBar menuData={{}} />)
-  .add("With custom link components", () => <NavBar menuData={{ primaryMenu: primaryMenuCustomLinks }} />)
+  .add("With custom link components", () => (
+    <NavBar menuData={{ primaryMenu: primaryMenuCustomLinks, secondaryMenu: secondaryMenuCustomLinks, search }} />
+  ))
   .add("With text in the menu", () => <NavBar menuData={{ primaryMenu: primaryMenuText }} />)
   .add("With subtext", () => (
     <NavBar subtext="Logo Subtext" menuData={{ primaryMenu: primaryMenuCustomLinks, search }} />

--- a/components/src/NavBar/__snapshots__/NavBar.story.storyshot
+++ b/components/src/NavBar/__snapshots__/NavBar.story.storyshot
@@ -76,7 +76,7 @@ exports[`Storyshots NavBar NavBar 1`] = `
                 <button
                   aria-expanded="false"
                   aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                   color="#ffffff"
                   type="button"
                 >
@@ -90,7 +90,7 @@ exports[`Storyshots NavBar NavBar 1`] = `
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px"
+                    style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -104,7 +104,7 @@ exports[`Storyshots NavBar NavBar 1`] = `
                 <button
                   aria-expanded="false"
                   aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                   color="#ffffff"
                   type="button"
                 >
@@ -118,7 +118,7 @@ exports[`Storyshots NavBar NavBar 1`] = `
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px"
+                    style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -132,7 +132,7 @@ exports[`Storyshots NavBar NavBar 1`] = `
                 <button
                   aria-expanded="false"
                   aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                   color="#ffffff"
                   type="button"
                 >
@@ -146,7 +146,7 @@ exports[`Storyshots NavBar NavBar 1`] = `
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px"
+                    style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -234,7 +234,7 @@ exports[`Storyshots NavBar NavBar 1`] = `
                   <button
                     aria-expanded="false"
                     aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                    class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                     color="#ffffff"
                     type="button"
                   >
@@ -248,7 +248,7 @@ exports[`Storyshots NavBar NavBar 1`] = `
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px"
+                      style="position:absolute;top:11px;right:8px"
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -262,7 +262,7 @@ exports[`Storyshots NavBar NavBar 1`] = `
                   <button
                     aria-expanded="false"
                     aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                    class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                     color="#ffffff"
                     type="button"
                   >
@@ -276,7 +276,7 @@ exports[`Storyshots NavBar NavBar 1`] = `
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px"
+                      style="position:absolute;top:11px;right:8px"
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -383,7 +383,7 @@ exports[`Storyshots NavBar With alternate themeColor 1`] = `
                 <button
                   aria-expanded="false"
                   aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 cMhQQz"
+                  class="MenuTrigger__StyledButton-sm3xx0-0 dZyBSn"
                   color="#00438f"
                   type="button"
                 >
@@ -397,7 +397,7 @@ exports[`Storyshots NavBar With alternate themeColor 1`] = `
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px"
+                    style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -515,7 +515,7 @@ exports[`Storyshots NavBar With alternative branding link 1`] = `
                 <button
                   aria-expanded="false"
                   aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                   color="#ffffff"
                   type="button"
                 >
@@ -529,7 +529,7 @@ exports[`Storyshots NavBar With alternative branding link 1`] = `
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px"
+                    style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -726,7 +726,7 @@ exports[`Storyshots NavBar With custom link components 1`] = `
                 <button
                   aria-expanded="false"
                   aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                   color="#ffffff"
                   type="button"
                 >
@@ -740,7 +740,7 @@ exports[`Storyshots NavBar With custom link components 1`] = `
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px"
+                    style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -838,7 +838,7 @@ exports[`Storyshots NavBar With custom link components 1`] = `
                   <button
                     aria-expanded="false"
                     aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                    class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                     color="#ffffff"
                     type="button"
                   >
@@ -852,7 +852,7 @@ exports[`Storyshots NavBar With custom link components 1`] = `
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px"
+                      style="position:absolute;top:11px;right:8px"
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -867,7 +867,7 @@ exports[`Storyshots NavBar With custom link components 1`] = `
                     aria-expanded="false"
                     aria-haspopup="true"
                     aria-label="Settings"
-                    class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                    class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                     color="#ffffff"
                     type="button"
                   >
@@ -895,7 +895,7 @@ exports[`Storyshots NavBar With custom link components 1`] = `
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px"
+                      style="position:absolute;top:11px;right:8px"
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -1002,7 +1002,7 @@ exports[`Storyshots NavBar With subtext 1`] = `
                 <button
                   aria-expanded="false"
                   aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                   color="#ffffff"
                   type="button"
                 >
@@ -1016,7 +1016,7 @@ exports[`Storyshots NavBar With subtext 1`] = `
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px"
+                    style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -1191,7 +1191,7 @@ exports[`Storyshots NavBar With text in the menu 1`] = `
                 <button
                   aria-expanded="false"
                   aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                   color="#ffffff"
                   type="button"
                 >
@@ -1205,7 +1205,7 @@ exports[`Storyshots NavBar With text in the menu 1`] = `
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px"
+                    style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -1319,7 +1319,7 @@ exports[`Storyshots NavBar Without search 1`] = `
                 <button
                   aria-expanded="false"
                   aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                   color="#ffffff"
                   type="button"
                 >
@@ -1333,7 +1333,7 @@ exports[`Storyshots NavBar Without search 1`] = `
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px"
+                    style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -1347,7 +1347,7 @@ exports[`Storyshots NavBar Without search 1`] = `
                 <button
                   aria-expanded="false"
                   aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                   color="#ffffff"
                   type="button"
                 >
@@ -1361,7 +1361,7 @@ exports[`Storyshots NavBar Without search 1`] = `
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px"
+                    style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -1375,7 +1375,7 @@ exports[`Storyshots NavBar Without search 1`] = `
                 <button
                   aria-expanded="false"
                   aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                   color="#ffffff"
                   type="button"
                 >
@@ -1389,7 +1389,7 @@ exports[`Storyshots NavBar Without search 1`] = `
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px"
+                    style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -1421,7 +1421,7 @@ exports[`Storyshots NavBar Without search 1`] = `
                   <button
                     aria-expanded="false"
                     aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                    class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                     color="#ffffff"
                     type="button"
                   >
@@ -1435,7 +1435,7 @@ exports[`Storyshots NavBar Without search 1`] = `
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px"
+                      style="position:absolute;top:11px;right:8px"
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -1449,7 +1449,7 @@ exports[`Storyshots NavBar Without search 1`] = `
                   <button
                     aria-expanded="false"
                     aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                    class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                     color="#ffffff"
                     type="button"
                   >
@@ -1463,7 +1463,7 @@ exports[`Storyshots NavBar Without search 1`] = `
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px"
+                      style="position:absolute;top:11px;right:8px"
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -1562,7 +1562,7 @@ exports[`Storyshots NavBar Without search and primary menu 1`] = `
                   <button
                     aria-expanded="false"
                     aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                    class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                     color="#ffffff"
                     type="button"
                   >
@@ -1576,7 +1576,7 @@ exports[`Storyshots NavBar Without search and primary menu 1`] = `
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px"
+                      style="position:absolute;top:11px;right:8px"
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -1590,7 +1590,7 @@ exports[`Storyshots NavBar Without search and primary menu 1`] = `
                   <button
                     aria-expanded="false"
                     aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                    class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                     color="#ffffff"
                     type="button"
                   >
@@ -1604,7 +1604,7 @@ exports[`Storyshots NavBar Without search and primary menu 1`] = `
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px"
+                      style="position:absolute;top:11px;right:8px"
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -1700,7 +1700,7 @@ exports[`Storyshots NavBar Without search and secondary menu 1`] = `
                 <button
                   aria-expanded="false"
                   aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                   color="#ffffff"
                   type="button"
                 >
@@ -1714,7 +1714,7 @@ exports[`Storyshots NavBar Without search and secondary menu 1`] = `
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px"
+                    style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -1728,7 +1728,7 @@ exports[`Storyshots NavBar Without search and secondary menu 1`] = `
                 <button
                   aria-expanded="false"
                   aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                   color="#ffffff"
                   type="button"
                 >
@@ -1742,7 +1742,7 @@ exports[`Storyshots NavBar Without search and secondary menu 1`] = `
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px"
+                    style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -1756,7 +1756,7 @@ exports[`Storyshots NavBar Without search and secondary menu 1`] = `
                 <button
                   aria-expanded="false"
                   aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                   color="#ffffff"
                   type="button"
                 >
@@ -1770,7 +1770,7 @@ exports[`Storyshots NavBar Without search and secondary menu 1`] = `
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px"
+                    style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -1878,7 +1878,7 @@ exports[`Storyshots NavBar Without secondary menu 1`] = `
                 <button
                   aria-expanded="false"
                   aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                   color="#ffffff"
                   type="button"
                 >
@@ -1892,7 +1892,7 @@ exports[`Storyshots NavBar Without secondary menu 1`] = `
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px"
+                    style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -1906,7 +1906,7 @@ exports[`Storyshots NavBar Without secondary menu 1`] = `
                 <button
                   aria-expanded="false"
                   aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                   color="#ffffff"
                   type="button"
                 >
@@ -1920,7 +1920,7 @@ exports[`Storyshots NavBar Without secondary menu 1`] = `
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px"
+                    style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -1934,7 +1934,7 @@ exports[`Storyshots NavBar Without secondary menu 1`] = `
                 <button
                   aria-expanded="false"
                   aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                   color="#ffffff"
                   type="button"
                 >
@@ -1948,7 +1948,7 @@ exports[`Storyshots NavBar Without secondary menu 1`] = `
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px"
+                    style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
                   >

--- a/components/src/NavBar/__snapshots__/NavBar.story.storyshot
+++ b/components/src/NavBar/__snapshots__/NavBar.story.storyshot
@@ -773,7 +773,140 @@ exports[`Storyshots NavBar With custom link components 1`] = `
             <div
               class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
               style="float:right"
-            />
+            >
+              <div
+                class="Box-sc-1qu1edy-0 eBpgUm"
+              >
+                <form
+                  class="NavBarSearch-sc-1aq0npd-0 lfszCe"
+                >
+                  <div
+                    class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+                    role="search"
+                  >
+                    <div
+                      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+                    >
+                      <div
+                        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+                      >
+                        <div
+                          class="Box-sc-1qu1edy-0 hxUhcg"
+                          display="flex"
+                        >
+                          <input
+                            aria-invalid="false"
+                            aria-labelledby="global-search"
+                            aria-required="true"
+                            class="InputField__StyledInput-sc-6cu4mg-0 soqcT"
+                            id="navbar-search"
+                            placeholder="Search Nulogy..."
+                            required=""
+                            type="search"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                    <button
+                      aria-label="global-search"
+                      id="global-search"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="Icon-fc7twp-0 dkBAgY"
+                        color="currentColor"
+                        fill="currentColor"
+                        focusable="false"
+                        height="24px"
+                        icon="search"
+                        viewBox="0 0 24 24"
+                        width="24px"
+                      >
+                        <path
+                          d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </form>
+              </div>
+              <nav
+                aria-label="Secondary navigation"
+                class="DesktopMenu__Nav-e4dzdq-3 bWwdcq DesktopMenu-e4dzdq-4 irbObu"
+              >
+                <div>
+                  <button
+                    aria-expanded="false"
+                    aria-haspopup="true"
+                    class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                    color="#ffffff"
+                    type="button"
+                  >
+                    User@Nulogy.com
+                    <svg
+                      aria-hidden="true"
+                      class="Icon-fc7twp-0 hIxIEB"
+                      color="#ffffff"
+                      fill="#ffffff"
+                      focusable="false"
+                      height="20px"
+                      icon="downArrow"
+                      p="2px"
+                      style="position:absolute;top:11px"
+                      viewBox="0 0 24 24"
+                      width="20px"
+                    >
+                      <path
+                        d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+                <div>
+                  <button
+                    aria-expanded="false"
+                    aria-haspopup="true"
+                    aria-label="Settings"
+                    class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                    color="#ffffff"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="Icon-fc7twp-0 dkBAgY"
+                      color="currentColor"
+                      fill="currentColor"
+                      focusable="false"
+                      height="24px"
+                      icon="settings"
+                      viewBox="0 0 20 20"
+                      width="24px"
+                    >
+                      <path
+                        d="M15.95 10.78c.03-.25.05-.51.05-.78s-.02-.53-.06-.78l1.69-1.32c.15-.12.19-.34.1-.51l-1.6-2.77c-.1-.18-.31-.24-.49-.18l-1.99.8c-.42-.32-.86-.58-1.35-.78L12 2.34c-.03-.2-.2-.34-.4-.34H8.4c-.2 0-.36.14-.39.34l-.3 2.12c-.49.2-.94.47-1.35.78l-1.99-.8c-.18-.07-.39 0-.49.18l-1.6 2.77c-.1.18-.06.39.1.51l1.69 1.32c-.04.25-.07.52-.07.78s.02.53.06.78L2.37 12.1c-.15.12-.19.34-.1.51l1.6 2.77c.1.18.31.24.49.18l1.99-.8c.42.32.86.58 1.35.78l.3 2.12c.04.2.2.34.4.34h3.2c.2 0 .37-.14.39-.34l.3-2.12c.49-.2.94-.47 1.35-.78l1.99.8c.18.07.39 0 .49-.18l1.6-2.77c.1-.18.06-.39-.1-.51l-1.67-1.32zM10 13c-1.65 0-3-1.35-3-3s1.35-3 3-3 3 1.35 3 3-1.35 3-3 3z"
+                      />
+                    </svg>
+                    <svg
+                      aria-hidden="true"
+                      class="Icon-fc7twp-0 hIxIEB"
+                      color="#ffffff"
+                      fill="#ffffff"
+                      focusable="false"
+                      height="20px"
+                      icon="downArrow"
+                      p="2px"
+                      style="position:absolute;top:11px"
+                      viewBox="0 0 24 24"
+                      width="20px"
+                    >
+                      <path
+                        d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </nav>
+            </div>
           </div>
         </div>
       </header>

--- a/components/src/NavBar/isValidMenuItem.js
+++ b/components/src/NavBar/isValidMenuItem.js
@@ -11,7 +11,8 @@ const isValidMenuItem = function validArrayItem(arr, idx, componentName, locatio
 
   PropTypes.checkPropTypes(
     {
-      name: PropTypes.string.isRequired,
+      name: PropTypes.node.isRequired,
+      ariaLabel: PropTypes.string,
       href: PropTypes.string,
       items: PropTypes.arrayOf(isValidMenuItem),
       render: PropTypes.func

--- a/components/src/pages/__snapshots__/Custom.story.storyshot
+++ b/components/src/pages/__snapshots__/Custom.story.storyshot
@@ -76,7 +76,7 @@ exports[`Storyshots Pages/Custom Default 1`] = `
                 <button
                   aria-expanded="false"
                   aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                   color="#ffffff"
                   type="button"
                 >
@@ -90,7 +90,7 @@ exports[`Storyshots Pages/Custom Default 1`] = `
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px"
+                    style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -122,7 +122,7 @@ exports[`Storyshots Pages/Custom Default 1`] = `
                   <button
                     aria-expanded="false"
                     aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                    class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                     color="#ffffff"
                     type="button"
                   >
@@ -136,7 +136,7 @@ exports[`Storyshots Pages/Custom Default 1`] = `
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px"
+                      style="position:absolute;top:11px;right:8px"
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -254,7 +254,7 @@ exports[`Storyshots Pages/Custom With breadcrumbs and actions 1`] = `
                 <button
                   aria-expanded="false"
                   aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                   color="#ffffff"
                   type="button"
                 >
@@ -268,7 +268,7 @@ exports[`Storyshots Pages/Custom With breadcrumbs and actions 1`] = `
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px"
+                    style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -300,7 +300,7 @@ exports[`Storyshots Pages/Custom With breadcrumbs and actions 1`] = `
                   <button
                     aria-expanded="false"
                     aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                    class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                     color="#ffffff"
                     type="button"
                   >
@@ -314,7 +314,7 @@ exports[`Storyshots Pages/Custom With breadcrumbs and actions 1`] = `
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px"
+                      style="position:absolute;top:11px;right:8px"
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -551,7 +551,7 @@ exports[`Storyshots Pages/Custom With sidebar 1`] = `
                 <button
                   aria-expanded="false"
                   aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                   color="#ffffff"
                   type="button"
                 >
@@ -565,7 +565,7 @@ exports[`Storyshots Pages/Custom With sidebar 1`] = `
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px"
+                    style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -597,7 +597,7 @@ exports[`Storyshots Pages/Custom With sidebar 1`] = `
                   <button
                     aria-expanded="false"
                     aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                    class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                     color="#ffffff"
                     type="button"
                   >
@@ -611,7 +611,7 @@ exports[`Storyshots Pages/Custom With sidebar 1`] = `
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px"
+                      style="position:absolute;top:11px;right:8px"
                       viewBox="0 0 24 24"
                       width="20px"
                     >

--- a/components/src/pages/__snapshots__/Details.story.storyshot
+++ b/components/src/pages/__snapshots__/Details.story.storyshot
@@ -76,7 +76,7 @@ exports[`Storyshots Pages/Details page Default 1`] = `
                 <button
                   aria-expanded="false"
                   aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                   color="#ffffff"
                   type="button"
                 >
@@ -90,7 +90,7 @@ exports[`Storyshots Pages/Details page Default 1`] = `
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px"
+                    style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -122,7 +122,7 @@ exports[`Storyshots Pages/Details page Default 1`] = `
                   <button
                     aria-expanded="false"
                     aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                    class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                     color="#ffffff"
                     type="button"
                   >
@@ -136,7 +136,7 @@ exports[`Storyshots Pages/Details page Default 1`] = `
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px"
+                      style="position:absolute;top:11px;right:8px"
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -849,7 +849,7 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                 <button
                   aria-expanded="false"
                   aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                   color="#ffffff"
                   type="button"
                 >
@@ -863,7 +863,7 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px"
+                    style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -895,7 +895,7 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                   <button
                     aria-expanded="false"
                     aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                    class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                     color="#ffffff"
                     type="button"
                   >
@@ -909,7 +909,7 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px"
+                      style="position:absolute;top:11px;right:8px"
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -1741,7 +1741,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 <button
                   aria-expanded="false"
                   aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                   color="#ffffff"
                   type="button"
                 >
@@ -1755,7 +1755,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px"
+                    style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -1787,7 +1787,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                   <button
                     aria-expanded="false"
                     aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sm3xx0-0 ePWTMl"
+                    class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
                     color="#ffffff"
                     type="button"
                   >
@@ -1801,7 +1801,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px"
+                      style="position:absolute;top:11px;right:8px"
                       viewBox="0 0 24 24"
                       width="20px"
                     >

--- a/docs/src/pages/components/navbar.js
+++ b/docs/src/pages/components/navbar.js
@@ -109,8 +109,14 @@ const menuDataKeyRows = [
 const menuItemKeyRows = [
   {
     name: "name",
-    type: "string (required)",
+    type: "string | node (required)",
     description: "Unique identifier for the menu item."
+  },
+  {
+    name: "ariaLabel",
+    type: "string",
+    description:
+      "Add an aria-label if the `name` value is not a readable label, like an icon."
   },
   {
     name: "href",
@@ -128,7 +134,7 @@ const menuItemKeyRows = [
     name: "render",
     type: "function",
     description:
-      "Function that returns JSX. This causes the menu item to render as the JSX provided wrapped in a component that provides styling and an onClick handler to close the menu."
+      "Function that returns JSX. This causes the menu item to render as the JSX provided wrapped in a component that provides styling and an onClick handler to close the menu. NOTE: Do not use `href` and `items` keys if you intend to use the render function."
   }
 ];
 


### PR DESCRIPTION
## Description

Adds the ability to add an icon instead of name string to the NavBar so the label will display as an icon. 

- the name field will now accept react nodes
- aria-label can be added to a menu item (for cases where the name isn't text)
- converted buttons to use display: flex to fix sizing and alignment issues which makes it more robust when using an icon in the button


## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [x] Storybook updated with examples of new functionality
- [x] Storybook uses variable and realistic data (ex: short and long text)
- [x] Docs updated with correct props and examples
- [x] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [x] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
