### PR TITLE
fix: even odd striping in PMTable

### DIFF
--- a/components/src/PMTable/PMTable.js
+++ b/components/src/PMTable/PMTable.js
@@ -63,7 +63,7 @@ const PMCss = {
 
 const markRowsEvenOdd = rows => {
   return rows.map((row, index) => {
-    const evenOddClassName = index % 2 === 0 ? "table-row--even" : "table-row--odd";
+    const evenOddClassName = (index + 1) % 2 === 0 ? "table-row--even" : "table-row--odd";
     return {
       ...row,
       rowClassName: evenOddClassName

--- a/components/src/PMTable/__snapshots__/PMTable.story.storyshot
+++ b/components/src/PMTable/__snapshots__/PMTable.story.storyshot
@@ -102,7 +102,7 @@ exports[`Storyshots PM/PMTable default 1`] = `
         data-testid="table-body"
       >
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--even"
+          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--odd"
           data-testid="table-row"
         >
           <td
@@ -175,7 +175,7 @@ exports[`Storyshots PM/PMTable default 1`] = `
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--odd"
+          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--even"
           data-testid="table-row"
         >
           <td
@@ -468,7 +468,7 @@ exports[`Storyshots PM/PMTable default 1`] = `
         data-testid="table-body"
       >
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--even"
+          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--odd"
           data-testid="table-row"
         >
           <td>
@@ -518,7 +518,7 @@ exports[`Storyshots PM/PMTable default 1`] = `
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--odd"
+          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--even"
           data-testid="table-row"
         >
           <td>
@@ -568,7 +568,7 @@ exports[`Storyshots PM/PMTable default 1`] = `
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--even"
+          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--odd"
           data-testid="table-row"
         >
           <td>
@@ -618,7 +618,7 @@ exports[`Storyshots PM/PMTable default 1`] = `
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--odd"
+          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--even"
           data-testid="table-row"
         >
           <td>
@@ -668,7 +668,7 @@ exports[`Storyshots PM/PMTable default 1`] = `
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--even"
+          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--odd"
           data-testid="table-row"
         >
           <td>
@@ -718,7 +718,7 @@ exports[`Storyshots PM/PMTable default 1`] = `
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--odd"
+          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--even"
           data-testid="table-row"
         >
           <td>
@@ -768,7 +768,7 @@ exports[`Storyshots PM/PMTable default 1`] = `
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--even"
+          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--odd"
           data-testid="table-row"
         >
           <td>
@@ -818,7 +818,7 @@ exports[`Storyshots PM/PMTable default 1`] = `
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--odd"
+          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--even"
           data-testid="table-row"
         >
           <td>
@@ -1111,7 +1111,7 @@ exports[`Storyshots PM/PMTable with expandable rows 1`] = `
         data-testid="table-body"
       >
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--even"
+          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--odd"
           data-testid="table-row"
         >
           <td
@@ -1186,7 +1186,7 @@ exports[`Storyshots PM/PMTable with expandable rows 1`] = `
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--odd"
+          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--even"
           data-testid="table-row"
         >
           <td
@@ -1261,7 +1261,7 @@ exports[`Storyshots PM/PMTable with expandable rows 1`] = `
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--even"
+          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--odd"
           data-testid="table-row"
         >
           <td


### PR DESCRIPTION
## Description

There was a mistake in the code of even and odd striping

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
