### PR TITLE
fix: add typography props to ListItem and Link

### DIFF
--- a/components/src/Alert/__snapshots__/Alert.story.storyshot
+++ b/components/src/Alert/__snapshots__/Alert.story.storyshot
@@ -137,8 +137,9 @@ exports[`Storyshots Alert With a close button 1`] = `
       >
         <button
           aria-label="Close"
-          class="Link-sc-1lpx3d0-0 iYMUBq"
+          class="Link-sc-1lpx3d0-0 eyTmUh"
           color="darkGrey"
+          font-size="medium"
         >
           <svg
             aria-hidden="true"
@@ -179,8 +180,9 @@ exports[`Storyshots Alert With a link 1`] = `
       >
         An alert with 
         <a
-          class="Link-sc-1lpx3d0-0 geMpSb"
+          class="Link-sc-1lpx3d0-0 gxbSxg"
           color="blue"
+          font-size="medium"
           href="/"
         >
           linked details

--- a/components/src/Breadcrumbs/__snapshots__/Breadcrumbs.story.storyshot
+++ b/components/src/Breadcrumbs/__snapshots__/Breadcrumbs.story.storyshot
@@ -17,8 +17,9 @@ exports[`Storyshots Breadcrumbs Breadcrumbs 1`] = `
           class="Breadcrumbs__StyledLi-sc-1l75jcp-0 dhHwFq"
         >
           <a
-            class="Link-sc-1lpx3d0-0 gJOWDu"
+            class="Link-sc-1lpx3d0-0 hcsgot"
             color="darkBlue"
+            font-size="medium"
             href="/"
           >
             Home
@@ -48,8 +49,9 @@ exports[`Storyshots Breadcrumbs Breadcrumbs 1`] = `
           class="Breadcrumbs__StyledLi-sc-1l75jcp-0 dhHwFq"
         >
           <a
-            class="Link-sc-1lpx3d0-0 gJOWDu"
+            class="Link-sc-1lpx3d0-0 hcsgot"
             color="darkBlue"
+            font-size="medium"
             href="/Tenants"
           >
             Tenants
@@ -98,8 +100,9 @@ exports[`Storyshots Breadcrumbs without link 1`] = `
           class="Breadcrumbs__StyledLi-sc-1l75jcp-0 dhHwFq"
         >
           <a
-            class="Link-sc-1lpx3d0-0 gJOWDu"
+            class="Link-sc-1lpx3d0-0 hcsgot"
             color="darkBlue"
+            font-size="medium"
             href="/"
           >
             Home
@@ -129,8 +132,9 @@ exports[`Storyshots Breadcrumbs without link 1`] = `
           class="Breadcrumbs__StyledLi-sc-1l75jcp-0 dhHwFq"
         >
           <a
-            class="Link-sc-1lpx3d0-0 gJOWDu"
+            class="Link-sc-1lpx3d0-0 hcsgot"
             color="darkBlue"
+            font-size="medium"
             href="/Tenants"
           >
             Tenants

--- a/components/src/Checkbox/__snapshots__/CheckboxGroup.story.storyshot
+++ b/components/src/Checkbox/__snapshots__/CheckboxGroup.story.storyshot
@@ -589,13 +589,13 @@ exports[`Storyshots CheckboxGroup with error list 1`] = `
             color="currentColor"
           >
             <li
-              class="ListItem-qqenhw-0 fGfFTP"
+              class="ListItem-qqenhw-0 gzsWDK"
               color="currentColor"
             >
               Error message 1
             </li>
             <li
-              class="ListItem-qqenhw-0 fGfFTP"
+              class="ListItem-qqenhw-0 gzsWDK"
               color="currentColor"
             >
               Error message 2

--- a/components/src/FieldLabel/__snapshots__/FieldLabel.story.storyshot
+++ b/components/src/FieldLabel/__snapshots__/FieldLabel.story.storyshot
@@ -55,8 +55,9 @@ exports[`Storyshots FieldLabel with HelpText 1`] = `
         >
           I am help text. I can be a string or a node that includes a 
           <a
