### PR TITLE
fix: Corrects Link underline prop type

### DIFF
--- a/docs/src/pages/components/link.js
+++ b/docs/src/pages/components/link.js
@@ -39,8 +39,8 @@ const propsRows = [
   },
   {
     name: "underline",
-    type: "String",
-    defaultValue: "true",
+    type: "Boolean",
+    defaultValue: true,
     description: "Whether to show an underline or not."
   },
   {


### PR DESCRIPTION
## Description

**Fixes Link.underline prop type in documentation**

`string` --> `boolean`

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [x] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [x] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
