### PR TITLE
fix: add large shadow to Modal

### DIFF
--- a/components/src/Modal/Modal.js
+++ b/components/src/Modal/Modal.js
@@ -80,6 +80,7 @@ const StyledReactModal = styled(ReactModal)(
     bottom: 0,
     backgroundColor: theme.colors.white,
     borderRadius: theme.radii.medium,
+    boxShadow: theme.shadows.large,
     border: null,
     width: "100%",
     height: "auto",


### PR DESCRIPTION
## Description

The Modal was supposed to have a large shadow on it to give it depth. 

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
