### PR TITLE
feat: allow toasts to be manually closeable

### DIFF
--- a/components-e2e/cypress/integration/components/Toast.spec.js
+++ b/components-e2e/cypress/integration/components/Toast.spec.js
@@ -1,7 +1,7 @@
 describe("Toast", () => {
   const TOAST_SELECTOR = '[role="alert"]';
   const toast = () => cy.get(TOAST_SELECTOR);
-  const button = () => cy.get("button");
+  const button = () => cy.get("button").contains("Save Changes");
   describe("Default", () => {
     beforeEach(() => {
       cy.renderFromStorybook("toast--toast");
@@ -34,6 +34,31 @@ describe("Toast", () => {
       toast().should("have.css", "opacity", "1");
       toast().trigger("mouseover");
       cy.wait(2000);
+    });
+  });
+  describe("Closeable", () => {
+    const CLOSE_BTN_SELECTOR = '[aria-label="Close"]';
+    beforeEach(() => {
+      cy.renderFromStorybook("toast--with-close-button");
+    });
+
+    it("is hidden by default", () => {
+      toast().should("have.css", "opacity", "0");
+    });
+
+    it("shows the alert when triggered and does not automatically hide it", () => {
+      button().click();
+      cy.isInViewport(TOAST_SELECTOR);
+      toast().should("have.css", "opacity", "1");
+      cy.wait(4000);
+      toast().should("have.css", "opacity", "1");
+    });
+    it("hides the alert when close button is clicked", () => {
+      button().click();
+      toast().should("have.css", "opacity", "1");
+      cy.get(CLOSE_BTN_SELECTOR).click();
+      cy.wait(4000);
+      toast().should("not.exist");
     });
   });
 });

--- a/components-e2e/cypress/integration/components/Toast.spec.js
+++ b/components-e2e/cypress/integration/components/Toast.spec.js
@@ -58,7 +58,7 @@ describe("Toast", () => {
       toast().should("have.css", "opacity", "1");
       cy.get(CLOSE_BTN_SELECTOR).click();
       cy.wait(4000);
-      toast().should("not.exist");
+      toast().should("have.css", "opacity", "0");
     });
   });
 });

--- a/components/src/Alert/Alert.js
+++ b/components/src/Alert/Alert.js
@@ -57,10 +57,11 @@ CloseButton.defaultProps = {
   "aria-label": undefined
 };
 
