### PR TITLE
fix: Allows objects as a table cellData prop

### DIFF
--- a/components/src/Table/TableCell.js
+++ b/components/src/Table/TableCell.js
@@ -36,7 +36,7 @@ TableCell.propTypes = {
   column: columnPropType,
   row: rowPropType,
   colSpan: PropTypes.number,
-  cellData: PropTypes.oneOfType([PropTypes.node, PropTypes.bool]),
+  cellData: PropTypes.oneOfType([PropTypes.object, PropTypes.node, PropTypes.bool]),
   compact: PropTypes.bool
 };
 


### PR DESCRIPTION
## Description

**Allows an `object` as a valid table `cellData` prop**

The existing propTypes for this prop was too restrictive and causing a lot of warnings on NDS-using apps. It should be valid to use an object prop, since it can then be transformed into a React element via the cell formatter/renderer.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component interations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