-            class="Link-sc-1lpx3d0-0 geMpSb"
+            class="Link-sc-1lpx3d0-0 gxbSxg"
             color="blue"
+            font-size="medium"
             href="http://nulogy.design"
           >
             link

--- a/components/src/Form/__snapshots__/Form.story.storyshot
+++ b/components/src/Form/__snapshots__/Form.story.storyshot
@@ -60,19 +60,19 @@ exports[`Storyshots Form Demo form 1`] = `
             color="currentColor"
           >
             <li
-              class="ListItem-qqenhw-0 fGfFTP"
+              class="ListItem-qqenhw-0 gzsWDK"
               color="currentColor"
             >
               Affected field
             </li>
             <li
-              class="ListItem-qqenhw-0 fGfFTP"
+              class="ListItem-qqenhw-0 gzsWDK"
               color="currentColor"
             >
               Unmet criteria
             </li>
             <li
-              class="ListItem-qqenhw-0 fGfFTP"
+              class="ListItem-qqenhw-0 gzsWDK"
               color="currentColor"
             >
               <a

--- a/components/src/Input/__snapshots__/Input.story.storyshot
+++ b/components/src/Input/__snapshots__/Input.story.storyshot
@@ -759,13 +759,13 @@ exports[`Storyshots Input with error list  1`] = `
             color="currentColor"
           >
             <li
-              class="ListItem-qqenhw-0 fGfFTP"
+              class="ListItem-qqenhw-0 gzsWDK"
               color="currentColor"
             >
               Error message 1
             </li>
             <li
-              class="ListItem-qqenhw-0 fGfFTP"
+              class="ListItem-qqenhw-0 gzsWDK"
               color="currentColor"
             >
               Error message 2

--- a/components/src/Link/Link.js
+++ b/components/src/Link/Link.js
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import { color, space } from "styled-system";
+import { color, space, typography } from "styled-system";
 import { themeGet } from "@styled-system/theme-get";
 import propTypes from "@styled-system/prop-types";
 import { darken } from "polished";
@@ -8,8 +8,7 @@ import theme from "../theme";
 
 const resetButtonStyles = {
   background: "none",
-  border: "none",
-  fontSize: theme.fontSizes.medium
+  border: "none"
 };
 
 const getHoverColor = props =>
@@ -17,7 +16,7 @@ const getHoverColor = props =>
     ? themeGet(`colors.${props.hover}`, props.hover)(props)
     : darken("0.1", themeGet(`colors.${props.color}`, props.color)(props));
 
