### PR TITLE
fix: build tokens before building components

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -11,7 +11,7 @@
     "eslint": "eslint --config .eslintrc './**/*.js'",
     "eslint:fix": "yarn run eslint --fix",
     "start": "yarn workspace @nulogy/tokens build && start-storybook -p 8080",
-    "build": "webpack --config ../webpack.config.js",
+    "build": "yarn workspace @nulogy/tokens build && webpack --config ../webpack.config.js",
     "build:watch": "yarn build --watch",
     "build-storybook": "build-storybook",
     "storyshots": "yarn workspace @nulogy/tokens build && jest --testPathPattern='Storyshots.spec.js'",


### PR DESCRIPTION
## Description

Fresh tokens should be built when building components, since components relies on tokens. 
Without this there is an error unless you've built the tokens before. 

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
