### PR TITLE
feat: support filtering with pagination and expandable rows for PMTable

### DIFF
--- a/components-e2e/cypress/integration/components/Table.spec.js
+++ b/components-e2e/cypress/integration/components/Table.spec.js
@@ -169,51 +169,43 @@ describe("Table", () => {
     });
   });
   describe("with filtering and pagination", () => {
+    const filterIinput = () => cy.get('input[name="Name"]');
     beforeEach(() => {
       cy.renderFromStorybook(
         "table--with-filtering-and-pagination-skipstoryshot"
       );
     });
     it("filters down to fewer pages", () => {
-      paginationButtons(3).toExist();
-      cy.get("label")
-        .contains("Filter by Name")
-        .type("a");
-      paginationButtons(2).toExist();
-      paginationButtons(3).not.toExist();
+      paginationButtons(3).should("exist");
+      filterIinput().type("a");
+      paginationButtons(2).should("exist");
+      paginationButtons(3).should("not.exist");
     });
     it("changes the selected page when results are filtered", () => {
       paginationButtons(3).click();
-      cy.get("label")
-        .contains("Filter by Name")
-        .type("a");
+      filterIinput().type("a");
       cy.get("button")
         .contains(2)
         .should("be.disabled");
-      paginationButtons(3).not.toExist();
+      paginationButtons(3).should("not.exist");
     });
     it("filters down to to 1 page result", () => {
       paginationButtons(3).click();
-      cy.get("label")
-        .contains("Filter by Name")
-        .type("alb");
+      filterIinput().type("alb");
       cy.get("button")
         .contains(1)
         .should("be.disabled");
-      paginationButtons(2).not.toExist();
+      paginationButtons(2).should("not.exist");
     });
     it("clearing the filter restores the page results", () => {
       paginationButtons(3).click();
-      cy.get("label")
-        .contains("Filter by Name")
-        .type("alb");
-      cy.get("label")
-        .contains("Filter by Name")
-        .type("{backspace}{backspace}");
+      filterIinput().type("alb");
+      filterIinput().type("{backspace}{backspace}");
       cy.get("button")
-        .contains(2)
+        .contains(1)
         .should("be.disabled");
-      paginationButtons(3).not.toExist();
+      paginationButtons(2).should("exist");
+      paginationButtons(3).should("not.exist");
     });
   });
 });

--- a/components-e2e/cypress/integration/components/Table.spec.js
+++ b/components-e2e/cypress/integration/components/Table.spec.js
@@ -168,4 +168,52 @@ describe("Table", () => {
       cy.get("[data-testid='table-body']").should("contain", "Expands!");
     });
   });
+  describe("with filtering and pagination", () => {
+    beforeEach(() => {
+      cy.renderFromStorybook(
+        "table--with-filtering-and-pagination-skipstoryshot"
+      );
+    });
+    it("filters down to fewer pages", () => {
+      paginationButtons(3).toExist();
+      cy.get("label")
+        .contains("Filter by Name")
+        .type("a");
+      paginationButtons(2).toExist();
+      paginationButtons(3).not.toExist();
+    });
+    it("changes the selected page when results are filtered", () => {
+      paginationButtons(3).click();
+      cy.get("label")
+        .contains("Filter by Name")
+        .type("a");
+      cy.get("button")
+        .contains(2)
+        .should("be.disabled");
+      paginationButtons(3).not.toExist();
+    });
+    it("filters down to to 1 page result", () => {
+      paginationButtons(3).click();
+      cy.get("label")
+        .contains("Filter by Name")
+        .type("alb");
+      cy.get("button")
+        .contains(1)
+        .should("be.disabled");
+      paginationButtons(2).not.toExist();
+    });
+    it("clearing the filter restores the page results", () => {
+      paginationButtons(3).click();
+      cy.get("label")
+        .contains("Filter by Name")
+        .type("alb");
+      cy.get("label")
+        .contains("Filter by Name")
+        .type("{backspace}{backspace}");
+      cy.get("button")
+        .contains(2)
+        .should("be.disabled");
+      paginationButtons(3).not.toExist();
+    });
+  });
 });

