### PR TITLE
chore: code clean up after theming

### DIFF
--- a/components/src/Alert/__snapshots__/Alert.story.storyshot
+++ b/components/src/Alert/__snapshots__/Alert.story.storyshot
@@ -13,13 +13,11 @@ exports[`Storyshots Alert Danger 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 ewGQci"
+        class="StyledSvg-sc-1h19zm3-0 fveekS Icon-fc7twp-0 ewGQci"
         color="red"
         fill="#cc1439"
         focusable="false"
         height="24px"
-        icon="error"
-        mr="x1"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -71,13 +69,11 @@ exports[`Storyshots Alert Success 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 dqoulF"
+        class="StyledSvg-sc-1h19zm3-0 jszHsh Icon-fc7twp-0 dqoulF"
         color="green"
         fill="#008059"
         focusable="false"
         height="24px"
-        icon="check"
-        mr="x1"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -143,12 +139,11 @@ exports[`Storyshots Alert With a close button 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="Icon-fc7twp-0 gNwFhh"
+            class="StyledSvg-sc-1h19zm3-0 izUDCo Icon-fc7twp-0 gNwFhh"
             color="currentColor"
             fill="currentColor"
             focusable="false"
             height="16"
-            icon="close"
             size="16"
             viewBox="0 0 24 24"
             width="16"
@@ -207,13 +202,11 @@ exports[`Storyshots Alert With a title 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 ewGQci"
+        class="StyledSvg-sc-1h19zm3-0 fveekS Icon-fc7twp-0 ewGQci"
         color="red"
         fill="#cc1439"
         focusable="false"
         height="24px"
-        icon="error"
-        mr="x1"
         viewBox="0 0 24 24"
         width="24px"
       >

--- a/components/src/Breadcrumbs/__snapshots__/Breadcrumbs.story.storyshot
+++ b/components/src/Breadcrumbs/__snapshots__/Breadcrumbs.story.storyshot
@@ -31,12 +31,11 @@ exports[`Storyshots Breadcrumbs Breadcrumbs 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="Icon-fc7twp-0 dkBAgY"
+            class="StyledSvg-sc-1h19zm3-0 ezlJgg Icon-fc7twp-0 dkBAgY"
             color="currentColor"
             fill="currentColor"
             focusable="false"
             height="24px"
-            icon="rightArrow"
             viewBox="0 0 24 24"
             width="24px"
           >
@@ -63,12 +62,11 @@ exports[`Storyshots Breadcrumbs Breadcrumbs 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="Icon-fc7twp-0 dkBAgY"
+            class="StyledSvg-sc-1h19zm3-0 ezlJgg Icon-fc7twp-0 dkBAgY"
             color="currentColor"
             fill="currentColor"
             focusable="false"
             height="24px"
-            icon="rightArrow"
             viewBox="0 0 24 24"
             width="24px"
           >
@@ -114,12 +112,11 @@ exports[`Storyshots Breadcrumbs without link 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="Icon-fc7twp-0 dkBAgY"
+            class="StyledSvg-sc-1h19zm3-0 ezlJgg Icon-fc7twp-0 dkBAgY"
             color="currentColor"
             fill="currentColor"
             focusable="false"
             height="24px"
-            icon="rightArrow"
             viewBox="0 0 24 24"
             width="24px"
           >
@@ -146,12 +143,11 @@ exports[`Storyshots Breadcrumbs without link 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="Icon-fc7twp-0 dkBAgY"
+            class="StyledSvg-sc-1h19zm3-0 ezlJgg Icon-fc7twp-0 dkBAgY"
             color="currentColor"
             fill="currentColor"
             focusable="false"
             height="24px"
-            icon="rightArrow"
             viewBox="0 0 24 24"
             width="24px"
           >
@@ -177,12 +173,11 @@ exports[`Storyshots Breadcrumbs without link 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="Icon-fc7twp-0 dkBAgY"
+            class="StyledSvg-sc-1h19zm3-0 ezlJgg Icon-fc7twp-0 dkBAgY"
             color="currentColor"
             fill="currentColor"
             focusable="false"
             height="24px"
-            icon="rightArrow"
             viewBox="0 0 24 24"
             width="24px"
           >

--- a/components/src/Button/Button.js
+++ b/components/src/Button/Button.js
@@ -1,12 +1,11 @@
-import styled from "styled-components";
+import styled, { ThemeContext } from "styled-components";
 import { space } from "styled-system";
 import propTypes from "@styled-system/prop-types";
-import React from "react";
+import React, { useContext } from "react";
 import PropTypes from "prop-types";
 import icons from "@nulogy/icons";
 
 import { Icon } from "../Icon";
-import NDSTheme from "../theme";
 import { subPx } from "../utils";
 
 const iconNames = Object.keys(icons);
@@ -83,9 +82,10 @@ const WrapperButton = styled.button(
 );
 
 const Button = React.forwardRef(({ children, iconSide, icon, className, asLink, ...props }, ref) => {
+  const themeContext = useContext(ThemeContext);
   const {
     lineHeights: { smallTextCompressed }
-  } = NDSTheme;
+  } = themeContext;
   return (
     <WrapperButton as={asLink ? "a" : undefined} ref={ref} className={className} {...props}>
       {icon && iconSide === "left" && <Icon size={`${smallTextCompressed}em`} mr="half" icon={icon} />}

--- a/components/src/Button/ControlIcon.js
+++ b/components/src/Button/ControlIcon.js
@@ -4,7 +4,6 @@ import PropTypes from "prop-types";
 import { space } from "styled-system";
 import propTypes from "@styled-system/prop-types";
 import { Icon } from "../Icon";
-import NDSTheme from "../theme";
 
 const getIconColorByState = ({ toggled, disabled, theme }) => {
   if (toggled) {
@@ -59,7 +58,7 @@ ControlIcon.defaultProps = {
   onClick: null,
   toggled: false,
   disabled: false,
-  size: NDSTheme.space.x4,
+  size: "x4",
   type: "button"
 };
 export default ControlIcon;

--- a/components/src/Button/IconicButton.js
+++ b/components/src/Button/IconicButton.js
@@ -9,7 +9,6 @@ import icons from "@nulogy/icons";
 
 import { Icon } from "../Icon";
 import { Text } from "../Type";
-import NDSTheme from "../theme";
 
 const HoverText = styled.div(({ theme }) => ({
   whiteSpace: "nowrap",
@@ -86,7 +85,7 @@ const BaseIconicButton = React.forwardRef(({ children, icon, labelHidden, classN
   return (
     <WrapperButton ref={forwardedRef} aria-label={children} className={className} {...props}>
       <Manager>
-        <Reference>{({ ref }) => <Icon ref={ref} size={NDSTheme.space.x4} icon={icon} p="half" />}</Reference>
+        <Reference>{({ ref }) => <Icon ref={ref} size="x4" icon={icon} p="half" />}</Reference>
         <Popper
           placement="bottom"
           modifiers={{

--- a/components/src/Button/__snapshots__/Button.story.storyshot
+++ b/components/src/Button/__snapshots__/Button.story.storyshot
@@ -126,13 +126,11 @@ exports[`Storyshots Buttons With a selected Icon 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 iVDunr"
+        class="StyledSvg-sc-1h19zm3-0 iJxiiG Icon-fc7twp-0 iVDunr"
         color="currentColor"
         fill="currentColor"
         focusable="false"
         height="1.14285714em"
-        icon="add"
-        mr="half"
         viewBox="0 0 24 24"
         width="1.14285714em"
       >
@@ -148,13 +146,11 @@ exports[`Storyshots Buttons With a selected Icon 1`] = `
       Create project
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 ffVnNY"
+        class="StyledSvg-sc-1h19zm3-0 hEuTvh Icon-fc7twp-0 ffVnNY"
         color="currentColor"
         fill="currentColor"
         focusable="false"
         height="1.14285714em"
-        icon="add"
-        ml="half"
         viewBox="0 0 24 24"
         width="1.14285714em"
       >

--- a/components/src/Button/__snapshots__/ControlIcon.story.storyshot
+++ b/components/src/Button/__snapshots__/ControlIcon.story.storyshot
@@ -14,14 +14,13 @@ exports[`Storyshots ControlIcon Control Icon 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 efirdb"
+        class="StyledSvg-sc-1h19zm3-0 bXTOZY Icon-fc7twp-0 jCbLQW"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="32px"
-        icon="close"
+        height="x4"
         viewBox="0 0 24 24"
-        width="32px"
+        width="x4"
       >
         <path
           d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
@@ -47,14 +46,13 @@ exports[`Storyshots ControlIcon Disabled 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 efirdb"
+        class="StyledSvg-sc-1h19zm3-0 bXTOZY Icon-fc7twp-0 jCbLQW"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="32px"
-        icon="close"
+        height="x4"
         viewBox="0 0 24 24"
-        width="32px"
+        width="x4"
       >
         <path
           d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
@@ -79,14 +77,13 @@ exports[`Storyshots ControlIcon Toggled 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 efirdb"
+        class="StyledSvg-sc-1h19zm3-0 bXTOZY Icon-fc7twp-0 jCbLQW"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="32px"
-        icon="close"
+        height="x4"
         viewBox="0 0 24 24"
-        width="32px"
+        width="x4"
       >
         <path
           d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"

--- a/components/src/Button/__snapshots__/IconicButton.story.storyshot
+++ b/components/src/Button/__snapshots__/IconicButton.story.storyshot
@@ -14,15 +14,13 @@ exports[`Storyshots IconicButton set to disabled 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 cwKdbD"
+        class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="32px"
-        icon="cancel"
-        p="half"
+        height="x4"
         viewBox="0 0 24 24"
-        width="32px"
+        width="x4"
       >
         <path
           d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
@@ -43,15 +41,13 @@ exports[`Storyshots IconicButton set to disabled 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 cwKdbD"
+        class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="32px"
-        icon="lock"
-        p="half"
+        height="x4"
         viewBox="0 0 24 24"
-        width="32px"
+        width="x4"
       >
         <path
           d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z"
@@ -82,15 +78,13 @@ exports[`Storyshots IconicButton with a hidden label 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 cwKdbD"
+        class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="32px"
-        icon="user"
-        p="half"
+        height="x4"
         viewBox="0 0 24 24"
-        width="32px"
+        width="x4"
       >
         <path
           d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"
@@ -120,15 +114,13 @@ exports[`Storyshots IconicButton with a long label 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 cwKdbD"
+        class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="32px"
-        icon="user"
-        p="half"
+        height="x4"
         viewBox="0 0 24 24"
-        width="32px"
+        width="x4"
       >
         <path
           d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"
@@ -159,15 +151,13 @@ exports[`Storyshots IconicButton with label 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 cwKdbD"
+        class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="32px"
-        icon="delete"
-        p="half"
+        height="x4"
         viewBox="0 0 24 24"
-        width="32px"
+        width="x4"
       >
         <path
           d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
@@ -197,15 +187,13 @@ exports[`Storyshots IconicButton without a label 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 cwKdbD"
+        class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="32px"
-        icon="delete"
-        p="half"
+        height="x4"
         viewBox="0 0 24 24"
-        width="32px"
+        width="x4"
       >
         <path
           d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"

--- a/components/src/ButtonGroup/__snapshots__/ButtonGroup.story.storyshot
+++ b/components/src/ButtonGroup/__snapshots__/ButtonGroup.story.storyshot
@@ -74,15 +74,13 @@ exports[`Storyshots ButtonGroup more button types 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="Icon-fc7twp-0 cwKdbD"
+            class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
             color="currentColor"
             fill="currentColor"
             focusable="false"
-            height="32px"
-            icon="menu"
-            p="half"
+            height="x4"
             viewBox="0 0 24 24"
-            width="32px"
+            width="x4"
           >
             <path
               d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"
@@ -95,15 +93,13 @@ exports[`Storyshots ButtonGroup more button types 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="Icon-fc7twp-0 cwKdbD"
+            class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
             color="currentColor"
             fill="currentColor"
             focusable="false"
-            height="32px"
-            icon="menu"
-            p="half"
+            height="x4"
             viewBox="0 0 24 24"
-            width="32px"
+            width="x4"
           >
             <path
               d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"

--- a/components/src/Checkbox/CheckboxGroup.js
+++ b/components/src/Checkbox/CheckboxGroup.js
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import Checkbox from "./Checkbox";
 import { HelpText, RequirementText } from "../FieldLabel";
 import { InlineValidation } from "../Validation";
-import { Fieldset } from "../Form";
+import { Fieldset, Legend, LabelText } from "../Form";
 
 const getCheckboxButtons = props => {
   const checkboxButtons = React.Children.map(props.children, checkbox => {
@@ -25,16 +25,6 @@ const getCheckboxButtons = props => {
   });
   return checkboxButtons;
 };
-
-const LabelText = styled.span(({ theme }) => ({
-  fontSize: theme.fontSizes.small,
-  fontWeight: theme.fontWeights.bold,
-  lineHeight: theme.lineHeights.smallTextBase
-}));
-
-const Legend = styled.legend(({ theme }) => ({
-  marginBottom: theme.space.x1
-}));
 
 const BaseCheckboxGroup = ({
   className,

--- a/components/src/Checkbox/__snapshots__/CheckboxGroup.story.storyshot
+++ b/components/src/Checkbox/__snapshots__/CheckboxGroup.story.storyshot
@@ -8,13 +8,13 @@ exports[`Storyshots CheckboxGroup CheckboxGroup 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <fieldset
-      class="Fieldset-sc-9aoml1-0 eiFgjk CheckboxGroup-sc-16y7xr8-2 bfgHHz"
+      class="Fieldset-sc-9aoml1-0 eiFgjk CheckboxGroup-sc-16y7xr8-0 bpMmjl"
     >
       <legend
-        class="CheckboxGroup__Legend-sc-16y7xr8-1 FZknE"
+        class="Legend-sc-12h2r7a-0 fqZhwH"
       >
         <span
-          class="CheckboxGroup__LabelText-sc-16y7xr8-0 srOjp"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Setting Selection
         </span>
@@ -113,13 +113,13 @@ exports[`Storyshots CheckboxGroup CheckboxGroup with all props 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <fieldset
-      class="Fieldset-sc-9aoml1-0 eiFgjk CheckboxGroup-sc-16y7xr8-2 bfgHHz"
+      class="Fieldset-sc-9aoml1-0 eiFgjk CheckboxGroup-sc-16y7xr8-0 bpMmjl"
     >
       <legend
-        class="CheckboxGroup__Legend-sc-16y7xr8-1 FZknE"
+        class="Legend-sc-12h2r7a-0 fqZhwH"
       >
         <span
-          class="CheckboxGroup__LabelText-sc-16y7xr8-0 srOjp"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Setting Selection
         </span>
@@ -236,13 +236,13 @@ exports[`Storyshots CheckboxGroup Controlled 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <fieldset
-      class="Fieldset-sc-9aoml1-0 eiFgjk CheckboxGroup-sc-16y7xr8-2 bfgHHz"
+      class="Fieldset-sc-9aoml1-0 eiFgjk CheckboxGroup-sc-16y7xr8-0 bpMmjl"
     >
       <legend
-        class="CheckboxGroup__Legend-sc-16y7xr8-1 FZknE"
+        class="Legend-sc-12h2r7a-0 fqZhwH"
       >
         <span
-          class="CheckboxGroup__LabelText-sc-16y7xr8-0 srOjp"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Setting Selection
         </span>
@@ -343,13 +343,13 @@ exports[`Storyshots CheckboxGroup Set to disabled 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <fieldset
-      class="Fieldset-sc-9aoml1-0 eiFgjk CheckboxGroup-sc-16y7xr8-2 bfgHHz"
+      class="Fieldset-sc-9aoml1-0 eiFgjk CheckboxGroup-sc-16y7xr8-0 bpMmjl"
     >
       <legend
-        class="CheckboxGroup__Legend-sc-16y7xr8-1 FZknE"
+        class="Legend-sc-12h2r7a-0 fqZhwH"
       >
         <span
-          class="CheckboxGroup__LabelText-sc-16y7xr8-0 srOjp"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Setting Selection
         </span>
@@ -461,13 +461,13 @@ exports[`Storyshots CheckboxGroup with error list 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <fieldset
-      class="Fieldset-sc-9aoml1-0 eiFgjk CheckboxGroup-sc-16y7xr8-2 bfgHHz"
+      class="Fieldset-sc-9aoml1-0 eiFgjk CheckboxGroup-sc-16y7xr8-0 bpMmjl"
     >
       <legend
-        class="CheckboxGroup__Legend-sc-16y7xr8-1 FZknE"
+        class="Legend-sc-12h2r7a-0 fqZhwH"
       >
         <span
-          class="CheckboxGroup__LabelText-sc-16y7xr8-0 srOjp"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Setting Selection
         </span>
@@ -560,13 +560,11 @@ exports[`Storyshots CheckboxGroup with error list 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 QuoIa"
+          class="StyledSvg-sc-1h19zm3-0 jpOsNG Icon-fc7twp-0 QuoIa"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="error"
-          mr="x1"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -616,13 +614,13 @@ exports[`Storyshots CheckboxGroup with error message 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <fieldset
-      class="Fieldset-sc-9aoml1-0 eiFgjk CheckboxGroup-sc-16y7xr8-2 bfgHHz"
+      class="Fieldset-sc-9aoml1-0 eiFgjk CheckboxGroup-sc-16y7xr8-0 bpMmjl"
     >
       <legend
-        class="CheckboxGroup__Legend-sc-16y7xr8-1 FZknE"
+        class="Legend-sc-12h2r7a-0 fqZhwH"
       >
         <span
-          class="CheckboxGroup__LabelText-sc-16y7xr8-0 srOjp"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Setting Selection
         </span>
@@ -715,13 +713,11 @@ exports[`Storyshots CheckboxGroup with error message 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 QuoIa"
+          class="StyledSvg-sc-1h19zm3-0 jpOsNG Icon-fc7twp-0 QuoIa"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="error"
-          mr="x1"
           viewBox="0 0 24 24"
           width="24px"
         >

--- a/components/src/DatePicker/__snapshots__/DatePicker.story.storyshot
+++ b/components/src/DatePicker/__snapshots__/DatePicker.story.storyshot
@@ -17,7 +17,7 @@ exports[`Storyshots DatePicker default 1`] = `
           class="react-datepicker__input-container"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -26,7 +26,7 @@ exports[`Storyshots DatePicker default 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Expiry Date
               </span>
@@ -48,14 +48,13 @@ exports[`Storyshots DatePicker default 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -88,7 +87,7 @@ exports[`Storyshots DatePicker with custom date format 1`] = `
           class="react-datepicker__input-container"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -97,7 +96,7 @@ exports[`Storyshots DatePicker with custom date format 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Expiry Date
               </span>
@@ -119,14 +118,13 @@ exports[`Storyshots DatePicker with custom date format 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -159,7 +157,7 @@ exports[`Storyshots DatePicker with custom locale 1`] = `
           class="react-datepicker__input-container"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -168,7 +166,7 @@ exports[`Storyshots DatePicker with custom locale 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Expiry Date
               </span>
@@ -190,14 +188,13 @@ exports[`Storyshots DatePicker with custom locale 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -230,7 +227,7 @@ exports[`Storyshots DatePicker with custom placeholder 1`] = `
           class="react-datepicker__input-container"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -239,7 +236,7 @@ exports[`Storyshots DatePicker with custom placeholder 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Expiry Date
               </span>
@@ -261,14 +258,13 @@ exports[`Storyshots DatePicker with custom placeholder 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -301,7 +297,7 @@ exports[`Storyshots DatePicker with error state 1`] = `
           class="react-datepicker__input-container"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -310,7 +306,7 @@ exports[`Storyshots DatePicker with error state 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Expiry Date
               </span>
@@ -332,14 +328,13 @@ exports[`Storyshots DatePicker with error state 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -356,13 +351,11 @@ exports[`Storyshots DatePicker with error state 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 QuoIa"
+          class="StyledSvg-sc-1h19zm3-0 jpOsNG Icon-fc7twp-0 QuoIa"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="error"
-          mr="x1"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -404,7 +397,7 @@ exports[`Storyshots DatePicker with min and max date 1`] = `
           class="react-datepicker__input-container"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -413,7 +406,7 @@ exports[`Storyshots DatePicker with min and max date 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Expiry Date
               </span>
@@ -435,14 +428,13 @@ exports[`Storyshots DatePicker with min and max date 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"

--- a/components/src/DateRange/__snapshots__/DateRange.story.storyshot
+++ b/components/src/DateRange/__snapshots__/DateRange.story.storyshot
@@ -8,7 +8,7 @@ exports[`Storyshots DateRange customizing input props 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
       color="black"
       style="display:block"
     >
@@ -17,7 +17,7 @@ exports[`Storyshots DateRange customizing input props 1`] = `
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Date range
         </span>
@@ -53,14 +53,13 @@ exports[`Storyshots DateRange customizing input props 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -108,14 +107,13 @@ exports[`Storyshots DateRange customizing input props 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -139,7 +137,7 @@ exports[`Storyshots DateRange default 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
       color="black"
       style="display:block"
     >
@@ -148,7 +146,7 @@ exports[`Storyshots DateRange default 1`] = `
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Date range
         </span>
@@ -184,14 +182,13 @@ exports[`Storyshots DateRange default 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -239,14 +236,13 @@ exports[`Storyshots DateRange default 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -270,7 +266,7 @@ exports[`Storyshots DateRange default start and end date 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
       color="black"
       style="display:block"
     >
@@ -279,7 +275,7 @@ exports[`Storyshots DateRange default start and end date 1`] = `
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Date range
         </span>
@@ -315,14 +311,13 @@ exports[`Storyshots DateRange default start and end date 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -370,14 +365,13 @@ exports[`Storyshots DateRange default start and end date 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -401,7 +395,7 @@ exports[`Storyshots DateRange disabled range validation 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
       color="black"
       style="display:block"
     >
@@ -410,7 +404,7 @@ exports[`Storyshots DateRange disabled range validation 1`] = `
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Date range
         </span>
@@ -446,14 +440,13 @@ exports[`Storyshots DateRange disabled range validation 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -501,14 +494,13 @@ exports[`Storyshots DateRange disabled range validation 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -532,7 +524,7 @@ exports[`Storyshots DateRange individual input error 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
       color="black"
       style="display:block"
     >
@@ -541,7 +533,7 @@ exports[`Storyshots DateRange individual input error 1`] = `
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Date range
         </span>
@@ -578,14 +570,13 @@ exports[`Storyshots DateRange individual input error 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -601,13 +592,11 @@ exports[`Storyshots DateRange individual input error 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="Icon-fc7twp-0 QuoIa"
+            class="StyledSvg-sc-1h19zm3-0 jpOsNG Icon-fc7twp-0 QuoIa"
             color="currentColor"
             fill="currentColor"
             focusable="false"
             height="24px"
-            icon="error"
-            mr="x1"
             viewBox="0 0 24 24"
             width="24px"
           >
@@ -665,14 +654,13 @@ exports[`Storyshots DateRange individual input error 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -696,7 +684,7 @@ exports[`Storyshots DateRange with custom error 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
       color="black"
       style="display:block"
     >
@@ -705,7 +693,7 @@ exports[`Storyshots DateRange with custom error 1`] = `
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Date range
         </span>
@@ -741,14 +729,13 @@ exports[`Storyshots DateRange with custom error 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -796,14 +783,13 @@ exports[`Storyshots DateRange with custom error 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -821,13 +807,11 @@ exports[`Storyshots DateRange with custom error 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 QuoIa"
+        class="StyledSvg-sc-1h19zm3-0 jpOsNG Icon-fc7twp-0 QuoIa"
         color="currentColor"
         fill="currentColor"
         focusable="false"
         height="24px"
-        icon="error"
-        mr="x1"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -859,7 +843,7 @@ exports[`Storyshots DateRange with default start and end times 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
       color="black"
       style="display:block"
     >
@@ -868,7 +852,7 @@ exports[`Storyshots DateRange with default start and end times 1`] = `
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Date range
         </span>
@@ -904,14 +888,13 @@ exports[`Storyshots DateRange with default start and end times 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -987,12 +970,11 @@ exports[`Storyshots DateRange with default start and end times 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      class="StyledSvg-sc-1h19zm3-0 kpDHXQ Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
                       color="currentColor"
                       fill="currentColor"
                       focusable="false"
                       height="22px"
-                      icon="queryBuilder"
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -1083,12 +1065,11 @@ exports[`Storyshots DateRange with default start and end times 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      class="StyledSvg-sc-1h19zm3-0 kpDHXQ Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
                       color="currentColor"
                       fill="currentColor"
                       focusable="false"
                       height="22px"
-                      icon="queryBuilder"
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -1129,14 +1110,13 @@ exports[`Storyshots DateRange with default start and end times 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -1160,7 +1140,7 @@ exports[`Storyshots DateRange with time error 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
       color="black"
       style="display:block"
     >
@@ -1169,7 +1149,7 @@ exports[`Storyshots DateRange with time error 1`] = `
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Date range
         </span>
@@ -1205,14 +1185,13 @@ exports[`Storyshots DateRange with time error 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -1288,12 +1267,11 @@ exports[`Storyshots DateRange with time error 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      class="StyledSvg-sc-1h19zm3-0 kpDHXQ Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
                       color="currentColor"
                       fill="currentColor"
                       focusable="false"
                       height="22px"
-                      icon="queryBuilder"
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -1384,12 +1362,11 @@ exports[`Storyshots DateRange with time error 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      class="StyledSvg-sc-1h19zm3-0 kpDHXQ Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
                       color="currentColor"
                       fill="currentColor"
                       focusable="false"
                       height="22px"
-                      icon="queryBuilder"
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -1430,14 +1407,13 @@ exports[`Storyshots DateRange with time error 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -1461,7 +1437,7 @@ exports[`Storyshots DateRange with times 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
       color="black"
       style="display:block"
     >
@@ -1470,7 +1446,7 @@ exports[`Storyshots DateRange with times 1`] = `
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Date range
         </span>
@@ -1506,14 +1482,13 @@ exports[`Storyshots DateRange with times 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -1589,12 +1564,11 @@ exports[`Storyshots DateRange with times 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      class="StyledSvg-sc-1h19zm3-0 kpDHXQ Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
                       color="currentColor"
                       fill="currentColor"
                       focusable="false"
                       height="22px"
-                      icon="queryBuilder"
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -1685,12 +1659,11 @@ exports[`Storyshots DateRange with times 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      class="StyledSvg-sc-1h19zm3-0 kpDHXQ Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
                       color="currentColor"
                       fill="currentColor"
                       focusable="false"
                       height="22px"
-                      icon="queryBuilder"
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -1731,14 +1704,13 @@ exports[`Storyshots DateRange with times 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"

--- a/components/src/DropdownMenu/__snapshots__/DropdownMenu.story.storyshot
+++ b/components/src/DropdownMenu/__snapshots__/DropdownMenu.story.storyshot
@@ -16,15 +16,13 @@ exports[`Storyshots DropdownMenu DropdownMenu 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 cwKdbD"
+        class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="32px"
-        icon="more"
-        p="half"
+        height="x4"
         viewBox="0 0 24 24"
-        width="32px"
+        width="x4"
       >
         <path
           d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
@@ -52,15 +50,13 @@ exports[`Storyshots DropdownMenu Set to disabled 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 cwKdbD"
+        class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="32px"
-        icon="more"
-        p="half"
+        height="x4"
         viewBox="0 0 24 24"
-        width="32px"
+        width="x4"
       >
         <path
           d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
@@ -87,15 +83,13 @@ exports[`Storyshots DropdownMenu set to defaultOpen 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 cwKdbD"
+        class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="32px"
-        icon="more"
-        p="half"
+        height="x4"
         viewBox="0 0 24 24"
-        width="32px"
+        width="x4"
       >
         <path
           d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
@@ -155,15 +149,13 @@ exports[`Storyshots DropdownMenu with button closing menu 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 cwKdbD"
+        class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="32px"
-        icon="more"
-        p="half"
+        height="x4"
         viewBox="0 0 24 24"
-        width="32px"
+        width="x4"
       >
         <path
           d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
@@ -190,15 +182,13 @@ exports[`Storyshots DropdownMenu with custom colors 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 cwKdbD"
+        class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="32px"
-        icon="more"
-        p="half"
+        height="x4"
         viewBox="0 0 24 24"
-        width="32px"
+        width="x4"
       >
         <path
           d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
@@ -247,15 +237,13 @@ exports[`Storyshots DropdownMenu with custom item 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 cwKdbD"
+        class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="32px"
-        icon="more"
-        p="half"
+        height="x4"
         viewBox="0 0 24 24"
-        width="32px"
+        width="x4"
       >
         <path
           d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"

--- a/components/src/FieldLabel/FieldLabel.js
+++ b/components/src/FieldLabel/FieldLabel.js
@@ -6,6 +6,7 @@ import { Box } from "../Box";
 import RequirementText from "./RequirementText";
 import HelpText from "./HelpText";
 import { FieldLabelProps, FieldLabelDefaultProps } from "./FieldLabel.type";
+import { LabelText } from "../Form";
 
 const Label = styled.label(space, color, () => ({
   display: "inline-block"
@@ -18,12 +19,6 @@ Label.propTypes = {
 Label.defaultProps = {
   color: "black"
 };
-
-const LabelText = styled.span(({ theme }) => ({
-  fontSize: theme.fontSizes.small,
-  fontWeight: theme.fontWeights.bold,
-  lineHeight: theme.lineHeights.smallTextBase
-}));
 
 const BaseFieldLabel = ({ labelText, requirementText, helpText, children, ...props }) => (
   <Label style={{ display: "block" }} {...props}>

--- a/components/src/FieldLabel/__snapshots__/FieldLabel.story.storyshot
+++ b/components/src/FieldLabel/__snapshots__/FieldLabel.story.storyshot
@@ -8,7 +8,7 @@ exports[`Storyshots FieldLabel FieldLabel 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
       color="black"
       style="display:block"
     >
@@ -17,7 +17,7 @@ exports[`Storyshots FieldLabel FieldLabel 1`] = `
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Default label
         </span>
@@ -35,7 +35,7 @@ exports[`Storyshots FieldLabel with HelpText 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
       color="black"
       style="display:block"
     >
@@ -44,7 +44,7 @@ exports[`Storyshots FieldLabel with HelpText 1`] = `
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Default label
         </span>
@@ -78,7 +78,7 @@ exports[`Storyshots FieldLabel with RequirementText 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
       color="black"
       style="display:block"
     >
@@ -87,7 +87,7 @@ exports[`Storyshots FieldLabel with RequirementText 1`] = `
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Default label
         </span>
@@ -112,7 +112,7 @@ exports[`Storyshots FieldLabel with all additional text 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
       color="black"
       style="display:block"
     >
@@ -121,7 +121,7 @@ exports[`Storyshots FieldLabel with all additional text 1`] = `
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Default label
         </span>
@@ -153,7 +153,7 @@ exports[`Storyshots FieldLabel with associated custom input component 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
       color="black"
       style="display:block"
     >
@@ -162,7 +162,7 @@ exports[`Storyshots FieldLabel with associated custom input component 1`] = `
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Default label
         </span>

--- a/components/src/Form/LabelText.js
+++ b/components/src/Form/LabelText.js
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+
+const LabelText = styled.span(({ theme }) => ({
+  fontSize: theme.fontSizes.small,
+  fontWeight: theme.fontWeights.bold,
+  lineHeight: theme.lineHeights.smallTextBase
+}));
+
+export default LabelText;

--- a/components/src/Form/Legend.js
+++ b/components/src/Form/Legend.js
@@ -1,0 +1,7 @@
+import styled from "styled-components";
+
+const Legend = styled.legend(({ theme }) => ({
+  marginBottom: theme.space.x1
+}));
+
+export default Legend;

--- a/components/src/Form/__snapshots__/Form.story.storyshot
+++ b/components/src/Form/__snapshots__/Form.story.storyshot
@@ -23,13 +23,11 @@ exports[`Storyshots Form Demo form 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 ewGQci"
+          class="StyledSvg-sc-1h19zm3-0 fveekS Icon-fc7twp-0 ewGQci"
           color="red"
           fill="#cc1439"
           focusable="false"
           height="24px"
-          icon="error"
-          mr="x1"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -98,7 +96,7 @@ exports[`Storyshots Form Demo form 1`] = `
           class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -107,7 +105,7 @@ exports[`Storyshots Form Demo form 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Project
               </span>
@@ -134,7 +132,7 @@ exports[`Storyshots Form Demo form 1`] = `
           class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -143,7 +141,7 @@ exports[`Storyshots Form Demo form 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Project description
               </span>
@@ -183,7 +181,7 @@ exports[`Storyshots Form Demo form 1`] = `
           class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -192,7 +190,7 @@ exports[`Storyshots Form Demo form 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Project status
               </span>
@@ -280,7 +278,7 @@ exports[`Storyshots Form Demo form 1`] = `
           class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -289,7 +287,7 @@ exports[`Storyshots Form Demo form 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Item code
               </span>
@@ -317,13 +315,11 @@ exports[`Storyshots Form Demo form 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="Icon-fc7twp-0 QuoIa"
+              class="StyledSvg-sc-1h19zm3-0 jpOsNG Icon-fc7twp-0 QuoIa"
               color="currentColor"
               fill="currentColor"
               focusable="false"
               height="24px"
-              icon="error"
-              mr="x1"
               viewBox="0 0 24 24"
               width="24px"
             >
@@ -348,7 +344,7 @@ exports[`Storyshots Form Demo form 1`] = `
           class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -357,7 +353,7 @@ exports[`Storyshots Form Demo form 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Eaches expected on Job
               </span>
@@ -384,7 +380,7 @@ exports[`Storyshots Form Demo form 1`] = `
           class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -393,7 +389,7 @@ exports[`Storyshots Form Demo form 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Eaches remaining on Project
               </span>
@@ -421,7 +417,7 @@ exports[`Storyshots Form Demo form 1`] = `
           class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -430,7 +426,7 @@ exports[`Storyshots Form Demo form 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Scheduled start
               </span>
@@ -457,7 +453,7 @@ exports[`Storyshots Form Demo form 1`] = `
           class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -466,7 +462,7 @@ exports[`Storyshots Form Demo form 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Scheduled end
               </span>
@@ -490,13 +486,13 @@ exports[`Storyshots Form Demo form 1`] = `
           </label>
         </div>
         <fieldset
-          class="Fieldset-sc-9aoml1-0 eiFgjk CheckboxGroup-sc-16y7xr8-2 bfgHHz"
+          class="Fieldset-sc-9aoml1-0 eiFgjk CheckboxGroup-sc-16y7xr8-0 bpMmjl"
         >
           <legend
-            class="CheckboxGroup__Legend-sc-16y7xr8-1 FZknE"
+            class="Legend-sc-12h2r7a-0 fqZhwH"
           >
             <span
-              class="CheckboxGroup__LabelText-sc-16y7xr8-0 srOjp"
+              class="LabelText-sc-16fh5zk-0 lmVLTL"
             >
               Line Lead
             </span>
@@ -630,10 +626,10 @@ exports[`Storyshots Form Demo form 1`] = `
           id="reconcile"
         >
           <legend
-            style="margin-bottom:8px"
+            class="Legend-sc-12h2r7a-0 fqZhwH"
           >
             <span
-              style="font-size:14px;font-weight:600;line-height:1.71428571"
+              class="LabelText-sc-16fh5zk-0 lmVLTL"
             >
               Reconcile
             </span>
@@ -727,13 +723,11 @@ exports[`Storyshots Form Demo form 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="Icon-fc7twp-0 QuoIa"
+              class="StyledSvg-sc-1h19zm3-0 jpOsNG Icon-fc7twp-0 QuoIa"
               color="currentColor"
               fill="currentColor"
               focusable="false"
               height="24px"
-              icon="error"
-              mr="x1"
               viewBox="0 0 24 24"
               width="24px"
             >
@@ -764,7 +758,7 @@ exports[`Storyshots Form Demo form 1`] = `
               class="Box-sc-1qu1edy-0 ilQgHG"
             >
               <span
-                style="font-size:14px;font-weight:600;line-height:1.71428571"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Job Visibility
               </span>
@@ -813,7 +807,7 @@ exports[`Storyshots Form Demo form 1`] = `
           class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -822,7 +816,7 @@ exports[`Storyshots Form Demo form 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Item
               </span>
@@ -850,13 +844,11 @@ exports[`Storyshots Form Demo form 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="Icon-fc7twp-0 QuoIa"
+              class="StyledSvg-sc-1h19zm3-0 jpOsNG Icon-fc7twp-0 QuoIa"
               color="currentColor"
               fill="currentColor"
               focusable="false"
               height="24px"
-              icon="error"
-              mr="x1"
               viewBox="0 0 24 24"
               width="24px"
             >
@@ -881,7 +873,7 @@ exports[`Storyshots Form Demo form 1`] = `
           class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -890,7 +882,7 @@ exports[`Storyshots Form Demo form 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Quantity
               </span>
@@ -922,7 +914,7 @@ exports[`Storyshots Form Demo form 1`] = `
               class="Box-sc-1qu1edy-0 ilQgHG"
             >
               <span
-                style="font-size:14px;font-weight:600;line-height:1.71428571"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Reject visibility
               </span>
@@ -987,7 +979,7 @@ exports[`Storyshots Form Form 1`] = `
         class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
       >
         <label
-          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
           color="black"
           style="display:block"
         >
@@ -996,7 +988,7 @@ exports[`Storyshots Form Form 1`] = `
             data-testid="field-label"
           >
             <span
-              class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+              class="LabelText-sc-16fh5zk-0 lmVLTL"
             >
               Name
             </span>
@@ -1022,7 +1014,7 @@ exports[`Storyshots Form Form 1`] = `
         class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
       >
         <label
-          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
           color="black"
           style="display:block"
         >
@@ -1031,7 +1023,7 @@ exports[`Storyshots Form Form 1`] = `
             data-testid="field-label"
           >
             <span
-              class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+              class="LabelText-sc-16fh5zk-0 lmVLTL"
             >
               Date of birth
             </span>
@@ -1072,7 +1064,7 @@ exports[`Storyshots Form Form 1`] = `
         class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
       >
         <label
-          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
           color="black"
           style="display:block"
         >
@@ -1081,7 +1073,7 @@ exports[`Storyshots Form Form 1`] = `
             data-testid="field-label"
           >
             <span
-              class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+              class="LabelText-sc-16fh5zk-0 lmVLTL"
             >
               Place of birth
             </span>
@@ -1146,7 +1138,7 @@ exports[`Storyshots Form With form sections 1`] = `
           class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -1155,7 +1147,7 @@ exports[`Storyshots Form With form sections 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Name
               </span>
@@ -1181,7 +1173,7 @@ exports[`Storyshots Form With form sections 1`] = `
           class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -1190,7 +1182,7 @@ exports[`Storyshots Form With form sections 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Date of birth
               </span>
@@ -1231,7 +1223,7 @@ exports[`Storyshots Form With form sections 1`] = `
           class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -1240,7 +1232,7 @@ exports[`Storyshots Form With form sections 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Place of birth
               </span>
@@ -1284,7 +1276,7 @@ exports[`Storyshots Form With form sections 1`] = `
           class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -1293,7 +1285,7 @@ exports[`Storyshots Form With form sections 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Gender
               </span>
@@ -1319,7 +1311,7 @@ exports[`Storyshots Form With form sections 1`] = `
           class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -1328,7 +1320,7 @@ exports[`Storyshots Form With form sections 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Occupation
               </span>
@@ -1380,7 +1372,7 @@ exports[`Storyshots Form With form sections without titles 1`] = `
           class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -1389,7 +1381,7 @@ exports[`Storyshots Form With form sections without titles 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Name
               </span>
@@ -1415,7 +1407,7 @@ exports[`Storyshots Form With form sections without titles 1`] = `
           class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -1424,7 +1416,7 @@ exports[`Storyshots Form With form sections without titles 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Date of birth
               </span>
@@ -1465,7 +1457,7 @@ exports[`Storyshots Form With form sections without titles 1`] = `
           class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -1474,7 +1466,7 @@ exports[`Storyshots Form With form sections without titles 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Place of birth
               </span>
@@ -1511,7 +1503,7 @@ exports[`Storyshots Form With form sections without titles 1`] = `
           class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -1520,7 +1512,7 @@ exports[`Storyshots Form With form sections without titles 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Gender
               </span>
@@ -1546,7 +1538,7 @@ exports[`Storyshots Form With form sections without titles 1`] = `
           class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -1555,7 +1547,7 @@ exports[`Storyshots Form With form sections without titles 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Occupation
               </span>
@@ -1597,7 +1589,7 @@ exports[`Storyshots Form Without title 1`] = `
         class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
       >
         <label
-          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
           color="black"
           style="display:block"
         >
@@ -1606,7 +1598,7 @@ exports[`Storyshots Form Without title 1`] = `
             data-testid="field-label"
           >
             <span
-              class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+              class="LabelText-sc-16fh5zk-0 lmVLTL"
             >
               Name
             </span>
@@ -1632,7 +1624,7 @@ exports[`Storyshots Form Without title 1`] = `
         class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
       >
         <label
-          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
           color="black"
           style="display:block"
         >
@@ -1641,7 +1633,7 @@ exports[`Storyshots Form Without title 1`] = `
             data-testid="field-label"
           >
             <span
-              class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+              class="LabelText-sc-16fh5zk-0 lmVLTL"
             >
               Date of birth
             </span>
@@ -1682,7 +1674,7 @@ exports[`Storyshots Form Without title 1`] = `
         class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
       >
         <label
-          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
           color="black"
           style="display:block"
         >
@@ -1691,7 +1683,7 @@ exports[`Storyshots Form Without title 1`] = `
             data-testid="field-label"
           >
             <span
-              class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+              class="LabelText-sc-16fh5zk-0 lmVLTL"
             >
               Place of birth
             </span>

--- a/components/src/Form/index.js
+++ b/components/src/Form/index.js
@@ -2,3 +2,5 @@ export { default as Field } from "./Field";
 export { default as Fieldset } from "./Fieldset";
 export { default as Form } from "./Form";
 export { default as FormSection } from "./FormSection";
+export { default as LabelText } from "./LabelText";
+export { default as Legend } from "./Legend";

--- a/components/src/Icon/Icon.js
+++ b/components/src/Icon/Icon.js
@@ -1,11 +1,11 @@
-import React from "react";
+import React, { useContext } from "react";
 import PropTypes from "prop-types";
-import styled from "styled-components";
+import styled, { ThemeContext } from "styled-components";
 import { space, color } from "styled-system";
 import icons from "@nulogy/icons";
 
-import theme from "../theme";
 import LoadingIcon from "./LoadingIcon";
+import { StyledSvg } from "./StyledSvg";
 
 const iconNames = Object.keys(icons);
 
@@ -21,12 +21,13 @@ const getPathElements = icon => (
 
 const Svg = React.forwardRef((props, ref) => {
   const { icon, className, title, size, color: fillColor, focusable } = props;
+  const theme = useContext(ThemeContext);
   if (icon === "loading") {
     return <LoadingIcon color={theme.colors[fillColor] ? theme.colors[fillColor] : fillColor} {...props} />;
   }
   return (
     icons[icon] && (
-      <svg
+      <StyledSvg
         ref={ref}
         aria-hidden={title == null}
         width={size}
@@ -38,7 +39,7 @@ const Svg = React.forwardRef((props, ref) => {
         {...props}
       >
         {getPathElements(icons[icon])}
-      </svg>
+      </StyledSvg>
     )
   );
 });

--- a/components/src/Icon/Icon.story.js
+++ b/components/src/Icon/Icon.story.js
@@ -59,7 +59,7 @@ storiesOf("Icon", module)
   ))
   .add("With a size", () => (
     <>
-      {[theme.space.x1, theme.space.x2, theme.space.x3].map(size => (
+      {["x1", "x2", "x3"].map(size => (
         <Box key={size}>
           {iconSubset.map(iconName => (
             <Icon icon={iconName} size={size} key={iconName} />

--- a/components/src/Icon/LoadingIcon.js
+++ b/components/src/Icon/LoadingIcon.js
@@ -1,12 +1,20 @@
 import React from "react";
 import PropTypes from "prop-types";
 import generateId from "../utils/generateId";
+import { StyledSvg } from "./StyledSvg";
 
 const LoadingIcon = ({ color, size, title, ...props }) => {
   const id = generateId();
   return (
     // Modified svg By Sam Herbert (@sherb), for everyone. More @ http://goo.gl/7AJzbL
-    <svg title={title} width={size} height={size} viewBox="0 0 38 38" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <StyledSvg
+      title={title}
+      width={size}
+      height={size}
+      viewBox="0 0 38 38"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
       <defs>
         <linearGradient x1="8.042%" y1="0%" x2="65.682%" y2="23.865%" id={id}>
           <stop stopColor={color} stopOpacity="0" offset="0%" />
@@ -38,7 +46,7 @@ const LoadingIcon = ({ color, size, title, ...props }) => {
           </circle>
         </g>
       </g>
-    </svg>
+    </StyledSvg>
   );
 };
 

--- a/components/src/Icon/StyledSvg.js
+++ b/components/src/Icon/StyledSvg.js
@@ -1,0 +1,4 @@
+import styled from "styled-components";
+import { space, color, layout } from "styled-system";
+
+export const StyledSvg = styled.svg(color, space, layout);

--- a/components/src/Icon/__snapshots__/Icon.story.storyshot
+++ b/components/src/Icon/__snapshots__/Icon.story.storyshot
@@ -16,12 +16,11 @@ exports[`Storyshots Icon InlineIcon 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          class="StyledSvg-sc-1h19zm3-0 biVhYw Icon__CenteredIcon-fc7twp-1 dKjNdn"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="1.25em"
-          icon="accessTime"
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -38,12 +37,11 @@ exports[`Storyshots Icon InlineIcon 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          class="StyledSvg-sc-1h19zm3-0 biVhYw Icon__CenteredIcon-fc7twp-1 dKjNdn"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="1.25em"
-          icon="add"
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -57,12 +55,11 @@ exports[`Storyshots Icon InlineIcon 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          class="StyledSvg-sc-1h19zm3-0 biVhYw Icon__CenteredIcon-fc7twp-1 dKjNdn"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="1.25em"
-          icon="addCircleOutline"
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -76,12 +73,11 @@ exports[`Storyshots Icon InlineIcon 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          class="StyledSvg-sc-1h19zm3-0 biVhYw Icon__CenteredIcon-fc7twp-1 dKjNdn"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="1.25em"
-          icon="arrowForward"
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -95,12 +91,11 @@ exports[`Storyshots Icon InlineIcon 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          class="StyledSvg-sc-1h19zm3-0 biVhYw Icon__CenteredIcon-fc7twp-1 dKjNdn"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="1.25em"
-          icon="block"
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -113,10 +108,9 @@ exports[`Storyshots Icon InlineIcon 1`] = `
         class="Icon__IconContainer-fc7twp-2 jzPWAQ"
       >
         <svg
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          class="StyledSvg-sc-1h19zm3-0 dDksUU Icon__CenteredIcon-fc7twp-1 dKjNdn"
           focusable="false"
           height="1.25em"
-          icon="loading"
           viewBox="0 0 38 38"
           width="1.25em"
           xmlns="http://www.w3.org/2000/svg"
@@ -196,12 +190,11 @@ exports[`Storyshots Icon InlineIcon 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          class="StyledSvg-sc-1h19zm3-0 biVhYw Icon__CenteredIcon-fc7twp-1 dKjNdn"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="1.25em"
-          icon="accessTime"
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -218,12 +211,11 @@ exports[`Storyshots Icon InlineIcon 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          class="StyledSvg-sc-1h19zm3-0 biVhYw Icon__CenteredIcon-fc7twp-1 dKjNdn"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="1.25em"
-          icon="add"
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -237,12 +229,11 @@ exports[`Storyshots Icon InlineIcon 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          class="StyledSvg-sc-1h19zm3-0 biVhYw Icon__CenteredIcon-fc7twp-1 dKjNdn"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="1.25em"
-          icon="addCircleOutline"
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -256,12 +247,11 @@ exports[`Storyshots Icon InlineIcon 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          class="StyledSvg-sc-1h19zm3-0 biVhYw Icon__CenteredIcon-fc7twp-1 dKjNdn"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="1.25em"
-          icon="arrowForward"
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -275,12 +265,11 @@ exports[`Storyshots Icon InlineIcon 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          class="StyledSvg-sc-1h19zm3-0 biVhYw Icon__CenteredIcon-fc7twp-1 dKjNdn"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="1.25em"
-          icon="block"
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -293,10 +282,9 @@ exports[`Storyshots Icon InlineIcon 1`] = `
         class="Icon__IconContainer-fc7twp-2 jzPWAQ"
       >
         <svg
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          class="StyledSvg-sc-1h19zm3-0 dDksUU Icon__CenteredIcon-fc7twp-1 dKjNdn"
           focusable="false"
           height="1.25em"
-          icon="loading"
           viewBox="0 0 38 38"
           width="1.25em"
           xmlns="http://www.w3.org/2000/svg"
@@ -376,12 +364,11 @@ exports[`Storyshots Icon InlineIcon 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          class="StyledSvg-sc-1h19zm3-0 biVhYw Icon__CenteredIcon-fc7twp-1 dKjNdn"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="1.25em"
-          icon="accessTime"
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -398,12 +385,11 @@ exports[`Storyshots Icon InlineIcon 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          class="StyledSvg-sc-1h19zm3-0 biVhYw Icon__CenteredIcon-fc7twp-1 dKjNdn"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="1.25em"
-          icon="add"
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -417,12 +403,11 @@ exports[`Storyshots Icon InlineIcon 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          class="StyledSvg-sc-1h19zm3-0 biVhYw Icon__CenteredIcon-fc7twp-1 dKjNdn"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="1.25em"
-          icon="addCircleOutline"
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -436,12 +421,11 @@ exports[`Storyshots Icon InlineIcon 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          class="StyledSvg-sc-1h19zm3-0 biVhYw Icon__CenteredIcon-fc7twp-1 dKjNdn"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="1.25em"
-          icon="arrowForward"
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -455,12 +439,11 @@ exports[`Storyshots Icon InlineIcon 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          class="StyledSvg-sc-1h19zm3-0 biVhYw Icon__CenteredIcon-fc7twp-1 dKjNdn"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="1.25em"
-          icon="block"
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -473,10 +456,9 @@ exports[`Storyshots Icon InlineIcon 1`] = `
         class="Icon__IconContainer-fc7twp-2 jzPWAQ"
       >
         <svg
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          class="StyledSvg-sc-1h19zm3-0 dDksUU Icon__CenteredIcon-fc7twp-1 dKjNdn"
           focusable="false"
           height="1.25em"
-          icon="loading"
           viewBox="0 0 38 38"
           width="1.25em"
           xmlns="http://www.w3.org/2000/svg"
@@ -556,12 +538,11 @@ exports[`Storyshots Icon InlineIcon 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          class="StyledSvg-sc-1h19zm3-0 biVhYw Icon__CenteredIcon-fc7twp-1 dKjNdn"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="1.25em"
-          icon="accessTime"
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -578,12 +559,11 @@ exports[`Storyshots Icon InlineIcon 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          class="StyledSvg-sc-1h19zm3-0 biVhYw Icon__CenteredIcon-fc7twp-1 dKjNdn"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="1.25em"
-          icon="add"
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -597,12 +577,11 @@ exports[`Storyshots Icon InlineIcon 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          class="StyledSvg-sc-1h19zm3-0 biVhYw Icon__CenteredIcon-fc7twp-1 dKjNdn"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="1.25em"
-          icon="addCircleOutline"
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -616,12 +595,11 @@ exports[`Storyshots Icon InlineIcon 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          class="StyledSvg-sc-1h19zm3-0 biVhYw Icon__CenteredIcon-fc7twp-1 dKjNdn"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="1.25em"
-          icon="arrowForward"
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -635,12 +613,11 @@ exports[`Storyshots Icon InlineIcon 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          class="StyledSvg-sc-1h19zm3-0 biVhYw Icon__CenteredIcon-fc7twp-1 dKjNdn"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="1.25em"
-          icon="block"
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -653,10 +630,9 @@ exports[`Storyshots Icon InlineIcon 1`] = `
         class="Icon__IconContainer-fc7twp-2 jzPWAQ"
       >
         <svg
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          class="StyledSvg-sc-1h19zm3-0 dDksUU Icon__CenteredIcon-fc7twp-1 dKjNdn"
           focusable="false"
           height="1.25em"
-          icon="loading"
           viewBox="0 0 38 38"
           width="1.25em"
           xmlns="http://www.w3.org/2000/svg"
@@ -743,12 +719,11 @@ exports[`Storyshots Icon With a color 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 fjiVCY"
+        class="StyledSvg-sc-1h19zm3-0 cnlNMo Icon-fc7twp-0 fjiVCY"
         color="#cc1439"
         fill="#cc1439"
         focusable="false"
         height="24px"
-        icon="accessTime"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -761,12 +736,11 @@ exports[`Storyshots Icon With a color 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 fjiVCY"
+        class="StyledSvg-sc-1h19zm3-0 cnlNMo Icon-fc7twp-0 fjiVCY"
         color="#cc1439"
         fill="#cc1439"
         focusable="false"
         height="24px"
-        icon="add"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -776,12 +750,11 @@ exports[`Storyshots Icon With a color 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 fjiVCY"
+        class="StyledSvg-sc-1h19zm3-0 cnlNMo Icon-fc7twp-0 fjiVCY"
         color="#cc1439"
         fill="#cc1439"
         focusable="false"
         height="24px"
-        icon="addCircleOutline"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -791,12 +764,11 @@ exports[`Storyshots Icon With a color 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 fjiVCY"
+        class="StyledSvg-sc-1h19zm3-0 cnlNMo Icon-fc7twp-0 fjiVCY"
         color="#cc1439"
         fill="#cc1439"
         focusable="false"
         height="24px"
-        icon="arrowForward"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -806,12 +778,11 @@ exports[`Storyshots Icon With a color 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 fjiVCY"
+        class="StyledSvg-sc-1h19zm3-0 cnlNMo Icon-fc7twp-0 fjiVCY"
         color="#cc1439"
         fill="#cc1439"
         focusable="false"
         height="24px"
-        icon="block"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -820,10 +791,9 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        class="Icon-fc7twp-0 fjiVCY"
+        class="StyledSvg-sc-1h19zm3-0 ikqkgo Icon-fc7twp-0 fjiVCY"
         focusable="false"
         height="24px"
-        icon="loading"
         viewBox="0 0 38 38"
         width="24px"
         xmlns="http://www.w3.org/2000/svg"
@@ -898,12 +868,11 @@ exports[`Storyshots Icon With a color 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 fGpDPz"
+        class="StyledSvg-sc-1h19zm3-0 gQEiXL Icon-fc7twp-0 fGpDPz"
         color="#ffbb00"
         fill="#ffbb00"
         focusable="false"
         height="24px"
-        icon="accessTime"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -916,12 +885,11 @@ exports[`Storyshots Icon With a color 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 fGpDPz"
+        class="StyledSvg-sc-1h19zm3-0 gQEiXL Icon-fc7twp-0 fGpDPz"
         color="#ffbb00"
         fill="#ffbb00"
         focusable="false"
         height="24px"
-        icon="add"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -931,12 +899,11 @@ exports[`Storyshots Icon With a color 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 fGpDPz"
+        class="StyledSvg-sc-1h19zm3-0 gQEiXL Icon-fc7twp-0 fGpDPz"
         color="#ffbb00"
         fill="#ffbb00"
         focusable="false"
         height="24px"
-        icon="addCircleOutline"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -946,12 +913,11 @@ exports[`Storyshots Icon With a color 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 fGpDPz"
+        class="StyledSvg-sc-1h19zm3-0 gQEiXL Icon-fc7twp-0 fGpDPz"
         color="#ffbb00"
         fill="#ffbb00"
         focusable="false"
         height="24px"
-        icon="arrowForward"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -961,12 +927,11 @@ exports[`Storyshots Icon With a color 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 fGpDPz"
+        class="StyledSvg-sc-1h19zm3-0 gQEiXL Icon-fc7twp-0 fGpDPz"
         color="#ffbb00"
         fill="#ffbb00"
         focusable="false"
         height="24px"
-        icon="block"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -975,10 +940,9 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        class="Icon-fc7twp-0 fGpDPz"
+        class="StyledSvg-sc-1h19zm3-0 ikqkgo Icon-fc7twp-0 fGpDPz"
         focusable="false"
         height="24px"
-        icon="loading"
         viewBox="0 0 38 38"
         width="24px"
         xmlns="http://www.w3.org/2000/svg"
@@ -1053,12 +1017,11 @@ exports[`Storyshots Icon With a color 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 fAXHND"
+        class="StyledSvg-sc-1h19zm3-0 iYGoXP Icon-fc7twp-0 fAXHND"
         color="#008059"
         fill="#008059"
         focusable="false"
         height="24px"
-        icon="accessTime"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1071,12 +1034,11 @@ exports[`Storyshots Icon With a color 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 fAXHND"
+        class="StyledSvg-sc-1h19zm3-0 iYGoXP Icon-fc7twp-0 fAXHND"
         color="#008059"
         fill="#008059"
         focusable="false"
         height="24px"
-        icon="add"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1086,12 +1048,11 @@ exports[`Storyshots Icon With a color 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 fAXHND"
+        class="StyledSvg-sc-1h19zm3-0 iYGoXP Icon-fc7twp-0 fAXHND"
         color="#008059"
         fill="#008059"
         focusable="false"
         height="24px"
-        icon="addCircleOutline"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1101,12 +1062,11 @@ exports[`Storyshots Icon With a color 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 fAXHND"
+        class="StyledSvg-sc-1h19zm3-0 iYGoXP Icon-fc7twp-0 fAXHND"
         color="#008059"
         fill="#008059"
         focusable="false"
         height="24px"
-        icon="arrowForward"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1116,12 +1076,11 @@ exports[`Storyshots Icon With a color 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 fAXHND"
+        class="StyledSvg-sc-1h19zm3-0 iYGoXP Icon-fc7twp-0 fAXHND"
         color="#008059"
         fill="#008059"
         focusable="false"
         height="24px"
-        icon="block"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1130,10 +1089,9 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        class="Icon-fc7twp-0 fAXHND"
+        class="StyledSvg-sc-1h19zm3-0 ikqkgo Icon-fc7twp-0 fAXHND"
         focusable="false"
         height="24px"
-        icon="loading"
         viewBox="0 0 38 38"
         width="24px"
         xmlns="http://www.w3.org/2000/svg"
@@ -1208,12 +1166,11 @@ exports[`Storyshots Icon With a color 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 cQdNwL"
+        class="StyledSvg-sc-1h19zm3-0 gEpZhn Icon-fc7twp-0 cQdNwL"
         color="#216beb"
         fill="#216beb"
         focusable="false"
         height="24px"
-        icon="accessTime"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1226,12 +1183,11 @@ exports[`Storyshots Icon With a color 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 cQdNwL"
+        class="StyledSvg-sc-1h19zm3-0 gEpZhn Icon-fc7twp-0 cQdNwL"
         color="#216beb"
         fill="#216beb"
         focusable="false"
         height="24px"
-        icon="add"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1241,12 +1197,11 @@ exports[`Storyshots Icon With a color 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 cQdNwL"
+        class="StyledSvg-sc-1h19zm3-0 gEpZhn Icon-fc7twp-0 cQdNwL"
         color="#216beb"
         fill="#216beb"
         focusable="false"
         height="24px"
-        icon="addCircleOutline"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1256,12 +1211,11 @@ exports[`Storyshots Icon With a color 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 cQdNwL"
+        class="StyledSvg-sc-1h19zm3-0 gEpZhn Icon-fc7twp-0 cQdNwL"
         color="#216beb"
         fill="#216beb"
         focusable="false"
         height="24px"
-        icon="arrowForward"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1271,12 +1225,11 @@ exports[`Storyshots Icon With a color 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 cQdNwL"
+        class="StyledSvg-sc-1h19zm3-0 gEpZhn Icon-fc7twp-0 cQdNwL"
         color="#216beb"
         fill="#216beb"
         focusable="false"
         height="24px"
-        icon="block"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1285,10 +1238,9 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        class="Icon-fc7twp-0 cQdNwL"
+        class="StyledSvg-sc-1h19zm3-0 ikqkgo Icon-fc7twp-0 cQdNwL"
         focusable="false"
         height="24px"
-        icon="loading"
         viewBox="0 0 38 38"
         width="24px"
         xmlns="http://www.w3.org/2000/svg"
@@ -1363,12 +1315,11 @@ exports[`Storyshots Icon With a color 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 ckNWkf"
+        class="StyledSvg-sc-1h19zm3-0 ggKkHv Icon-fc7twp-0 ckNWkf"
         color="#122b47"
         fill="#122b47"
         focusable="false"
         height="24px"
-        icon="accessTime"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1381,12 +1332,11 @@ exports[`Storyshots Icon With a color 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 ckNWkf"
+        class="StyledSvg-sc-1h19zm3-0 ggKkHv Icon-fc7twp-0 ckNWkf"
         color="#122b47"
         fill="#122b47"
         focusable="false"
         height="24px"
-        icon="add"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1396,12 +1346,11 @@ exports[`Storyshots Icon With a color 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 ckNWkf"
+        class="StyledSvg-sc-1h19zm3-0 ggKkHv Icon-fc7twp-0 ckNWkf"
         color="#122b47"
         fill="#122b47"
         focusable="false"
         height="24px"
-        icon="addCircleOutline"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1411,12 +1360,11 @@ exports[`Storyshots Icon With a color 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 ckNWkf"
+        class="StyledSvg-sc-1h19zm3-0 ggKkHv Icon-fc7twp-0 ckNWkf"
         color="#122b47"
         fill="#122b47"
         focusable="false"
         height="24px"
-        icon="arrowForward"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1426,12 +1374,11 @@ exports[`Storyshots Icon With a color 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 ckNWkf"
+        class="StyledSvg-sc-1h19zm3-0 ggKkHv Icon-fc7twp-0 ckNWkf"
         color="#122b47"
         fill="#122b47"
         focusable="false"
         height="24px"
-        icon="block"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1440,10 +1387,9 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        class="Icon-fc7twp-0 ckNWkf"
+        class="StyledSvg-sc-1h19zm3-0 ikqkgo Icon-fc7twp-0 ckNWkf"
         focusable="false"
         height="24px"
-        icon="loading"
         viewBox="0 0 38 38"
         width="24px"
         xmlns="http://www.w3.org/2000/svg"
@@ -1529,14 +1475,13 @@ exports[`Storyshots Icon With a size 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 HAgHa"
+        class="StyledSvg-sc-1h19zm3-0 kJmnrQ Icon-fc7twp-0 cdvbdH"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="8px"
-        icon="accessTime"
+        height="x1"
         viewBox="0 0 24 24"
-        width="8px"
+        width="x1"
       >
         <path
           d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
@@ -1547,14 +1492,13 @@ exports[`Storyshots Icon With a size 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 HAgHa"
+        class="StyledSvg-sc-1h19zm3-0 kJmnrQ Icon-fc7twp-0 cdvbdH"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="8px"
-        icon="add"
+        height="x1"
         viewBox="0 0 24 24"
-        width="8px"
+        width="x1"
       >
         <path
           d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
@@ -1562,14 +1506,13 @@ exports[`Storyshots Icon With a size 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 HAgHa"
+        class="StyledSvg-sc-1h19zm3-0 kJmnrQ Icon-fc7twp-0 cdvbdH"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="8px"
-        icon="addCircleOutline"
+        height="x1"
         viewBox="0 0 24 24"
-        width="8px"
+        width="x1"
       >
         <path
           d="M13 7h-2v4H7v2h4v4h2v-4h4v-2h-4V7zm-1-5C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
@@ -1577,14 +1520,13 @@ exports[`Storyshots Icon With a size 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 HAgHa"
+        class="StyledSvg-sc-1h19zm3-0 kJmnrQ Icon-fc7twp-0 cdvbdH"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="8px"
-        icon="arrowForward"
+        height="x1"
         viewBox="0 0 24 24"
-        width="8px"
+        width="x1"
       >
         <path
           d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8-8-8z"
@@ -1592,26 +1534,24 @@ exports[`Storyshots Icon With a size 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 HAgHa"
+        class="StyledSvg-sc-1h19zm3-0 kJmnrQ Icon-fc7twp-0 cdvbdH"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="8px"
-        icon="block"
+        height="x1"
         viewBox="0 0 24 24"
-        width="8px"
+        width="x1"
       >
         <path
           d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zM4 12c0-4.42 3.58-8 8-8 1.85 0 3.55.63 4.9 1.69L5.69 16.9C4.63 15.55 4 13.85 4 12zm8 8c-1.85 0-3.55-.63-4.9-1.69L18.31 7.1C19.37 8.45 20 10.15 20 12c0 4.42-3.58 8-8 8z"
         />
       </svg>
       <svg
-        class="Icon-fc7twp-0 HAgHa"
+        class="StyledSvg-sc-1h19zm3-0 ksuAhA Icon-fc7twp-0 cdvbdH"
         focusable="false"
-        height="8px"
-        icon="loading"
+        height="x1"
         viewBox="0 0 38 38"
-        width="8px"
+        width="x1"
         xmlns="http://www.w3.org/2000/svg"
       >
         <defs>
@@ -1684,14 +1624,13 @@ exports[`Storyshots Icon With a size 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 fvcdOB"
+        class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 iOmWvk"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="16px"
-        icon="accessTime"
+        height="x2"
         viewBox="0 0 24 24"
-        width="16px"
+        width="x2"
       >
         <path
           d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
@@ -1702,14 +1641,13 @@ exports[`Storyshots Icon With a size 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 fvcdOB"
+        class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 iOmWvk"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="16px"
-        icon="add"
+        height="x2"
         viewBox="0 0 24 24"
-        width="16px"
+        width="x2"
       >
         <path
           d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
@@ -1717,14 +1655,13 @@ exports[`Storyshots Icon With a size 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 fvcdOB"
+        class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 iOmWvk"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="16px"
-        icon="addCircleOutline"
+        height="x2"
         viewBox="0 0 24 24"
-        width="16px"
+        width="x2"
       >
         <path
           d="M13 7h-2v4H7v2h4v4h2v-4h4v-2h-4V7zm-1-5C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
@@ -1732,14 +1669,13 @@ exports[`Storyshots Icon With a size 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 fvcdOB"
+        class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 iOmWvk"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="16px"
-        icon="arrowForward"
+        height="x2"
         viewBox="0 0 24 24"
-        width="16px"
+        width="x2"
       >
         <path
           d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8-8-8z"
@@ -1747,26 +1683,24 @@ exports[`Storyshots Icon With a size 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 fvcdOB"
+        class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 iOmWvk"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="16px"
-        icon="block"
+        height="x2"
         viewBox="0 0 24 24"
-        width="16px"
+        width="x2"
       >
         <path
           d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zM4 12c0-4.42 3.58-8 8-8 1.85 0 3.55.63 4.9 1.69L5.69 16.9C4.63 15.55 4 13.85 4 12zm8 8c-1.85 0-3.55-.63-4.9-1.69L18.31 7.1C19.37 8.45 20 10.15 20 12c0 4.42-3.58 8-8 8z"
         />
       </svg>
       <svg
-        class="Icon-fc7twp-0 fvcdOB"
+        class="StyledSvg-sc-1h19zm3-0 hiKQaM Icon-fc7twp-0 iOmWvk"
         focusable="false"
-        height="16px"
-        icon="loading"
+        height="x2"
         viewBox="0 0 38 38"
-        width="16px"
+        width="x2"
         xmlns="http://www.w3.org/2000/svg"
       >
         <defs>
@@ -1839,14 +1773,13 @@ exports[`Storyshots Icon With a size 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 dkBAgY"
+        class="StyledSvg-sc-1h19zm3-0 ezlJgg Icon-fc7twp-0 eycguF"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="24px"
-        icon="accessTime"
+        height="x3"
         viewBox="0 0 24 24"
-        width="24px"
+        width="x3"
       >
         <path
           d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
@@ -1857,14 +1790,13 @@ exports[`Storyshots Icon With a size 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 dkBAgY"
+        class="StyledSvg-sc-1h19zm3-0 ezlJgg Icon-fc7twp-0 eycguF"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="24px"
-        icon="add"
+        height="x3"
         viewBox="0 0 24 24"
-        width="24px"
+        width="x3"
       >
         <path
           d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
@@ -1872,14 +1804,13 @@ exports[`Storyshots Icon With a size 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 dkBAgY"
+        class="StyledSvg-sc-1h19zm3-0 ezlJgg Icon-fc7twp-0 eycguF"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="24px"
-        icon="addCircleOutline"
+        height="x3"
         viewBox="0 0 24 24"
-        width="24px"
+        width="x3"
       >
         <path
           d="M13 7h-2v4H7v2h4v4h2v-4h4v-2h-4V7zm-1-5C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"
@@ -1887,14 +1818,13 @@ exports[`Storyshots Icon With a size 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 dkBAgY"
+        class="StyledSvg-sc-1h19zm3-0 ezlJgg Icon-fc7twp-0 eycguF"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="24px"
-        icon="arrowForward"
+        height="x3"
         viewBox="0 0 24 24"
-        width="24px"
+        width="x3"
       >
         <path
           d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8-8-8z"
@@ -1902,26 +1832,24 @@ exports[`Storyshots Icon With a size 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 dkBAgY"
+        class="StyledSvg-sc-1h19zm3-0 ezlJgg Icon-fc7twp-0 eycguF"
         color="currentColor"
         fill="currentColor"
         focusable="false"
-        height="24px"
-        icon="block"
+        height="x3"
         viewBox="0 0 24 24"
-        width="24px"
+        width="x3"
       >
         <path
           d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zM4 12c0-4.42 3.58-8 8-8 1.85 0 3.55.63 4.9 1.69L5.69 16.9C4.63 15.55 4 13.85 4 12zm8 8c-1.85 0-3.55-.63-4.9-1.69L18.31 7.1C19.37 8.45 20 10.15 20 12c0 4.42-3.58 8-8 8z"
         />
       </svg>
       <svg
-        class="Icon-fc7twp-0 dkBAgY"
+        class="StyledSvg-sc-1h19zm3-0 ikqkgo Icon-fc7twp-0 eycguF"
         focusable="false"
-        height="24px"
-        icon="loading"
+        height="x3"
         viewBox="0 0 38 38"
-        width="24px"
+        width="x3"
         xmlns="http://www.w3.org/2000/svg"
       >
         <defs>
@@ -2005,12 +1933,11 @@ exports[`Storyshots Icon With accessibility title 1`] = `
     >
       <svg
         aria-hidden="false"
-        class="Icon-fc7twp-0 dkBAgY"
+        class="StyledSvg-sc-1h19zm3-0 ezlJgg Icon-fc7twp-0 dkBAgY"
         color="currentColor"
         fill="currentColor"
         focusable="false"
         height="24px"
-        icon="user"
         title="User account"
         viewBox="0 0 24 24"
         width="24px"
@@ -2026,12 +1953,11 @@ exports[`Storyshots Icon With accessibility title 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 dkBAgY"
+        class="StyledSvg-sc-1h19zm3-0 ezlJgg Icon-fc7twp-0 dkBAgY"
         color="currentColor"
         fill="currentColor"
         focusable="false"
         height="24px"
-        icon="user"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -2061,13 +1987,11 @@ exports[`Storyshots Icon With added margin 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 bCFepo"
+          class="StyledSvg-sc-1h19zm3-0 dgtmbk Icon-fc7twp-0 bCFepo"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="delete"
-          m="x2"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -2082,13 +2006,11 @@ exports[`Storyshots Icon With added margin 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 hAhxEu"
+          class="StyledSvg-sc-1h19zm3-0 iKyrAG Icon-fc7twp-0 hAhxEu"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="delete"
-          mt="x2"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -2103,13 +2025,11 @@ exports[`Storyshots Icon With added margin 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 gezant"
+          class="StyledSvg-sc-1h19zm3-0 gEdLNx Icon-fc7twp-0 gezant"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="delete"
-          mr="x2"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -2124,13 +2044,11 @@ exports[`Storyshots Icon With added margin 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 iCRWbe"
+          class="StyledSvg-sc-1h19zm3-0 ljNjFa Icon-fc7twp-0 iCRWbe"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="delete"
-          mb="x2"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -2145,13 +2063,11 @@ exports[`Storyshots Icon With added margin 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 ZEcAK"
+          class="StyledSvg-sc-1h19zm3-0 ggJnu Icon-fc7twp-0 ZEcAK"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="delete"
-          ml="x2"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -2166,13 +2082,11 @@ exports[`Storyshots Icon With added margin 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 bdShWb"
+          class="StyledSvg-sc-1h19zm3-0 tUaRz Icon-fc7twp-0 bdShWb"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="delete"
-          mx="x2"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -2187,13 +2101,11 @@ exports[`Storyshots Icon With added margin 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 iHUtzQ"
+          class="StyledSvg-sc-1h19zm3-0 FaUAI Icon-fc7twp-0 iHUtzQ"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="delete"
-          my="x2"
           viewBox="0 0 24 24"
           width="24px"
         >

--- a/components/src/Input/InputField.js
+++ b/components/src/Input/InputField.js
@@ -10,7 +10,6 @@ import { MaybeFieldLabel } from "../FieldLabel";
 import Prefix from "./Prefix";
 import Suffix from "./Suffix";
 import { InputFieldDefaultProps, InputFieldPropTypes } from "./InputField.type";
-import NDSTheme from "../theme";
 
 const inputStyles = theme => ({
   disabled: {
@@ -100,7 +99,7 @@ export const InputField = forwardRef(
         <Prefix prefix={prefix} prefixWidth={prefixWidth} textAlign={prefixAlignment} />
         <Box position="relative" display="flex" flexGrow="1" ref={ref}>
           <StyledInput aria-invalid={error} aria-required={required} required={required} error={error} {...props} />
-          {icon && <StyledInputIcon icon={icon} size={NDSTheme.space.x2} />}
+          {icon && <StyledInputIcon icon={icon} size="x2" />}
         </Box>
         <Suffix suffix={suffix} suffixWidth={suffixWidth} textAlign={suffixAlignment} />
       </Flex>

--- a/components/src/Input/__snapshots__/Input.story.storyshot
+++ b/components/src/Input/__snapshots__/Input.story.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Input Input 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -20,7 +20,7 @@ exports[`Storyshots Input Input 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Input
           </span>
@@ -56,7 +56,7 @@ exports[`Storyshots Input set to disabled 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -65,7 +65,7 @@ exports[`Storyshots Input set to disabled 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Set to disabled
           </span>
@@ -112,7 +112,7 @@ exports[`Storyshots Input set to required 1`] = `
         class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
       >
         <label
-          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
           color="black"
           style="display:block"
         >
@@ -121,7 +121,7 @@ exports[`Storyshots Input set to required 1`] = `
             data-testid="field-label"
           >
             <span
-              class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+              class="LabelText-sc-16fh5zk-0 lmVLTL"
             >
               Label
             </span>
@@ -588,7 +588,7 @@ exports[`Storyshots Input with all props 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -597,7 +597,7 @@ exports[`Storyshots Input with all props 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Input
           </span>
@@ -649,7 +649,7 @@ exports[`Storyshots Input with custom ID 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -658,7 +658,7 @@ exports[`Storyshots Input with custom ID 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Label
           </span>
@@ -695,7 +695,7 @@ exports[`Storyshots Input with error list  1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -704,7 +704,7 @@ exports[`Storyshots Input with error list  1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Label
           </span>
@@ -730,13 +730,11 @@ exports[`Storyshots Input with error list  1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 QuoIa"
+          class="StyledSvg-sc-1h19zm3-0 jpOsNG Icon-fc7twp-0 QuoIa"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="error"
-          mr="x1"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -789,7 +787,7 @@ exports[`Storyshots Input with error message 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -798,7 +796,7 @@ exports[`Storyshots Input with error message 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Label
           </span>
@@ -824,13 +822,11 @@ exports[`Storyshots Input with error message 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 QuoIa"
+          class="StyledSvg-sc-1h19zm3-0 jpOsNG Icon-fc7twp-0 QuoIa"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="error"
-          mr="x1"
           viewBox="0 0 24 24"
           width="24px"
         >

--- a/components/src/LoadingAnimation/LoadingAnimation.js
+++ b/components/src/LoadingAnimation/LoadingAnimation.js
@@ -1,10 +1,11 @@
-import React from "react";
+import React, { useContext } from "react";
 import PropTypes from "prop-types";
-import NDSTheme from "../theme";
+import { ThemeContext } from "styled-components";
 
 const LoadingAnimation = ({ inactive }) => {
-  const color1 = inactive ? NDSTheme.colors.grey : NDSTheme.colors.blue;
-  const color2 = inactive ? NDSTheme.colors.lightGrey : NDSTheme.colors.yellow;
+  const theme = useContext(ThemeContext);
+  const color1 = inactive ? theme.colors.grey : theme.colors.blue;
+  const color2 = inactive ? theme.colors.lightGrey : theme.colors.yellow;
   return (
     // Modified svg By Sam Herbert (@sherb), for everyone. More @ http://goo.gl/7AJzbL
     <svg

--- a/components/src/LoadingAnimation/__snapshots__/LoadingAnimation.story.storyshot
+++ b/components/src/LoadingAnimation/__snapshots__/LoadingAnimation.story.storyshot
@@ -507,14 +507,13 @@ exports[`Storyshots LoadingAnimation Page example - active 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="Icon-fc7twp-0 efirdb"
+            class="StyledSvg-sc-1h19zm3-0 bXTOZY Icon-fc7twp-0 jCbLQW"
             color="currentColor"
             fill="currentColor"
             focusable="false"
-            height="32px"
-            icon="refresh"
+            height="x4"
             viewBox="0 0 24 24"
-            width="32px"
+            width="x4"
           >
             <path
               d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
@@ -528,14 +527,13 @@ exports[`Storyshots LoadingAnimation Page example - active 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="Icon-fc7twp-0 efirdb"
+            class="StyledSvg-sc-1h19zm3-0 bXTOZY Icon-fc7twp-0 jCbLQW"
             color="currentColor"
             fill="currentColor"
             focusable="false"
-            height="32px"
-            icon="close"
+            height="x4"
             viewBox="0 0 24 24"
-            width="32px"
+            width="x4"
           >
             <path
               d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
@@ -748,14 +746,13 @@ exports[`Storyshots LoadingAnimation Page example - inactive 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="Icon-fc7twp-0 efirdb"
+            class="StyledSvg-sc-1h19zm3-0 bXTOZY Icon-fc7twp-0 jCbLQW"
             color="currentColor"
             fill="currentColor"
             focusable="false"
-            height="32px"
-            icon="refresh"
+            height="x4"
             viewBox="0 0 24 24"
-            width="32px"
+            width="x4"
           >
             <path
               d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
@@ -769,14 +766,13 @@ exports[`Storyshots LoadingAnimation Page example - inactive 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="Icon-fc7twp-0 efirdb"
+            class="StyledSvg-sc-1h19zm3-0 bXTOZY Icon-fc7twp-0 jCbLQW"
             color="currentColor"
             fill="currentColor"
             focusable="false"
-            height="32px"
-            icon="close"
+            height="x4"
             viewBox="0 0 24 24"
-            width="32px"
+            width="x4"
           >
             <path
               d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"

--- a/components/src/MonthPicker/MonthPicker.js
+++ b/components/src/MonthPicker/MonthPicker.js
@@ -8,7 +8,6 @@ import { format, isSameYear, isValid } from "date-fns";
 import { MonthPickerStyles } from "./MonthPickerStyles";
 import DatePickerInput from "../DatePicker/DatePickerInput";
 import { InlineValidation } from "../Validation";
-import NDStheme from "../theme";
 import { Field } from "../Form";
 import { InputFieldPropTypes, InputFieldDefaultProps } from "../Input/InputField.type";
 import { Icon } from "../Icon";
@@ -118,8 +117,8 @@ class MonthPicker extends Component {
                   />
                 )
                 }
-                previousYearButtonLabel={<Icon icon="leftArrow" size={NDStheme.space.x4} />}
-                nextYearButtonLabel={<Icon icon="rightArrow" size={NDStheme.space.x4} />}
+                previousYearButtonLabel={<Icon icon="leftArrow" size="x4" />}
+                nextYearButtonLabel={<Icon icon="rightArrow" size="x4" />}
                 excludeDates={[selectedDate]}
                 disabledKeyboardNavigation
                 minDate={minDate}

--- a/components/src/MonthPicker/__snapshots__/MonthPicker.story.storyshot
+++ b/components/src/MonthPicker/__snapshots__/MonthPicker.story.storyshot
@@ -18,7 +18,7 @@ exports[`Storyshots MonthPicker default 1`] = `
           class="react-datepicker__input-container"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -27,7 +27,7 @@ exports[`Storyshots MonthPicker default 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Month
               </span>
@@ -49,14 +49,13 @@ exports[`Storyshots MonthPicker default 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -90,7 +89,7 @@ exports[`Storyshots MonthPicker with a min and max date 1`] = `
           class="react-datepicker__input-container"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -99,7 +98,7 @@ exports[`Storyshots MonthPicker with a min and max date 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Month and Year
               </span>
@@ -121,14 +120,13 @@ exports[`Storyshots MonthPicker with a min and max date 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -162,7 +160,7 @@ exports[`Storyshots MonthPicker with custom placeholder 1`] = `
           class="react-datepicker__input-container"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -171,7 +169,7 @@ exports[`Storyshots MonthPicker with custom placeholder 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Month and Year
               </span>
@@ -193,14 +191,13 @@ exports[`Storyshots MonthPicker with custom placeholder 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -234,7 +231,7 @@ exports[`Storyshots MonthPicker with error state 1`] = `
           class="react-datepicker__input-container"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
             color="black"
             style="display:block"
           >
@@ -243,7 +240,7 @@ exports[`Storyshots MonthPicker with error state 1`] = `
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                class="LabelText-sc-16fh5zk-0 lmVLTL"
               >
                 Month and Year
               </span>
@@ -265,14 +262,13 @@ exports[`Storyshots MonthPicker with error state 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -289,13 +285,11 @@ exports[`Storyshots MonthPicker with error state 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 QuoIa"
+          class="StyledSvg-sc-1h19zm3-0 jpOsNG Icon-fc7twp-0 QuoIa"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="error"
-          mr="x1"
           viewBox="0 0 24 24"
           width="24px"
         >

--- a/components/src/MonthRange/__snapshots__/MonthRange.story.storyshot
+++ b/components/src/MonthRange/__snapshots__/MonthRange.story.storyshot
@@ -8,7 +8,7 @@ exports[`Storyshots MonthRange customizing input props 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
       color="black"
       style="display:block"
     >
@@ -17,7 +17,7 @@ exports[`Storyshots MonthRange customizing input props 1`] = `
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Month range
         </span>
@@ -54,14 +54,13 @@ exports[`Storyshots MonthRange customizing input props 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -110,14 +109,13 @@ exports[`Storyshots MonthRange customizing input props 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -141,7 +139,7 @@ exports[`Storyshots MonthRange default 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
       color="black"
       style="display:block"
     >
@@ -150,7 +148,7 @@ exports[`Storyshots MonthRange default 1`] = `
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Month range
         </span>
@@ -187,14 +185,13 @@ exports[`Storyshots MonthRange default 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -243,14 +240,13 @@ exports[`Storyshots MonthRange default 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -274,7 +270,7 @@ exports[`Storyshots MonthRange default start and end date 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
       color="black"
       style="display:block"
     >
@@ -283,7 +279,7 @@ exports[`Storyshots MonthRange default start and end date 1`] = `
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Month range
         </span>
@@ -320,14 +316,13 @@ exports[`Storyshots MonthRange default start and end date 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -376,14 +371,13 @@ exports[`Storyshots MonthRange default start and end date 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -407,7 +401,7 @@ exports[`Storyshots MonthRange disabled range validation 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
       color="black"
       style="display:block"
     >
@@ -416,7 +410,7 @@ exports[`Storyshots MonthRange disabled range validation 1`] = `
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Month range
         </span>
@@ -453,14 +447,13 @@ exports[`Storyshots MonthRange disabled range validation 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -509,14 +502,13 @@ exports[`Storyshots MonthRange disabled range validation 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -540,7 +532,7 @@ exports[`Storyshots MonthRange individual input error 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
       color="black"
       style="display:block"
     >
@@ -549,7 +541,7 @@ exports[`Storyshots MonthRange individual input error 1`] = `
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Month range
         </span>
@@ -587,14 +579,13 @@ exports[`Storyshots MonthRange individual input error 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -610,13 +601,11 @@ exports[`Storyshots MonthRange individual input error 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="Icon-fc7twp-0 QuoIa"
+            class="StyledSvg-sc-1h19zm3-0 jpOsNG Icon-fc7twp-0 QuoIa"
             color="currentColor"
             fill="currentColor"
             focusable="false"
             height="24px"
-            icon="error"
-            mr="x1"
             viewBox="0 0 24 24"
             width="24px"
           >
@@ -675,14 +664,13 @@ exports[`Storyshots MonthRange individual input error 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -706,7 +694,7 @@ exports[`Storyshots MonthRange with custom error 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
       color="black"
       style="display:block"
     >
@@ -715,7 +703,7 @@ exports[`Storyshots MonthRange with custom error 1`] = `
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Month range
         </span>
@@ -752,14 +740,13 @@ exports[`Storyshots MonthRange with custom error 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -808,14 +795,13 @@ exports[`Storyshots MonthRange with custom error 1`] = `
                 />
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  class="StyledSvg-sc-1h19zm3-0 fjWnTA Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 fqddVU"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="16px"
-                  icon="calendarToday"
+                  height="x2"
                   viewBox="0 0 24 24"
-                  width="16px"
+                  width="x2"
                 >
                   <path
                     d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
@@ -833,13 +819,11 @@ exports[`Storyshots MonthRange with custom error 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 QuoIa"
+        class="StyledSvg-sc-1h19zm3-0 jpOsNG Icon-fc7twp-0 QuoIa"
         color="currentColor"
         fill="currentColor"
         focusable="false"
         height="24px"
-        icon="error"
-        mr="x1"
         viewBox="0 0 24 24"
         width="24px"
       >

--- a/components/src/NavBar/__snapshots__/NavBar.story.storyshot
+++ b/components/src/NavBar/__snapshots__/NavBar.story.storyshot
@@ -84,13 +84,11 @@ exports[`Storyshots NavBar NavBar 1`] = `
                   Dashboard
                   <svg
                     aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                     color="#ffffff"
                     fill="#ffffff"
                     focusable="false"
                     height="20px"
-                    icon="downArrow"
-                    p="2px"
                     style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
@@ -112,13 +110,11 @@ exports[`Storyshots NavBar NavBar 1`] = `
                   Inspector
                   <svg
                     aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                     color="#ffffff"
                     fill="#ffffff"
                     focusable="false"
                     height="20px"
-                    icon="downArrow"
-                    p="2px"
                     style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
@@ -140,13 +136,11 @@ exports[`Storyshots NavBar NavBar 1`] = `
                   Operations
                   <svg
                     aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                     color="#ffffff"
                     fill="#ffffff"
                     focusable="false"
                     height="20px"
-                    icon="downArrow"
-                    p="2px"
                     style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
@@ -210,12 +204,11 @@ exports[`Storyshots NavBar NavBar 1`] = `
                     >
                       <svg
                         aria-hidden="true"
-                        class="Icon-fc7twp-0 dkBAgY"
+                        class="StyledSvg-sc-1h19zm3-0 ezlJgg Icon-fc7twp-0 dkBAgY"
                         color="currentColor"
                         fill="currentColor"
                         focusable="false"
                         height="24px"
-                        icon="search"
                         viewBox="0 0 24 24"
                         width="24px"
                       >
@@ -242,13 +235,11 @@ exports[`Storyshots NavBar NavBar 1`] = `
                     User@Nulogy.com
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 hIxIEB"
+                      class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                       color="#ffffff"
                       fill="#ffffff"
                       focusable="false"
                       height="20px"
-                      icon="downArrow"
-                      p="2px"
                       style="position:absolute;top:11px;right:8px"
                       viewBox="0 0 24 24"
                       width="20px"
@@ -270,13 +261,11 @@ exports[`Storyshots NavBar NavBar 1`] = `
                     Settings
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 hIxIEB"
+                      class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                       color="#ffffff"
                       fill="#ffffff"
                       focusable="false"
                       height="20px"
-                      icon="downArrow"
-                      p="2px"
                       style="position:absolute;top:11px;right:8px"
                       viewBox="0 0 24 24"
                       width="20px"
@@ -392,13 +381,11 @@ exports[`Storyshots NavBar With alternate themeColor 1`] = `
                   Dashboard
                   <svg
                     aria-hidden="true"
-                    class="Icon-fc7twp-0 ldBYos"
+                    class="StyledSvg-sc-1h19zm3-0 jyDtMc Icon-fc7twp-0 ldBYos"
                     color="#00438f"
                     fill="#00438f"
                     focusable="false"
                     height="20px"
-                    icon="downArrow"
-                    p="2px"
                     style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
@@ -525,13 +512,11 @@ exports[`Storyshots NavBar With alternative branding link 1`] = `
                   Dashboard
                   <svg
                     aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                     color="#ffffff"
                     fill="#ffffff"
                     focusable="false"
                     height="20px"
-                    icon="downArrow"
-                    p="2px"
                     style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
@@ -738,13 +723,11 @@ exports[`Storyshots NavBar With custom link components 1`] = `
                   Dashboard
                   <svg
                     aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                     color="#ffffff"
                     fill="#ffffff"
                     focusable="false"
                     height="20px"
-                    icon="downArrow"
-                    p="2px"
                     style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
@@ -818,12 +801,11 @@ exports[`Storyshots NavBar With custom link components 1`] = `
                     >
                       <svg
                         aria-hidden="true"
-                        class="Icon-fc7twp-0 dkBAgY"
+                        class="StyledSvg-sc-1h19zm3-0 ezlJgg Icon-fc7twp-0 dkBAgY"
                         color="currentColor"
                         fill="currentColor"
                         focusable="false"
                         height="24px"
-                        icon="search"
                         viewBox="0 0 24 24"
                         width="24px"
                       >
@@ -850,13 +832,11 @@ exports[`Storyshots NavBar With custom link components 1`] = `
                     User@Nulogy.com
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 hIxIEB"
+                      class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                       color="#ffffff"
                       fill="#ffffff"
                       focusable="false"
                       height="20px"
-                      icon="downArrow"
-                      p="2px"
                       style="position:absolute;top:11px;right:8px"
                       viewBox="0 0 24 24"
                       width="20px"
@@ -878,12 +858,11 @@ exports[`Storyshots NavBar With custom link components 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 dkBAgY"
+                      class="StyledSvg-sc-1h19zm3-0 ezlJgg Icon-fc7twp-0 dkBAgY"
                       color="currentColor"
                       fill="currentColor"
                       focusable="false"
                       height="24px"
-                      icon="settings"
                       viewBox="0 0 20 20"
                       width="24px"
                     >
@@ -893,13 +872,11 @@ exports[`Storyshots NavBar With custom link components 1`] = `
                     </svg>
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 hIxIEB"
+                      class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                       color="#ffffff"
                       fill="#ffffff"
                       focusable="false"
                       height="20px"
-                      icon="downArrow"
-                      p="2px"
                       style="position:absolute;top:11px;right:8px"
                       viewBox="0 0 24 24"
                       width="20px"
@@ -1015,13 +992,11 @@ exports[`Storyshots NavBar With subtext 1`] = `
                   Dashboard
                   <svg
                     aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                     color="#ffffff"
                     fill="#ffffff"
                     focusable="false"
                     height="20px"
-                    icon="downArrow"
-                    p="2px"
                     style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
@@ -1095,12 +1070,11 @@ exports[`Storyshots NavBar With subtext 1`] = `
                     >
                       <svg
                         aria-hidden="true"
-                        class="Icon-fc7twp-0 dkBAgY"
+                        class="StyledSvg-sc-1h19zm3-0 ezlJgg Icon-fc7twp-0 dkBAgY"
                         color="currentColor"
                         fill="currentColor"
                         focusable="false"
                         height="24px"
-                        icon="search"
                         viewBox="0 0 24 24"
                         width="24px"
                       >
@@ -1205,13 +1179,11 @@ exports[`Storyshots NavBar With text in the menu 1`] = `
                   Dashboard
                   <svg
                     aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                     color="#ffffff"
                     fill="#ffffff"
                     focusable="false"
                     height="20px"
-                    icon="downArrow"
-                    p="2px"
                     style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
@@ -1334,13 +1306,11 @@ exports[`Storyshots NavBar Without search 1`] = `
                   Dashboard
                   <svg
                     aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                     color="#ffffff"
                     fill="#ffffff"
                     focusable="false"
                     height="20px"
-                    icon="downArrow"
-                    p="2px"
                     style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
@@ -1362,13 +1332,11 @@ exports[`Storyshots NavBar Without search 1`] = `
                   Inspector
                   <svg
                     aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                     color="#ffffff"
                     fill="#ffffff"
                     focusable="false"
                     height="20px"
-                    icon="downArrow"
-                    p="2px"
                     style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
@@ -1390,13 +1358,11 @@ exports[`Storyshots NavBar Without search 1`] = `
                   Operations
                   <svg
                     aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                     color="#ffffff"
                     fill="#ffffff"
                     focusable="false"
                     height="20px"
-                    icon="downArrow"
-                    p="2px"
                     style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
@@ -1436,13 +1402,11 @@ exports[`Storyshots NavBar Without search 1`] = `
                     User@Nulogy.com
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 hIxIEB"
+                      class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                       color="#ffffff"
                       fill="#ffffff"
                       focusable="false"
                       height="20px"
-                      icon="downArrow"
-                      p="2px"
                       style="position:absolute;top:11px;right:8px"
                       viewBox="0 0 24 24"
                       width="20px"
@@ -1464,13 +1428,11 @@ exports[`Storyshots NavBar Without search 1`] = `
                     Settings
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 hIxIEB"
+                      class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                       color="#ffffff"
                       fill="#ffffff"
                       focusable="false"
                       height="20px"
-                      icon="downArrow"
-                      p="2px"
                       style="position:absolute;top:11px;right:8px"
                       viewBox="0 0 24 24"
                       width="20px"
@@ -1578,13 +1540,11 @@ exports[`Storyshots NavBar Without search and primary menu 1`] = `
                     User@Nulogy.com
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 hIxIEB"
+                      class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                       color="#ffffff"
                       fill="#ffffff"
                       focusable="false"
                       height="20px"
-                      icon="downArrow"
-                      p="2px"
                       style="position:absolute;top:11px;right:8px"
                       viewBox="0 0 24 24"
                       width="20px"
@@ -1606,13 +1566,11 @@ exports[`Storyshots NavBar Without search and primary menu 1`] = `
                     Settings
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 hIxIEB"
+                      class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                       color="#ffffff"
                       fill="#ffffff"
                       focusable="false"
                       height="20px"
-                      icon="downArrow"
-                      p="2px"
                       style="position:absolute;top:11px;right:8px"
                       viewBox="0 0 24 24"
                       width="20px"
@@ -1717,13 +1675,11 @@ exports[`Storyshots NavBar Without search and secondary menu 1`] = `
                   Dashboard
                   <svg
                     aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                     color="#ffffff"
                     fill="#ffffff"
                     focusable="false"
                     height="20px"
-                    icon="downArrow"
-                    p="2px"
                     style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
@@ -1745,13 +1701,11 @@ exports[`Storyshots NavBar Without search and secondary menu 1`] = `
                   Inspector
                   <svg
                     aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                     color="#ffffff"
                     fill="#ffffff"
                     focusable="false"
                     height="20px"
-                    icon="downArrow"
-                    p="2px"
                     style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
@@ -1773,13 +1727,11 @@ exports[`Storyshots NavBar Without search and secondary menu 1`] = `
                   Operations
                   <svg
                     aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                     color="#ffffff"
                     fill="#ffffff"
                     focusable="false"
                     height="20px"
-                    icon="downArrow"
-                    p="2px"
                     style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
@@ -1896,13 +1848,11 @@ exports[`Storyshots NavBar Without secondary menu 1`] = `
                   Dashboard
                   <svg
                     aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                     color="#ffffff"
                     fill="#ffffff"
                     focusable="false"
                     height="20px"
-                    icon="downArrow"
-                    p="2px"
                     style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
@@ -1924,13 +1874,11 @@ exports[`Storyshots NavBar Without secondary menu 1`] = `
                   Inspector
                   <svg
                     aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                     color="#ffffff"
                     fill="#ffffff"
                     focusable="false"
                     height="20px"
-                    icon="downArrow"
-                    p="2px"
                     style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
@@ -1952,13 +1900,11 @@ exports[`Storyshots NavBar Without secondary menu 1`] = `
                   Operations
                   <svg
                     aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                     color="#ffffff"
                     fill="#ffffff"
                     focusable="false"
                     height="20px"
-                    icon="downArrow"
-                    p="2px"
                     style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
@@ -2022,12 +1968,11 @@ exports[`Storyshots NavBar Without secondary menu 1`] = `
                     >
                       <svg
                         aria-hidden="true"
-                        class="Icon-fc7twp-0 dkBAgY"
+                        class="StyledSvg-sc-1h19zm3-0 ezlJgg Icon-fc7twp-0 dkBAgY"
                         color="currentColor"
                         fill="currentColor"
                         focusable="false"
                         height="24px"
-                        icon="search"
                         viewBox="0 0 24 24"
                         width="24px"
                       >

--- a/components/src/NavBarSearch/__snapshots__/NavBarSearch.story.storyshot
+++ b/components/src/NavBarSearch/__snapshots__/NavBarSearch.story.storyshot
@@ -46,12 +46,11 @@ exports[`Storyshots NavBarSearch NavBarSearch 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="Icon-fc7twp-0 dkBAgY"
+              class="StyledSvg-sc-1h19zm3-0 ezlJgg Icon-fc7twp-0 dkBAgY"
               color="currentColor"
               fill="currentColor"
               focusable="false"
               height="24px"
-              icon="search"
               viewBox="0 0 24 24"
               width="24px"
             >
@@ -113,12 +112,11 @@ exports[`Storyshots NavBarSearch With custom name 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="Icon-fc7twp-0 dkBAgY"
+              class="StyledSvg-sc-1h19zm3-0 ezlJgg Icon-fc7twp-0 dkBAgY"
               color="currentColor"
               fill="currentColor"
               focusable="false"
               height="24px"
-              icon="search"
               viewBox="0 0 24 24"
               width="24px"
             >

--- a/components/src/PMPagination/__snapshots__/PMPagination.story.storyshot
+++ b/components/src/PMPagination/__snapshots__/PMPagination.story.storyshot
@@ -18,13 +18,11 @@ exports[`Storyshots PM/PMPagination default 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 bLUmHQ"
+          class="StyledSvg-sc-1h19zm3-0 himFUY Icon-fc7twp-0 bLUmHQ"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="leftArrow"
-          ml="-8px"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -69,13 +67,11 @@ exports[`Storyshots PM/PMPagination default 1`] = `
         Next → 
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 dEtgXr"
+          class="StyledSvg-sc-1h19zm3-0 gEJFDT Icon-fc7twp-0 dEtgXr"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="rightArrow"
-          mr="-8px"
           viewBox="0 0 24 24"
           width="24px"
         >

--- a/components/src/PMTable/__snapshots__/PMTable.story.storyshot
+++ b/components/src/PMTable/__snapshots__/PMTable.story.storyshot
@@ -332,13 +332,11 @@ exports[`Storyshots PM/PMTable default 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 bLUmHQ"
+          class="StyledSvg-sc-1h19zm3-0 himFUY Icon-fc7twp-0 bLUmHQ"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="leftArrow"
-          ml="-8px"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -383,13 +381,11 @@ exports[`Storyshots PM/PMTable default 1`] = `
         Next → 
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 dEtgXr"
+          class="StyledSvg-sc-1h19zm3-0 gEJFDT Icon-fc7twp-0 dEtgXr"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="rightArrow"
-          mr="-8px"
           viewBox="0 0 24 24"
           width="24px"
         >

--- a/components/src/Pagination/__snapshots__/Pagination.story.storyshot
+++ b/components/src/Pagination/__snapshots__/Pagination.story.storyshot
@@ -18,13 +18,11 @@ exports[`Storyshots Pagination Pagination 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 bLUmHQ"
+          class="StyledSvg-sc-1h19zm3-0 himFUY Icon-fc7twp-0 bLUmHQ"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="leftArrow"
-          ml="-8px"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -90,13 +88,11 @@ exports[`Storyshots Pagination Pagination 1`] = `
         Next 
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 dEtgXr"
+          class="StyledSvg-sc-1h19zm3-0 gEJFDT Icon-fc7twp-0 dEtgXr"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="rightArrow"
-          mr="-8px"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -116,13 +112,11 @@ exports[`Storyshots Pagination Pagination 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 bLUmHQ"
+          class="StyledSvg-sc-1h19zm3-0 himFUY Icon-fc7twp-0 bLUmHQ"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="leftArrow"
-          ml="-8px"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -188,13 +182,11 @@ exports[`Storyshots Pagination Pagination 1`] = `
         Next 
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 dEtgXr"
+          class="StyledSvg-sc-1h19zm3-0 gEJFDT Icon-fc7twp-0 dEtgXr"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="rightArrow"
-          mr="-8px"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -214,13 +206,11 @@ exports[`Storyshots Pagination Pagination 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 bLUmHQ"
+          class="StyledSvg-sc-1h19zm3-0 himFUY Icon-fc7twp-0 bLUmHQ"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="leftArrow"
-          ml="-8px"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -286,13 +276,11 @@ exports[`Storyshots Pagination Pagination 1`] = `
         Next 
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 dEtgXr"
+          class="StyledSvg-sc-1h19zm3-0 gEJFDT Icon-fc7twp-0 dEtgXr"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="rightArrow"
-          mr="-8px"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -312,13 +300,11 @@ exports[`Storyshots Pagination Pagination 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 bLUmHQ"
+          class="StyledSvg-sc-1h19zm3-0 himFUY Icon-fc7twp-0 bLUmHQ"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="leftArrow"
-          ml="-8px"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -384,13 +370,11 @@ exports[`Storyshots Pagination Pagination 1`] = `
         Next 
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 dEtgXr"
+          class="StyledSvg-sc-1h19zm3-0 gEJFDT Icon-fc7twp-0 dEtgXr"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="rightArrow"
-          mr="-8px"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -410,13 +394,11 @@ exports[`Storyshots Pagination Pagination 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 bLUmHQ"
+          class="StyledSvg-sc-1h19zm3-0 himFUY Icon-fc7twp-0 bLUmHQ"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="leftArrow"
-          ml="-8px"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -482,13 +464,11 @@ exports[`Storyshots Pagination Pagination 1`] = `
         Next 
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 dEtgXr"
+          class="StyledSvg-sc-1h19zm3-0 gEJFDT Icon-fc7twp-0 dEtgXr"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="rightArrow"
-          mr="-8px"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -508,13 +488,11 @@ exports[`Storyshots Pagination Pagination 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 bLUmHQ"
+          class="StyledSvg-sc-1h19zm3-0 himFUY Icon-fc7twp-0 bLUmHQ"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="leftArrow"
-          ml="-8px"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -580,13 +558,11 @@ exports[`Storyshots Pagination Pagination 1`] = `
         Next 
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 dEtgXr"
+          class="StyledSvg-sc-1h19zm3-0 gEJFDT Icon-fc7twp-0 dEtgXr"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="rightArrow"
-          mr="-8px"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -606,13 +582,11 @@ exports[`Storyshots Pagination Pagination 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 bLUmHQ"
+          class="StyledSvg-sc-1h19zm3-0 himFUY Icon-fc7twp-0 bLUmHQ"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="leftArrow"
-          ml="-8px"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -679,13 +653,11 @@ exports[`Storyshots Pagination Pagination 1`] = `
         Next 
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 dEtgXr"
+          class="StyledSvg-sc-1h19zm3-0 gEJFDT Icon-fc7twp-0 dEtgXr"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="rightArrow"
-          mr="-8px"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -717,13 +689,11 @@ exports[`Storyshots Pagination on the first page 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 bLUmHQ"
+          class="StyledSvg-sc-1h19zm3-0 himFUY Icon-fc7twp-0 bLUmHQ"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="leftArrow"
-          ml="-8px"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -789,13 +759,11 @@ exports[`Storyshots Pagination on the first page 1`] = `
         Next 
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 dEtgXr"
+          class="StyledSvg-sc-1h19zm3-0 gEJFDT Icon-fc7twp-0 dEtgXr"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="rightArrow"
-          mr="-8px"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -826,13 +794,11 @@ exports[`Storyshots Pagination on the last page 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 bLUmHQ"
+          class="StyledSvg-sc-1h19zm3-0 himFUY Icon-fc7twp-0 bLUmHQ"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="leftArrow"
-          ml="-8px"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -899,13 +865,11 @@ exports[`Storyshots Pagination on the last page 1`] = `
         Next 
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 dEtgXr"
+          class="StyledSvg-sc-1h19zm3-0 gEJFDT Icon-fc7twp-0 dEtgXr"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="rightArrow"
-          mr="-8px"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -936,13 +900,11 @@ exports[`Storyshots Pagination with less than 5 pages 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 bLUmHQ"
+          class="StyledSvg-sc-1h19zm3-0 himFUY Icon-fc7twp-0 bLUmHQ"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="leftArrow"
-          ml="-8px"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -987,13 +949,11 @@ exports[`Storyshots Pagination with less than 5 pages 1`] = `
         Next 
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 dEtgXr"
+          class="StyledSvg-sc-1h19zm3-0 gEJFDT Icon-fc7twp-0 dEtgXr"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="rightArrow"
-          mr="-8px"
           viewBox="0 0 24 24"
           width="24px"
         >

--- a/components/src/Radio/RadioGroup.js
+++ b/components/src/Radio/RadioGroup.js
@@ -1,17 +1,11 @@
-import React, { useContext } from "react";
+import React from "react";
 import PropTypes from "prop-types";
-import styled, { ThemeContext } from "styled-components";
+import styled from "styled-components";
 
 import Radio from "./Radio";
 import { HelpText, RequirementText } from "../FieldLabel";
 import { InlineValidation } from "../Validation";
-import { Fieldset } from "../Form";
-
-const labelTextStyles = theme => ({
-  fontSize: theme.fontSizes.small,
-  fontWeight: theme.fontWeights.bold,
-  lineHeight: theme.lineHeights.smallTextBase
-});
+import { Fieldset, Legend, LabelText } from "../Form";
 
 const getRadioButtons = props => {
   const radioButtons = React.Children.map(props.children, radio => {
@@ -35,14 +29,12 @@ const getRadioButtons = props => {
 
 const BaseRadioGroup = ({ className, id, errorMessage, errorList, labelText, helpText, requirementText, ...props }) => {
   const otherProps = { ...props, errorMessage, errorList };
-  const themeContext = useContext(ThemeContext);
-
   return (
     <Fieldset className={className} id={id} hasHelpText={!!helpText}>
-      <legend style={{ marginBottom: themeContext.space.x1 }}>
-        <span style={labelTextStyles(themeContext)}>{labelText}</span>
+      <Legend>
+        <LabelText>{labelText}</LabelText>
         {requirementText && <RequirementText>{requirementText}</RequirementText>}
-      </legend>
+      </Legend>
       {helpText && <HelpText>{helpText}</HelpText>}
       {getRadioButtons(otherProps)}
       <InlineValidation mt="x1" errorMessage={errorMessage} errorList={errorList} />

--- a/components/src/Radio/__snapshots__/RadioGroup.story.storyshot
+++ b/components/src/Radio/__snapshots__/RadioGroup.story.storyshot
@@ -11,10 +11,10 @@ exports[`Storyshots RadioGroup Controlled 1`] = `
       class="Fieldset-sc-9aoml1-0 eiFgjk RadioGroup-pgv2w1-0 hFKzrk"
     >
       <legend
-        style="margin-bottom:8px"
+        class="Legend-sc-12h2r7a-0 fqZhwH"
       >
         <span
-          style="font-size:14px;font-weight:600;line-height:1.71428571"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Setting Selection
         </span>
@@ -118,10 +118,10 @@ exports[`Storyshots RadioGroup RadioGroup 1`] = `
       class="Fieldset-sc-9aoml1-0 eiFgjk RadioGroup-pgv2w1-0 hFKzrk"
     >
       <legend
-        style="margin-bottom:8px"
+        class="Legend-sc-12h2r7a-0 fqZhwH"
       >
         <span
-          style="font-size:14px;font-weight:600;line-height:1.71428571"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Setting Selection
         </span>
@@ -220,10 +220,10 @@ exports[`Storyshots RadioGroup RadioGroup with all props 1`] = `
       class="Fieldset-sc-9aoml1-0 eiFgjk RadioGroup-pgv2w1-0 hFKzrk"
     >
       <legend
-        style="margin-bottom:8px"
+        class="Legend-sc-12h2r7a-0 fqZhwH"
       >
         <span
-          style="font-size:14px;font-weight:600;line-height:1.71428571"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Setting Selection
         </span>
@@ -340,10 +340,10 @@ exports[`Storyshots RadioGroup Set to disabled 1`] = `
       class="Fieldset-sc-9aoml1-0 eiFgjk RadioGroup-pgv2w1-0 hFKzrk"
     >
       <legend
-        style="margin-bottom:8px"
+        class="Legend-sc-12h2r7a-0 fqZhwH"
       >
         <span
-          style="font-size:14px;font-weight:600;line-height:1.71428571"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Setting Selection
         </span>
@@ -455,10 +455,10 @@ exports[`Storyshots RadioGroup with error list 1`] = `
       class="Fieldset-sc-9aoml1-0 eiFgjk RadioGroup-pgv2w1-0 hFKzrk"
     >
       <legend
-        style="margin-bottom:8px"
+        class="Legend-sc-12h2r7a-0 fqZhwH"
       >
         <span
-          style="font-size:14px;font-weight:600;line-height:1.71428571"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Setting Selection
         </span>
@@ -548,13 +548,11 @@ exports[`Storyshots RadioGroup with error list 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 QuoIa"
+          class="StyledSvg-sc-1h19zm3-0 jpOsNG Icon-fc7twp-0 QuoIa"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="error"
-          mr="x1"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -607,10 +605,10 @@ exports[`Storyshots RadioGroup with error message 1`] = `
       class="Fieldset-sc-9aoml1-0 eiFgjk RadioGroup-pgv2w1-0 hFKzrk"
     >
       <legend
-        style="margin-bottom:8px"
+        class="Legend-sc-12h2r7a-0 fqZhwH"
       >
         <span
-          style="font-size:14px;font-weight:600;line-height:1.71428571"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Setting Selection
         </span>
@@ -700,13 +698,11 @@ exports[`Storyshots RadioGroup with error message 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 QuoIa"
+          class="StyledSvg-sc-1h19zm3-0 jpOsNG Icon-fc7twp-0 QuoIa"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="error"
-          mr="x1"
           viewBox="0 0 24 24"
           width="24px"
         >

--- a/components/src/RangeContainer/__snapshots__/RangeContainer.story.storyshot
+++ b/components/src/RangeContainer/__snapshots__/RangeContainer.story.storyshot
@@ -8,7 +8,7 @@ exports[`Storyshots RangeContainer RangeContainer 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
       color="black"
       style="display:block"
     >
@@ -17,7 +17,7 @@ exports[`Storyshots RangeContainer RangeContainer 1`] = `
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Range
         </span>

--- a/components/src/Select/__snapshots__/Select.story.storyshot
+++ b/components/src/Select/__snapshots__/Select.story.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Select Select 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -20,7 +20,7 @@ exports[`Storyshots Select Select 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Inventory status
           </span>
@@ -119,7 +119,7 @@ exports[`Storyshots Select With wrapping text 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -128,7 +128,7 @@ exports[`Storyshots Select With wrapping text 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Inventory status
           </span>
@@ -271,7 +271,7 @@ exports[`Storyshots Select set to disabled 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -280,7 +280,7 @@ exports[`Storyshots Select set to disabled 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Inventory status
           </span>
@@ -400,7 +400,7 @@ exports[`Storyshots Select set to required 1`] = `
         class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
       >
         <label
-          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
           color="black"
           style="display:block"
         >
@@ -409,7 +409,7 @@ exports[`Storyshots Select set to required 1`] = `
             data-testid="field-label"
           >
             <span
-              class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+              class="LabelText-sc-16fh5zk-0 lmVLTL"
             >
               Inventory status
             </span>
@@ -522,7 +522,7 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -531,7 +531,7 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Inventory status
           </span>
@@ -697,7 +697,7 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
         class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
       >
         <label
-          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
           color="black"
           style="display:block"
         >
@@ -706,7 +706,7 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
             data-testid="field-label"
           >
             <span
-              class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+              class="LabelText-sc-16fh5zk-0 lmVLTL"
             >
               PCN
             </span>
@@ -1018,7 +1018,7 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
         class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
       >
         <label
-          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
           color="black"
           style="display:block"
         >
@@ -1027,7 +1027,7 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
             data-testid="field-label"
           >
             <span
-              class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+              class="LabelText-sc-16fh5zk-0 lmVLTL"
             >
               Inventory status
             </span>
@@ -1346,7 +1346,7 @@ exports[`Storyshots Select with a blank value 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -1355,7 +1355,7 @@ exports[`Storyshots Select with a blank value 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Inventory status
           </span>
@@ -1454,7 +1454,7 @@ exports[`Storyshots Select with a defaultValue 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -1463,7 +1463,7 @@ exports[`Storyshots Select with a defaultValue 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Inventory status
           </span>
@@ -1562,7 +1562,7 @@ exports[`Storyshots Select with an option selected 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -1571,7 +1571,7 @@ exports[`Storyshots Select with an option selected 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Inventory status
           </span>
@@ -1660,7 +1660,7 @@ exports[`Storyshots Select with an option selected 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -1669,7 +1669,7 @@ exports[`Storyshots Select with an option selected 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Inventory status
           </span>
@@ -1892,7 +1892,7 @@ exports[`Storyshots Select with custom id 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -1901,7 +1901,7 @@ exports[`Storyshots Select with custom id 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Inventory status
           </span>
@@ -2007,7 +2007,7 @@ exports[`Storyshots Select with error list 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -2016,7 +2016,7 @@ exports[`Storyshots Select with error list 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Inventory status
           </span>
@@ -2104,13 +2104,11 @@ exports[`Storyshots Select with error list 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="Icon-fc7twp-0 QuoIa"
+            class="StyledSvg-sc-1h19zm3-0 jpOsNG Icon-fc7twp-0 QuoIa"
             color="currentColor"
             fill="currentColor"
             focusable="false"
             height="24px"
-            icon="error"
-            mr="x1"
             viewBox="0 0 24 24"
             width="24px"
           >
@@ -2360,13 +2358,11 @@ exports[`Storyshots Select with error list 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 QuoIa"
+          class="StyledSvg-sc-1h19zm3-0 jpOsNG Icon-fc7twp-0 QuoIa"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="error"
-          mr="x1"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -2419,7 +2415,7 @@ exports[`Storyshots Select with error message 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -2428,7 +2424,7 @@ exports[`Storyshots Select with error message 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Inventory status
           </span>
@@ -2516,13 +2512,11 @@ exports[`Storyshots Select with error message 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="Icon-fc7twp-0 QuoIa"
+            class="StyledSvg-sc-1h19zm3-0 jpOsNG Icon-fc7twp-0 QuoIa"
             color="currentColor"
             fill="currentColor"
             focusable="false"
             height="24px"
-            icon="error"
-            mr="x1"
             viewBox="0 0 24 24"
             width="24px"
           >
@@ -2755,13 +2749,11 @@ exports[`Storyshots Select with error message 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 QuoIa"
+          class="StyledSvg-sc-1h19zm3-0 jpOsNG Icon-fc7twp-0 QuoIa"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="error"
-          mr="x1"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -2801,7 +2793,7 @@ exports[`Storyshots Select with fixed positioning 1`] = `
         class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
       >
         <label
-          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
           color="black"
           style="display:block"
         >
@@ -2810,7 +2802,7 @@ exports[`Storyshots Select with fixed positioning 1`] = `
             data-testid="field-label"
           >
             <span
-              class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+              class="LabelText-sc-16fh5zk-0 lmVLTL"
             >
               Inventory status
             </span>
@@ -2910,7 +2902,7 @@ exports[`Storyshots Select with helpText 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -2919,7 +2911,7 @@ exports[`Storyshots Select with helpText 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Inventory status
           </span>
@@ -3025,7 +3017,7 @@ exports[`Storyshots Select with multiselect 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -3034,7 +3026,7 @@ exports[`Storyshots Select with multiselect 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Select PCN
           </span>
@@ -3207,7 +3199,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -3216,7 +3208,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Inventory status
           </span>
@@ -3439,7 +3431,7 @@ exports[`Storyshots Select with state 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -3448,7 +3440,7 @@ exports[`Storyshots Select with state 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Inventory status
           </span>

--- a/components/src/Table/SortingColumnHeader.js
+++ b/components/src/Table/SortingColumnHeader.js
@@ -4,7 +4,6 @@ import { useTranslation } from "react-i18next";
 import { Text } from "../Type";
 import { Flex } from "../Flex";
 import { ControlIcon } from "../Button";
-import NDStheme from "../theme";
 
 const SortingColumnHeader = ({ onChange, label, ascending, active, ariaLabel }) => {
   const { t } = useTranslation();
@@ -13,7 +12,7 @@ const SortingColumnHeader = ({ onChange, label, ascending, active, ariaLabel }) 
     <Flex alignItems="center">
       <Text mr="x1">{label}</Text>
       <ControlIcon
-        size={NDStheme.space.x3}
+        size="x3"
         icon={ascending ? "sortDown" : "sortUp"}
         label={ariaLabel || defaultAriaLabel}
         toggled={active}

--- a/components/src/Table/__snapshots__/BaseTable.story.storyshot
+++ b/components/src/Table/__snapshots__/BaseTable.story.storyshot
@@ -479,15 +479,13 @@ exports[`Storyshots Table with a custom cell component 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 cwKdbD"
+                  class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="32px"
-                  icon="more"
-                  p="half"
+                  height="x4"
                   viewBox="0 0 24 24"
-                  width="32px"
+                  width="x4"
                 >
                   <path
                     d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
@@ -524,15 +522,13 @@ exports[`Storyshots Table with a custom cell component 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 cwKdbD"
+                  class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="32px"
-                  icon="more"
-                  p="half"
+                  height="x4"
                   viewBox="0 0 24 24"
-                  width="32px"
+                  width="x4"
                 >
                   <path
                     d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
@@ -569,15 +565,13 @@ exports[`Storyshots Table with a custom cell component 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 cwKdbD"
+                  class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="32px"
-                  icon="more"
-                  p="half"
+                  height="x4"
                   viewBox="0 0 24 24"
-                  width="32px"
+                  width="x4"
                 >
                   <path
                     d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
@@ -614,15 +608,13 @@ exports[`Storyshots Table with a custom cell component 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 cwKdbD"
+                  class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="32px"
-                  icon="more"
-                  p="half"
+                  height="x4"
                   viewBox="0 0 24 24"
-                  width="32px"
+                  width="x4"
                 >
                   <path
                     d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
@@ -659,15 +651,13 @@ exports[`Storyshots Table with a custom cell component 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 cwKdbD"
+                  class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="32px"
-                  icon="more"
-                  p="half"
+                  height="x4"
                   viewBox="0 0 24 24"
-                  width="32px"
+                  width="x4"
                 >
                   <path
                     d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
@@ -704,15 +694,13 @@ exports[`Storyshots Table with a custom cell component 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 cwKdbD"
+                  class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="32px"
-                  icon="more"
-                  p="half"
+                  height="x4"
                   viewBox="0 0 24 24"
-                  width="32px"
+                  width="x4"
                 >
                   <path
                     d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
@@ -749,15 +737,13 @@ exports[`Storyshots Table with a custom cell component 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 cwKdbD"
+                  class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="32px"
-                  icon="more"
-                  p="half"
+                  height="x4"
                   viewBox="0 0 24 24"
-                  width="32px"
+                  width="x4"
                 >
                   <path
                     d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
@@ -794,15 +780,13 @@ exports[`Storyshots Table with a custom cell component 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 cwKdbD"
+                  class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="32px"
-                  icon="more"
-                  p="half"
+                  height="x4"
                   viewBox="0 0 24 24"
-                  width="32px"
+                  width="x4"
                 >
                   <path
                     d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"

--- a/components/src/Table/__snapshots__/SortingColumnHeader.story.storyshot
+++ b/components/src/Table/__snapshots__/SortingColumnHeader.story.storyshot
@@ -24,14 +24,13 @@ exports[`Storyshots Table.Headers Sorting Header 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 dkBAgY"
+          class="StyledSvg-sc-1h19zm3-0 ezlJgg Icon-fc7twp-0 eycguF"
           color="currentColor"
           fill="currentColor"
           focusable="false"
-          height="24px"
-          icon="sortUp"
+          height="x3"
           viewBox="0 0 24 24"
-          width="24px"
+          width="x3"
         >
           <path
             d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"

--- a/components/src/Table/__snapshots__/Table.story.storyshot
+++ b/components/src/Table/__snapshots__/Table.story.storyshot
@@ -147,14 +147,13 @@ exports[`Storyshots Table with everything 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="Icon-fc7twp-0 efirdb"
+                class="StyledSvg-sc-1h19zm3-0 bXTOZY Icon-fc7twp-0 jCbLQW"
                 color="currentColor"
                 fill="currentColor"
                 focusable="false"
-                height="32px"
-                icon="downArrow"
+                height="x4"
                 viewBox="0 0 24 24"
-                width="32px"
+                width="x4"
               >
                 <path
                   d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
@@ -193,15 +192,13 @@ exports[`Storyshots Table with everything 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 cwKdbD"
+                  class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="32px"
-                  icon="more"
-                  p="half"
+                  height="x4"
                   viewBox="0 0 24 24"
-                  width="32px"
+                  width="x4"
                 >
                   <path
                     d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
@@ -272,15 +269,13 @@ exports[`Storyshots Table with everything 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 cwKdbD"
+                  class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="32px"
-                  icon="more"
-                  p="half"
+                  height="x4"
                   viewBox="0 0 24 24"
-                  width="32px"
+                  width="x4"
                 >
                   <path
                     d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
@@ -351,15 +346,13 @@ exports[`Storyshots Table with everything 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 cwKdbD"
+                  class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="32px"
-                  icon="more"
-                  p="half"
+                  height="x4"
                   viewBox="0 0 24 24"
-                  width="32px"
+                  width="x4"
                 >
                   <path
                     d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
@@ -432,15 +425,13 @@ exports[`Storyshots Table with everything 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  class="Icon-fc7twp-0 cwKdbD"
+                  class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
                   color="currentColor"
                   fill="currentColor"
                   focusable="false"
-                  height="32px"
-                  icon="more"
-                  p="half"
+                  height="x4"
                   viewBox="0 0 24 24"
-                  width="32px"
+                  width="x4"
                 >
                   <path
                     d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
@@ -517,13 +508,11 @@ exports[`Storyshots Table with everything 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 bLUmHQ"
+          class="StyledSvg-sc-1h19zm3-0 himFUY Icon-fc7twp-0 bLUmHQ"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="leftArrow"
-          ml="-8px"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -561,13 +550,11 @@ exports[`Storyshots Table with everything 1`] = `
         Next 
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 dEtgXr"
+          class="StyledSvg-sc-1h19zm3-0 gEJFDT Icon-fc7twp-0 dEtgXr"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="rightArrow"
-          mr="-8px"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -655,13 +642,11 @@ exports[`Storyshots Table with pagination 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 bLUmHQ"
+          class="StyledSvg-sc-1h19zm3-0 himFUY Icon-fc7twp-0 bLUmHQ"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="leftArrow"
-          ml="-8px"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -727,13 +712,11 @@ exports[`Storyshots Table with pagination 1`] = `
         Next 
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 dEtgXr"
+          class="StyledSvg-sc-1h19zm3-0 gEJFDT Icon-fc7twp-0 dEtgXr"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="rightArrow"
-          mr="-8px"
           viewBox="0 0 24 24"
           width="24px"
         >

--- a/components/src/Table/__snapshots__/TableWithExpandableRows.story.storyshot
+++ b/components/src/Table/__snapshots__/TableWithExpandableRows.story.storyshot
@@ -83,14 +83,13 @@ exports[`Storyshots Table/with expandable rows with expandable rows 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="Icon-fc7twp-0 efirdb"
+                class="StyledSvg-sc-1h19zm3-0 bXTOZY Icon-fc7twp-0 jCbLQW"
                 color="currentColor"
                 fill="currentColor"
                 focusable="false"
-                height="32px"
-                icon="downArrow"
+                height="x4"
                 viewBox="0 0 24 24"
-                width="32px"
+                width="x4"
               >
                 <path
                   d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
@@ -151,14 +150,13 @@ exports[`Storyshots Table/with expandable rows with expandable rows 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="Icon-fc7twp-0 efirdb"
+                class="StyledSvg-sc-1h19zm3-0 bXTOZY Icon-fc7twp-0 jCbLQW"
                 color="currentColor"
                 fill="currentColor"
                 focusable="false"
-                height="32px"
-                icon="downArrow"
+                height="x4"
                 viewBox="0 0 24 24"
-                width="32px"
+                width="x4"
               >
                 <path
                   d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
@@ -219,14 +217,13 @@ exports[`Storyshots Table/with expandable rows with expandable rows 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="Icon-fc7twp-0 efirdb"
+                class="StyledSvg-sc-1h19zm3-0 bXTOZY Icon-fc7twp-0 jCbLQW"
                 color="currentColor"
                 fill="currentColor"
                 focusable="false"
-                height="32px"
-                icon="downArrow"
+                height="x4"
                 viewBox="0 0 24 24"
-                width="32px"
+                width="x4"
               >
                 <path
                   d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
@@ -386,14 +383,13 @@ exports[`Storyshots Table/with expandable rows with rows expanded by default 1`]
             >
               <svg
                 aria-hidden="true"
-                class="Icon-fc7twp-0 efirdb"
+                class="StyledSvg-sc-1h19zm3-0 bXTOZY Icon-fc7twp-0 jCbLQW"
                 color="currentColor"
                 fill="currentColor"
                 focusable="false"
-                height="32px"
-                icon="downArrow"
+                height="x4"
                 viewBox="0 0 24 24"
-                width="32px"
+                width="x4"
               >
                 <path
                   d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
@@ -454,14 +450,13 @@ exports[`Storyshots Table/with expandable rows with rows expanded by default 1`]
             >
               <svg
                 aria-hidden="true"
-                class="Icon-fc7twp-0 efirdb"
+                class="StyledSvg-sc-1h19zm3-0 bXTOZY Icon-fc7twp-0 jCbLQW"
                 color="currentColor"
                 fill="currentColor"
                 focusable="false"
-                height="32px"
-                icon="upArrow"
+                height="x4"
                 viewBox="0 0 24 24"
-                width="32px"
+                width="x4"
               >
                 <path
                   d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"
@@ -542,14 +537,13 @@ exports[`Storyshots Table/with expandable rows with rows expanded by default 1`]
             >
               <svg
                 aria-hidden="true"
-                class="Icon-fc7twp-0 efirdb"
+                class="StyledSvg-sc-1h19zm3-0 bXTOZY Icon-fc7twp-0 jCbLQW"
                 color="currentColor"
                 fill="currentColor"
                 focusable="false"
-                height="32px"
-                icon="upArrow"
+                height="x4"
                 viewBox="0 0 24 24"
-                width="32px"
+                width="x4"
               >
                 <path
                   d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"

--- a/components/src/Textarea/__snapshots__/Textarea.story.storyshot
+++ b/components/src/Textarea/__snapshots__/Textarea.story.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots Textarea Set to disabled 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -20,7 +20,7 @@ exports[`Storyshots Textarea Set to disabled 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Label
           </span>
@@ -49,7 +49,7 @@ exports[`Storyshots Textarea Textarea 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -58,7 +58,7 @@ exports[`Storyshots Textarea Textarea 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Label
           </span>
@@ -86,7 +86,7 @@ exports[`Storyshots Textarea Textarea with all props 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -95,7 +95,7 @@ exports[`Storyshots Textarea Textarea with all props 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Label
           </span>
@@ -139,7 +139,7 @@ exports[`Storyshots Textarea With custom id 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -148,7 +148,7 @@ exports[`Storyshots Textarea With custom id 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Label
           </span>
@@ -177,7 +177,7 @@ exports[`Storyshots Textarea With custom number of rows 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -186,7 +186,7 @@ exports[`Storyshots Textarea With custom number of rows 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Label
           </span>
@@ -224,7 +224,7 @@ exports[`Storyshots Textarea set to required 1`] = `
         class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
       >
         <label
-          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
           color="black"
           style="display:block"
         >
@@ -233,7 +233,7 @@ exports[`Storyshots Textarea set to required 1`] = `
             data-testid="field-label"
           >
             <span
-              class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+              class="LabelText-sc-16fh5zk-0 lmVLTL"
             >
               Label
             </span>
@@ -268,7 +268,7 @@ exports[`Storyshots Textarea with error list 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -277,7 +277,7 @@ exports[`Storyshots Textarea with error list 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Label
           </span>
@@ -295,13 +295,11 @@ exports[`Storyshots Textarea with error list 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 QuoIa"
+          class="StyledSvg-sc-1h19zm3-0 jpOsNG Icon-fc7twp-0 QuoIa"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="error"
-          mr="x1"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -354,7 +352,7 @@ exports[`Storyshots Textarea with error message 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -363,7 +361,7 @@ exports[`Storyshots Textarea with error message 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Label
           </span>
@@ -381,13 +379,11 @@ exports[`Storyshots Textarea with error message 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 QuoIa"
+          class="StyledSvg-sc-1h19zm3-0 jpOsNG Icon-fc7twp-0 QuoIa"
           color="currentColor"
           fill="currentColor"
           focusable="false"
           height="24px"
-          icon="error"
-          mr="x1"
           viewBox="0 0 24 24"
           width="24px"
         >

--- a/components/src/TimePicker/__snapshots__/TimePicker.story.storyshot
+++ b/components/src/TimePicker/__snapshots__/TimePicker.story.storyshot
@@ -11,7 +11,7 @@ exports[`Storyshots TimePicker default 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -20,7 +20,7 @@ exports[`Storyshots TimePicker default 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Start Time
           </span>
@@ -87,12 +87,11 @@ exports[`Storyshots TimePicker default 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      class="StyledSvg-sc-1h19zm3-0 kpDHXQ Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
                       color="currentColor"
                       fill="currentColor"
                       focusable="false"
                       height="22px"
-                      icon="queryBuilder"
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -123,7 +122,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -132,7 +131,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Duration
           </span>
@@ -199,12 +198,11 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      class="StyledSvg-sc-1h19zm3-0 kpDHXQ Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
                       color="currentColor"
                       fill="currentColor"
                       focusable="false"
                       height="22px"
-                      icon="queryBuilder"
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -235,7 +233,7 @@ exports[`Storyshots TimePicker with custom time format 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -244,7 +242,7 @@ exports[`Storyshots TimePicker with custom time format 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Duration
           </span>
@@ -311,12 +309,11 @@ exports[`Storyshots TimePicker with custom time format 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      class="StyledSvg-sc-1h19zm3-0 kpDHXQ Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
                       color="currentColor"
                       fill="currentColor"
                       focusable="false"
                       height="22px"
-                      icon="queryBuilder"
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -347,7 +344,7 @@ exports[`Storyshots TimePicker with custom time interval 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -356,7 +353,7 @@ exports[`Storyshots TimePicker with custom time interval 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Duration
           </span>
@@ -423,12 +420,11 @@ exports[`Storyshots TimePicker with custom time interval 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      class="StyledSvg-sc-1h19zm3-0 kpDHXQ Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
                       color="currentColor"
                       fill="currentColor"
                       focusable="false"
                       height="22px"
-                      icon="queryBuilder"
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -459,7 +455,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -468,7 +464,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             End Time
           </span>
@@ -535,12 +531,11 @@ exports[`Storyshots TimePicker with error state 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      class="StyledSvg-sc-1h19zm3-0 kpDHXQ Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
                       color="currentColor"
                       fill="currentColor"
                       focusable="false"
                       height="22px"
-                      icon="queryBuilder"
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -560,13 +555,11 @@ exports[`Storyshots TimePicker with error state 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="Icon-fc7twp-0 QuoIa"
+            class="StyledSvg-sc-1h19zm3-0 jpOsNG Icon-fc7twp-0 QuoIa"
             color="currentColor"
             fill="currentColor"
             focusable="false"
             height="24px"
-            icon="error"
-            mr="x1"
             viewBox="0 0 24 24"
             width="24px"
           >
@@ -603,7 +596,7 @@ exports[`Storyshots TimePicker with min and max time 1`] = `
       class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
         color="black"
         style="display:block"
       >
@@ -612,7 +605,7 @@ exports[`Storyshots TimePicker with min and max time 1`] = `
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             End Time
           </span>
@@ -679,12 +672,11 @@ exports[`Storyshots TimePicker with min and max time 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      class="StyledSvg-sc-1h19zm3-0 kpDHXQ Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
                       color="currentColor"
                       fill="currentColor"
                       focusable="false"
                       height="22px"
-                      icon="queryBuilder"
                       viewBox="0 0 24 24"
                       width="22px"
                     >

--- a/components/src/TimeRange/__snapshots__/TimeRange.story.storyshot
+++ b/components/src/TimeRange/__snapshots__/TimeRange.story.storyshot
@@ -8,7 +8,7 @@ exports[`Storyshots TimeRange default 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
       color="black"
       style="display:block"
     >
@@ -17,7 +17,7 @@ exports[`Storyshots TimeRange default 1`] = `
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Time range
         </span>
@@ -92,12 +92,11 @@ exports[`Storyshots TimeRange default 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      class="StyledSvg-sc-1h19zm3-0 kpDHXQ Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
                       color="currentColor"
                       fill="currentColor"
                       focusable="false"
                       height="22px"
-                      icon="queryBuilder"
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -188,12 +187,11 @@ exports[`Storyshots TimeRange default 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      class="StyledSvg-sc-1h19zm3-0 kpDHXQ Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
                       color="currentColor"
                       fill="currentColor"
                       focusable="false"
                       height="22px"
-                      icon="queryBuilder"
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -221,7 +219,7 @@ exports[`Storyshots TimeRange default selections 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
       color="black"
       style="display:block"
     >
@@ -230,7 +228,7 @@ exports[`Storyshots TimeRange default selections 1`] = `
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Time range
         </span>
@@ -305,12 +303,11 @@ exports[`Storyshots TimeRange default selections 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      class="StyledSvg-sc-1h19zm3-0 kpDHXQ Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
                       color="currentColor"
                       fill="currentColor"
                       focusable="false"
                       height="22px"
-                      icon="queryBuilder"
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -401,12 +398,11 @@ exports[`Storyshots TimeRange default selections 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      class="StyledSvg-sc-1h19zm3-0 kpDHXQ Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
                       color="currentColor"
                       fill="currentColor"
                       focusable="false"
                       height="22px"
-                      icon="queryBuilder"
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -434,7 +430,7 @@ exports[`Storyshots TimeRange with min and max time range 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
       color="black"
       style="display:block"
     >
@@ -443,7 +439,7 @@ exports[`Storyshots TimeRange with min and max time range 1`] = `
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Time range
         </span>
@@ -518,12 +514,11 @@ exports[`Storyshots TimeRange with min and max time range 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      class="StyledSvg-sc-1h19zm3-0 kpDHXQ Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
                       color="currentColor"
                       fill="currentColor"
                       focusable="false"
                       height="22px"
-                      icon="queryBuilder"
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -614,12 +609,11 @@ exports[`Storyshots TimeRange with min and max time range 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      class="StyledSvg-sc-1h19zm3-0 kpDHXQ Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
                       color="currentColor"
                       fill="currentColor"
                       focusable="false"
                       height="22px"
-                      icon="queryBuilder"
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -647,7 +641,7 @@ exports[`Storyshots TimeRange with range validation 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
       color="black"
       style="display:block"
     >
@@ -656,7 +650,7 @@ exports[`Storyshots TimeRange with range validation 1`] = `
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          class="LabelText-sc-16fh5zk-0 lmVLTL"
         >
           Time range
         </span>
@@ -731,12 +725,11 @@ exports[`Storyshots TimeRange with range validation 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      class="StyledSvg-sc-1h19zm3-0 kpDHXQ Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
                       color="currentColor"
                       fill="currentColor"
                       focusable="false"
                       height="22px"
-                      icon="queryBuilder"
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -827,12 +820,11 @@ exports[`Storyshots TimeRange with range validation 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      class="StyledSvg-sc-1h19zm3-0 kpDHXQ Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
                       color="currentColor"
                       fill="currentColor"
                       focusable="false"
                       height="22px"
-                      icon="queryBuilder"
                       viewBox="0 0 24 24"
                       width="22px"
                     >

--- a/components/src/Toast/__snapshots__/Toast.story.storyshot
+++ b/components/src/Toast/__snapshots__/Toast.story.storyshot
@@ -61,15 +61,13 @@ exports[`Storyshots Toast multiple toasts example 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 cwKdbD"
+          class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
           color="currentColor"
           fill="currentColor"
           focusable="false"
-          height="32px"
-          icon="delete"
-          p="half"
+          height="x4"
           viewBox="0 0 24 24"
-          width="32px"
+          width="x4"
         >
           <path
             d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
@@ -93,13 +91,11 @@ exports[`Storyshots Toast multiple toasts example 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 dqoulF"
+          class="StyledSvg-sc-1h19zm3-0 jszHsh Icon-fc7twp-0 dqoulF"
           color="green"
           fill="#008059"
           focusable="false"
           height="24px"
-          icon="check"
-          mr="x1"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -123,13 +119,11 @@ exports[`Storyshots Toast multiple toasts example 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 dqoulF"
+          class="StyledSvg-sc-1h19zm3-0 jszHsh Icon-fc7twp-0 dqoulF"
           color="green"
           fill="#008059"
           focusable="false"
           height="24px"
-          icon="check"
-          mr="x1"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -153,13 +147,11 @@ exports[`Storyshots Toast multiple toasts example 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 dqoulF"
+          class="StyledSvg-sc-1h19zm3-0 jszHsh Icon-fc7twp-0 dqoulF"
           color="green"
           fill="#008059"
           focusable="false"
           height="24px"
-          icon="check"
-          mr="x1"
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -183,13 +175,11 @@ exports[`Storyshots Toast multiple toasts example 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="Icon-fc7twp-0 ewGQci"
+          class="StyledSvg-sc-1h19zm3-0 fveekS Icon-fc7twp-0 ewGQci"
           color="red"
           fill="#cc1439"
           focusable="false"
           height="24px"
-          icon="error"
-          mr="x1"
           viewBox="0 0 24 24"
           width="24px"
         >

--- a/components/src/Toggle/Toggle.js
+++ b/components/src/Toggle/Toggle.js
@@ -1,25 +1,18 @@
-import React, { useState, useContext } from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
-import styled, { ThemeContext } from "styled-components";
+import styled from "styled-components";
 import { Box } from "../Box";
 import { HelpText, RequirementText } from "../FieldLabel";
-import { Field } from "../Form";
+import { Field, LabelText } from "../Form";
 import { Text } from "../Type";
 import { ClickInputLabel } from "../utils";
 import ToggleButton from "./ToggleButton";
 
-const labelTextStyles = theme => ({
-  fontSize: theme.fontSizes.small,
-  fontWeight: theme.fontWeights.bold,
-  lineHeight: theme.lineHeights.smallTextBase
-});
-
 const MaybeToggleTitle = ({ labelText, requirementText, helpText, children, ...props }) => {
-  const themeContext = useContext(ThemeContext);
   return labelText ? (
     <div {...props}>
       <Box mb={children && "x1"}>
-        <span style={labelTextStyles(themeContext)}>{labelText}</span>
+        <LabelText>{labelText}</LabelText>
         {requirementText && <RequirementText>{requirementText}</RequirementText>}
         {helpText && <HelpText>{helpText}</HelpText>}
       </Box>

--- a/components/src/Toggle/__snapshots__/Toggle.story.storyshot
+++ b/components/src/Toggle/__snapshots__/Toggle.story.storyshot
@@ -17,7 +17,7 @@ exports[`Storyshots Toggle Controlled Toggle 1`] = `
           class="Box-sc-1qu1edy-0 ilQgHG"
         >
           <span
-            style="font-size:14px;font-weight:600;line-height:1.71428571"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Controlled Toggle
           </span>
@@ -104,7 +104,7 @@ exports[`Storyshots Toggle Toggle set to defaultToggled 1`] = `
           class="Box-sc-1qu1edy-0 ilQgHG"
         >
           <span
-            style="font-size:14px;font-weight:600;line-height:1.71428571"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Toggle
           </span>
@@ -152,7 +152,7 @@ exports[`Storyshots Toggle Toggle set to disabled 1`] = `
           class="Box-sc-1qu1edy-0 ilQgHG"
         >
           <span
-            style="font-size:14px;font-weight:600;line-height:1.71428571"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Toggle
           </span>
@@ -199,7 +199,7 @@ exports[`Storyshots Toggle Toggle set to disabled 1`] = `
           class="Box-sc-1qu1edy-0 ilQgHG"
         >
           <span
-            style="font-size:14px;font-weight:600;line-height:1.71428571"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Toggle
           </span>
@@ -259,7 +259,7 @@ exports[`Storyshots Toggle Toggle with all props 1`] = `
           class="Box-sc-1qu1edy-0 ilQgHG"
         >
           <span
-            style="font-size:14px;font-weight:600;line-height:1.71428571"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Toggle
           </span>
@@ -329,7 +329,7 @@ exports[`Storyshots Toggle With custom id 1`] = `
           class="Box-sc-1qu1edy-0 ilQgHG"
         >
           <span
-            style="font-size:14px;font-weight:600;line-height:1.71428571"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Toggle
           </span>
@@ -384,7 +384,7 @@ exports[`Storyshots Toggle With long text 1`] = `
           class="Box-sc-1qu1edy-0 ilQgHG"
         >
           <span
-            style="font-size:14px;font-weight:600;line-height:1.71428571"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Toggle
           </span>
@@ -439,7 +439,7 @@ exports[`Storyshots Toggle With text 1`] = `
           class="Box-sc-1qu1edy-0 ilQgHG"
         >
           <span
-            style="font-size:14px;font-weight:600;line-height:1.71428571"
+            class="LabelText-sc-16fh5zk-0 lmVLTL"
           >
             Toggle
           </span>

--- a/components/src/Validation/__snapshots__/InlineValidation.story.storyshot
+++ b/components/src/Validation/__snapshots__/InlineValidation.story.storyshot
@@ -13,13 +13,11 @@ exports[`Storyshots Inline Validation Inline Validation 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 QuoIa"
+        class="StyledSvg-sc-1h19zm3-0 jpOsNG Icon-fc7twp-0 QuoIa"
         color="currentColor"
         fill="currentColor"
         focusable="false"
         height="24px"
-        icon="error"
-        mr="x1"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -56,13 +54,11 @@ exports[`Storyshots Inline Validation with custom content 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 QuoIa"
+        class="StyledSvg-sc-1h19zm3-0 jpOsNG Icon-fc7twp-0 QuoIa"
         color="currentColor"
         fill="currentColor"
         focusable="false"
         height="24px"
-        icon="error"
-        mr="x1"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -129,13 +125,11 @@ exports[`Storyshots Inline Validation with list items 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 QuoIa"
+        class="StyledSvg-sc-1h19zm3-0 jpOsNG Icon-fc7twp-0 QuoIa"
         color="currentColor"
         fill="currentColor"
         focusable="false"
         height="24px"
-        icon="error"
-        mr="x1"
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -189,13 +183,11 @@ exports[`Storyshots Inline Validation with only list items 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="Icon-fc7twp-0 QuoIa"
+        class="StyledSvg-sc-1h19zm3-0 jpOsNG Icon-fc7twp-0 QuoIa"
         color="currentColor"
         fill="currentColor"
         focusable="false"
         height="24px"
-        icon="error"
-        mr="x1"
         viewBox="0 0 24 24"
         width="24px"
       >

--- a/components/src/pages/__snapshots__/Custom.story.storyshot
+++ b/components/src/pages/__snapshots__/Custom.story.storyshot
@@ -84,13 +84,11 @@ exports[`Storyshots Pages/Custom Default 1`] = `
                   Dashboard
                   <svg
                     aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                     color="#ffffff"
                     fill="#ffffff"
                     focusable="false"
                     height="20px"
-                    icon="downArrow"
-                    p="2px"
                     style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
@@ -130,13 +128,11 @@ exports[`Storyshots Pages/Custom Default 1`] = `
                     Settings
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 hIxIEB"
+                      class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                       color="#ffffff"
                       fill="#ffffff"
                       focusable="false"
                       height="20px"
-                      icon="downArrow"
-                      p="2px"
                       style="position:absolute;top:11px;right:8px"
                       viewBox="0 0 24 24"
                       width="20px"
@@ -263,13 +259,11 @@ exports[`Storyshots Pages/Custom With breadcrumbs and actions 1`] = `
                   Dashboard
                   <svg
                     aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                     color="#ffffff"
                     fill="#ffffff"
                     focusable="false"
                     height="20px"
-                    icon="downArrow"
-                    p="2px"
                     style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
@@ -309,13 +303,11 @@ exports[`Storyshots Pages/Custom With breadcrumbs and actions 1`] = `
                     Settings
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 hIxIEB"
+                      class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                       color="#ffffff"
                       fill="#ffffff"
                       focusable="false"
                       height="20px"
-                      icon="downArrow"
-                      p="2px"
                       style="position:absolute;top:11px;right:8px"
                       viewBox="0 0 24 24"
                       width="20px"
@@ -354,13 +346,11 @@ exports[`Storyshots Pages/Custom With breadcrumbs and actions 1`] = `
               </a>
               <svg
                 aria-hidden="true"
-                class="Icon-fc7twp-0 fQFStW"
+                class="StyledSvg-sc-1h19zm3-0 jOtbLy Icon-fc7twp-0 fQFStW"
                 color="darkGrey"
                 fill="#434d59"
                 focusable="false"
                 height="20px"
-                icon="rightArrow"
-                mr="half"
                 viewBox="0 0 24 24"
                 width="20px"
               >
@@ -377,13 +367,11 @@ exports[`Storyshots Pages/Custom With breadcrumbs and actions 1`] = `
               </a>
               <svg
                 aria-hidden="true"
-                class="Icon-fc7twp-0 fQFStW"
+                class="StyledSvg-sc-1h19zm3-0 jOtbLy Icon-fc7twp-0 fQFStW"
                 color="darkGrey"
                 fill="#434d59"
                 focusable="false"
                 height="20px"
-                icon="rightArrow"
-                mr="half"
                 viewBox="0 0 24 24"
                 width="20px"
               >
@@ -397,15 +385,13 @@ exports[`Storyshots Pages/Custom With breadcrumbs and actions 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="Icon-fc7twp-0 cwKdbD"
+                class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
                 color="currentColor"
                 fill="currentColor"
                 focusable="false"
-                height="32px"
-                icon="more"
-                p="half"
+                height="x4"
                 viewBox="0 0 24 24"
-                width="32px"
+                width="x4"
               >
                 <path
                   d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
@@ -447,15 +433,13 @@ exports[`Storyshots Pages/Custom With breadcrumbs and actions 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="Icon-fc7twp-0 cwKdbD"
+                class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
                 color="currentColor"
                 fill="currentColor"
                 focusable="false"
-                height="32px"
-                icon="close"
-                p="half"
+                height="x4"
                 viewBox="0 0 24 24"
-                width="32px"
+                width="x4"
               >
                 <path
                   d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
@@ -561,13 +545,11 @@ exports[`Storyshots Pages/Custom With sidebar 1`] = `
                   Dashboard
                   <svg
                     aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                     color="#ffffff"
                     fill="#ffffff"
                     focusable="false"
                     height="20px"
-                    icon="downArrow"
-                    p="2px"
                     style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
@@ -607,13 +589,11 @@ exports[`Storyshots Pages/Custom With sidebar 1`] = `
                     Settings
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 hIxIEB"
+                      class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                       color="#ffffff"
                       fill="#ffffff"
                       focusable="false"
                       height="20px"
-                      icon="downArrow"
-                      p="2px"
                       style="position:absolute;top:11px;right:8px"
                       viewBox="0 0 24 24"
                       width="20px"
@@ -669,15 +649,13 @@ exports[`Storyshots Pages/Custom With sidebar 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="Icon-fc7twp-0 cwKdbD"
+                class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
                 color="currentColor"
                 fill="currentColor"
                 focusable="false"
-                height="32px"
-                icon="close"
-                p="half"
+                height="x4"
                 viewBox="0 0 24 24"
-                width="32px"
+                width="x4"
               >
                 <path
                   d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"

--- a/components/src/pages/__snapshots__/Details.story.storyshot
+++ b/components/src/pages/__snapshots__/Details.story.storyshot
@@ -84,13 +84,11 @@ exports[`Storyshots Pages/Details page Default 1`] = `
                   Dashboard
                   <svg
                     aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                     color="#ffffff"
                     fill="#ffffff"
                     focusable="false"
                     height="20px"
-                    icon="downArrow"
-                    p="2px"
                     style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
@@ -130,13 +128,11 @@ exports[`Storyshots Pages/Details page Default 1`] = `
                     Settings
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 hIxIEB"
+                      class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                       color="#ffffff"
                       fill="#ffffff"
                       focusable="false"
                       height="20px"
-                      icon="downArrow"
-                      p="2px"
                       style="position:absolute;top:11px;right:8px"
                       viewBox="0 0 24 24"
                       width="20px"
@@ -419,13 +415,11 @@ exports[`Storyshots Pages/Details page Default 1`] = `
                       >
                         <svg
                           aria-hidden="true"
-                          class="Icon-fc7twp-0 bKcUEK"
+                          class="StyledSvg-sc-1h19zm3-0 gUKvne Icon-fc7twp-0 bKcUEK"
                           color="red"
                           fill="#cc1439"
                           focusable="false"
                           height="24px"
-                          icon="error"
-                          mr="half"
                           viewBox="0 0 24 24"
                           width="24px"
                         >
@@ -468,13 +462,11 @@ exports[`Storyshots Pages/Details page Default 1`] = `
                       >
                         <svg
                           aria-hidden="true"
-                          class="Icon-fc7twp-0 bKcUEK"
+                          class="StyledSvg-sc-1h19zm3-0 gUKvne Icon-fc7twp-0 bKcUEK"
                           color="red"
                           fill="#cc1439"
                           focusable="false"
                           height="24px"
-                          icon="error"
-                          mr="half"
                           viewBox="0 0 24 24"
                           width="24px"
                         >
@@ -517,13 +509,11 @@ exports[`Storyshots Pages/Details page Default 1`] = `
                       >
                         <svg
                           aria-hidden="true"
-                          class="Icon-fc7twp-0 bKcUEK"
+                          class="StyledSvg-sc-1h19zm3-0 gUKvne Icon-fc7twp-0 bKcUEK"
                           color="red"
                           fill="#cc1439"
                           focusable="false"
                           height="24px"
-                          icon="error"
-                          mr="half"
                           viewBox="0 0 24 24"
                           width="24px"
                         >
@@ -566,13 +556,11 @@ exports[`Storyshots Pages/Details page Default 1`] = `
                       >
                         <svg
                           aria-hidden="true"
-                          class="Icon-fc7twp-0 bKcUEK"
+                          class="StyledSvg-sc-1h19zm3-0 gUKvne Icon-fc7twp-0 bKcUEK"
                           color="red"
                           fill="#cc1439"
                           focusable="false"
                           height="24px"
-                          icon="error"
-                          mr="half"
                           viewBox="0 0 24 24"
                           width="24px"
                         >
@@ -858,13 +846,11 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                   Dashboard
                   <svg
                     aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                     color="#ffffff"
                     fill="#ffffff"
                     focusable="false"
                     height="20px"
-                    icon="downArrow"
-                    p="2px"
                     style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
@@ -904,13 +890,11 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                     Settings
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 hIxIEB"
+                      class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                       color="#ffffff"
                       fill="#ffffff"
                       focusable="false"
                       height="20px"
-                      icon="downArrow"
-                      p="2px"
                       style="position:absolute;top:11px;right:8px"
                       viewBox="0 0 24 24"
                       width="20px"
@@ -949,13 +933,11 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
               </a>
               <svg
                 aria-hidden="true"
-                class="Icon-fc7twp-0 fQFStW"
+                class="StyledSvg-sc-1h19zm3-0 jOtbLy Icon-fc7twp-0 fQFStW"
                 color="darkGrey"
                 fill="#434d59"
                 focusable="false"
                 height="20px"
-                icon="rightArrow"
-                mr="half"
                 viewBox="0 0 24 24"
                 width="20px"
               >
@@ -972,13 +954,11 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
               </a>
               <svg
                 aria-hidden="true"
-                class="Icon-fc7twp-0 fQFStW"
+                class="StyledSvg-sc-1h19zm3-0 jOtbLy Icon-fc7twp-0 fQFStW"
                 color="darkGrey"
                 fill="#434d59"
                 focusable="false"
                 height="20px"
-                icon="rightArrow"
-                mr="half"
                 viewBox="0 0 24 24"
                 width="20px"
               >
@@ -992,15 +972,13 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="Icon-fc7twp-0 cwKdbD"
+                class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
                 color="currentColor"
                 fill="currentColor"
                 focusable="false"
-                height="32px"
-                icon="more"
-                p="half"
+                height="x4"
                 viewBox="0 0 24 24"
-                width="32px"
+                width="x4"
               >
                 <path
                   d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
@@ -1269,13 +1247,11 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                       >
                         <svg
                           aria-hidden="true"
-                          class="Icon-fc7twp-0 bKcUEK"
+                          class="StyledSvg-sc-1h19zm3-0 gUKvne Icon-fc7twp-0 bKcUEK"
                           color="red"
                           fill="#cc1439"
                           focusable="false"
                           height="24px"
-                          icon="error"
-                          mr="half"
                           viewBox="0 0 24 24"
                           width="24px"
                         >
@@ -1318,13 +1294,11 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                       >
                         <svg
                           aria-hidden="true"
-                          class="Icon-fc7twp-0 bKcUEK"
+                          class="StyledSvg-sc-1h19zm3-0 gUKvne Icon-fc7twp-0 bKcUEK"
                           color="red"
                           fill="#cc1439"
                           focusable="false"
                           height="24px"
-                          icon="error"
-                          mr="half"
                           viewBox="0 0 24 24"
                           width="24px"
                         >
@@ -1367,13 +1341,11 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                       >
                         <svg
                           aria-hidden="true"
-                          class="Icon-fc7twp-0 bKcUEK"
+                          class="StyledSvg-sc-1h19zm3-0 gUKvne Icon-fc7twp-0 bKcUEK"
                           color="red"
                           fill="#cc1439"
                           focusable="false"
                           height="24px"
-                          icon="error"
-                          mr="half"
                           viewBox="0 0 24 24"
                           width="24px"
                         >
@@ -1416,13 +1388,11 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                       >
                         <svg
                           aria-hidden="true"
-                          class="Icon-fc7twp-0 bKcUEK"
+                          class="StyledSvg-sc-1h19zm3-0 gUKvne Icon-fc7twp-0 bKcUEK"
                           color="red"
                           fill="#cc1439"
                           focusable="false"
                           height="24px"
-                          icon="error"
-                          mr="half"
                           viewBox="0 0 24 24"
                           width="24px"
                         >
@@ -1637,15 +1607,13 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="Icon-fc7twp-0 cwKdbD"
+                class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
                 color="currentColor"
                 fill="currentColor"
                 focusable="false"
-                height="32px"
-                icon="close"
-                p="half"
+                height="x4"
                 viewBox="0 0 24 24"
-                width="32px"
+                width="x4"
               >
                 <path
                   d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
@@ -1751,13 +1719,11 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                   Dashboard
                   <svg
                     aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                     color="#ffffff"
                     fill="#ffffff"
                     focusable="false"
                     height="20px"
-                    icon="downArrow"
-                    p="2px"
                     style="position:absolute;top:11px;right:8px"
                     viewBox="0 0 24 24"
                     width="20px"
@@ -1797,13 +1763,11 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                     Settings
                     <svg
                       aria-hidden="true"
-                      class="Icon-fc7twp-0 hIxIEB"
+                      class="StyledSvg-sc-1h19zm3-0 eKQTPV Icon-fc7twp-0 hIxIEB"
                       color="#ffffff"
                       fill="#ffffff"
                       focusable="false"
                       height="20px"
-                      icon="downArrow"
-                      p="2px"
                       style="position:absolute;top:11px;right:8px"
                       viewBox="0 0 24 24"
                       width="20px"
@@ -2086,13 +2050,11 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                       >
                         <svg
                           aria-hidden="true"
-                          class="Icon-fc7twp-0 bKcUEK"
+                          class="StyledSvg-sc-1h19zm3-0 gUKvne Icon-fc7twp-0 bKcUEK"
                           color="red"
                           fill="#cc1439"
                           focusable="false"
                           height="24px"
-                          icon="error"
-                          mr="half"
                           viewBox="0 0 24 24"
                           width="24px"
                         >
@@ -2135,13 +2097,11 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                       >
                         <svg
                           aria-hidden="true"
-                          class="Icon-fc7twp-0 bKcUEK"
+                          class="StyledSvg-sc-1h19zm3-0 gUKvne Icon-fc7twp-0 bKcUEK"
                           color="red"
                           fill="#cc1439"
                           focusable="false"
                           height="24px"
-                          icon="error"
-                          mr="half"
                           viewBox="0 0 24 24"
                           width="24px"
                         >
@@ -2184,13 +2144,11 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                       >
                         <svg
                           aria-hidden="true"
-                          class="Icon-fc7twp-0 bKcUEK"
+                          class="StyledSvg-sc-1h19zm3-0 gUKvne Icon-fc7twp-0 bKcUEK"
                           color="red"
                           fill="#cc1439"
                           focusable="false"
                           height="24px"
-                          icon="error"
-                          mr="half"
                           viewBox="0 0 24 24"
                           width="24px"
                         >
@@ -2233,13 +2191,11 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                       >
                         <svg
                           aria-hidden="true"
-                          class="Icon-fc7twp-0 bKcUEK"
+                          class="StyledSvg-sc-1h19zm3-0 gUKvne Icon-fc7twp-0 bKcUEK"
                           color="red"
                           fill="#cc1439"
                           focusable="false"
                           height="24px"
-                          icon="error"
-                          mr="half"
                           viewBox="0 0 24 24"
                           width="24px"
                         >
@@ -2454,15 +2410,13 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="Icon-fc7twp-0 cwKdbD"
+                class="StyledSvg-sc-1h19zm3-0 SkXo Icon-fc7twp-0 hsWmjq"
                 color="currentColor"
                 fill="currentColor"
                 focusable="false"
-                height="32px"
-                icon="close"
-                p="half"
+                height="x4"
                 viewBox="0 0 24 24"
-                width="32px"
+                width="x4"
               >
                 <path
                   d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
@@ -2487,7 +2441,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
               >
                 <label
-                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
                   color="black"
                   style="display:block"
                 >
@@ -2496,7 +2450,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                     data-testid="field-label"
                   >
                     <span
-                      class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                      class="LabelText-sc-16fh5zk-0 lmVLTL"
                     >
                       Project
                     </span>
@@ -2523,7 +2477,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
               >
                 <label
-                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
                   color="black"
                   style="display:block"
                 >
@@ -2532,7 +2486,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                     data-testid="field-label"
                   >
                     <span
-                      class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                      class="LabelText-sc-16fh5zk-0 lmVLTL"
                     >
                       Project description
                     </span>
@@ -2572,7 +2526,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
               >
                 <label
-                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
                   color="black"
                   style="display:block"
                 >
@@ -2581,7 +2535,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                     data-testid="field-label"
                   >
                     <span
-                      class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                      class="LabelText-sc-16fh5zk-0 lmVLTL"
                     >
                       Project status
                     </span>
@@ -2669,7 +2623,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
               >
                 <label
-                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
                   color="black"
                   style="display:block"
                 >
@@ -2678,7 +2632,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                     data-testid="field-label"
                   >
                     <span
-                      class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                      class="LabelText-sc-16fh5zk-0 lmVLTL"
                     >
                       Item code
                     </span>
@@ -2706,13 +2660,11 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="Icon-fc7twp-0 QuoIa"
+                    class="StyledSvg-sc-1h19zm3-0 jpOsNG Icon-fc7twp-0 QuoIa"
                     color="currentColor"
                     fill="currentColor"
                     focusable="false"
                     height="24px"
-                    icon="error"
-                    mr="x1"
                     viewBox="0 0 24 24"
                     width="24px"
                   >
@@ -2737,7 +2689,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
               >
                 <label
-                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
                   color="black"
                   style="display:block"
                 >
@@ -2746,7 +2698,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                     data-testid="field-label"
                   >
                     <span
-                      class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                      class="LabelText-sc-16fh5zk-0 lmVLTL"
                     >
                       Eaches expected on Job
                     </span>
@@ -2773,7 +2725,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
               >
                 <label
-                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
                   color="black"
                   style="display:block"
                 >
@@ -2782,7 +2734,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                     data-testid="field-label"
                   >
                     <span
-                      class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                      class="LabelText-sc-16fh5zk-0 lmVLTL"
                     >
                       Eaches remaining on Project
                     </span>
@@ -2810,7 +2762,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
               >
                 <label
-                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
                   color="black"
                   style="display:block"
                 >
@@ -2819,7 +2771,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                     data-testid="field-label"
                   >
                     <span
-                      class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                      class="LabelText-sc-16fh5zk-0 lmVLTL"
                     >
                       Scheduled start
                     </span>
@@ -2846,7 +2798,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
               >
                 <label
-                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
                   color="black"
                   style="display:block"
                 >
@@ -2855,7 +2807,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                     data-testid="field-label"
                   >
                     <span
-                      class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                      class="LabelText-sc-16fh5zk-0 lmVLTL"
                     >
                       Scheduled end
                     </span>
@@ -2879,13 +2831,13 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 </label>
               </div>
               <fieldset
-                class="Fieldset-sc-9aoml1-0 eiFgjk CheckboxGroup-sc-16y7xr8-2 bfgHHz"
+                class="Fieldset-sc-9aoml1-0 eiFgjk CheckboxGroup-sc-16y7xr8-0 bpMmjl"
               >
                 <legend
-                  class="CheckboxGroup__Legend-sc-16y7xr8-1 FZknE"
+                  class="Legend-sc-12h2r7a-0 fqZhwH"
                 >
                   <span
-                    class="CheckboxGroup__LabelText-sc-16y7xr8-0 srOjp"
+                    class="LabelText-sc-16fh5zk-0 lmVLTL"
                   >
                     Line Lead
                   </span>
@@ -3019,10 +2971,10 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 id="reconcile"
               >
                 <legend
-                  style="margin-bottom:8px"
+                  class="Legend-sc-12h2r7a-0 fqZhwH"
                 >
                   <span
-                    style="font-size:14px;font-weight:600;line-height:1.71428571"
+                    class="LabelText-sc-16fh5zk-0 lmVLTL"
                   >
                     Reconcile
                   </span>
@@ -3116,13 +3068,11 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="Icon-fc7twp-0 QuoIa"
+                    class="StyledSvg-sc-1h19zm3-0 jpOsNG Icon-fc7twp-0 QuoIa"
                     color="currentColor"
                     fill="currentColor"
                     focusable="false"
                     height="24px"
-                    icon="error"
-                    mr="x1"
                     viewBox="0 0 24 24"
                     width="24px"
                   >
@@ -3153,7 +3103,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                     class="Box-sc-1qu1edy-0 ilQgHG"
                   >
                     <span
-                      style="font-size:14px;font-weight:600;line-height:1.71428571"
+                      class="LabelText-sc-16fh5zk-0 lmVLTL"
                     >
                       Job Visibility
                     </span>
@@ -3202,7 +3152,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
               >
                 <label
-                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
                   color="black"
                   style="display:block"
                 >
@@ -3211,7 +3161,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                     data-testid="field-label"
                   >
                     <span
-                      class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                      class="LabelText-sc-16fh5zk-0 lmVLTL"
                     >
                       Item
                     </span>
@@ -3239,13 +3189,11 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 >
                   <svg
                     aria-hidden="true"
-                    class="Icon-fc7twp-0 QuoIa"
+                    class="StyledSvg-sc-1h19zm3-0 jpOsNG Icon-fc7twp-0 QuoIa"
                     color="currentColor"
                     fill="currentColor"
                     focusable="false"
                     height="24px"
-                    icon="error"
-                    mr="x1"
                     viewBox="0 0 24 24"
                     width="24px"
                   >
@@ -3270,7 +3218,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
               >
                 <label
-                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
                   color="black"
                   style="display:block"
                 >
@@ -3279,7 +3227,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                     data-testid="field-label"
                   >
                     <span
-                      class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                      class="LabelText-sc-16fh5zk-0 lmVLTL"
                     >
                       Quantity
                     </span>
@@ -3311,7 +3259,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                     class="Box-sc-1qu1edy-0 ilQgHG"
                   >
                     <span
-                      style="font-size:14px;font-weight:600;line-height:1.71428571"
+                      class="LabelText-sc-16fh5zk-0 lmVLTL"
                     >
                       Reject visibility
                     </span>

--- a/components/src/pages/__snapshots__/ErrorPage.story.storyshot
+++ b/components/src/pages/__snapshots__/ErrorPage.story.storyshot
@@ -70,13 +70,11 @@ exports[`Storyshots Pages/ErrorPage Base 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="Icon-fc7twp-0 ewGQci"
+                class="StyledSvg-sc-1h19zm3-0 fveekS Icon-fc7twp-0 ewGQci"
                 color="red"
                 fill="#cc1439"
                 focusable="false"
                 height="24px"
-                icon="error"
-                mr="x1"
                 viewBox="0 0 24 24"
                 width="24px"
               >
@@ -282,13 +280,11 @@ exports[`Storyshots Pages/ErrorPage With a link 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="Icon-fc7twp-0 ewGQci"
+                class="StyledSvg-sc-1h19zm3-0 fveekS Icon-fc7twp-0 ewGQci"
                 color="red"
                 fill="#cc1439"
                 focusable="false"
                 height="24px"
-                icon="error"
-                mr="x1"
                 viewBox="0 0 24 24"
                 width="24px"
               >

--- a/components/src/pages/__snapshots__/LoginPage.story.storyshot
+++ b/components/src/pages/__snapshots__/LoginPage.story.storyshot
@@ -92,7 +92,7 @@ exports[`Storyshots Pages/LoginPage Base 1`] = `
               class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
             >
               <label
-                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
                 color="black"
                 style="display:block"
               >
@@ -101,7 +101,7 @@ exports[`Storyshots Pages/LoginPage Base 1`] = `
                   data-testid="field-label"
                 >
                   <span
-                    class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                    class="LabelText-sc-16fh5zk-0 lmVLTL"
                   >
                     Email
                   </span>
@@ -126,7 +126,7 @@ exports[`Storyshots Pages/LoginPage Base 1`] = `
               class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
             >
               <label
-                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
                 color="black"
                 style="display:block"
               >
@@ -135,7 +135,7 @@ exports[`Storyshots Pages/LoginPage Base 1`] = `
                   data-testid="field-label"
                 >
                   <span
-                    class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                    class="LabelText-sc-16fh5zk-0 lmVLTL"
                   >
                     Password
                   </span>
@@ -274,13 +274,11 @@ exports[`Storyshots Pages/LoginPage with error 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="Icon-fc7twp-0 ewGQci"
+              class="StyledSvg-sc-1h19zm3-0 fveekS Icon-fc7twp-0 ewGQci"
               color="red"
               fill="#cc1439"
               focusable="false"
               height="24px"
-              icon="error"
-              mr="x1"
               viewBox="0 0 24 24"
               width="24px"
             >
@@ -302,7 +300,7 @@ exports[`Storyshots Pages/LoginPage with error 1`] = `
               class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
             >
               <label
-                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
                 color="black"
                 style="display:block"
               >
@@ -311,7 +309,7 @@ exports[`Storyshots Pages/LoginPage with error 1`] = `
                   data-testid="field-label"
                 >
                   <span
-                    class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                    class="LabelText-sc-16fh5zk-0 lmVLTL"
                   >
                     Email
                   </span>
@@ -336,7 +334,7 @@ exports[`Storyshots Pages/LoginPage with error 1`] = `
               class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
             >
               <label
-                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
                 color="black"
                 style="display:block"
               >
@@ -345,7 +343,7 @@ exports[`Storyshots Pages/LoginPage with error 1`] = `
                   data-testid="field-label"
                 >
                   <span
-                    class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                    class="LabelText-sc-16fh5zk-0 lmVLTL"
                   >
                     Password
                   </span>
@@ -477,13 +475,11 @@ exports[`Storyshots Pages/LoginPage with error and no additional text 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="Icon-fc7twp-0 ewGQci"
+              class="StyledSvg-sc-1h19zm3-0 fveekS Icon-fc7twp-0 ewGQci"
               color="red"
               fill="#cc1439"
               focusable="false"
               height="24px"
-              icon="error"
-              mr="x1"
               viewBox="0 0 24 24"
               width="24px"
             >
@@ -505,7 +501,7 @@ exports[`Storyshots Pages/LoginPage with error and no additional text 1`] = `
               class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
             >
               <label
-                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
                 color="black"
                 style="display:block"
               >
@@ -514,7 +510,7 @@ exports[`Storyshots Pages/LoginPage with error and no additional text 1`] = `
                   data-testid="field-label"
                 >
                   <span
-                    class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                    class="LabelText-sc-16fh5zk-0 lmVLTL"
                   >
                     Email
                   </span>
@@ -539,7 +535,7 @@ exports[`Storyshots Pages/LoginPage with error and no additional text 1`] = `
               class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
             >
               <label
-                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
                 color="black"
                 style="display:block"
               >
@@ -548,7 +544,7 @@ exports[`Storyshots Pages/LoginPage with error and no additional text 1`] = `
                   data-testid="field-label"
                 >
                   <span
-                    class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                    class="LabelText-sc-16fh5zk-0 lmVLTL"
                   >
                     Password
                   </span>
@@ -688,7 +684,7 @@ exports[`Storyshots Pages/LoginPage with forgot password link 1`] = `
               class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
             >
               <label
-                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
                 color="black"
                 style="display:block"
               >
@@ -697,7 +693,7 @@ exports[`Storyshots Pages/LoginPage with forgot password link 1`] = `
                   data-testid="field-label"
                 >
                   <span
-                    class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                    class="LabelText-sc-16fh5zk-0 lmVLTL"
                   >
                     Email
                   </span>
@@ -722,7 +718,7 @@ exports[`Storyshots Pages/LoginPage with forgot password link 1`] = `
               class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
             >
               <label
-                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
                 color="black"
                 style="display:block"
               >
@@ -731,7 +727,7 @@ exports[`Storyshots Pages/LoginPage with forgot password link 1`] = `
                   data-testid="field-label"
                 >
                   <span
-                    class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                    class="LabelText-sc-16fh5zk-0 lmVLTL"
                   >
                     Password
                   </span>
@@ -882,7 +878,7 @@ exports[`Storyshots Pages/LoginPage with remember me 1`] = `
               class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
             >
               <label
-                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
                 color="black"
                 style="display:block"
               >
@@ -891,7 +887,7 @@ exports[`Storyshots Pages/LoginPage with remember me 1`] = `
                   data-testid="field-label"
                 >
                   <span
-                    class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                    class="LabelText-sc-16fh5zk-0 lmVLTL"
                   >
                     Email
                   </span>
@@ -916,7 +912,7 @@ exports[`Storyshots Pages/LoginPage with remember me 1`] = `
               class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
             >
               <label
-                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-1 gjIfQG"
                 color="black"
                 style="display:block"
               >
@@ -925,7 +921,7 @@ exports[`Storyshots Pages/LoginPage with remember me 1`] = `
                   data-testid="field-label"
                 >
                   <span
-                    class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                    class="LabelText-sc-16fh5zk-0 lmVLTL"
                   >
                     Password
                   </span>

--- a/components/src/theme.js
+++ b/components/src/theme.js
@@ -53,6 +53,17 @@ export default {
     x6: tokens.size_base_x_6,
     x8: tokens.size_base_x_8
   },
+  sizes: {
+    none: tokens.size_base_none,
+    half: tokens.size_base_half,
+    x1: tokens.size_base_x_1,
+    x2: tokens.size_base_x_2,
+    x3: tokens.size_base_x_3,
+    x4: tokens.size_base_x_4,
+    x5: tokens.size_base_x_5,
+    x6: tokens.size_base_x_6,
+    x8: tokens.size_base_x_8
+  },
   fonts: {
     base: tokens.font_family_base,
     mono: tokens.font_family_mono


### PR DESCRIPTION
## Description
Cleans up a few spots we found while theming:

- Includes icons in theming so now the size keywords can be used to specify size
- Removes NDSTheme wherever directly used in the components
- add reusable Legend and labelText components

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
