### PR TITLE
fix: Tables without pagination now rerender on row updates

### DIFF
--- a/components/src/Table/StatefulTable.js
+++ b/components/src/Table/StatefulTable.js
@@ -27,16 +27,13 @@ class StatefulTable extends Component {
 
   static getDerivedStateFromProps(nextProps, prevState) {
     const { rows, rowsPerPage } = nextProps;
-    if (rowsPerPage) {
-      const paginatedRows = paginateRows(rows, rowsPerPage);
-      const { currentPage } = prevState;
-      // when the rows prop changes paginate the new rows and reset the current page
-      return {
-        paginatedRows,
-        currentPage: paginatedRows.length < currentPage ? paginatedRows.length || 1 : currentPage
-      };
-    }
-    return null;
+    const paginatedRows = paginateRows(rows, rowsPerPage);
+    const { currentPage } = prevState;
+    // when the rows prop changes paginate the new rows and reset the current page
+    return {
+      paginatedRows,
+      currentPage: paginatedRows.length < currentPage ? paginatedRows.length || 1 : currentPage
+    };
   }
 
   onRowExpansionChangeHandler = () => {


### PR DESCRIPTION
## Description

Removes the if statement that stops the update when rows aren't paginated. 

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