--- a/components/src/PMTable/PMTable.js
+++ b/components/src/PMTable/PMTable.js
@@ -27,7 +27,7 @@ const PMCss = {
       paddingLeft: "8px"
     }
   },
-  "tbody tr:nth-child(odd):not([data-test-id='expanded-table-row'])": {
+  "tbody tr:not([data-test-id='expanded-table-row']):nth-child(odd)": {
     backgroundColor: "#f0f0f0"
   },
 

--- a/components/src/PMTable/PMTable.js
+++ b/components/src/PMTable/PMTable.js
@@ -36,6 +36,9 @@ const PMCss = {
     height: "34px",
     color: "#444"
   },
+  "tbody td:first-child": {
+    paddingLeft: 0
+  },
   nav: {
     backgroundColor: "#660099"
   },

--- a/components/src/PMTable/PMTable.js
+++ b/components/src/PMTable/PMTable.js
@@ -27,7 +27,7 @@ const PMCss = {
       paddingLeft: "8px"
     }
   },
-  "tbody tr:nth-child(odd)": {
+  "tbody tr:nth-child(odd):not([data-test-id='expanded-table-row'])": {
     backgroundColor: "#f0f0f0"
   },
 

--- a/components/src/PMTable/PMTable.story.js
+++ b/components/src/PMTable/PMTable.story.js
@@ -5,6 +5,7 @@ import { action } from "@storybook/addon-actions";
 import { withKnobs } from "@storybook/addon-knobs";
 import { Link } from "../Link";
 import { PMTable } from ".";
+import { Box, Text } from "..";
 
 const columns = [
   { label: "ID", dataKey: "id" },
@@ -17,6 +18,14 @@ const columns = [
   { label: "Notes", dataKey: "notes" }
 ];
 
+const expandedContent = () => (
+  <Box bg="lightBlue" py="x1" px="x2">
+    <Text fontWeight="bold" color="blackBlue">
+      Expands!
+    </Text>
+  </Box>
+);
+
 const rowData = [
   {
     id: "1234454",
@@ -26,7 +35,8 @@ const rowData = [
     shipped: "No",
     expectedQuantity: "2,025 eaches",
     actualQuantity: "1,800 eaches",
-    notes: "--"
+    notes: "--",
+    expandedContent
   },
   {
     id: "1234455",
@@ -36,7 +46,8 @@ const rowData = [
     shipped: "Yes",
     expectedQuantity: "2,475 eaches",
     actualQuantity: "2,250 eaches",
-    notes: "--"
+    notes: "--",
+    expandedContent
   },
   {
     id: "1234461",
@@ -46,7 +57,8 @@ const rowData = [
     shipped: "No",
     expectedQuantity: "2,475 eaches",
     actualQuantity: "1,425 eaches",
-    notes: "--"
+    notes: "--",
+    expandedContent
   },
   {
     id: "1234424",
@@ -56,7 +68,8 @@ const rowData = [
     shipped: "No",
     expectedQuantity: "2,475 eaches",
     actualQuantity: "675 eaches",
-    notes: "--"
+    notes: "--",
+    expandedContent
   },
   {
     id: "1234453",
@@ -66,7 +79,8 @@ const rowData = [
     shipped: "No",
     expectedQuantity: "2,475 eaches",
     actualQuantity: "1,575 eaches",
-    notes: "--"
+    notes: "--",
+    expandedContent
   },
   {
     id: "1232221",
@@ -76,7 +90,8 @@ const rowData = [
     shipped: "No",
     expectedQuantity: "1,725 eaches",
     actualQuantity: "--",
-    notes: "--"
+    notes: "--",
+    expandedContent
   },
   {
     id: "1444453",
@@ -86,7 +101,8 @@ const rowData = [
     shipped: "Yes",
     expectedQuantity: "2,475 eaches",
     actualQuantity: "--",
-    notes: "--"
+    notes: "--",
+    expandedContent
   },
   {
     id: "1224478",
@@ -96,7 +112,8 @@ const rowData = [
     shipped: "No",
     expectedQuantity: "2,475 eaches",
     actualQuantity: "--",
-    notes: "--"
+    notes: "--",
+    expandedContent
   }
 ];
 
@@ -134,5 +151,31 @@ storiesOf("PM/PMTable", module)
         <PMTable columns={columnsWithLinks} rows={rowData} footerRows={footerRowData} />
         <PMTable columns={columnsWithLinks} rows={[]} />
       </>
+    );
+  })
+  .add("with expandable rows", () => {
+    const columnsWithLinks = columns.map((column, i) => {
+      if (i === 0) {
+        return {
+          ...column,
+          cellRenderer: ({ cellData }) => <Link href="/">{cellData}</Link>
+        };
+      }
+      return column;
+    });
+    return (
+      <PMTable
+        columns={columnsWithLinks}
+        rows={rowData}
+        footerRows={footerRowData}
+        // hasSelectableRows
+        hasExpandableRows
+        // onRowSelectionChange={action("row selection changed")}
+        rowsPerPage={2}
+        paginationProps={{
+          nextLabel: "Next \u2192",
+          previousLabel: "\u2190 Previous"
+        }}
+      />
     );
   });

--- a/components/src/PMTable/__snapshots__/PMTable.story.storyshot
+++ b/components/src/PMTable/__snapshots__/PMTable.story.storyshot
@@ -8,7 +8,7 @@ exports[`Storyshots PM/PMTable default 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub PMTable___StyledTable-sc-1bray0a-0 lnHGsX"
+      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub PMTable___StyledTable-sc-1bray0a-0 hZntFA"
     >
       <thead>
         <tr
@@ -400,7 +400,7 @@ exports[`Storyshots PM/PMTable default 1`] = `
       </button>
     </nav>
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub PMTable___StyledTable-sc-1bray0a-0 lnHGsX"
+      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub PMTable___StyledTable-sc-1bray0a-0 hZntFA"
     >
       <thead>
         <tr
@@ -942,7 +942,7 @@ exports[`Storyshots PM/PMTable default 1`] = `
       </tfoot>
     </table>
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub PMTable___StyledTable-sc-1bray0a-0 lnHGsX"
+      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub PMTable___StyledTable-sc-1bray0a-0 hZntFA"
     >
       <thead>
         <tr
@@ -1025,6 +1025,393 @@ exports[`Storyshots PM/PMTable default 1`] = `
       </tbody>
       <tfoot />
     </table>
+  </div>
+</div>
+`;
+
+exports[`Storyshots PM/PMTable with expandable rows 1`] = `
+<div
+  style="padding:24px"
+>
+  <div
+    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+  >
+    <table
+      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub PMTable___StyledTable-sc-1bray0a-0 hZntFA"
+    >
+      <thead>
+        <tr
+          class="TableHead__StyledHeaderRow-msr3t5-0 jbkNdg"
+        >
+          <th
+            class="StyledTh-sc-10nzyk9-0 kfgNsH"
+            data-testid="table-head"
+            scope="col"
+            width="30px"
+          />
+          <th
+            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            data-testid="table-head"
+            scope="col"
+          >
+            ID
+          </th>
+          <th
+            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            data-testid="table-head"
+            scope="col"
+          >
+            Expected Ship
+          </th>
+          <th
+            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            data-testid="table-head"
+            scope="col"
+          >
+            Customer
+          </th>
+          <th
+            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            data-testid="table-head"
+            scope="col"
+          >
+            Ship To
+          </th>
+          <th
+            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            data-testid="table-head"
+            scope="col"
+          >
+            Shipped
+          </th>
+          <th
+            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            data-testid="table-head"
+            scope="col"
+          >
+            Expected Quantity
+          </th>
+          <th
+            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            data-testid="table-head"
+            scope="col"
+          >
+            Actual Quantity
+          </th>
+          <th
+            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            data-testid="table-head"
+            scope="col"
+          >
+            Notes
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        data-testid="table-body"
+      >
+        <tr
+          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv"
+          data-testid="table-row"
+        >
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            <button
+              aria-label="Expand row"
+              class="ControlIcon__StyledButton-sc-1h83lvi-0 cCdEvo"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="Icon-fc7twp-0 efirdb"
+                color="currentColor"
+                fill="currentColor"
+                focusable="false"
+                height="32px"
+                icon="downArrow"
+                viewBox="0 0 24 24"
+                width="32px"
+              >
+                <path
+                  d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                />
+              </svg>
+            </button>
+          </td>
+          <td>
+            <a
+              class="Link-sc-1lpx3d0-0 gxbSxg"
+              color="blue"
+              font-size="medium"
+              href="/"
+            >
+              1234454
+            </a>
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            2019-10-01
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            National Widgets
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            99 Reactor Blvd., Springfield, SI
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            No
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            2,025 eaches
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            1,800 eaches
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            --
+          </td>
+        </tr>
+        <tr
+          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv"
+          data-testid="table-row"
+        >
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            <button
+              aria-label="Expand row"
+              class="ControlIcon__StyledButton-sc-1h83lvi-0 cCdEvo"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="Icon-fc7twp-0 efirdb"
+                color="currentColor"
+                fill="currentColor"
+                focusable="false"
+                height="32px"
+                icon="downArrow"
+                viewBox="0 0 24 24"
+                width="32px"
+              >
+                <path
+                  d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                />
+              </svg>
+            </button>
+          </td>
+          <td>
+            <a
+              class="Link-sc-1lpx3d0-0 gxbSxg"
+              color="blue"
+              font-size="medium"
+              href="/"
+            >
+              1234455
+            </a>
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            2019-10-02
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            National Widgets
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            7 New St., New York, NY
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            Yes
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            2,475 eaches
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            2,250 eaches
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            --
+          </td>
+        </tr>
+      </tbody>
+      <tfoot>
+        <tr
+          class="TableFoot__StyledFooterRow-sc-1q56pdo-0 mxGTg"
+        >
+          <th
+            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            colspan="2"
+            scope="row"
+          >
+            Total
+          </th>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          />
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          />
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          />
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          />
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            18,000 eaches
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            7,725 eaches
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          />
+        </tr>
+        <tr
+          class="TableFoot__StyledFooterRow-sc-1q56pdo-0 mxGTg"
+        >
+          <th
+            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            colspan="2"
+            scope="row"
+          >
+            Attainment
+          </th>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          />
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          />
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          />
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          />
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          />
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            41.5%
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          />
+        </tr>
+      </tfoot>
+    </table>
+    <nav
+      aria-label="Pagination navigation"
+      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iCmkqG StatefulTable___StyledPagination-sc-196ra2t-0 hJdjBx"
+    >
+      <button
+        aria-label="Go to previous results"
+        class="Pagination__PaginationButton-sc-1fsx1pp-0 kZsQns"
+        disabled=""
+      >
+        <svg
+          aria-hidden="true"
+          class="Icon-fc7twp-0 bLUmHQ"
+          color="currentColor"
+          fill="currentColor"
+          focusable="false"
+          height="24px"
+          icon="leftArrow"
+          ml="-8px"
+          viewBox="0 0 24 24"
+          width="24px"
+        >
+          <path
+            d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
+          />
+        </svg>
+         ← Previous
+      </button>
+      <button
+        aria-current="true"
+        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 khkrHJ"
+        disabled=""
+      >
+        1
+      </button>
+      <button
+        aria-current="false"
+        aria-label="Go to page {{count}}"
+        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+      >
+        2
+      </button>
+      <button
+        aria-current="false"
+        aria-label="Go to page {{count}}"
+        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+      >
+        3
+      </button>
+      <button
+        aria-current="false"
+        aria-label="Go to page {{count}}"
+        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+      >
+        4
+      </button>
+      <button
+        aria-label="Go to next results"
+        class="Pagination__PaginationButton-sc-1fsx1pp-0 iFOkT"
+      >
+        Next → 
+        <svg
+          aria-hidden="true"
+          class="Icon-fc7twp-0 dEtgXr"
+          color="currentColor"
+          fill="currentColor"
+          focusable="false"
+          height="24px"
+          icon="rightArrow"
+          mr="-8px"
+          viewBox="0 0 24 24"
+          width="24px"
+        >
+          <path
+            d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+          />
+        </svg>
+      </button>
+    </nav>
   </div>
 </div>
 `;

--- a/components/src/Table/StatefulTable.js
+++ b/components/src/Table/StatefulTable.js
@@ -169,7 +169,10 @@ class StatefulTable extends Component {
 
   getControlProps = () => {
     const { selectedRows, isHeaderSelected, currentPage, expandedRows } = this.state;
-    const { hasSelectableRows, hasExpandableRows } = this.props;
+    const { hasSelectableRows, hasExpandableRows, rowsPerPage } = this.props;
+    const pagedRowsConfig = {
+      rows: this.rowsByPageSelector(currentPage)
+    };
     const selectionConfig = {
       onSelectRow: this.onSelectRow,
       onSelectHeader: this.onSelectHeader,
@@ -182,7 +185,7 @@ class StatefulTable extends Component {
     };
     const props = {
       ...this.props,
-      rows: this.rowsByPageSelector(currentPage),
+      ...(rowsPerPage && pagedRowsConfig),
       ...(hasSelectableRows && selectionConfig),
       ...(hasExpandableRows && expandableConfig)
     };

--- a/components/src/Table/TableWithFiltering.story.js
+++ b/components/src/Table/TableWithFiltering.story.js
@@ -28,7 +28,7 @@ const transformColumn = (column, onChange) => {
 };
 
 const ColumnHeaderWithFilter = ({ onChange, label }) => (
-  <Input labelText={`Filter by ${label}`} onChange={onChange} name={`Filter by ${label}`} />
+  <Input labelText={`Filter by ${label}`} onChange={onChange} name={label} />
 );
 
 const TableWithFilters = ({ rowsPerPage }) => {

--- a/components/src/Table/TableWithFiltering.story.js
+++ b/components/src/Table/TableWithFiltering.story.js
@@ -27,9 +27,11 @@ const transformColumn = (column, onChange) => {
   };
 };
 
-const ColumnHeaderWithFilter = ({ onChange, label }) => <Input labelText={`Filter by ${label}`} onChange={onChange} />;
+const ColumnHeaderWithFilter = ({ onChange, label }) => (
+  <Input labelText={`Filter by ${label}`} onChange={onChange} name={`Filter by ${label}`} />
+);
 
-const TableWithFilters = () => {
+const TableWithFilters = ({ rowsPerPage }) => {
   const [rows, setRows] = useState(ROWS);
   const [filter, setFilter] = useState({});
 
@@ -56,7 +58,9 @@ const TableWithFilters = () => {
     }));
   };
   const columns = COLUMNS.map(column => transformColumn(column, onFilterInputChange));
-  return <Table columns={columns} rows={rows} keyField="name" />;
+  return <Table columns={columns} rows={rows} keyField="name" rowsPerPage={rowsPerPage} />;
 };
 
-storiesOf("Table", module).add("with filtering (SkipStoryshot)", () => <TableWithFilters />);
+storiesOf("Table", module)
+  .add("with filtering (SkipStoryshot)", () => <TableWithFilters />)
+  .add("with filtering and pagination (SkipStoryshot)", () => <TableWithFilters rowsPerPage={4} />);


### PR DESCRIPTION
## Description

- Fixes bug where table with pagination does not respond to new rows being passed in (preventing it from being updated in a scenario where the rows are filtered, story added  to show pagination with filtering)
- Removes expanded rows from zebra striping rules for PMTable

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [x] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [x] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