-const BaseAlert = ({ children, isCloseable, title, type, className, closeAriaLabel, ...props }) => {
+const BaseAlert = ({ children, isCloseable, title, type, className, closeAriaLabel, onClose, ...props }) => {
   const [isVisible, setIsVisible] = useState(true);
 
   const hideAlert = () => {
+    onClose();
     setIsVisible(false);
   };
   return isVisible ? (
@@ -91,6 +92,7 @@ BaseAlert.propTypes = {
   closeAriaLabel: PropTypes.string,
   title: PropTypes.string,
   type: PropTypes.oneOf(["danger", "informative", "success", "warning"]),
+  onClose: PropTypes.func,
   ...propTypes.space,
   ...propTypes.layout
 };
@@ -100,7 +102,8 @@ BaseAlert.defaultProps = {
   isCloseable: false,
   closeAriaLabel: undefined,
   title: null,
-  type: "informative"
+  type: "informative",
+  onClose: () => {}
 };
 
 const Alert = styled(BaseAlert)(space, layout, alertStyles);

--- a/components/src/Alert/Alert.js
+++ b/components/src/Alert/Alert.js
@@ -57,12 +57,24 @@ CloseButton.defaultProps = {
   "aria-label": undefined
 };
 
-const BaseAlert = ({ children, isCloseable, title, type, className, closeAriaLabel, onClose, ...props }) => {
+const BaseAlert = ({
+  children,
+  isCloseable,
+  title,
+  type,
+  className,
+  closeAriaLabel,
+  onClose,
+  controlled,
+  ...props
+}) => {
   const [isVisible, setIsVisible] = useState(true);
 
   const hideAlert = () => {
     onClose();
-    setIsVisible(false);
+    if (!controlled) {
+      setIsVisible(false);
+    }
   };
   return isVisible ? (
     <Flex
@@ -93,6 +105,7 @@ BaseAlert.propTypes = {
   title: PropTypes.string,
   type: PropTypes.oneOf(["danger", "informative", "success", "warning"]),
   onClose: PropTypes.func,
+  controlled: PropTypes.bool,
   ...propTypes.space,
   ...propTypes.layout
 };
@@ -103,6 +116,7 @@ BaseAlert.defaultProps = {
   closeAriaLabel: undefined,
   title: null,
   type: "informative",
+  controlled: false,
   onClose: () => {}
 };
 

--- a/components/src/Toast/Toast.js
+++ b/components/src/Toast/Toast.js
@@ -52,7 +52,7 @@ const AnimatedBoxBottom = styled(Box)(({ visible }) => ({
   ...(visible ? SLIDE_IN_STYLES : SLIDE_OUT_STYLES)
 }));
 
-export const Toast = ({ triggered, onHide, onShow, isCloseable, children, ...props }) => {
+export const Toast = ({ triggered, onHide, onShow, isCloseable, children, showDuration, ...props }) => {
   const [visible, setVisible] = useState(triggered);
   const [timeoutID, setTimeoutID] = useState(undefined);
   const cancelHidingToast = () => {
@@ -72,7 +72,7 @@ export const Toast = ({ triggered, onHide, onShow, isCloseable, children, ...pro
     setVisible(true);
     onShow();
     if (!isCloseable) {
-      hideToast();
+      hideToast(showDuration);
     }
   };
 
@@ -120,7 +120,8 @@ Toast.propTypes = {
   onShow: PropTypes.func,
   onHide: PropTypes.func,
   children: PropTypes.node,
-  isCloseable: PropTypes.bool
+  isCloseable: PropTypes.bool,
+  showDuration: PropTypes.number
 };
 
 Toast.defaultProps = {
@@ -128,7 +129,8 @@ Toast.defaultProps = {
   onShow: () => {},
   onHide: () => {},
   children: undefined,
-  isCloseable: false
+  isCloseable: false,
+  showDuration: ANIMATION_DURATION
 };
 
 export default Toast;

--- a/components/src/Toast/Toast.js
+++ b/components/src/Toast/Toast.js
@@ -52,7 +52,7 @@ const AnimatedBoxBottom = styled(Box)(({ visible }) => ({
   ...(visible ? SLIDE_IN_STYLES : SLIDE_OUT_STYLES)
 }));
 
-export const Toast = ({ triggered, onHide, onShow, children, ...props }) => {
+export const Toast = ({ triggered, onHide, onShow, isCloseable, children, ...props }) => {
   const [visible, setVisible] = useState(triggered);
   const [timeoutID, setTimeoutID] = useState(undefined);
   const cancelHidingToast = () => {
@@ -60,6 +60,7 @@ export const Toast = ({ triggered, onHide, onShow, children, ...props }) => {
   };
   const hideToast = (delay = ANIMATION_DURATION) => {
     cancelHidingToast();
+
     setTimeoutID(
       setTimeout(() => {
         setVisible(false);
@@ -70,7 +71,9 @@ export const Toast = ({ triggered, onHide, onShow, children, ...props }) => {
   const triggerToast = () => {
     setVisible(true);
     onShow();
-    hideToast();
+    if (!isCloseable) {
+      hideToast();
+    }
   };
 
   useEffect(() => {
@@ -83,9 +86,17 @@ export const Toast = ({ triggered, onHide, onShow, children, ...props }) => {
   }, [triggered]);
 
   const onMouseIn = () => {
-    cancelHidingToast(timeoutID);
+    if (!isCloseable) {
+      cancelHidingToast(timeoutID);
+    }
   };
   const onMouseOut = () => {
+    if (!isCloseable) {
+      hideToast(ANIMATION_DURATION / 2);
+    }
+  };
+
+  const handleCloseButtonClick = () => {
     hideToast(ANIMATION_DURATION / 2);
   };
 
@@ -97,7 +108,7 @@ export const Toast = ({ triggered, onHide, onShow, children, ...props }) => {
       onMouseLeave={onMouseOut}
       onBlur={onMouseOut}
     >
-      <AnimatedAlert visible={visible} {...props}>
+      <AnimatedAlert visible={visible} isCloseable={isCloseable} onClose={handleCloseButtonClick} {...props}>
         {children}
       </AnimatedAlert>
     </AnimatedBoxBottom>
@@ -108,14 +119,16 @@ Toast.propTypes = {
   triggered: PropTypes.bool,
   onShow: PropTypes.func,
   onHide: PropTypes.func,
-  children: PropTypes.node
+  children: PropTypes.node,
+  isCloseable: PropTypes.bool
 };
 
 Toast.defaultProps = {
   triggered: false,
   onShow: () => {},
   onHide: () => {},
-  children: undefined
+  children: undefined,
+  isCloseable: false
 };
 
 export default Toast;

--- a/components/src/Toast/Toast.js
+++ b/components/src/Toast/Toast.js
@@ -97,7 +97,7 @@ export const Toast = ({ triggered, onHide, onShow, isCloseable, children, showDu
   };
 
   const handleCloseButtonClick = () => {
-    hideToast(ANIMATION_DURATION / 2);
+    hideToast(0);
   };
 
   return (
@@ -108,7 +108,7 @@ export const Toast = ({ triggered, onHide, onShow, isCloseable, children, showDu
       onMouseLeave={onMouseOut}
       onBlur={onMouseOut}
     >
-      <AnimatedAlert visible={visible} isCloseable={isCloseable} onClose={handleCloseButtonClick} {...props}>
+      <AnimatedAlert visible={visible} isCloseable={isCloseable} onClose={handleCloseButtonClick} controlled {...props}>
         {children}
       </AnimatedAlert>
     </AnimatedBoxBottom>

--- a/components/src/Toast/Toast.js
+++ b/components/src/Toast/Toast.js
@@ -5,7 +5,8 @@ import theme from "../theme";
 import { Box } from "../Box";
 import { Alert } from "../Alert";
 
-const ANIMATION_DURATION = 2000; // in ms
+const SHOW_DURATION = 2000; // in ms
+const ANIMATE_OUT_DURATION = 1000;
 const TOAST_Y_MAX = "0px";
 const TOAST_Y_MIN = "-32px";
 const ACTIVE_Z_INDEX = 2;
@@ -20,7 +21,8 @@ const SLIDE_IN_STYLES = {
 const SLIDE_OUT_STYLES = {
   transform: `translateY(${TOAST_Y_MAX})`,
   transition: "transform 0.9s ease-in",
-  zIndex: INACTIVE_Z_INDEX
+  zIndex: INACTIVE_Z_INDEX,
+  pointerEvents: "none"
 };
 
 const FADE_IN_STYLES = {
@@ -52,19 +54,24 @@ const AnimatedBoxBottom = styled(Box)(({ visible }) => ({
   ...(visible ? SLIDE_IN_STYLES : SLIDE_OUT_STYLES)
 }));
 
-export const Toast = ({ triggered, onHide, onShow, isCloseable, children, showDuration, ...props }) => {
+export const Toast = ({ triggered, onHide, onShow, isCloseable, children, showDuration, onHidden, ...props }) => {
   const [visible, setVisible] = useState(triggered);
   const [timeoutID, setTimeoutID] = useState(undefined);
   const cancelHidingToast = () => {
     clearTimeout(timeoutID);
   };
-  const hideToast = (delay = ANIMATION_DURATION) => {
+  const hideToast = (delay = SHOW_DURATION) => {
     cancelHidingToast();
 
     setTimeoutID(
       setTimeout(() => {
         setVisible(false);
         onHide();
+        setTimeoutID(
+          setTimeout(() => {
+            onHidden();
+          }, ANIMATE_OUT_DURATION)
+        );
       }, delay)
     );
   };
@@ -92,7 +99,7 @@ export const Toast = ({ triggered, onHide, onShow, isCloseable, children, showDu
   };
   const onMouseOut = () => {
     if (!isCloseable) {
-      hideToast(ANIMATION_DURATION / 2);
+      hideToast(SHOW_DURATION / 2);
     }
   };
 
@@ -121,7 +128,8 @@ Toast.propTypes = {
   onHide: PropTypes.func,
   children: PropTypes.node,
   isCloseable: PropTypes.bool,
-  showDuration: PropTypes.number
+  showDuration: PropTypes.number,
+  onHidden: PropTypes.func
 };
 
 Toast.defaultProps = {
@@ -130,7 +138,8 @@ Toast.defaultProps = {
   onHide: () => {},
   children: undefined,
   isCloseable: false,
-  showDuration: ANIMATION_DURATION
+  showDuration: SHOW_DURATION,
+  onHidden: () => {}
 };
 
 export default Toast;

--- a/components/src/Toast/Toast.spec.js
+++ b/components/src/Toast/Toast.spec.js
@@ -1,11 +1,12 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, fireEvent } from "@testing-library/react";
 import { Toast } from ".";
 
 describe("Toast", () => {
   describe("callbacks", () => {
     const onHideHandler = jest.fn();
     const onShowHandler = jest.fn();
+    const onCloseHandler = jest.fn();
 
     it("calls onShow callback when triggered", () => {
       render(
@@ -23,6 +24,18 @@ describe("Toast", () => {
         </Toast>
       );
       expect(onHideHandler).toHaveBeenCalledTimes(1);
+    });
+    describe("closeable toast", () => {
+      it("calls onClose callback when dismissed with a close button", () => {
+        const { getByLabelText } = render(
+          <Toast triggered onClose={onCloseHandler} isCloseable>
+            Saved
+          </Toast>
+        );
+        const closeBtn = getByLabelText("Close");
+        fireEvent.click(closeBtn);
+        expect(onCloseHandler).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/components/src/Toast/Toast.story.js
+++ b/components/src/Toast/Toast.story.js
@@ -108,6 +108,26 @@ storiesOf("Toast", module)
     };
     return <MultipleToastsExample />;
   })
+  .add("customize length of time toast is visible", () => {
+    const ToastWithTrigger = () => {
+      const [triggered, setTriggered] = useState(false);
+      const triggerToast = () => {
+        setTriggered(!triggered);
+      };
+      const onHideHandler = () => {
+        setTriggered(false);
+      };
+      return (
+        <>
+          <Button onClick={triggerToast}>Save Changes</Button>
+          <Toast triggered={triggered} onHide={onHideHandler} showDuration={5000}>
+            Saved
+          </Toast>
+        </>
+      );
+    };
+    return <ToastWithTrigger />;
+  })
   .add("with close button", () => {
     const ToastWithTrigger = () => {
       const [triggered, setTriggered] = useState(false);

--- a/components/src/Toast/Toast.story.js
+++ b/components/src/Toast/Toast.story.js
@@ -107,4 +107,24 @@ storiesOf("Toast", module)
       );
     };
     return <MultipleToastsExample />;
+  })
+  .add("with close button", () => {
+    const ToastWithTrigger = () => {
+      const [triggered, setTriggered] = useState(false);
+      const triggerToast = () => {
+        setTriggered(!triggered);
+      };
+      const onHideHandler = () => {
+        setTriggered(false);
+      };
+      return (
+        <>
+          <Button onClick={triggerToast}>Save Changes</Button>
+          <Toast triggered={triggered} onHide={onHideHandler} isCloseable>
+            Saved
+          </Toast>
+        </>
+      );
+    };
+    return <ToastWithTrigger />;
   });

--- a/components/src/Toast/Toast.story.js
+++ b/components/src/Toast/Toast.story.js
@@ -147,4 +147,71 @@ storiesOf("Toast", module)
       );
     };
     return <ToastWithTrigger />;
+  })
+  .add("multiple closeable toasts example", () => {
+    const MultipleToastsExample = () => {
+      const [currentToasts, setCurrentToasts] = useState([]);
+      const triggerToast = toastName => {
+        setCurrentToasts([...currentToasts, toastName]);
+      };
+      const onHideHandler = toastName => {
+        setCurrentToasts(currentToasts.filter(toast => toast !== toastName));
+      };
+      const TOAST_ACTIONS = {
+        SAVE: "save",
+        RESET: "reset",
+        DELETE: "delete",
+        ERROR: "error"
+      };
+      const TOASTS = [
+        {
+          action: TOAST_ACTIONS.SAVE,
+          message: "Error saving all your changes"
+        },
+        {
+          action: TOAST_ACTIONS.RESET,
+          message: "Error: changes were reset"
+        },
+        {
+          action: TOAST_ACTIONS.DELETE,
+          message: "An error occurred, could not deleted"
+        },
+        {
+          action: TOAST_ACTIONS.ERROR,
+          message: "An error occurred, please retry"
+        }
+      ];
+      return (
+        <>
+          <Flex alignItems="center">
+            <PrimaryButton onClick={() => triggerToast(TOAST_ACTIONS.SAVE)} mr="x2">
+              Save Changes
+            </PrimaryButton>
+            <Button onClick={() => triggerToast(TOAST_ACTIONS.RESET)} mr="x2">
+              Reset
+            </Button>
+            <DangerButton onClick={() => triggerToast(TOAST_ACTIONS.ERROR)} mr="x2">
+              Trigger Error
+            </DangerButton>
+            <IconicButton icon="delete" onClick={() => triggerToast(TOAST_ACTIONS.DELETE)}>
+              Delete
+            </IconicButton>
+          </Flex>
+          {TOASTS.map(toast => {
+            return (
+              <Toast
+                triggered={currentToasts.includes(toast.action)}
+                onHide={() => onHideHandler(toast.action)}
+                type="danger"
+                key={toast.action}
+                isCloseable
+              >
+                {toast.message}
+              </Toast>
+            );
+          })}
+        </>
+      );
+    };
+    return <MultipleToastsExample />;
   });

--- a/components/src/Toast/__snapshots__/Toast.story.storyshot
+++ b/components/src/Toast/__snapshots__/Toast.story.storyshot
@@ -30,6 +30,36 @@ exports[`Storyshots Toast Toast 1`] = `
 </div>
 `;
 
+exports[`Storyshots Toast customize length of time toast is visible 1`] = `
+<div
+  style="padding:24px"
+>
+  <div
+    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+  >
+    <button
+      class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+    >
+      Save Changes
+    </button>
+    <div
+      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 hEHPqx"
+    >
+      <div
+        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 bxjnP Alert-u8lbe-0 Toast__AnimatedAlert-sc-1gp7eev-0 fbHKHW"
+        role="alert"
+      >
+        <div
+          class="Box-sc-1qu1edy-0 iDnpba"
+        >
+          Saved
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Toast multiple toasts example 1`] = `
 <div
   style="padding:24px"
@@ -201,6 +231,62 @@ exports[`Storyshots Toast multiple toasts example 1`] = `
           class="Box-sc-1qu1edy-0 iDnpba"
         >
           An error occurred, please retry
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Toast with close button 1`] = `
+<div
+  style="padding:24px"
+>
+  <div
+    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+  >
+    <button
+      class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+    >
+      Save Changes
+    </button>
+    <div
+      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 hEHPqx"
+    >
+      <div
+        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 bxjnP Alert-u8lbe-0 Toast__AnimatedAlert-sc-1gp7eev-0 fbHKHW"
+        role="alert"
+      >
+        <div
+          class="Box-sc-1qu1edy-0 iDnpba"
+        >
+          Saved
+        </div>
+        <div
+          class="Box-sc-1qu1edy-0 jlPsmj"
+        >
+          <button
+            aria-label="Close"
+            class="Link-sc-1lpx3d0-0 iYMUBq"
+            color="darkGrey"
+          >
+            <svg
+              aria-hidden="true"
+              class="Icon-fc7twp-0 gNwFhh"
+              color="currentColor"
+              fill="currentColor"
+              focusable="false"
+              height="16"
+              icon="close"
+              size="16"
+              viewBox="0 0 24 24"
+              width="16"
+            >
+              <path
+                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+              />
+            </svg>
+          </button>
         </div>
       </div>
     </div>

--- a/components/src/Toast/__snapshots__/Toast.story.storyshot
+++ b/components/src/Toast/__snapshots__/Toast.story.storyshot
@@ -60,6 +60,288 @@ exports[`Storyshots Toast customize length of time toast is visible 1`] = `
 </div>
 `;
 
+exports[`Storyshots Toast multiple closeable toasts example 1`] = `
+<div
+  style="padding:24px"
+>
+  <div
+    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+  >
+    <div
+      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 geyRYt"
+    >
+      <button
+        class="Button__WrapperButton-sc-1omxup2-0 bclWrW PrimaryButton-qz78sb-0 cGyyDq"
+      >
+        Save Changes
+      </button>
+      <button
+        class="Button__WrapperButton-sc-1omxup2-0 bclWrW"
+      >
+        Reset
+      </button>
+      <button
+        class="Button__WrapperButton-sc-1omxup2-0 bclWrW DangerButton-sc-1220u5k-0 ehzMsl"
+      >
+        Trigger Error
+      </button>
+      <button
+        aria-label="Delete"
+        class="IconicButton__WrapperButton-sc-1u3dojp-1 UMPof IconicButton-sc-1u3dojp-2 gZASNp"
+      >
+        <svg
+          aria-hidden="true"
+          class="Icon-fc7twp-0 cwKdbD"
+          color="currentColor"
+          fill="currentColor"
+          focusable="false"
+          height="32px"
+          icon="delete"
+          p="half"
+          viewBox="0 0 24 24"
+          width="32px"
+        >
+          <path
+            d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+          />
+        </svg>
+        <p
+          class="Text-sc-1wu7vpu-0 hHlnON"
+          color="currentColor"
+          font-size="16px"
+        >
+          Delete
+        </p>
+      </button>
+    </div>
+    <div
+      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 hEHPqx"
+    >
+      <div
+        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 kLLvso Alert-u8lbe-0 Toast__AnimatedAlert-sc-1gp7eev-0 fbHKHW"
+        role="alert"
+      >
+        <svg
+          aria-hidden="true"
+          class="Icon-fc7twp-0 ewGQci"
+          color="#cc1439"
+          fill="#cc1439"
+          focusable="false"
+          height="24px"
+          icon="error"
+          mr="x1"
+          viewBox="0 0 24 24"
+          width="24px"
+        >
+          <path
+            d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+          />
+        </svg>
+        <div
+          class="Box-sc-1qu1edy-0 iDnpba"
+        >
+          Error saving all your changes
+        </div>
+        <div
+          class="Box-sc-1qu1edy-0 jlPsmj"
+        >
+          <button
+            aria-label="Close"
+            class="Link-sc-1lpx3d0-0 iYMUBq"
+            color="darkGrey"
+          >
+            <svg
+              aria-hidden="true"
+              class="Icon-fc7twp-0 gNwFhh"
+              color="currentColor"
+              fill="currentColor"
+              focusable="false"
+              height="16"
+              icon="close"
+              size="16"
+              viewBox="0 0 24 24"
+              width="16"
+            >
+              <path
+                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 hEHPqx"
+    >
+      <div
+        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 kLLvso Alert-u8lbe-0 Toast__AnimatedAlert-sc-1gp7eev-0 fbHKHW"
+        role="alert"
+      >
+        <svg
+          aria-hidden="true"
+          class="Icon-fc7twp-0 ewGQci"
+          color="#cc1439"
+          fill="#cc1439"
+          focusable="false"
+          height="24px"
+          icon="error"
+          mr="x1"
+          viewBox="0 0 24 24"
+          width="24px"
+        >
+          <path
+            d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+          />
+        </svg>
+        <div
+          class="Box-sc-1qu1edy-0 iDnpba"
+        >
+          Error: changes were reset
+        </div>
+        <div
+          class="Box-sc-1qu1edy-0 jlPsmj"
+        >
+          <button
+            aria-label="Close"
+            class="Link-sc-1lpx3d0-0 iYMUBq"
+            color="darkGrey"
+          >
+            <svg
+              aria-hidden="true"
+              class="Icon-fc7twp-0 gNwFhh"
+              color="currentColor"
+              fill="currentColor"
+              focusable="false"
+              height="16"
+              icon="close"
+              size="16"
+              viewBox="0 0 24 24"
+              width="16"
+            >
+              <path
+                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 hEHPqx"
+    >
+      <div
+        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 kLLvso Alert-u8lbe-0 Toast__AnimatedAlert-sc-1gp7eev-0 fbHKHW"
+        role="alert"
+      >
+        <svg
+          aria-hidden="true"
+          class="Icon-fc7twp-0 ewGQci"
+          color="#cc1439"
+          fill="#cc1439"
+          focusable="false"
+          height="24px"
+          icon="error"
+          mr="x1"
+          viewBox="0 0 24 24"
+          width="24px"
+        >
+          <path
+            d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+          />
+        </svg>
+        <div
+          class="Box-sc-1qu1edy-0 iDnpba"
+        >
+          An error occurred, could not deleted
+        </div>
+        <div
+          class="Box-sc-1qu1edy-0 jlPsmj"
+        >
+          <button
+            aria-label="Close"
+            class="Link-sc-1lpx3d0-0 iYMUBq"
+            color="darkGrey"
+          >
+            <svg
+              aria-hidden="true"
+              class="Icon-fc7twp-0 gNwFhh"
+              color="currentColor"
+              fill="currentColor"
+              focusable="false"
+              height="16"
+              icon="close"
+              size="16"
+              viewBox="0 0 24 24"
+              width="16"
+            >
+              <path
+                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 hEHPqx"
+    >
+      <div
+        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 kLLvso Alert-u8lbe-0 Toast__AnimatedAlert-sc-1gp7eev-0 fbHKHW"
+        role="alert"
+      >
+        <svg
+          aria-hidden="true"
+          class="Icon-fc7twp-0 ewGQci"
+          color="#cc1439"
+          fill="#cc1439"
+          focusable="false"
+          height="24px"
+          icon="error"
+          mr="x1"
+          viewBox="0 0 24 24"
+          width="24px"
+        >
+          <path
+            d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+          />
+        </svg>
+        <div
+          class="Box-sc-1qu1edy-0 iDnpba"
+        >
+          An error occurred, please retry
+        </div>
+        <div
+          class="Box-sc-1qu1edy-0 jlPsmj"
+        >
+          <button
+            aria-label="Close"
+            class="Link-sc-1lpx3d0-0 iYMUBq"
+            color="darkGrey"
+          >
+            <svg
+              aria-hidden="true"
+              class="Icon-fc7twp-0 gNwFhh"
+              color="currentColor"
+              fill="currentColor"
+              focusable="false"
+              height="16"
+              icon="close"
+              size="16"
+              viewBox="0 0 24 24"
+              width="16"
+            >
+              <path
+                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Toast multiple toasts example 1`] = `
 <div
   style="padding:24px"

--- a/components/src/Toast/__snapshots__/Toast.story.storyshot
+++ b/components/src/Toast/__snapshots__/Toast.story.storyshot
@@ -13,7 +13,7 @@ exports[`Storyshots Toast Toast 1`] = `
       Save Changes
     </button>
     <div
-      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 hEHPqx"
+      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 kVXqtj"
     >
       <div
         class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 bxjnP Alert-u8lbe-0 Toast__AnimatedAlert-sc-1gp7eev-0 fbHKHW"
@@ -43,7 +43,7 @@ exports[`Storyshots Toast customize length of time toast is visible 1`] = `
       Save Changes
     </button>
     <div
-      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 hEHPqx"
+      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 kVXqtj"
     >
       <div
         class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 bxjnP Alert-u8lbe-0 Toast__AnimatedAlert-sc-1gp7eev-0 fbHKHW"
@@ -115,7 +115,7 @@ exports[`Storyshots Toast multiple closeable toasts example 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 hEHPqx"
+      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 kVXqtj"
     >
       <div
         class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 kLLvso Alert-u8lbe-0 Toast__AnimatedAlert-sc-1gp7eev-0 fbHKHW"
@@ -171,7 +171,7 @@ exports[`Storyshots Toast multiple closeable toasts example 1`] = `
       </div>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 hEHPqx"
+      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 kVXqtj"
     >
       <div
         class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 kLLvso Alert-u8lbe-0 Toast__AnimatedAlert-sc-1gp7eev-0 fbHKHW"
@@ -227,7 +227,7 @@ exports[`Storyshots Toast multiple closeable toasts example 1`] = `
       </div>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 hEHPqx"
+      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 kVXqtj"
     >
       <div
         class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 kLLvso Alert-u8lbe-0 Toast__AnimatedAlert-sc-1gp7eev-0 fbHKHW"
@@ -283,7 +283,7 @@ exports[`Storyshots Toast multiple closeable toasts example 1`] = `
       </div>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 hEHPqx"
+      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 kVXqtj"
     >
       <div
         class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 kLLvso Alert-u8lbe-0 Toast__AnimatedAlert-sc-1gp7eev-0 fbHKHW"
@@ -397,7 +397,7 @@ exports[`Storyshots Toast multiple toasts example 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 hEHPqx"
+      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 kVXqtj"
     >
       <div
         class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 jQknty Alert-u8lbe-0 Toast__AnimatedAlert-sc-1gp7eev-0 fbHKHW"
@@ -427,7 +427,7 @@ exports[`Storyshots Toast multiple toasts example 1`] = `
       </div>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 hEHPqx"
+      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 kVXqtj"
     >
       <div
         class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 jQknty Alert-u8lbe-0 Toast__AnimatedAlert-sc-1gp7eev-0 fbHKHW"
@@ -457,7 +457,7 @@ exports[`Storyshots Toast multiple toasts example 1`] = `
       </div>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 hEHPqx"
+      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 kVXqtj"
     >
       <div
         class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 jQknty Alert-u8lbe-0 Toast__AnimatedAlert-sc-1gp7eev-0 fbHKHW"
@@ -487,7 +487,7 @@ exports[`Storyshots Toast multiple toasts example 1`] = `
       </div>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 hEHPqx"
+      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 kVXqtj"
     >
       <div
         class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 kLLvso Alert-u8lbe-0 Toast__AnimatedAlert-sc-1gp7eev-0 fbHKHW"
@@ -533,7 +533,7 @@ exports[`Storyshots Toast with close button 1`] = `
       Save Changes
     </button>
     <div
-      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 hEHPqx"
+      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 kVXqtj"
     >
       <div
         class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 bxjnP Alert-u8lbe-0 Toast__AnimatedAlert-sc-1gp7eev-0 fbHKHW"

--- a/components/src/Toast/__snapshots__/Toast.story.storyshot
+++ b/components/src/Toast/__snapshots__/Toast.story.storyshot
@@ -147,8 +147,9 @@ exports[`Storyshots Toast multiple closeable toasts example 1`] = `
         >
           <button
             aria-label="Close"
-            class="Link-sc-1lpx3d0-0 iYMUBq"
+            class="Link-sc-1lpx3d0-0 eyTmUh"
             color="darkGrey"
+            font-size="medium"
           >
             <svg
               aria-hidden="true"
@@ -203,8 +204,9 @@ exports[`Storyshots Toast multiple closeable toasts example 1`] = `
         >
           <button
             aria-label="Close"
-            class="Link-sc-1lpx3d0-0 iYMUBq"
+            class="Link-sc-1lpx3d0-0 eyTmUh"
             color="darkGrey"
+            font-size="medium"
           >
             <svg
               aria-hidden="true"
@@ -259,8 +261,9 @@ exports[`Storyshots Toast multiple closeable toasts example 1`] = `
         >
           <button
             aria-label="Close"
-            class="Link-sc-1lpx3d0-0 iYMUBq"
+            class="Link-sc-1lpx3d0-0 eyTmUh"
             color="darkGrey"
+            font-size="medium"
           >
             <svg
               aria-hidden="true"
@@ -315,8 +318,9 @@ exports[`Storyshots Toast multiple closeable toasts example 1`] = `
         >
           <button
             aria-label="Close"
-            class="Link-sc-1lpx3d0-0 iYMUBq"
+            class="Link-sc-1lpx3d0-0 eyTmUh"
             color="darkGrey"
+            font-size="medium"
           >
             <svg
               aria-hidden="true"
@@ -549,8 +553,9 @@ exports[`Storyshots Toast with close button 1`] = `
         >
           <button
             aria-label="Close"
-            class="Link-sc-1lpx3d0-0 iYMUBq"
+            class="Link-sc-1lpx3d0-0 eyTmUh"
             color="darkGrey"
+            font-size="medium"
           >
             <svg
               aria-hidden="true"

--- a/docs/src/pages/components/alert.js
+++ b/docs/src/pages/components/alert.js
@@ -26,12 +26,6 @@ import {
 
 const propsRows = [
   {
-    name: "isCloseable",
-    type: "boolean",
-    defaultValue: "false",
-    description: "Provides a close icon in the top right corner."
-  },
-  {
     name: "title",
     type: "string",
     defaultValue: "",
@@ -51,10 +45,23 @@ const propsRows = [
     description: "className passed to the alert component."
   },
   {
+    name: "isCloseable",
+    type: "boolean",
+    defaultValue: "false",
+    description: "Provides a close icon in the top right corner."
+  },
+  {
     name: "closeAriaLabel",
     type: "String",
     defaultValue: "close",
     description: "aria label for close button"
+  },
+  {
+    name: "controlled",
+    type: "boolean",
+    defaultValue: "false",
+    description:
+      "If true, will allow the Alert's opened and closed state to be controlled through props rather than within the component's internal state"
   }
 ];
 

--- a/docs/src/pages/components/toast.js
+++ b/docs/src/pages/components/toast.js
@@ -54,7 +54,14 @@ const propsRows = [
   {
     name: "onHide",
     type: "function",
-    description: "callback that is called when the tooltip is hidden"
+    description:
+      "callback that is called when the tooltip is dismissed or begins to fade out"
+  },
+  {
+    name: "onHidden",
+    type: "function",
+    description:
+      "callback that is called when the tooltip has been completely hidden after the fade out animation is complete"
   },
   {
     name: "showDuration",

--- a/docs/src/pages/components/toast.js
+++ b/docs/src/pages/components/toast.js
@@ -52,9 +52,20 @@ const propsRows = [
     description: "callback that is called when the tooltip is shown"
   },
   {
-    name: "onHidden",
+    name: "onHide",
     type: "function",
     description: "callback that is called when the tooltip is hidden"
+  },
+  {
+    name: "showDuration",
+    type: "number",
+    description: "length of time in ms to display the Toast before hiding it"
+  },
+  {
+    name: "isCloseable",
+    type: "boolean",
+    description:
+      "displays a close button in the Toast when true, and the Toast must then by manually dismissed by clicking the close button"
   }
 ];
 


### PR DESCRIPTION
## Description

Toast: 
- Adds isCloseable to display a close button that will be used to dismiss it rather than automatically faded out over time
-  showDuration prop to the Toast component to allow the  duration the toast is shown to be overriden

Alert:
- Adds "controlled" prop to the Alert to allow closing it to be controlled, needed to show the animation for the toast before removing it

TODO:
- [x] test with a title, and multiple lines of text to ensure animation is consistent
- [ ] change to docs on content/ usage guidelines for Toasts? 


## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