-const Link = styled.a(color, space, ({ underline, as, ...props }) => ({
+const Link = styled.a(color, space, typography, ({ underline, as, ...props }) => ({
   ...resetButtonStyles,
   padding: as === "button" ? "0" : null,
   textDecoration: underline ? "underline" : "none",
@@ -31,6 +30,7 @@ Link.propTypes = {
   className: PropTypes.string,
   underline: PropTypes.bool,
   hover: PropTypes.string,
+  ...propTypes.typography,
   ...propTypes.color,
   ...propTypes.space
 };
@@ -38,6 +38,7 @@ Link.propTypes = {
 Link.defaultProps = {
   className: undefined,
   underline: true,
+  fontSize: "medium",
   color: "blue",
   theme
 };

--- a/components/src/Link/Link.story.js
+++ b/components/src/Link/Link.story.js
@@ -14,4 +14,9 @@ storiesOf("Link", module)
       Link
     </Link>
   ))
+  .add("With a different size", () => (
+    <Link color="black" fontSize="large" href="http://nulogy.design">
+      Link
+    </Link>
+  ))
   .add("As a <button>", () => <Link as="button">Link</Link>);

--- a/components/src/Link/__snapshots__/Link.story.storyshot
+++ b/components/src/Link/__snapshots__/Link.story.storyshot
@@ -8,8 +8,9 @@ exports[`Storyshots Link As a <button> 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <button
-      class="Link-sc-1lpx3d0-0 dpQmZf"
+      class="Link-sc-1lpx3d0-0 cLSnCY"
       color="blue"
+      font-size="medium"
     >
       Link
     </button>
@@ -25,8 +26,9 @@ exports[`Storyshots Link Link 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <a
-      class="Link-sc-1lpx3d0-0 geMpSb"
+      class="Link-sc-1lpx3d0-0 gxbSxg"
       color="blue"
+      font-size="medium"
       href="http://nulogy.design"
     >
       Link
@@ -43,8 +45,28 @@ exports[`Storyshots Link With a different color 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <a
-      class="Link-sc-1lpx3d0-0 hOpqxk"
+      class="Link-sc-1lpx3d0-0 cpcHzb"
       color="black"
+      font-size="medium"
+      href="http://nulogy.design"
+    >
+      Link
+    </a>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Link With a different size 1`] = `
+<div
+  style="padding:24px"
+>
+  <div
+    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+  >
+    <a
+      class="Link-sc-1lpx3d0-0 jFBEBU"
+      color="black"
+      font-size="large"
       href="http://nulogy.design"
     >
       Link
@@ -61,8 +83,9 @@ exports[`Storyshots Link Without underline 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <a
-      class="Link-sc-1lpx3d0-0 hoHKDj"
+      class="Link-sc-1lpx3d0-0 clvBNI"
       color="blue"
+      font-size="medium"
       href="http://nulogy.design"
     >
       Link

--- a/components/src/List/List.story.js
+++ b/components/src/List/List.story.js
@@ -21,7 +21,7 @@ storiesOf("List", module)
     <List fontSize="small" lineHeight="smallTextBase">
       <ListItem>List Item 1</ListItem>
       <ListItem>List Item 2 that is really really really really really really really really really long</ListItem>
-      <ListItem>List Item 3</ListItem>
+      <ListItem fontSize="large">Larger List Item 3</ListItem>
     </List>
   ))
   .add("With compact spacing", () => (

--- a/components/src/List/ListItem.js
+++ b/components/src/List/ListItem.js
@@ -1,10 +1,10 @@
 import styled from "styled-components";
 import PropTypes from "prop-types";
-import { space, color } from "styled-system";
+import { space, color, typography } from "styled-system";
 import propTypes from "@styled-system/prop-types";
 import theme from "../theme";
 
-const ListItem = styled.li(space, color, {
+const ListItem = styled.li(space, color, typography, {
   "&:last-child": {
     marginBottom: 0
   }
@@ -12,6 +12,7 @@ const ListItem = styled.li(space, color, {
 
 ListItem.propTypes = {
   className: PropTypes.string,
+  ...propTypes.typography,
   ...propTypes.space,
   ...propTypes.color
 };

--- a/components/src/List/__snapshots__/List.story.storyshot
+++ b/components/src/List/__snapshots__/List.story.storyshot
@@ -12,19 +12,19 @@ exports[`Storyshots List List 1`] = `
       color="currentColor"
     >
       <li
-        class="ListItem-qqenhw-0 fGfFTP"
+        class="ListItem-qqenhw-0 gzsWDK"
         color="currentColor"
       >
         List Item 1
       </li>
       <li
-        class="ListItem-qqenhw-0 fGfFTP"
+        class="ListItem-qqenhw-0 gzsWDK"
         color="currentColor"
       >
         List Item 2 that is really really really really really really really really really long
       </li>
       <li
-        class="ListItem-qqenhw-0 fGfFTP"
+        class="ListItem-qqenhw-0 gzsWDK"
         color="currentColor"
       >
         List Item 3
@@ -46,19 +46,19 @@ exports[`Storyshots List With compact spacing 1`] = `
       color="currentColor"
     >
       <li
-        class="ListItem-qqenhw-0 fGfFTP"
+        class="ListItem-qqenhw-0 gzsWDK"
         color="currentColor"
       >
         List Item 1
       </li>
       <li
-        class="ListItem-qqenhw-0 fGfFTP"
+        class="ListItem-qqenhw-0 gzsWDK"
         color="currentColor"
       >
         List Item 2 that is really really really really really really really really really long
       </li>
       <li
-        class="ListItem-qqenhw-0 fGfFTP"
+        class="ListItem-qqenhw-0 gzsWDK"
         color="currentColor"
       >
         List Item 3
@@ -80,19 +80,19 @@ exports[`Storyshots List With custom colour 1`] = `
       color="red"
     >
       <li
-        class="ListItem-qqenhw-0 fGfFTP"
+        class="ListItem-qqenhw-0 gzsWDK"
         color="currentColor"
       >
         List Item 1
       </li>
       <li
-        class="ListItem-qqenhw-0 fGfFTP"
+        class="ListItem-qqenhw-0 gzsWDK"
         color="currentColor"
       >
         List Item 2 that is really really really really really really really really really long
       </li>
       <li
-        class="ListItem-qqenhw-0 fGfFTP"
+        class="ListItem-qqenhw-0 gzsWDK"
         color="currentColor"
       >
         List Item 3
@@ -115,22 +115,23 @@ exports[`Storyshots List With custom font size and line height 1`] = `
       font-size="small"
     >
       <li
-        class="ListItem-qqenhw-0 fGfFTP"
+        class="ListItem-qqenhw-0 gzsWDK"
         color="currentColor"
       >
         List Item 1
       </li>
       <li
-        class="ListItem-qqenhw-0 fGfFTP"
+        class="ListItem-qqenhw-0 gzsWDK"
         color="currentColor"
       >
         List Item 2 that is really really really really really really really really really long
       </li>
       <li
-        class="ListItem-qqenhw-0 fGfFTP"
+        class="ListItem-qqenhw-0 deWKnu"
         color="currentColor"
+        font-size="large"
       >
-        List Item 3
+        Larger List Item 3
       </li>
     </ul>
   </div>
@@ -149,19 +150,19 @@ exports[`Storyshots List With left alignment 1`] = `
       color="currentColor"
     >
       <li
-        class="ListItem-qqenhw-0 fGfFTP"
+        class="ListItem-qqenhw-0 gzsWDK"
         color="currentColor"
       >
         List Item 1
       </li>
       <li
-        class="ListItem-qqenhw-0 fGfFTP"
+        class="ListItem-qqenhw-0 gzsWDK"
         color="currentColor"
       >
         List Item 2 that is really really really really really really really really really long
       </li>
       <li
-        class="ListItem-qqenhw-0 fGfFTP"
+        class="ListItem-qqenhw-0 gzsWDK"
         color="currentColor"
       >
         List Item 3

--- a/components/src/NavBar/__snapshots__/NavBar.story.storyshot
+++ b/components/src/NavBar/__snapshots__/NavBar.story.storyshot
@@ -18,8 +18,9 @@ exports[`Storyshots NavBar NavBar 1`] = `
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 hoHKDj"
+            class="Link-sc-1lpx3d0-0 clvBNI"
             color="blue"
+            font-size="medium"
             href="/"
             style="display:block;height:40px"
           >
@@ -314,8 +315,9 @@ exports[`Storyshots NavBar With alternate themeColor 1`] = `
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 eYTYYH"
+            class="Link-sc-1lpx3d0-0 egQWMc"
             color="blue"
+            font-size="medium"
             href="/"
             style="display:block;height:56px"
           >
@@ -457,8 +459,9 @@ exports[`Storyshots NavBar With alternative branding link 1`] = `
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 hoHKDj"
+            class="Link-sc-1lpx3d0-0 clvBNI"
             color="blue"
+            font-size="medium"
             href="/portal"
             style="display:block;height:40px"
           >
@@ -589,8 +592,9 @@ exports[`Storyshots NavBar With branding only 1`] = `
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 hoHKDj"
+            class="Link-sc-1lpx3d0-0 clvBNI"
             color="blue"
+            font-size="medium"
             href="/"
             style="display:block;height:40px"
           >
@@ -668,8 +672,9 @@ exports[`Storyshots NavBar With custom link components 1`] = `
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 hoHKDj"
+            class="Link-sc-1lpx3d0-0 clvBNI"
             color="blue"
+            font-size="medium"
             href="/"
             style="display:block;height:40px"
           >
@@ -933,8 +938,9 @@ exports[`Storyshots NavBar With subtext 1`] = `
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 eYTYYH"
+            class="Link-sc-1lpx3d0-0 egQWMc"
             color="blue"
+            font-size="medium"
             href="/"
             style="display:block;height:56px"
           >
@@ -1133,8 +1139,9 @@ exports[`Storyshots NavBar With text in the menu 1`] = `
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 hoHKDj"
+            class="Link-sc-1lpx3d0-0 clvBNI"
             color="blue"
+            font-size="medium"
             href="/"
             style="display:block;height:40px"
           >
@@ -1261,8 +1268,9 @@ exports[`Storyshots NavBar Without search 1`] = `
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 hoHKDj"
+            class="Link-sc-1lpx3d0-0 clvBNI"
             color="blue"
+            font-size="medium"
             href="/"
             style="display:block;height:40px"
           >
@@ -1501,8 +1509,9 @@ exports[`Storyshots NavBar Without search and primary menu 1`] = `
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 hoHKDj"
+            class="Link-sc-1lpx3d0-0 clvBNI"
             color="blue"
+            font-size="medium"
             href="/"
             style="display:block;height:40px"
           >
@@ -1642,8 +1651,9 @@ exports[`Storyshots NavBar Without search and secondary menu 1`] = `
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 hoHKDj"
+            class="Link-sc-1lpx3d0-0 clvBNI"
             color="blue"
+            font-size="medium"
             href="/"
             style="display:block;height:40px"
           >
@@ -1820,8 +1830,9 @@ exports[`Storyshots NavBar Without secondary menu 1`] = `
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 hoHKDj"
+            class="Link-sc-1lpx3d0-0 clvBNI"
             color="blue"
+            font-size="medium"
             href="/"
             style="display:block;height:40px"
           >

--- a/components/src/PMTable/__snapshots__/PMTable.story.storyshot
+++ b/components/src/PMTable/__snapshots__/PMTable.story.storyshot
@@ -130,8 +130,9 @@ exports[`Storyshots PM/PMTable default 1`] = `
           </td>
           <td>
             <a
-              class="Link-sc-1lpx3d0-0 geMpSb"
+              class="Link-sc-1lpx3d0-0 gxbSxg"
               color="blue"
+              font-size="medium"
               href="/"
             >
               1234454
@@ -202,8 +203,9 @@ exports[`Storyshots PM/PMTable default 1`] = `
           </td>
           <td>
             <a
-              class="Link-sc-1lpx3d0-0 geMpSb"
+              class="Link-sc-1lpx3d0-0 gxbSxg"
               color="blue"
+              font-size="medium"
               href="/"
             >
               1234455
@@ -471,8 +473,9 @@ exports[`Storyshots PM/PMTable default 1`] = `
         >
           <td>
             <a
-              class="Link-sc-1lpx3d0-0 geMpSb"
+              class="Link-sc-1lpx3d0-0 gxbSxg"
               color="blue"
+              font-size="medium"
               href="/"
             >
               1234454
@@ -520,8 +523,9 @@ exports[`Storyshots PM/PMTable default 1`] = `
         >
           <td>
             <a
-              class="Link-sc-1lpx3d0-0 geMpSb"
+              class="Link-sc-1lpx3d0-0 gxbSxg"
               color="blue"
+              font-size="medium"
               href="/"
             >
               1234455
@@ -569,8 +573,9 @@ exports[`Storyshots PM/PMTable default 1`] = `
         >
           <td>
             <a
-              class="Link-sc-1lpx3d0-0 geMpSb"
+              class="Link-sc-1lpx3d0-0 gxbSxg"
               color="blue"
+              font-size="medium"
               href="/"
             >
               1234461
@@ -618,8 +623,9 @@ exports[`Storyshots PM/PMTable default 1`] = `
         >
           <td>
             <a
-              class="Link-sc-1lpx3d0-0 geMpSb"
+              class="Link-sc-1lpx3d0-0 gxbSxg"
               color="blue"
+              font-size="medium"
               href="/"
             >
               1234424
@@ -667,8 +673,9 @@ exports[`Storyshots PM/PMTable default 1`] = `
         >
           <td>
             <a
-              class="Link-sc-1lpx3d0-0 geMpSb"
+              class="Link-sc-1lpx3d0-0 gxbSxg"
               color="blue"
+              font-size="medium"
               href="/"
             >
               1234453
@@ -716,8 +723,9 @@ exports[`Storyshots PM/PMTable default 1`] = `
         >
           <td>
             <a
-              class="Link-sc-1lpx3d0-0 geMpSb"
+              class="Link-sc-1lpx3d0-0 gxbSxg"
               color="blue"
+              font-size="medium"
               href="/"
             >
               1232221
@@ -765,8 +773,9 @@ exports[`Storyshots PM/PMTable default 1`] = `
         >
           <td>
             <a
-              class="Link-sc-1lpx3d0-0 geMpSb"
+              class="Link-sc-1lpx3d0-0 gxbSxg"
               color="blue"
+              font-size="medium"
               href="/"
             >
               1444453
@@ -814,8 +823,9 @@ exports[`Storyshots PM/PMTable default 1`] = `
         >
           <td>
             <a
-              class="Link-sc-1lpx3d0-0 geMpSb"
+              class="Link-sc-1lpx3d0-0 gxbSxg"
               color="blue"
+              font-size="medium"
               href="/"
             >
               1224478

--- a/components/src/Radio/__snapshots__/RadioGroup.story.storyshot
+++ b/components/src/Radio/__snapshots__/RadioGroup.story.storyshot
@@ -577,13 +577,13 @@ exports[`Storyshots RadioGroup with error list 1`] = `
             color="currentColor"
           >
             <li
-              class="ListItem-qqenhw-0 fGfFTP"
+              class="ListItem-qqenhw-0 gzsWDK"
               color="currentColor"
             >
               Error message 1
             </li>
             <li
-              class="ListItem-qqenhw-0 fGfFTP"
+              class="ListItem-qqenhw-0 gzsWDK"
               color="currentColor"
             >
               Error message 2

--- a/components/src/Select/__snapshots__/Select.story.storyshot
+++ b/components/src/Select/__snapshots__/Select.story.storyshot
@@ -2133,13 +2133,13 @@ exports[`Storyshots Select with error list 1`] = `
               color="currentColor"
             >
               <li
-                class="ListItem-qqenhw-0 fGfFTP"
+                class="ListItem-qqenhw-0 gzsWDK"
                 color="currentColor"
               >
                 Error message 1
               </li>
               <li
-                class="ListItem-qqenhw-0 fGfFTP"
+                class="ListItem-qqenhw-0 gzsWDK"
                 color="currentColor"
               >
                 Error message 2
@@ -2389,13 +2389,13 @@ exports[`Storyshots Select with error list 1`] = `
             color="currentColor"
           >
             <li
-              class="ListItem-qqenhw-0 fGfFTP"
+              class="ListItem-qqenhw-0 gzsWDK"
               color="currentColor"
             >
               Error message 1
             </li>
             <li
-              class="ListItem-qqenhw-0 fGfFTP"
+              class="ListItem-qqenhw-0 gzsWDK"
               color="currentColor"
             >
               Error message 2

--- a/components/src/Textarea/__snapshots__/Textarea.story.storyshot
+++ b/components/src/Textarea/__snapshots__/Textarea.story.storyshot
@@ -324,13 +324,13 @@ exports[`Storyshots Textarea with error list 1`] = `
             color="currentColor"
           >
             <li
-              class="ListItem-qqenhw-0 fGfFTP"
+              class="ListItem-qqenhw-0 gzsWDK"
               color="currentColor"
             >
               Error message 1
             </li>
             <li
-              class="ListItem-qqenhw-0 fGfFTP"
+              class="ListItem-qqenhw-0 gzsWDK"
               color="currentColor"
             >
               Error message 2

--- a/components/src/Tooltip/__snapshots__/Tooltip.story.storyshot
+++ b/components/src/Tooltip/__snapshots__/Tooltip.story.storyshot
@@ -193,8 +193,9 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
       aria-expanded="false"
       aria-haspopup="true"
       aria-label="Open"
-      class="Link-sc-1lpx3d0-0 geMpSb"
+      class="Link-sc-1lpx3d0-0 gxbSxg"
       color="blue"
+      font-size="medium"
       href="/"
     >
        Link 

--- a/components/src/Type/__snapshots__/Typography.story.storyshot
+++ b/components/src/Type/__snapshots__/Typography.story.storyshot
@@ -82,19 +82,19 @@ exports[`Storyshots Typography Article 1`] = `
       color="currentColor"
     >
       <li
-        class="ListItem-qqenhw-0 fGfFTP"
+        class="ListItem-qqenhw-0 gzsWDK"
         color="currentColor"
       >
         List Item 1
       </li>
       <li
-        class="ListItem-qqenhw-0 fGfFTP"
+        class="ListItem-qqenhw-0 gzsWDK"
         color="currentColor"
       >
         List Item 2 that is really really really really really really really really really long
       </li>
       <li
-        class="ListItem-qqenhw-0 fGfFTP"
+        class="ListItem-qqenhw-0 gzsWDK"
         color="currentColor"
       >
         List Item 3

--- a/components/src/Validation/__snapshots__/InlineValidation.story.storyshot
+++ b/components/src/Validation/__snapshots__/InlineValidation.story.storyshot
@@ -85,24 +85,25 @@ exports[`Storyshots Inline Validation with custom content 1`] = `
           color="currentColor"
         >
           <li
-            class="ListItem-qqenhw-0 fGfFTP"
+            class="ListItem-qqenhw-0 gzsWDK"
             color="currentColor"
           >
             Entry must be at least 3 characters long.
           </li>
           <li
-            class="ListItem-qqenhw-0 fGfFTP"
+            class="ListItem-qqenhw-0 gzsWDK"
             color="currentColor"
           >
             Entry must contain a number
           </li>
           <li
-            class="ListItem-qqenhw-0 fGfFTP"
+            class="ListItem-qqenhw-0 gzsWDK"
             color="currentColor"
           >
             <a
-              class="Link-sc-1lpx3d0-0 geMpSb"
+              class="Link-sc-1lpx3d0-0 gxbSxg"
               color="blue"
+              font-size="medium"
               href="https://nulogy.design/"
             >
               Custom Link
@@ -157,13 +158,13 @@ exports[`Storyshots Inline Validation with list items 1`] = `
           color="currentColor"
         >
           <li
-            class="ListItem-qqenhw-0 fGfFTP"
+            class="ListItem-qqenhw-0 gzsWDK"
             color="currentColor"
           >
             Entry must be at least 3 characters long.
           </li>
           <li
-            class="ListItem-qqenhw-0 fGfFTP"
+            class="ListItem-qqenhw-0 gzsWDK"
             color="currentColor"
           >
             Entry must contain a number.
@@ -210,13 +211,13 @@ exports[`Storyshots Inline Validation with only list items 1`] = `
           color="currentColor"
         >
           <li
-            class="ListItem-qqenhw-0 fGfFTP"
+            class="ListItem-qqenhw-0 gzsWDK"
             color="currentColor"
           >
             Entry must be at least 3 characters long.
           </li>
           <li
-            class="ListItem-qqenhw-0 fGfFTP"
+            class="ListItem-qqenhw-0 gzsWDK"
             color="currentColor"
           >
             Entry must contain a number.

--- a/components/src/pages/__snapshots__/Custom.story.storyshot
+++ b/components/src/pages/__snapshots__/Custom.story.storyshot
@@ -18,8 +18,9 @@ exports[`Storyshots Pages/Custom Default 1`] = `
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 hoHKDj"
+            class="Link-sc-1lpx3d0-0 clvBNI"
             color="blue"
+            font-size="medium"
             href="/"
             style="display:block;height:40px"
           >
@@ -196,8 +197,9 @@ exports[`Storyshots Pages/Custom With breadcrumbs and actions 1`] = `
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 hoHKDj"
+            class="Link-sc-1lpx3d0-0 clvBNI"
             color="blue"
+            font-size="medium"
             href="/"
             style="display:block;height:40px"
           >
@@ -344,7 +346,7 @@ exports[`Storyshots Pages/Custom With breadcrumbs and actions 1`] = `
               width="[object Object]"
             >
               <a
-                class="Link-sc-1lpx3d0-0 dNsOaA"
+                class="Link-sc-1lpx3d0-0 fEeoTP"
                 color="darkBlue"
                 font-size="smaller"
               >
@@ -367,7 +369,7 @@ exports[`Storyshots Pages/Custom With breadcrumbs and actions 1`] = `
                 />
               </svg>
               <a
-                class="Link-sc-1lpx3d0-0 dNsOaA"
+                class="Link-sc-1lpx3d0-0 fEeoTP"
                 color="darkBlue"
                 font-size="smaller"
               >
@@ -493,8 +495,9 @@ exports[`Storyshots Pages/Custom With sidebar 1`] = `
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 hoHKDj"
+            class="Link-sc-1lpx3d0-0 clvBNI"
             color="blue"
+            font-size="medium"
             href="/"
             style="display:block;height:40px"
           >

--- a/components/src/pages/__snapshots__/Details.story.storyshot
+++ b/components/src/pages/__snapshots__/Details.story.storyshot
@@ -18,8 +18,9 @@ exports[`Storyshots Pages/Details page Default 1`] = `
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 hoHKDj"
+            class="Link-sc-1lpx3d0-0 clvBNI"
             color="blue"
+            font-size="medium"
             href="/"
             style="display:block;height:40px"
           >
@@ -791,8 +792,9 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 hoHKDj"
+            class="Link-sc-1lpx3d0-0 clvBNI"
             color="blue"
+            font-size="medium"
             href="/"
             style="display:block;height:40px"
           >
@@ -939,7 +941,7 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
               width="[object Object]"
             >
               <a
-                class="Link-sc-1lpx3d0-0 dNsOaA"
+                class="Link-sc-1lpx3d0-0 fEeoTP"
                 color="darkBlue"
                 font-size="smaller"
               >
@@ -962,7 +964,7 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                 />
               </svg>
               <a
-                class="Link-sc-1lpx3d0-0 dNsOaA"
+                class="Link-sc-1lpx3d0-0 fEeoTP"
                 color="darkBlue"
                 font-size="smaller"
               >
@@ -1683,8 +1685,9 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 hoHKDj"
+            class="Link-sc-1lpx3d0-0 clvBNI"
             color="blue"
+            font-size="medium"
             href="/"
             style="display:block;height:40px"
           >

--- a/components/src/pages/__snapshots__/ErrorPage.story.storyshot
+++ b/components/src/pages/__snapshots__/ErrorPage.story.storyshot
@@ -311,8 +311,9 @@ exports[`Storyshots Pages/ErrorPage With a link 1`] = `
               </div>
             </div>
             <a
-              class="Link-sc-1lpx3d0-0 geMpSb"
+              class="Link-sc-1lpx3d0-0 gxbSxg"
               color="blue"
+              font-size="medium"
               href="#"
             >
               Back to homepage

--- a/components/src/pages/__snapshots__/LoginPage.story.storyshot
+++ b/components/src/pages/__snapshots__/LoginPage.story.storyshot
@@ -763,8 +763,9 @@ exports[`Storyshots Pages/LoginPage with forgot password link 1`] = `
             class="Box-sc-1qu1edy-0 csERpy"
           >
             <a
-              class="Link-sc-1lpx3d0-0 geMpSb"
+              class="Link-sc-1lpx3d0-0 gxbSxg"
               color="blue"
+              font-size="medium"
               href="/"
             >
               Forgot your password?


### PR DESCRIPTION
## Description

<Link> and <ListItem> should have typography props available for customizing type styles.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [x] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
