### PR TITLE
fix: typo in zIndex tokens

### DIFF
--- a/tokens/src/zIndex/zIndex.json
+++ b/tokens/src/zIndex/zIndex.json
@@ -3,7 +3,7 @@
     "content": {
       "value": 100
     },
-    "tabsScollIndicator": {
+    "tabsScrollIndicator": {
       "value": 200
     },
     "tabsBar": {


### PR DESCRIPTION
## Description

Token should be `tabsScrollIndicator` not `tabsScollIndicator`.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
