### PR TITLE
fix: allows overriding px and py props in Card

### DIFF
--- a/components/src/Card/Card.js
+++ b/components/src/Card/Card.js
@@ -13,7 +13,8 @@ Card.defaultProps = {
   borderRadius: "medium",
   boxShadow: "small",
   bg: "whiteGrey",
-  p: "x2",
+  py: "x2",
+  px: "x2",
   position: "relative"
 };
 

--- a/components/src/Card/__snapshots__/Card.story.storyshot
+++ b/components/src/Card/__snapshots__/Card.story.storyshot
@@ -8,7 +8,7 @@ exports[`Storyshots Card Card 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       I am a card.
     </div>
@@ -27,17 +27,17 @@ exports[`Storyshots Card Cardset 1`] = `
       class="Box-sc-1qu1edy-0 jlPsmj CardSet-sc-143b99f-0 cmMRfh"
     >
       <div
-        class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+        class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
       >
         I am a 1st card in a cardset.
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+        class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
       >
         I am a 2nd card in a cardset.
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+        class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
       >
         I am a 3rd card in a cardset.
       </div>
@@ -54,7 +54,7 @@ exports[`Storyshots Card Custom card 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 ftWbZx"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 bdKSSm"
       color="white"
     >
       I am a custom card.

--- a/components/src/DropdownMenu/__snapshots__/DropdownMenu.story.storyshot
+++ b/components/src/DropdownMenu/__snapshots__/DropdownMenu.story.storyshot
@@ -43,7 +43,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -78,7 +78,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -113,7 +113,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -148,7 +148,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -183,7 +183,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -218,7 +218,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -253,7 +253,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -288,7 +288,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -323,7 +323,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -358,7 +358,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -393,7 +393,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -428,7 +428,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -463,7 +463,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -498,7 +498,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -533,7 +533,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -568,7 +568,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -603,7 +603,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -638,7 +638,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -673,7 +673,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -708,7 +708,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -743,7 +743,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -778,7 +778,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -813,7 +813,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -848,7 +848,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -883,7 +883,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -918,7 +918,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -953,7 +953,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -988,7 +988,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -1023,7 +1023,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -1058,7 +1058,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -1093,7 +1093,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -1128,7 +1128,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -1163,7 +1163,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -1198,7 +1198,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -1233,7 +1233,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -1268,7 +1268,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -1303,7 +1303,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -1338,7 +1338,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -1373,7 +1373,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -1408,7 +1408,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -1443,7 +1443,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -1478,7 +1478,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -1513,7 +1513,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -1548,7 +1548,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -1583,7 +1583,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -1618,7 +1618,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -1653,7 +1653,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -1688,7 +1688,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -1723,7 +1723,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -1758,7 +1758,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -1793,7 +1793,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -1828,7 +1828,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -1863,7 +1863,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -1898,7 +1898,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -1933,7 +1933,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -1968,7 +1968,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -2003,7 +2003,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -2038,7 +2038,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -2073,7 +2073,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -2108,7 +2108,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -2143,7 +2143,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -2178,7 +2178,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -2213,7 +2213,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -2248,7 +2248,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -2283,7 +2283,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -2318,7 +2318,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -2353,7 +2353,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -2388,7 +2388,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -2423,7 +2423,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -2458,7 +2458,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -2493,7 +2493,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -2528,7 +2528,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -2563,7 +2563,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -2598,7 +2598,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -2633,7 +2633,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -2668,7 +2668,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -2703,7 +2703,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -2738,7 +2738,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -2773,7 +2773,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -2808,7 +2808,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -2843,7 +2843,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -2878,7 +2878,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -2913,7 +2913,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -2948,7 +2948,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -2983,7 +2983,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -3018,7 +3018,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -3053,7 +3053,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -3088,7 +3088,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -3123,7 +3123,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -3158,7 +3158,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -3193,7 +3193,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -3228,7 +3228,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -3263,7 +3263,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -3298,7 +3298,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -3333,7 +3333,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -3368,7 +3368,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -3403,7 +3403,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -3438,7 +3438,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -3473,7 +3473,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"
@@ -3508,7 +3508,7 @@ exports[`Storyshots DropdownMenu Many dropdowns 1`] = `
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
     >
       <p
         class="Text-sc-1wu7vpu-0 RbfMK"

--- a/components/src/Overlay/__snapshots__/Overlay.story.storyshot
+++ b/components/src/Overlay/__snapshots__/Overlay.story.storyshot
@@ -18,7 +18,7 @@ exports[`Storyshots Overlay Dark 1`] = `
       class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 Overlay-spdky8-0 eOYFJr"
     >
       <div
-        class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 gCFvbM"
+        class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
       >
         <p
           class="Text-sc-1wu7vpu-0 RbfMK"


### PR DESCRIPTION
## Description

The Card component set a default `p` value which expanded to the `padding` shorthand in CSS which overrides `padding-left` and `padding-right`. This became an issue when somebody tried to set a `py`. This change ensures the CSS doesn't use the shorthand, and instead individually sets padding-left, padding-right, etc. 

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
