### PR TITLE
feat: make PMTable noRowsContent accessible

### DIFF
--- a/components/src/PMTable/PMTable.js
+++ b/components/src/PMTable/PMTable.js
@@ -10,8 +10,7 @@ const PMCss = {
   fontSize: "12px",
   ".nds-table__no-rows-content": {
     padding: 0,
-    fontSize: "12px",
-    color: "#aaa"
+    fontSize: "12px"
   },
   "thead tr": {
     borderBottom: "none"

--- a/components/src/PMTable/__snapshots__/PMTable.story.storyshot
+++ b/components/src/PMTable/__snapshots__/PMTable.story.storyshot
@@ -8,7 +8,7 @@ exports[`Storyshots PM/PMTable default 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub PMTable___StyledTable-sc-1bray0a-0 ideIOb"
+      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub PMTable___StyledTable-sc-1bray0a-0 lnHGsX"
     >
       <thead>
         <tr
@@ -400,7 +400,7 @@ exports[`Storyshots PM/PMTable default 1`] = `
       </button>
     </nav>
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub PMTable___StyledTable-sc-1bray0a-0 ideIOb"
+      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub PMTable___StyledTable-sc-1bray0a-0 lnHGsX"
     >
       <thead>
         <tr
@@ -942,7 +942,7 @@ exports[`Storyshots PM/PMTable default 1`] = `
       </tfoot>
     </table>
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub PMTable___StyledTable-sc-1bray0a-0 ideIOb"
+      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub PMTable___StyledTable-sc-1bray0a-0 lnHGsX"
     >
       <thead>
         <tr


### PR DESCRIPTION
## Description

From PackManager super-light-grey to NDS black. 

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
