### PR TITLE
[WIP] Show styles in storyshots

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -82,6 +82,7 @@
     "eslint-import-resolver-webpack": "^0.12.1",
     "identity-obj-proxy": "3.0.0",
     "jest": "24.1.0",
+    "jest-specific-snapshot": "^3.0.0",
     "jest-styled-components": "7",
     "plop": "^2.4.0",
     "prop-types": "15.7.2",

--- a/components/spec/Storyshots.spec.js
+++ b/components/spec/Storyshots.spec.js
@@ -1,17 +1,23 @@
 import initStoryshots, { multiSnapshotWithOptions } from "@storybook/addon-storyshots";
 import { render } from "enzyme";
 import { createSerializer } from "enzyme-to-json";
+import { styleSheetSerializer } from "jest-styled-components/serializer";
 import "jest-styled-components";
+import { addSerializer } from "jest-specific-snapshot";
+
+addSerializer(styleSheetSerializer);
 
 // mock createPortal since it is used by react-modal and not supported by the test renderer
-jest.mock("react-dom", () => ({
-  createPortal: node => node
-}));
+jest.mock("react-dom", () => {
+  const original = jest.requireActual("react-dom");
+  return {
+    ...original,
+    createPortal: node => node
+  };
+});
 
 initStoryshots({
   storyNameRegex: /^((?!.*?SkipStoryshot).)*$/,
   snapshotSerializers: [createSerializer()],
-  test: multiSnapshotWithOptions({
-    renderer: render
-  })
+  test: multiSnapshotWithOptions()
 });

--- a/components/spec/Storyshots.spec.js
+++ b/components/spec/Storyshots.spec.js
@@ -1,5 +1,4 @@
 import initStoryshots, { multiSnapshotWithOptions } from "@storybook/addon-storyshots";
-import { render } from "enzyme";
 import { createSerializer } from "enzyme-to-json";
 import { styleSheetSerializer } from "jest-styled-components/serializer";
 import "jest-styled-components";

--- a/components/src/Alert/__snapshots__/Alert.story.storyshot
+++ b/components/src/Alert/__snapshots__/Alert.story.storyshot
@@ -1,25 +1,80 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Alert Danger 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c4 {
+  margin-right: auto;
+}
+
+.c1 {
+  background-color: #fae6ea;
+  padding: 16px;
+  border-radius: 4px;
+  border-left-width: half;
+  border-left-color: #cc1439;
+  border-left-style: solid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  margin-right: 8px;
+  color: #cc1439;
+  min-width: 24px;
+}
+
+.c2 .Link-sc-1lpx3d0-0 {
+  color: #011e38;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 gjRpuy Alert-u8lbe-0 kjZZUq"
+      className="c1 c2"
       role="alert"
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 ewGQci"
+        aria-hidden={true}
+        className="c3"
         color="red"
         fill="#cc1439"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="error"
         mr="x1"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -28,7 +83,7 @@ exports[`Storyshots Alert Danger 1`] = `
         />
       </svg>
       <div
-        class="Box-sc-1qu1edy-0 iDnpba"
+        className="c4"
       >
         Danger alert
       </div>
@@ -38,18 +93,65 @@ exports[`Storyshots Alert Danger 1`] = `
 `;
 
 exports[`Storyshots Alert Informative 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-right: auto;
+}
+
+.c1 {
+  background-color: #e1ebfa;
+  padding: 16px;
+  border-radius: 4px;
+  border-left-width: half;
+  border-left-color: #216beb;
+  border-left-style: solid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c2 .Link-sc-1lpx3d0-0 {
+  color: #011e38;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 eBpEPp Alert-u8lbe-0 kjZZUq"
+      className="c1 c2"
       role="alert"
     >
       <div
-        class="Box-sc-1qu1edy-0 iDnpba"
+        className="c3"
       >
         Informative alert
       </div>
@@ -59,25 +161,80 @@ exports[`Storyshots Alert Informative 1`] = `
 `;
 
 exports[`Storyshots Alert Success 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c4 {
+  margin-right: auto;
+}
+
+.c1 {
+  background-color: #e9f7f2;
+  padding: 16px;
+  border-radius: 4px;
+  border-left-width: half;
+  border-left-color: #008059;
+  border-left-style: solid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  margin-right: 8px;
+  color: #008059;
+  min-width: 24px;
+}
+
+.c2 .Link-sc-1lpx3d0-0 {
+  color: #011e38;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 jumLLM Alert-u8lbe-0 kjZZUq"
+      className="c1 c2"
       role="alert"
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 dqoulF"
+        aria-hidden={true}
+        className="c3"
         color="green"
         fill="#008059"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="check"
         mr="x1"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -86,7 +243,7 @@ exports[`Storyshots Alert Success 1`] = `
         />
       </svg>
       <div
-        class="Box-sc-1qu1edy-0 iDnpba"
+        className="c4"
       >
         Success alert
       </div>
@@ -96,18 +253,65 @@ exports[`Storyshots Alert Success 1`] = `
 `;
 
 exports[`Storyshots Alert Warning 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-right: auto;
+}
+
+.c1 {
+  background-color: #fcf5e3;
+  padding: 16px;
+  border-radius: 4px;
+  border-left-width: half;
+  border-left-color: #ffbb00;
+  border-left-style: solid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c2 .Link-sc-1lpx3d0-0 {
+  color: #011e38;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iZHNxR Alert-u8lbe-0 kjZZUq"
+      className="c1 c2"
       role="alert"
     >
       <div
-        class="Box-sc-1qu1edy-0 iDnpba"
+        className="c3"
       >
         Warning alert
       </div>
@@ -117,39 +321,108 @@ exports[`Storyshots Alert Warning 1`] = `
 `;
 
 exports[`Storyshots Alert With a close button 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-right: auto;
+}
+
+.c1 {
+  background-color: #e1ebfa;
+  padding: 16px;
+  border-radius: 4px;
+  border-left-width: half;
+  border-left-color: #216beb;
+  border-left-style: solid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c6 {
+  color: currentColor;
+  min-width: 16;
+}
+
+.c5 {
+  color: #434d59;
+  font-size: 16px;
+  background: none;
+  border: none;
+  padding: 0;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c5:hover {
+  cursor: pointer;
+  color: #216beb;
+}
+
+.c2 .c4 {
+  color: #011e38;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 eBpEPp Alert-u8lbe-0 kjZZUq"
+      className="c1 c2"
       role="alert"
     >
       <div
-        class="Box-sc-1qu1edy-0 iDnpba"
+        className="c3"
       >
         Warning alert
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
+        className=""
       >
         <button
           aria-label="Close"
-          class="Link-sc-1lpx3d0-0 eyTmUh"
+          className="c4 c5"
           color="darkGrey"
-          font-size="medium"
+          fontSize="medium"
+          onClick={[Function]}
         >
           <svg
-            aria-hidden="true"
-            class="Icon-fc7twp-0 gNwFhh"
+            aria-hidden={true}
+            className="c6"
             color="currentColor"
             fill="currentColor"
-            focusable="false"
+            focusable={false}
             height="16"
             icon="close"
             size="16"
+            title={null}
             viewBox="0 0 24 24"
             width="16"
           >
@@ -165,24 +438,85 @@ exports[`Storyshots Alert With a close button 1`] = `
 `;
 
 exports[`Storyshots Alert With a link 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-right: auto;
+}
+
+.c1 {
+  background-color: #e1ebfa;
+  padding: 16px;
+  border-radius: 4px;
+  border-left-width: half;
+  border-left-color: #216beb;
+  border-left-style: solid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c5 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c5:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
+.c2 .c4 {
+  color: #011e38;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 eBpEPp Alert-u8lbe-0 kjZZUq"
+      className="c1 c2"
       role="alert"
     >
       <div
-        class="Box-sc-1qu1edy-0 iDnpba"
+        className="c3"
       >
         An alert with 
         <a
-          class="Link-sc-1lpx3d0-0 gxbSxg"
+          className="c4 c5"
           color="blue"
-          font-size="medium"
+          fontSize="medium"
           href="/"
         >
           linked details
@@ -195,25 +529,89 @@ exports[`Storyshots Alert With a link 1`] = `
 `;
 
 exports[`Storyshots Alert With a title 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c4 {
+  margin-right: auto;
+}
+
+.c1 {
+  background-color: #fae6ea;
+  padding: 16px;
+  border-radius: 4px;
+  border-left-width: half;
+  border-left-color: #cc1439;
+  border-left-style: solid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  margin-right: 8px;
+  color: #cc1439;
+  min-width: 24px;
+}
+
+.c5 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c2 .Link-sc-1lpx3d0-0 {
+  color: #011e38;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 gjRpuy Alert-u8lbe-0 kjZZUq"
+      className="c1 c2"
       role="alert"
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 ewGQci"
+        aria-hidden={true}
+        className="c3"
         color="red"
         fill="#cc1439"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="error"
         mr="x1"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -222,13 +620,14 @@ exports[`Storyshots Alert With a title 1`] = `
         />
       </svg>
       <div
-        class="Box-sc-1qu1edy-0 iDnpba"
+        className="c4"
       >
         <p
-          class="Text-sc-1wu7vpu-0 dFPjNj"
+          className="c5"
           color="currentColor"
-          font-size="medium"
-          font-weight="bold"
+          disabled={false}
+          fontSize="medium"
+          fontWeight="bold"
         >
           Danger title!
         </p>

--- a/components/src/Box/__snapshots__/Box.story.storyshot
+++ b/components/src/Box/__snapshots__/Box.story.storyshot
@@ -1,14 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Box Box 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  padding: 24px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 iuijxl"
+      className="c1"
     >
       Hello World
     </div>
@@ -17,14 +47,46 @@ exports[`Storyshots Box Box 1`] = `
 `;
 
 exports[`Storyshots Box With a background colour 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  color: #ffffff;
+  background-color: #216beb;
+  padding: 24px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 jamsbG"
+      className="c1"
       color="white"
     >
       Hello World
@@ -34,15 +96,70 @@ exports[`Storyshots Box With a background colour 1`] = `
 `;
 
 exports[`Storyshots Box With a responsive width 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  background-color: #f0f2f5;
+  padding: 24px;
+}
+
+@media screen and (min-width:0px) {
+  .c1 {
+    width: 100%;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c1 {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c1 {
+    width: 25%;
+  }
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 cxGsXU"
-      width="[object Object]"
+      className="c1"
+      width={
+        Object {
+          "extraSmall": 1,
+          "medium": 0.25,
+          "small": 0.5,
+        }
+      }
     >
       Full width on extra small screens, 1/2 width on small and 1/4 width on medium
     </div>
@@ -51,15 +168,47 @@ exports[`Storyshots Box With a responsive width 1`] = `
 `;
 
 exports[`Storyshots Box With a set width 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  background-color: #f0f2f5;
+  padding: 24px;
+  width: 50%;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 clejNr"
-      width="0.5"
+      className="c1"
+      width={0.5}
     >
       Half Width
     </div>
@@ -68,24 +217,68 @@ exports[`Storyshots Box With a set width 1`] = `
 `;
 
 exports[`Storyshots Box With a shadow 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  padding: 8px;
+  margin-bottom: 16px;
+  box-shadow: 0px 0px 3px 0px rgba(1,30,56,0.2);
+}
+
+.c2 {
+  padding: 24px;
+  margin-bottom: 16px;
+  box-shadow: 0px 1px 4px 0px rgba(1,30,56,0.15);
+}
+
+.c3 {
+  padding: 48px;
+  margin-bottom: 16px;
+  box-shadow: 0px 3px 5px 0px rgba(1,30,56,0.1);
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 bHmSeb"
+      className="c1"
     >
       Small shadow
     </div>
     <div
-      class="Box-sc-1qu1edy-0 eyfCVZ"
+      className="c2"
     >
       Medium shadow
     </div>
     <div
-      class="Box-sc-1qu1edy-0 bGaQQB"
+      className="c3"
     >
       Large shadow
     </div>
@@ -94,14 +287,45 @@ exports[`Storyshots Box With a shadow 1`] = `
 `;
 
 exports[`Storyshots Box With a text colour 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  color: #216beb;
+  padding: 24px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 dCMDFS"
+      className="c1"
       color="blue"
     >
       Hello World
@@ -111,47 +335,114 @@ exports[`Storyshots Box With a text colour 1`] = `
 `;
 
 exports[`Storyshots Box With margin 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  padding: 24px;
+}
+
+.c2 {
+  background-color: #f0f2f5;
+  margin: 24px;
+}
+
+.c3 {
+  background-color: #f0f2f5;
+  margin-top: 24px;
+}
+
+.c4 {
+  background-color: #f0f2f5;
+  margin-right: 24px;
+}
+
+.c5 {
+  background-color: #f0f2f5;
+  margin-bottom: 24px;
+}
+
+.c6 {
+  background-color: #f0f2f5;
+  margin-left: 24px;
+}
+
+.c7 {
+  background-color: #f0f2f5;
+  margin-left: 24px;
+  margin-right: 24px;
+}
+
+.c8 {
+  background-color: #f0f2f5;
+  margin-top: 24px;
+  margin-bottom: 24px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 iuijxl"
+      className="c1"
     >
       <div
-        class="Box-sc-1qu1edy-0 bIpQPr"
+        className="c2"
       >
         Margin
       </div>
       <div
-        class="Box-sc-1qu1edy-0 fNJCWd"
+        className="c3"
       >
         Margin top
       </div>
       <div
-        class="Box-sc-1qu1edy-0 cfKJLu"
+        className="c4"
       >
         Margin right
       </div>
       <div
-        class="Box-sc-1qu1edy-0 hSzfDt"
+        className="c5"
       >
         Margin bottom
       </div>
       <div
-        class="Box-sc-1qu1edy-0 dTezRN"
+        className="c6"
       >
         Margin left
       </div>
       <div
-        class="Box-sc-1qu1edy-0 cgLFQx"
+        className="c7"
       >
         Margin x
       </div>
       <div
-        class="Box-sc-1qu1edy-0 iWmXdK"
+        className="c8"
       >
         Margin y
       </div>
@@ -161,47 +452,115 @@ exports[`Storyshots Box With margin 1`] = `
 `;
 
 exports[`Storyshots Box With padding 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  padding: 16px;
+}
+
+.c2 {
+  background-color: #f0f2f5;
+  margin: 8px;
+  padding: 24px;
+}
+
+.c3 {
+  background-color: #f0f2f5;
+  margin: 8px;
+  padding-right: 24px;
+}
+
+.c4 {
+  background-color: #f0f2f5;
+  margin: 8px;
+  padding-bottom: 24px;
+}
+
+.c5 {
+  background-color: #f0f2f5;
+  margin: 8px;
+  padding-left: 24px;
+}
+
+.c6 {
+  background-color: #f0f2f5;
+  margin: 8px;
+  padding-left: 24px;
+  padding-right: 24px;
+}
+
+.c7 {
+  background-color: #f0f2f5;
+  margin: 8px;
+  padding-top: 24px;
+  padding-bottom: 24px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 kbDFVk"
+      className="c1"
     >
       <div
-        class="Box-sc-1qu1edy-0 UfyFz"
+        className="c2"
       >
         Padding
       </div>
       <div
-        class="Box-sc-1qu1edy-0 UfyFz"
+        className="c2"
       >
         Padding top
       </div>
       <div
-        class="Box-sc-1qu1edy-0 dFirUG"
+        className="c3"
       >
         Padding right
       </div>
       <div
-        class="Box-sc-1qu1edy-0 kjVnmN"
+        className="c4"
       >
         Padding bottom
       </div>
       <div
-        class="Box-sc-1qu1edy-0 kYJNBN"
+        className="c5"
       >
         Padding left
       </div>
       <div
-        class="Box-sc-1qu1edy-0 qFcSW"
+        className="c6"
       >
         Padding x
       </div>
       <div
-        class="Box-sc-1qu1edy-0 iDOULB"
+        className="c7"
       >
         Padding y
       </div>

--- a/components/src/BrandedNavBar/__snapshots__/NavBar.story.storyshot
+++ b/components/src/BrandedNavBar/__snapshots__/NavBar.story.storyshot
@@ -1,38 +1,266 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots BrandedNavBar BrandedNavBar 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  max-width: 184px;
+  max-height: 36px;
+}
+
+.c6 {
+  margin-left: 24px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-content: flex-end;
+  -ms-flex-line-pack: end;
+  align-content: flex-end;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  justify-self: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c10 {
+  padding: 2px;
+  color: #00438f;
+  min-width: 20px;
+}
+
+.c4 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c4:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
+.c5 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding: 2px 0;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  font-weight: 500;
+  color: #00438f;
+  border: none;
+  background-color: transparent;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  line-height: 1.5;
+  -webkit-transition: background-color .2s;
+  transition: background-color .2s;
+  font-size: 16px;
+  padding: 8px 28px 8px 16px;
+  border-radius: 4px;
+}
+
+.c9:hover,
+.c9:focus {
+  outline: none;
+  color: #122b47;
+  background-color: #f0f2f5;
+  cursor: pointer;
+}
+
+.c9:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c9:disabled {
+  opacity: .5;
+}
+
+.c11 {
+  display: block;
+  color: #00438f;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: none;
+  background-color: transparent;
+  vertical-align: middle;
+  line-height: 1.5;
+  font-size: 16px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  font-weight: 500;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c11:hover,
+.c11:focus {
+  outline: none;
+  color: #122b47;
+  background-color: #f0f2f5;
+  cursor: pointer;
+}
+
+.c11:disabled {
+  opacity: .5;
+}
+
+.c11:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c8 div:not(:last-of-type) {
+  margin-right: 8px;
+}
+
+.c2 {
+  background-color: #ffffff;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: white;
+  padding: 8px 24px;
+  box-shadow: 0px 3px 5px 0px rgba(1,30,56,0.1);
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 56px;
+}
+
+.c1 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="NavBarstory__ResetStorybookView-sc-1a6ght2-0 bqKXCt"
+      className="c1"
     >
       <header
-        class="NavBar-sc-1o0etgx-3 jwwFUB"
+        className=""
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 NavBar__NavBarBackground-sc-1o0etgx-0 eRLIKf"
+          className="c2"
         >
           <div
-            class="Box-sc-1qu1edy-0 cRMmlC"
+            className="c3"
           >
             <a
               aria-label="Home"
-              class="Link-sc-1lpx3d0-0 clvBNI"
+              className="c4"
               color="blue"
-              font-size="medium"
+              fontSize="medium"
               href="/"
-              style="display:block"
+              style={
+                Object {
+                  "display": "block",
+                }
+              }
             >
               <div
-                class="Branding__BrandingWrap-ranqri-0 gACiZG Branding-ranqri-2 kQRWHN"
+                className="c5 "
+                size="medium"
               >
                 <svg
                   height="32px"
-                  style="display:block;margin:2px 0"
+                  style={
+                    Object {
+                      "display": "block",
+                      "margin": "2px 0",
+                    }
+                  }
                   viewBox="0 0 133 32"
                   width="133px"
                 >
@@ -69,31 +297,41 @@ exports[`Storyshots BrandedNavBar BrandedNavBar 1`] = `
             </a>
           </div>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 csbfff"
+            className="c6"
           >
             <nav
               aria-label="Primary navigation"
-              class="DesktopMenu__Nav-sc-1a9mp43-3 jhGCqC DesktopMenu-sc-1a9mp43-4 jXTSCm"
+              className="c7 c8"
             >
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sc-16wbhtr-0 ddFaFV"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c9"
                   color="darkBlue"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Dashboard
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 ldBYos"
+                    aria-hidden={true}
+                    className="c10"
                     color="darkBlue"
                     fill="#00438f"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -105,23 +343,33 @@ exports[`Storyshots BrandedNavBar BrandedNavBar 1`] = `
               </div>
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sc-16wbhtr-0 ddFaFV"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c9"
                   color="darkBlue"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Inspector
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 ldBYos"
+                    aria-hidden={true}
+                    className="c10"
                     color="darkBlue"
                     fill="#00438f"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -133,23 +381,33 @@ exports[`Storyshots BrandedNavBar BrandedNavBar 1`] = `
               </div>
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sc-16wbhtr-0 ddFaFV"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c9"
                   color="darkBlue"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Operations
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 ldBYos"
+                    aria-hidden={true}
+                    className="c10"
                     color="darkBlue"
                     fill="#00438f"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -161,7 +419,7 @@ exports[`Storyshots BrandedNavBar BrandedNavBar 1`] = `
               </div>
               <div>
                 <a
-                  class="DesktopMenu__MenuLink-sc-1a9mp43-1 fqBigT"
+                  className="c11"
                   color="darkBlue"
                   href="/"
                 >
@@ -170,31 +428,41 @@ exports[`Storyshots BrandedNavBar BrandedNavBar 1`] = `
               </div>
             </nav>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 bqzqvC"
+              className="c12"
             >
               <nav
                 aria-label="Secondary navigation"
-                class="DesktopMenu__Nav-sc-1a9mp43-3 jhGCqC DesktopMenu-sc-1a9mp43-4 jXTSCm"
+                className="c7 c8"
               >
                 <div>
                   <button
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sc-16wbhtr-0 ddFaFV"
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="c9"
                     color="darkBlue"
+                    onBlur={[Function]}
+                    onClick={[Function]}
                     type="button"
                   >
                     User@Nulogy.com
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 ldBYos"
+                      aria-hidden={true}
+                      className="c10"
                       color="darkBlue"
                       fill="#00438f"
-                      focusable="false"
+                      focusable={false}
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px;right:8px"
+                      size="20px"
+                      style={
+                        Object {
+                          "position": "absolute",
+                          "right": "8px",
+                          "top": "11px",
+                        }
+                      }
+                      title={null}
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -206,23 +474,33 @@ exports[`Storyshots BrandedNavBar BrandedNavBar 1`] = `
                 </div>
                 <div>
                   <button
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sc-16wbhtr-0 ddFaFV"
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="c9"
                     color="darkBlue"
+                    onBlur={[Function]}
+                    onClick={[Function]}
                     type="button"
                   >
                     Settings
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 ldBYos"
+                      aria-hidden={true}
+                      className="c10"
                       color="darkBlue"
                       fill="#00438f"
-                      focusable="false"
+                      focusable={false}
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px;right:8px"
+                      size="20px"
+                      style={
+                        Object {
+                          "position": "absolute",
+                          "right": "8px",
+                          "top": "11px",
+                        }
+                      }
+                      title={null}
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -243,78 +521,361 @@ exports[`Storyshots BrandedNavBar BrandedNavBar 1`] = `
 `;
 
 exports[`Storyshots BrandedNavBar In a training environment 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c2 {
+  background-color: #00438f;
+  text-align: center;
+}
+
+.c5 {
+  max-width: 184px;
+  max-height: 36px;
+}
+
+.c14 {
+  padding-left: 24px;
+}
+
+.c16 {
+  width: 76px;
+  height: 18px;
+}
+
+.c7 {
+  margin-left: 24px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-content: flex-end;
+  -ms-flex-line-pack: end;
+  align-content: flex-end;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  justify-self: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c15 {
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  min-height: 36px;
+  border-radius: 4px;
+  box-shadow: 0px 0px 3px 0px rgba(1,30,56,0.2);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c11 {
+  padding: 2px;
+  color: #00438f;
+  min-width: 20px;
+}
+
+.c3 {
+  padding-top: 2px;
+  padding-bottom: 2px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 10px;
+  -webkit-letter-spacing: 0.5px;
+  -moz-letter-spacing: 0.5px;
+  -ms-letter-spacing: 0.5px;
+  letter-spacing: 0.5px;
+  font-weight: 600;
+  line-height: 1.5;
+  color: #ffffff;
+  text-transform: uppercase;
+}
+
+.c17 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 8px;
+  line-height: 10px;
+  font-weight: 500;
+  -webkit-letter-spacing: .5px;
+  -moz-letter-spacing: .5px;
+  -ms-letter-spacing: .5px;
+  letter-spacing: .5px;
+  color: #434d59;
+  text-transform: uppercase;
+}
+
+.c6 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c6:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  font-weight: 500;
+  color: #00438f;
+  border: none;
+  background-color: transparent;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  line-height: 1.5;
+  -webkit-transition: background-color .2s;
+  transition: background-color .2s;
+  font-size: 16px;
+  padding: 8px 28px 8px 16px;
+  border-radius: 4px;
+}
+
+.c10:hover,
+.c10:focus {
+  outline: none;
+  color: #122b47;
+  background-color: #f0f2f5;
+  cursor: pointer;
+}
+
+.c10:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c10:disabled {
+  opacity: .5;
+}
+
+.c12 {
+  display: block;
+  color: #00438f;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: none;
+  background-color: transparent;
+  vertical-align: middle;
+  line-height: 1.5;
+  font-size: 16px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  font-weight: 500;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c12:hover,
+.c12:focus {
+  outline: none;
+  color: #122b47;
+  background-color: #f0f2f5;
+  cursor: pointer;
+}
+
+.c12:disabled {
+  opacity: .5;
+}
+
+.c12:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c9 div:not(:last-of-type) {
+  margin-right: 8px;
+}
+
+.c4 {
+  background-color: #ffffff;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: white;
+  padding: 8px 24px;
+  box-shadow: 0px 3px 5px 0px rgba(1,30,56,0.1);
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 56px;
+}
+
+.c1 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="NavBarstory__ResetStorybookView-sc-1a6ght2-0 bqKXCt"
+      className="c1"
     >
       <div
-        class="Box-sc-1qu1edy-0 eyTYtp"
+        className="c2"
       >
         <p
-          class="Text-sc-1wu7vpu-0 dUswLN"
+          className="c3"
           color="white"
-          font-size="10px"
-          font-weight="bold"
-          letter-spacing="0.5px"
+          disabled={false}
+          fontSize="10px"
+          fontWeight="bold"
+          letterSpacing="0.5px"
         >
           Training
         </p>
       </div>
       <header
-        class="NavBar-sc-1o0etgx-3 jwwFUB"
+        className=""
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 NavBar__NavBarBackground-sc-1o0etgx-0 eRLIKf"
+          className="c4"
         >
           <div
-            class="Box-sc-1qu1edy-0 cRMmlC"
+            className="c5"
           >
             <a
               aria-label="Home"
-              class="Link-sc-1lpx3d0-0 clvBNI"
+              className="c6"
               color="blue"
-              font-size="medium"
+              fontSize="medium"
               href="/"
-              style="display:block"
+              style={
+                Object {
+                  "display": "block",
+                }
+              }
             >
               <img
                 alt=""
                 src="http://pigment.github.io/fake-logos/logos/vector/color/auto-speed.svg"
-                style="max-width:184px;max-height:36px"
+                style={
+                  Object {
+                    "maxHeight": "36px",
+                    "maxWidth": "184px",
+                  }
+                }
               />
             </a>
           </div>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 csbfff"
+            className="c7"
           >
             <nav
               aria-label="Primary navigation"
-              class="DesktopMenu__Nav-sc-1a9mp43-3 jhGCqC DesktopMenu-sc-1a9mp43-4 jXTSCm"
+              className="c8 c9"
             >
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sc-16wbhtr-0 ddFaFV"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c10"
                   color="darkBlue"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Dashboard
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 ldBYos"
+                    aria-hidden={true}
+                    className="c11"
                     color="darkBlue"
                     fill="#00438f"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -326,23 +887,33 @@ exports[`Storyshots BrandedNavBar In a training environment 1`] = `
               </div>
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sc-16wbhtr-0 ddFaFV"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c10"
                   color="darkBlue"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Inspector
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 ldBYos"
+                    aria-hidden={true}
+                    className="c11"
                     color="darkBlue"
                     fill="#00438f"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -354,23 +925,33 @@ exports[`Storyshots BrandedNavBar In a training environment 1`] = `
               </div>
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sc-16wbhtr-0 ddFaFV"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c10"
                   color="darkBlue"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Operations
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 ldBYos"
+                    aria-hidden={true}
+                    className="c11"
                     color="darkBlue"
                     fill="#00438f"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -382,7 +963,7 @@ exports[`Storyshots BrandedNavBar In a training environment 1`] = `
               </div>
               <div>
                 <a
-                  class="DesktopMenu__MenuLink-sc-1a9mp43-1 fqBigT"
+                  className="c12"
                   color="darkBlue"
                   href="/"
                 >
@@ -391,31 +972,41 @@ exports[`Storyshots BrandedNavBar In a training environment 1`] = `
               </div>
             </nav>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 bqzqvC"
+              className="c13"
             >
               <nav
                 aria-label="Secondary navigation"
-                class="DesktopMenu__Nav-sc-1a9mp43-3 jhGCqC DesktopMenu-sc-1a9mp43-4 jXTSCm"
+                className="c8 c9"
               >
                 <div>
                   <button
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sc-16wbhtr-0 ddFaFV"
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="c10"
                     color="darkBlue"
+                    onBlur={[Function]}
+                    onClick={[Function]}
                     type="button"
                   >
                     User@Nulogy.com
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 ldBYos"
+                      aria-hidden={true}
+                      className="c11"
                       color="darkBlue"
                       fill="#00438f"
-                      focusable="false"
+                      focusable={false}
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px;right:8px"
+                      size="20px"
+                      style={
+                        Object {
+                          "position": "absolute",
+                          "right": "8px",
+                          "top": "11px",
+                        }
+                      }
+                      title={null}
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -427,23 +1018,33 @@ exports[`Storyshots BrandedNavBar In a training environment 1`] = `
                 </div>
                 <div>
                   <button
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sc-16wbhtr-0 ddFaFV"
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="c10"
                     color="darkBlue"
+                    onBlur={[Function]}
+                    onClick={[Function]}
                     type="button"
                   >
                     Settings
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 ldBYos"
+                      aria-hidden={true}
+                      className="c11"
                       color="darkBlue"
                       fill="#00438f"
-                      focusable="false"
+                      focusable={false}
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px;right:8px"
+                      size="20px"
+                      style={
+                        Object {
+                          "position": "absolute",
+                          "right": "8px",
+                          "top": "11px",
+                        }
+                      }
+                      title={null}
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -455,13 +1056,13 @@ exports[`Storyshots BrandedNavBar In a training environment 1`] = `
                 </div>
               </nav>
               <div
-                class="Box-sc-1qu1edy-0 fsLsir"
+                className="c14"
               >
                 <div
-                  class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 lfrZjs"
+                  className="c15"
                 >
                   <div
-                    class="Box-sc-1qu1edy-0 fBwUqO"
+                    className="c16"
                     height="18px"
                     width="76px"
                   >
@@ -472,10 +1073,10 @@ exports[`Storyshots BrandedNavBar In a training environment 1`] = `
                     >
                       <g
                         fill="none"
-                        fill-rule="evenodd"
+                        fillRule="evenodd"
                         id="FInal"
                         stroke="none"
-                        stroke-width="1"
+                        strokeWidth="1"
                       >
                         <g
                           id="DQI"
@@ -535,11 +1136,12 @@ exports[`Storyshots BrandedNavBar In a training environment 1`] = `
                     </svg>
                   </div>
                   <p
-                    class="Text-sc-1wu7vpu-0 hqOtAf"
+                    className="c17"
                     color="darkGrey"
-                    font-size="8px"
-                    font-weight="medium"
-                    letter-spacing=".5px"
+                    disabled={false}
+                    fontSize="8px"
+                    fontWeight="medium"
+                    letterSpacing=".5px"
                   >
                     Quality control
                   </p>
@@ -555,65 +1157,312 @@ exports[`Storyshots BrandedNavBar In a training environment 1`] = `
 `;
 
 exports[`Storyshots BrandedNavBar With a company logo 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  max-width: 184px;
+  max-height: 36px;
+}
+
+.c12 {
+  padding-left: 24px;
+}
+
+.c14 {
+  width: 76px;
+  height: 18px;
+}
+
+.c5 {
+  margin-left: 24px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-content: flex-end;
+  -ms-flex-line-pack: end;
+  align-content: flex-end;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  justify-self: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c13 {
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  min-height: 36px;
+  border-radius: 4px;
+  box-shadow: 0px 0px 3px 0px rgba(1,30,56,0.2);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c9 {
+  padding: 2px;
+  color: #00438f;
+  min-width: 20px;
+}
+
+.c4 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c4:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  font-weight: 500;
+  color: #00438f;
+  border: none;
+  background-color: transparent;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  line-height: 1.5;
+  -webkit-transition: background-color .2s;
+  transition: background-color .2s;
+  font-size: 16px;
+  padding: 8px 28px 8px 16px;
+  border-radius: 4px;
+}
+
+.c8:hover,
+.c8:focus {
+  outline: none;
+  color: #122b47;
+  background-color: #f0f2f5;
+  cursor: pointer;
+}
+
+.c8:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c8:disabled {
+  opacity: .5;
+}
+
+.c10 {
+  display: block;
+  color: #00438f;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: none;
+  background-color: transparent;
+  vertical-align: middle;
+  line-height: 1.5;
+  font-size: 16px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  font-weight: 500;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c10:hover,
+.c10:focus {
+  outline: none;
+  color: #122b47;
+  background-color: #f0f2f5;
+  cursor: pointer;
+}
+
+.c10:disabled {
+  opacity: .5;
+}
+
+.c10:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c7 div:not(:last-of-type) {
+  margin-right: 8px;
+}
+
+.c2 {
+  background-color: #ffffff;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: white;
+  padding: 8px 24px;
+  box-shadow: 0px 3px 5px 0px rgba(1,30,56,0.1);
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 56px;
+}
+
+.c1 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="NavBarstory__ResetStorybookView-sc-1a6ght2-0 bqKXCt"
+      className="c1"
     >
       <header
-        class="NavBar-sc-1o0etgx-3 jwwFUB"
+        className=""
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 NavBar__NavBarBackground-sc-1o0etgx-0 eRLIKf"
+          className="c2"
         >
           <div
-            class="Box-sc-1qu1edy-0 cRMmlC"
+            className="c3"
           >
             <a
               aria-label="Home"
-              class="Link-sc-1lpx3d0-0 clvBNI"
+              className="c4"
               color="blue"
-              font-size="medium"
+              fontSize="medium"
               href="/"
-              style="display:block"
+              style={
+                Object {
+                  "display": "block",
+                }
+              }
             >
               <img
                 alt=""
                 src="http://pigment.github.io/fake-logos/logos/vector/color/auto-speed.svg"
-                style="max-width:184px;max-height:36px"
+                style={
+                  Object {
+                    "maxHeight": "36px",
+                    "maxWidth": "184px",
+                  }
+                }
               />
             </a>
           </div>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 csbfff"
+            className="c5"
           >
             <nav
               aria-label="Primary navigation"
-              class="DesktopMenu__Nav-sc-1a9mp43-3 jhGCqC DesktopMenu-sc-1a9mp43-4 jXTSCm"
+              className="c6 c7"
             >
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sc-16wbhtr-0 ddFaFV"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c8"
                   color="darkBlue"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Dashboard
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 ldBYos"
+                    aria-hidden={true}
+                    className="c9"
                     color="darkBlue"
                     fill="#00438f"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -625,23 +1474,33 @@ exports[`Storyshots BrandedNavBar With a company logo 1`] = `
               </div>
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sc-16wbhtr-0 ddFaFV"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c8"
                   color="darkBlue"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Inspector
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 ldBYos"
+                    aria-hidden={true}
+                    className="c9"
                     color="darkBlue"
                     fill="#00438f"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -653,23 +1512,33 @@ exports[`Storyshots BrandedNavBar With a company logo 1`] = `
               </div>
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sc-16wbhtr-0 ddFaFV"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c8"
                   color="darkBlue"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Operations
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 ldBYos"
+                    aria-hidden={true}
+                    className="c9"
                     color="darkBlue"
                     fill="#00438f"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -681,7 +1550,7 @@ exports[`Storyshots BrandedNavBar With a company logo 1`] = `
               </div>
               <div>
                 <a
-                  class="DesktopMenu__MenuLink-sc-1a9mp43-1 fqBigT"
+                  className="c10"
                   color="darkBlue"
                   href="/"
                 >
@@ -690,31 +1559,41 @@ exports[`Storyshots BrandedNavBar With a company logo 1`] = `
               </div>
             </nav>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 bqzqvC"
+              className="c11"
             >
               <nav
                 aria-label="Secondary navigation"
-                class="DesktopMenu__Nav-sc-1a9mp43-3 jhGCqC DesktopMenu-sc-1a9mp43-4 jXTSCm"
+                className="c6 c7"
               >
                 <div>
                   <button
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sc-16wbhtr-0 ddFaFV"
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="c8"
                     color="darkBlue"
+                    onBlur={[Function]}
+                    onClick={[Function]}
                     type="button"
                   >
                     User@Nulogy.com
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 ldBYos"
+                      aria-hidden={true}
+                      className="c9"
                       color="darkBlue"
                       fill="#00438f"
-                      focusable="false"
+                      focusable={false}
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px;right:8px"
+                      size="20px"
+                      style={
+                        Object {
+                          "position": "absolute",
+                          "right": "8px",
+                          "top": "11px",
+                        }
+                      }
+                      title={null}
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -726,23 +1605,33 @@ exports[`Storyshots BrandedNavBar With a company logo 1`] = `
                 </div>
                 <div>
                   <button
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sc-16wbhtr-0 ddFaFV"
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="c8"
                     color="darkBlue"
+                    onBlur={[Function]}
+                    onClick={[Function]}
                     type="button"
                   >
                     Settings
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 ldBYos"
+                      aria-hidden={true}
+                      className="c9"
                       color="darkBlue"
                       fill="#00438f"
-                      focusable="false"
+                      focusable={false}
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px;right:8px"
+                      size="20px"
+                      style={
+                        Object {
+                          "position": "absolute",
+                          "right": "8px",
+                          "top": "11px",
+                        }
+                      }
+                      title={null}
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -754,13 +1643,13 @@ exports[`Storyshots BrandedNavBar With a company logo 1`] = `
                 </div>
               </nav>
               <div
-                class="Box-sc-1qu1edy-0 fsLsir"
+                className="c12"
               >
                 <div
-                  class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fIQakI"
+                  className="c13"
                 >
                   <div
-                    class="Box-sc-1qu1edy-0 fBwUqO"
+                    className="c14"
                     height="18px"
                     width="76px"
                   >
@@ -771,10 +1660,10 @@ exports[`Storyshots BrandedNavBar With a company logo 1`] = `
                     >
                       <g
                         fill="none"
-                        fill-rule="evenodd"
+                        fillRule="evenodd"
                         id="FInal"
                         stroke="none"
-                        stroke-width="1"
+                        strokeWidth="1"
                       >
                         <g
                           id="DQI"
@@ -845,65 +1734,326 @@ exports[`Storyshots BrandedNavBar With a company logo 1`] = `
 `;
 
 exports[`Storyshots BrandedNavBar With a company logo and app name 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  max-width: 184px;
+  max-height: 36px;
+}
+
+.c12 {
+  padding-left: 24px;
+}
+
+.c14 {
+  width: 76px;
+  height: 18px;
+}
+
+.c5 {
+  margin-left: 24px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-content: flex-end;
+  -ms-flex-line-pack: end;
+  align-content: flex-end;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  justify-self: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c13 {
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  min-height: 36px;
+  border-radius: 4px;
+  box-shadow: 0px 0px 3px 0px rgba(1,30,56,0.2);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c9 {
+  padding: 2px;
+  color: #00438f;
+  min-width: 20px;
+}
+
+.c15 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 8px;
+  line-height: 10px;
+  font-weight: 500;
+  -webkit-letter-spacing: .5px;
+  -moz-letter-spacing: .5px;
+  -ms-letter-spacing: .5px;
+  letter-spacing: .5px;
+  color: #434d59;
+  text-transform: uppercase;
+}
+
+.c4 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c4:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  font-weight: 500;
+  color: #00438f;
+  border: none;
+  background-color: transparent;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  line-height: 1.5;
+  -webkit-transition: background-color .2s;
+  transition: background-color .2s;
+  font-size: 16px;
+  padding: 8px 28px 8px 16px;
+  border-radius: 4px;
+}
+
+.c8:hover,
+.c8:focus {
+  outline: none;
+  color: #122b47;
+  background-color: #f0f2f5;
+  cursor: pointer;
+}
+
+.c8:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c8:disabled {
+  opacity: .5;
+}
+
+.c10 {
+  display: block;
+  color: #00438f;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: none;
+  background-color: transparent;
+  vertical-align: middle;
+  line-height: 1.5;
+  font-size: 16px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  font-weight: 500;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c10:hover,
+.c10:focus {
+  outline: none;
+  color: #122b47;
+  background-color: #f0f2f5;
+  cursor: pointer;
+}
+
+.c10:disabled {
+  opacity: .5;
+}
+
+.c10:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c7 div:not(:last-of-type) {
+  margin-right: 8px;
+}
+
+.c2 {
+  background-color: #ffffff;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: white;
+  padding: 8px 24px;
+  box-shadow: 0px 3px 5px 0px rgba(1,30,56,0.1);
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 56px;
+}
+
+.c1 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="NavBarstory__ResetStorybookView-sc-1a6ght2-0 bqKXCt"
+      className="c1"
     >
       <header
-        class="NavBar-sc-1o0etgx-3 jwwFUB"
+        className=""
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 NavBar__NavBarBackground-sc-1o0etgx-0 eRLIKf"
+          className="c2"
         >
           <div
-            class="Box-sc-1qu1edy-0 cRMmlC"
+            className="c3"
           >
             <a
               aria-label="Home"
-              class="Link-sc-1lpx3d0-0 clvBNI"
+              className="c4"
               color="blue"
-              font-size="medium"
+              fontSize="medium"
               href="/"
-              style="display:block"
+              style={
+                Object {
+                  "display": "block",
+                }
+              }
             >
               <img
                 alt=""
                 src="http://pigment.github.io/fake-logos/logos/vector/color/auto-speed.svg"
-                style="max-width:184px;max-height:36px"
+                style={
+                  Object {
+                    "maxHeight": "36px",
+                    "maxWidth": "184px",
+                  }
+                }
               />
             </a>
           </div>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 csbfff"
+            className="c5"
           >
             <nav
               aria-label="Primary navigation"
-              class="DesktopMenu__Nav-sc-1a9mp43-3 jhGCqC DesktopMenu-sc-1a9mp43-4 jXTSCm"
+              className="c6 c7"
             >
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sc-16wbhtr-0 ddFaFV"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c8"
                   color="darkBlue"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Dashboard
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 ldBYos"
+                    aria-hidden={true}
+                    className="c9"
                     color="darkBlue"
                     fill="#00438f"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -915,23 +2065,33 @@ exports[`Storyshots BrandedNavBar With a company logo and app name 1`] = `
               </div>
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sc-16wbhtr-0 ddFaFV"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c8"
                   color="darkBlue"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Inspector
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 ldBYos"
+                    aria-hidden={true}
+                    className="c9"
                     color="darkBlue"
                     fill="#00438f"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -943,23 +2103,33 @@ exports[`Storyshots BrandedNavBar With a company logo and app name 1`] = `
               </div>
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sc-16wbhtr-0 ddFaFV"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c8"
                   color="darkBlue"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Operations
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 ldBYos"
+                    aria-hidden={true}
+                    className="c9"
                     color="darkBlue"
                     fill="#00438f"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -971,7 +2141,7 @@ exports[`Storyshots BrandedNavBar With a company logo and app name 1`] = `
               </div>
               <div>
                 <a
-                  class="DesktopMenu__MenuLink-sc-1a9mp43-1 fqBigT"
+                  className="c10"
                   color="darkBlue"
                   href="/"
                 >
@@ -980,31 +2150,41 @@ exports[`Storyshots BrandedNavBar With a company logo and app name 1`] = `
               </div>
             </nav>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 bqzqvC"
+              className="c11"
             >
               <nav
                 aria-label="Secondary navigation"
-                class="DesktopMenu__Nav-sc-1a9mp43-3 jhGCqC DesktopMenu-sc-1a9mp43-4 jXTSCm"
+                className="c6 c7"
               >
                 <div>
                   <button
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sc-16wbhtr-0 ddFaFV"
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="c8"
                     color="darkBlue"
+                    onBlur={[Function]}
+                    onClick={[Function]}
                     type="button"
                   >
                     User@Nulogy.com
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 ldBYos"
+                      aria-hidden={true}
+                      className="c9"
                       color="darkBlue"
                       fill="#00438f"
-                      focusable="false"
+                      focusable={false}
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px;right:8px"
+                      size="20px"
+                      style={
+                        Object {
+                          "position": "absolute",
+                          "right": "8px",
+                          "top": "11px",
+                        }
+                      }
+                      title={null}
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -1016,23 +2196,33 @@ exports[`Storyshots BrandedNavBar With a company logo and app name 1`] = `
                 </div>
                 <div>
                   <button
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sc-16wbhtr-0 ddFaFV"
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="c8"
                     color="darkBlue"
+                    onBlur={[Function]}
+                    onClick={[Function]}
                     type="button"
                   >
                     Settings
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 ldBYos"
+                      aria-hidden={true}
+                      className="c9"
                       color="darkBlue"
                       fill="#00438f"
-                      focusable="false"
+                      focusable={false}
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px;right:8px"
+                      size="20px"
+                      style={
+                        Object {
+                          "position": "absolute",
+                          "right": "8px",
+                          "top": "11px",
+                        }
+                      }
+                      title={null}
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -1044,13 +2234,13 @@ exports[`Storyshots BrandedNavBar With a company logo and app name 1`] = `
                 </div>
               </nav>
               <div
-                class="Box-sc-1qu1edy-0 fsLsir"
+                className="c12"
               >
                 <div
-                  class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 lfrZjs"
+                  className="c13"
                 >
                   <div
-                    class="Box-sc-1qu1edy-0 fBwUqO"
+                    className="c14"
                     height="18px"
                     width="76px"
                   >
@@ -1061,10 +2251,10 @@ exports[`Storyshots BrandedNavBar With a company logo and app name 1`] = `
                     >
                       <g
                         fill="none"
-                        fill-rule="evenodd"
+                        fillRule="evenodd"
                         id="FInal"
                         stroke="none"
-                        stroke-width="1"
+                        strokeWidth="1"
                       >
                         <g
                           id="DQI"
@@ -1124,11 +2314,12 @@ exports[`Storyshots BrandedNavBar With a company logo and app name 1`] = `
                     </svg>
                   </div>
                   <p
-                    class="Text-sc-1wu7vpu-0 hqOtAf"
+                    className="c15"
                     color="darkGrey"
-                    font-size="8px"
-                    font-weight="medium"
-                    letter-spacing=".5px"
+                    disabled={false}
+                    fontSize="8px"
+                    fontWeight="medium"
+                    letterSpacing=".5px"
                   >
                     Quality control
                   </p>
@@ -1144,38 +2335,302 @@ exports[`Storyshots BrandedNavBar With a company logo and app name 1`] = `
 `;
 
 exports[`Storyshots BrandedNavBar With app name 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  max-width: 184px;
+  max-height: 36px;
+}
+
+.c6 {
+  padding-top: 0;
+  padding-bottom: 0;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c8 {
+  margin-left: 24px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-content: flex-end;
+  -ms-flex-line-pack: end;
+  align-content: flex-end;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  justify-self: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c12 {
+  padding: 2px;
+  color: #00438f;
+  min-width: 20px;
+}
+
+.c4 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c4:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
+.c7 {
+  color: #0E77D2;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 500;
+  -webkit-letter-spacing: 0.0333em;
+  -moz-letter-spacing: 0.0333em;
+  -ms-letter-spacing: 0.0333em;
+  letter-spacing: 0.0333em;
+  text-transform: uppercase;
+  font-size: 10px;
+  line-height: 12px;
+  white-space: nowrap;
+}
+
+.c7 active {
+  color: #0E77D2;
+}
+
+.c7 visited {
+  color: #0E77D2;
+}
+
+.c5 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  font-weight: 500;
+  color: #00438f;
+  border: none;
+  background-color: transparent;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  line-height: 1.5;
+  -webkit-transition: background-color .2s;
+  transition: background-color .2s;
+  font-size: 16px;
+  padding: 8px 28px 8px 16px;
+  border-radius: 4px;
+}
+
+.c11:hover,
+.c11:focus {
+  outline: none;
+  color: #122b47;
+  background-color: #f0f2f5;
+  cursor: pointer;
+}
+
+.c11:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c11:disabled {
+  opacity: .5;
+}
+
+.c13 {
+  display: block;
+  color: #00438f;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: none;
+  background-color: transparent;
+  vertical-align: middle;
+  line-height: 1.5;
+  font-size: 16px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  font-weight: 500;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c13:hover,
+.c13:focus {
+  outline: none;
+  color: #122b47;
+  background-color: #f0f2f5;
+  cursor: pointer;
+}
+
+.c13:disabled {
+  opacity: .5;
+}
+
+.c13:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c10 div:not(:last-of-type) {
+  margin-right: 8px;
+}
+
+.c2 {
+  background-color: #ffffff;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: white;
+  padding: 8px 24px;
+  box-shadow: 0px 3px 5px 0px rgba(1,30,56,0.1);
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: 56px;
+}
+
+.c1 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="NavBarstory__ResetStorybookView-sc-1a6ght2-0 bqKXCt"
+      className="c1"
     >
       <header
-        class="NavBar-sc-1o0etgx-3 jwwFUB"
+        className=""
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 NavBar__NavBarBackground-sc-1o0etgx-0 eRLIKf"
+          className="c2"
         >
           <div
-            class="Box-sc-1qu1edy-0 cRMmlC"
+            className="c3"
           >
             <a
               aria-label="Home"
-              class="Link-sc-1lpx3d0-0 clvBNI"
+              className="c4"
               color="blue"
-              font-size="medium"
+              fontSize="medium"
               href="/"
-              style="display:block"
+              style={
+                Object {
+                  "display": "block",
+                }
+              }
             >
               <div
-                class="Branding__BrandingWrap-ranqri-0 kLCNLY Branding-ranqri-2 kQRWHN"
+                className="c5 "
+                size="small"
               >
                 <svg
                   height="24px"
-                  style="display:block"
+                  style={
+                    Object {
+                      "display": "block",
+                      "margin": null,
+                    }
+                  }
                   viewBox="0 0 133 32"
                   width="100px"
                 >
@@ -1209,12 +2664,18 @@ exports[`Storyshots BrandedNavBar With app name 1`] = `
                   </g>
                 </svg>
                 <div
-                  class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 ctbZXD"
+                  className="c6"
                   width="100%"
                 >
                   <span
-                    class="BrandingText-nluvkd-0 cboEiS"
-                    style="margin-left:;margin-right:4px"
+                    className="c7"
+                    size="small"
+                    style={
+                      Object {
+                        "marginLeft": false,
+                        "marginRight": "4px",
+                      }
+                    }
                   >
                     Quality Control
                   </span>
@@ -1223,31 +2684,41 @@ exports[`Storyshots BrandedNavBar With app name 1`] = `
             </a>
           </div>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 csbfff"
+            className="c8"
           >
             <nav
               aria-label="Primary navigation"
-              class="DesktopMenu__Nav-sc-1a9mp43-3 jhGCqC DesktopMenu-sc-1a9mp43-4 jXTSCm"
+              className="c9 c10"
             >
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sc-16wbhtr-0 ddFaFV"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c11"
                   color="darkBlue"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Dashboard
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 ldBYos"
+                    aria-hidden={true}
+                    className="c12"
                     color="darkBlue"
                     fill="#00438f"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -1259,23 +2730,33 @@ exports[`Storyshots BrandedNavBar With app name 1`] = `
               </div>
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sc-16wbhtr-0 ddFaFV"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c11"
                   color="darkBlue"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Inspector
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 ldBYos"
+                    aria-hidden={true}
+                    className="c12"
                     color="darkBlue"
                     fill="#00438f"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -1287,23 +2768,33 @@ exports[`Storyshots BrandedNavBar With app name 1`] = `
               </div>
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sc-16wbhtr-0 ddFaFV"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c11"
                   color="darkBlue"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Operations
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 ldBYos"
+                    aria-hidden={true}
+                    className="c12"
                     color="darkBlue"
                     fill="#00438f"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -1315,7 +2806,7 @@ exports[`Storyshots BrandedNavBar With app name 1`] = `
               </div>
               <div>
                 <a
-                  class="DesktopMenu__MenuLink-sc-1a9mp43-1 fqBigT"
+                  className="c13"
                   color="darkBlue"
                   href="/"
                 >
@@ -1324,31 +2815,41 @@ exports[`Storyshots BrandedNavBar With app name 1`] = `
               </div>
             </nav>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 bqzqvC"
+              className="c14"
             >
               <nav
                 aria-label="Secondary navigation"
-                class="DesktopMenu__Nav-sc-1a9mp43-3 jhGCqC DesktopMenu-sc-1a9mp43-4 jXTSCm"
+                className="c9 c10"
               >
                 <div>
                   <button
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sc-16wbhtr-0 ddFaFV"
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="c11"
                     color="darkBlue"
+                    onBlur={[Function]}
+                    onClick={[Function]}
                     type="button"
                   >
                     User@Nulogy.com
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 ldBYos"
+                      aria-hidden={true}
+                      className="c12"
                       color="darkBlue"
                       fill="#00438f"
-                      focusable="false"
+                      focusable={false}
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px;right:8px"
+                      size="20px"
+                      style={
+                        Object {
+                          "position": "absolute",
+                          "right": "8px",
+                          "top": "11px",
+                        }
+                      }
+                      title={null}
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -1360,23 +2861,33 @@ exports[`Storyshots BrandedNavBar With app name 1`] = `
                 </div>
                 <div>
                   <button
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sc-16wbhtr-0 ddFaFV"
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="c11"
                     color="darkBlue"
+                    onBlur={[Function]}
+                    onClick={[Function]}
                     type="button"
                   >
                     Settings
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 ldBYos"
+                      aria-hidden={true}
+                      className="c12"
                       color="darkBlue"
                       fill="#00438f"
-                      focusable="false"
+                      focusable={false}
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px;right:8px"
+                      size="20px"
+                      style={
+                        Object {
+                          "position": "absolute",
+                          "right": "8px",
+                          "top": "11px",
+                        }
+                      }
+                      title={null}
                       viewBox="0 0 24 24"
                       width="20px"
                     >

--- a/components/src/Branding/__snapshots__/Branding.story.storyshot
+++ b/components/src/Branding/__snapshots__/Branding.story.storyshot
@@ -1,25 +1,371 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Branding Branding 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c2 {
+  padding: 16px;
+  width: 50%;
+}
+
+.c9 {
+  background-color: #011e38;
+  padding: 16px;
+  width: 50%;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c5 {
+  padding-top: 2px;
+  padding-bottom: 2px;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c8 {
+  padding-top: 6px;
+  padding-bottom: 6px;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c12 {
+  margin-top: 16px;
+  margin-bottom: 16px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c14 {
+  padding-top: 2px;
+  padding-bottom: 2px;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c16 {
+  padding-top: 2px;
+  padding-bottom: 2px;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c18 {
+  padding-top: 6px;
+  padding-bottom: 6px;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c20 {
+  padding-top: 6px;
+  padding-bottom: 6px;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c6 {
+  color: #0E77D2;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 500;
+  -webkit-letter-spacing: 0.0333em;
+  -moz-letter-spacing: 0.0333em;
+  -ms-letter-spacing: 0.0333em;
+  letter-spacing: 0.0333em;
+  text-transform: uppercase;
+  font-size: 11px;
+  line-height: 12px;
+  white-space: nowrap;
+}
+
+.c6 active {
+  color: #0E77D2;
+}
+
+.c6 visited {
+  color: #0E77D2;
+}
+
+.c10 {
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 500;
+  -webkit-letter-spacing: 0.0333em;
+  -moz-letter-spacing: 0.0333em;
+  -ms-letter-spacing: 0.0333em;
+  letter-spacing: 0.0333em;
+  text-transform: uppercase;
+  font-size: 11px;
+  line-height: 12px;
+  white-space: nowrap;
+}
+
+.c10 active {
+  color: #ffffff;
+}
+
+.c10 visited {
+  color: #ffffff;
+}
+
+.c3 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c4 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding: 2px 0;
+}
+
+.c13 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 2px 0;
+}
+
+.c15 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  padding: 2px 0;
+}
+
+.c17 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c19 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c7 {
+  position: relative;
+  width: 100%;
+}
+
+.c7:before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 0;
+  border-top: 1px solid #e1ebfa;
+  background: #e1ebfa;
+  width: 100%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+}
+
+.c11 {
+  position: relative;
+  width: 100%;
+}
+
+.c11:before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 0;
+  border-top: 1px solid #e4e7eb;
+  background: #e4e7eb;
+  width: 100%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+      className="c1"
     >
       <div
-        class="Box-sc-1qu1edy-0 cqHFoz"
-        width="0.5"
+        className="c2"
+        width={0.5}
       >
         <div
-          class="Branding__BrandingWrap-ranqri-0 kLCNLY Branding-ranqri-2 kQRWHN"
+          className="c3 "
+          size="small"
         >
           <svg
             height="24px"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+                "margin": null,
+              }
+            }
             viewBox="0 0 133 32"
             width="100px"
           >
@@ -56,11 +402,17 @@ exports[`Storyshots Branding Branding 1`] = `
         <br />
         <br />
         <div
-          class="Branding__BrandingWrap-ranqri-0 gACiZG Branding-ranqri-2 kQRWHN"
+          className="c4 "
+          size="medium"
         >
           <svg
             height="32px"
-            style="display:block;margin:2px 0"
+            style={
+              Object {
+                "display": "block",
+                "margin": "2px 0",
+              }
+            }
             viewBox="0 0 133 32"
             width="133px"
           >
@@ -97,11 +449,17 @@ exports[`Storyshots Branding Branding 1`] = `
         <br />
         <br />
         <div
-          class="Branding__BrandingWrap-ranqri-0 gACiZG Branding-ranqri-2 kQRWHN"
+          className="c4 "
+          size="medium"
         >
           <svg
             height="32px"
-            style="display:block;margin:2px 0"
+            style={
+              Object {
+                "display": "block",
+                "margin": "2px 0",
+              }
+            }
             viewBox="0 0 37 32"
             width="37px"
           >
@@ -114,11 +472,17 @@ exports[`Storyshots Branding Branding 1`] = `
         <br />
         <br />
         <div
-          class="Branding__BrandingWrap-ranqri-0 gACiZG Branding-ranqri-2 kQRWHN"
+          className="c4 "
+          size="medium"
         >
           <svg
             height="32px"
-            style="display:block;margin:2px 0"
+            style={
+              Object {
+                "display": "block",
+                "margin": "2px 0",
+              }
+            }
             viewBox="0 0 133 32"
             width="133px"
           >
@@ -152,12 +516,18 @@ exports[`Storyshots Branding Branding 1`] = `
             </g>
           </svg>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hfSUkz"
+            className="c5"
             width="100%"
           >
             <span
-              class="BrandingText-nluvkd-0 TxcJr"
-              style="margin-left:;margin-right:4px"
+              className="c6"
+              size="medium"
+              style={
+                Object {
+                  "marginLeft": false,
+                  "marginRight": "4px",
+                }
+              }
             >
               Logo Subtext
             </span>
@@ -166,11 +536,17 @@ exports[`Storyshots Branding Branding 1`] = `
         <br />
         <br />
         <div
-          class="Branding__BrandingWrap-ranqri-0 gACiZG Branding-ranqri-2 kQRWHN"
+          className="c4 "
+          size="medium"
         >
           <svg
             height="32px"
-            style="display:block;margin:2px 0"
+            style={
+              Object {
+                "display": "block",
+                "margin": "2px 0",
+              }
+            }
             viewBox="0 0 133 32"
             width="133px"
           >
@@ -204,28 +580,40 @@ exports[`Storyshots Branding Branding 1`] = `
             </g>
           </svg>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hfSUkz"
+            className="c5"
             width="100%"
           >
             <span
-              class="BrandingText-nluvkd-0 TxcJr"
-              style="margin-left:;margin-right:4px"
+              className="c6"
+              size="medium"
+              style={
+                Object {
+                  "marginLeft": false,
+                  "marginRight": "4px",
+                }
+              }
             >
               Logo Subtext
             </span>
             <div
-              class="Branding__Line-ranqri-1 gfZuug"
+              className="c7"
             />
           </div>
         </div>
         <br />
         <br />
         <div
-          class="Branding__BrandingWrap-ranqri-0 kLCNLY Branding-ranqri-2 kQRWHN"
+          className="c3 "
+          size="large"
         >
           <svg
             height="48px"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+                "margin": null,
+              }
+            }
             viewBox="0 0 133 32"
             width="200px"
           >
@@ -262,11 +650,17 @@ exports[`Storyshots Branding Branding 1`] = `
         <br />
         <br />
         <div
-          class="Branding__BrandingWrap-ranqri-0 kLCNLY Branding-ranqri-2 kQRWHN"
+          className="c3 "
+          size="large"
         >
           <svg
             height="48px"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+                "margin": null,
+              }
+            }
             viewBox="0 0 37 32"
             width="56px"
           >
@@ -279,11 +673,17 @@ exports[`Storyshots Branding Branding 1`] = `
         <br />
         <br />
         <div
-          class="Branding__BrandingWrap-ranqri-0 kLCNLY Branding-ranqri-2 kQRWHN"
+          className="c3 "
+          size="large"
         >
           <svg
             height="48px"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+                "margin": null,
+              }
+            }
             viewBox="0 0 133 32"
             width="200px"
           >
@@ -317,12 +717,18 @@ exports[`Storyshots Branding Branding 1`] = `
             </g>
           </svg>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 exzrEz"
+            className="c8"
             width="100%"
           >
             <span
-              class="BrandingText-nluvkd-0 TxcJr"
-              style="margin-left:;margin-right:4px"
+              className="c6"
+              size="large"
+              style={
+                Object {
+                  "marginLeft": false,
+                  "marginRight": "4px",
+                }
+              }
             >
               Logo Subtext
             </span>
@@ -331,11 +737,17 @@ exports[`Storyshots Branding Branding 1`] = `
         <br />
         <br />
         <div
-          class="Branding__BrandingWrap-ranqri-0 kLCNLY Branding-ranqri-2 kQRWHN"
+          className="c3 "
+          size="large"
         >
           <svg
             height="48px"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+                "margin": null,
+              }
+            }
             viewBox="0 0 133 32"
             width="200px"
           >
@@ -369,31 +781,43 @@ exports[`Storyshots Branding Branding 1`] = `
             </g>
           </svg>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 exzrEz"
+            className="c8"
             width="100%"
           >
             <span
-              class="BrandingText-nluvkd-0 TxcJr"
-              style="margin-left:;margin-right:4px"
+              className="c6"
+              size="large"
+              style={
+                Object {
+                  "marginLeft": false,
+                  "marginRight": "4px",
+                }
+              }
             >
               Logo Subtext
             </span>
             <div
-              class="Branding__Line-ranqri-1 gfZuug"
+              className="c7"
             />
           </div>
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 cNiTF"
-        width="0.5"
+        className="c9"
+        width={0.5}
       >
         <div
-          class="Branding__BrandingWrap-ranqri-0 gACiZG Branding-ranqri-2 kQRWHN"
+          className="c4 "
+          size="medium"
         >
           <svg
             height="32px"
-            style="display:block;margin:2px 0"
+            style={
+              Object {
+                "display": "block",
+                "margin": "2px 0",
+              }
+            }
             viewBox="0 0 133 32"
             width="133px"
           >
@@ -430,11 +854,17 @@ exports[`Storyshots Branding Branding 1`] = `
         <br />
         <br />
         <div
-          class="Branding__BrandingWrap-ranqri-0 gACiZG Branding-ranqri-2 kQRWHN"
+          className="c4 "
+          size="medium"
         >
           <svg
             height="32px"
-            style="display:block;margin:2px 0"
+            style={
+              Object {
+                "display": "block",
+                "margin": "2px 0",
+              }
+            }
             viewBox="0 0 37 32"
             width="37px"
           >
@@ -447,11 +877,17 @@ exports[`Storyshots Branding Branding 1`] = `
         <br />
         <br />
         <div
-          class="Branding__BrandingWrap-ranqri-0 gACiZG Branding-ranqri-2 kQRWHN"
+          className="c4 "
+          size="medium"
         >
           <svg
             height="32px"
-            style="display:block;margin:2px 0"
+            style={
+              Object {
+                "display": "block",
+                "margin": "2px 0",
+              }
+            }
             viewBox="0 0 133 32"
             width="133px"
           >
@@ -485,12 +921,18 @@ exports[`Storyshots Branding Branding 1`] = `
             </g>
           </svg>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hfSUkz"
+            className="c5"
             width="100%"
           >
             <span
-              class="BrandingText-nluvkd-0 klrjtc"
-              style="margin-left:;margin-right:4px"
+              className="c10"
+              size="medium"
+              style={
+                Object {
+                  "marginLeft": false,
+                  "marginRight": "4px",
+                }
+              }
             >
               Logo Subtext
             </span>
@@ -499,11 +941,17 @@ exports[`Storyshots Branding Branding 1`] = `
         <br />
         <br />
         <div
-          class="Branding__BrandingWrap-ranqri-0 gACiZG Branding-ranqri-2 kQRWHN"
+          className="c4 "
+          size="medium"
         >
           <svg
             height="32px"
-            style="display:block;margin:2px 0"
+            style={
+              Object {
+                "display": "block",
+                "margin": "2px 0",
+              }
+            }
             viewBox="0 0 133 32"
             width="133px"
           >
@@ -537,28 +985,40 @@ exports[`Storyshots Branding Branding 1`] = `
             </g>
           </svg>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hfSUkz"
+            className="c5"
             width="100%"
           >
             <span
-              class="BrandingText-nluvkd-0 klrjtc"
-              style="margin-left:;margin-right:4px"
+              className="c10"
+              size="medium"
+              style={
+                Object {
+                  "marginLeft": false,
+                  "marginRight": "4px",
+                }
+              }
             >
               Logo Subtext
             </span>
             <div
-              class="Branding__Line-ranqri-1 iooZEo"
+              className="c11"
             />
           </div>
         </div>
         <br />
         <br />
         <div
-          class="Branding__BrandingWrap-ranqri-0 kLCNLY Branding-ranqri-2 kQRWHN"
+          className="c3 "
+          size="large"
         >
           <svg
             height="48px"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+                "margin": null,
+              }
+            }
             viewBox="0 0 133 32"
             width="200px"
           >
@@ -595,11 +1055,17 @@ exports[`Storyshots Branding Branding 1`] = `
         <br />
         <br />
         <div
-          class="Branding__BrandingWrap-ranqri-0 kLCNLY Branding-ranqri-2 kQRWHN"
+          className="c3 "
+          size="large"
         >
           <svg
             height="48px"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+                "margin": null,
+              }
+            }
             viewBox="0 0 37 32"
             width="56px"
           >
@@ -612,11 +1078,17 @@ exports[`Storyshots Branding Branding 1`] = `
         <br />
         <br />
         <div
-          class="Branding__BrandingWrap-ranqri-0 kLCNLY Branding-ranqri-2 kQRWHN"
+          className="c3 "
+          size="large"
         >
           <svg
             height="48px"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+                "margin": null,
+              }
+            }
             viewBox="0 0 133 32"
             width="200px"
           >
@@ -650,12 +1122,18 @@ exports[`Storyshots Branding Branding 1`] = `
             </g>
           </svg>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 exzrEz"
+            className="c8"
             width="100%"
           >
             <span
-              class="BrandingText-nluvkd-0 klrjtc"
-              style="margin-left:;margin-right:4px"
+              className="c10"
+              size="large"
+              style={
+                Object {
+                  "marginLeft": false,
+                  "marginRight": "4px",
+                }
+              }
             >
               Logo Subtext
             </span>
@@ -664,11 +1142,17 @@ exports[`Storyshots Branding Branding 1`] = `
         <br />
         <br />
         <div
-          class="Branding__BrandingWrap-ranqri-0 kLCNLY Branding-ranqri-2 kQRWHN"
+          className="c3 "
+          size="large"
         >
           <svg
             height="48px"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+                "margin": null,
+              }
+            }
             viewBox="0 0 133 32"
             width="200px"
           >
@@ -702,31 +1186,43 @@ exports[`Storyshots Branding Branding 1`] = `
             </g>
           </svg>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 exzrEz"
+            className="c8"
             width="100%"
           >
             <span
-              class="BrandingText-nluvkd-0 klrjtc"
-              style="margin-left:;margin-right:4px"
+              className="c10"
+              size="large"
+              style={
+                Object {
+                  "marginLeft": false,
+                  "marginRight": "4px",
+                }
+              }
             >
               Logo Subtext
             </span>
             <div
-              class="Branding__Line-ranqri-1 iooZEo"
+              className="c11"
             />
           </div>
         </div>
       </div>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iPsInh"
+      className="c12"
     >
       <div
-        class="Branding__BrandingWrap-ranqri-0 gACiZG Branding-ranqri-2 kQRWHN"
+        className="c4 "
+        size="medium"
       >
         <svg
           height="32px"
-          style="display:block;margin:2px 0"
+          style={
+            Object {
+              "display": "block",
+              "margin": "2px 0",
+            }
+          }
           viewBox="0 0 133 32"
           width="133px"
         >
@@ -760,23 +1256,35 @@ exports[`Storyshots Branding Branding 1`] = `
           </g>
         </svg>
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hfSUkz"
+          className="c5"
           width="100%"
         >
           <span
-            class="BrandingText-nluvkd-0 TxcJr"
-            style="margin-left:;margin-right:4px"
+            className="c6"
+            size="medium"
+            style={
+              Object {
+                "marginLeft": false,
+                "marginRight": "4px",
+              }
+            }
           >
             Left Align
           </span>
         </div>
       </div>
       <div
-        class="Branding__BrandingWrap-ranqri-0 heEDKn Branding-ranqri-2 kQRWHN"
+        className="c13 "
+        size="medium"
       >
         <svg
           height="32px"
-          style="display:block;margin:2px 0"
+          style={
+            Object {
+              "display": "block",
+              "margin": "2px 0",
+            }
+          }
           viewBox="0 0 133 32"
           width="133px"
         >
@@ -810,23 +1318,35 @@ exports[`Storyshots Branding Branding 1`] = `
           </g>
         </svg>
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 enlTuW"
+          className="c14"
           width="100%"
         >
           <span
-            class="BrandingText-nluvkd-0 TxcJr"
-            style="margin-left:4px;margin-right:4px"
+            className="c6"
+            size="medium"
+            style={
+              Object {
+                "marginLeft": "4px",
+                "marginRight": "4px",
+              }
+            }
           >
             Center Align
           </span>
         </div>
       </div>
       <div
-        class="Branding__BrandingWrap-ranqri-0 bOWbLF Branding-ranqri-2 kQRWHN"
+        className="c15 "
+        size="medium"
       >
         <svg
           height="32px"
-          style="display:block;margin:2px 0"
+          style={
+            Object {
+              "display": "block",
+              "margin": "2px 0",
+            }
+          }
           viewBox="0 0 133 32"
           width="133px"
         >
@@ -860,12 +1380,18 @@ exports[`Storyshots Branding Branding 1`] = `
           </g>
         </svg>
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iDtevk"
+          className="c16"
           width="100%"
         >
           <span
-            class="BrandingText-nluvkd-0 TxcJr"
-            style="margin-left:4px;margin-right:"
+            className="c6"
+            size="medium"
+            style={
+              Object {
+                "marginLeft": "4px",
+                "marginRight": false,
+              }
+            }
           >
             Right Align
           </span>
@@ -873,14 +1399,20 @@ exports[`Storyshots Branding Branding 1`] = `
       </div>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iPsInh"
+      className="c12"
     >
       <div
-        class="Branding__BrandingWrap-ranqri-0 gACiZG Branding-ranqri-2 kQRWHN"
+        className="c4 "
+        size="medium"
       >
         <svg
           height="32px"
-          style="display:block;margin:2px 0"
+          style={
+            Object {
+              "display": "block",
+              "margin": "2px 0",
+            }
+          }
           viewBox="0 0 133 32"
           width="133px"
         >
@@ -914,26 +1446,38 @@ exports[`Storyshots Branding Branding 1`] = `
           </g>
         </svg>
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hfSUkz"
+          className="c5"
           width="100%"
         >
           <span
-            class="BrandingText-nluvkd-0 TxcJr"
-            style="margin-left:;margin-right:4px"
+            className="c6"
+            size="medium"
+            style={
+              Object {
+                "marginLeft": false,
+                "marginRight": "4px",
+              }
+            }
           >
             Left Align
           </span>
           <div
-            class="Branding__Line-ranqri-1 gfZuug"
+            className="c7"
           />
         </div>
       </div>
       <div
-        class="Branding__BrandingWrap-ranqri-0 heEDKn Branding-ranqri-2 kQRWHN"
+        className="c13 "
+        size="medium"
       >
         <svg
           height="32px"
-          style="display:block;margin:2px 0"
+          style={
+            Object {
+              "display": "block",
+              "margin": "2px 0",
+            }
+          }
           viewBox="0 0 133 32"
           width="133px"
         >
@@ -967,29 +1511,41 @@ exports[`Storyshots Branding Branding 1`] = `
           </g>
         </svg>
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 enlTuW"
+          className="c14"
           width="100%"
         >
           <div
-            class="Branding__Line-ranqri-1 gfZuug"
+            className="c7"
           />
           <span
-            class="BrandingText-nluvkd-0 TxcJr"
-            style="margin-left:4px;margin-right:4px"
+            className="c6"
+            size="medium"
+            style={
+              Object {
+                "marginLeft": "4px",
+                "marginRight": "4px",
+              }
+            }
           >
             Center Align
           </span>
           <div
-            class="Branding__Line-ranqri-1 gfZuug"
+            className="c7"
           />
         </div>
       </div>
       <div
-        class="Branding__BrandingWrap-ranqri-0 bOWbLF Branding-ranqri-2 kQRWHN"
+        className="c15 "
+        size="medium"
       >
         <svg
           height="32px"
-          style="display:block;margin:2px 0"
+          style={
+            Object {
+              "display": "block",
+              "margin": "2px 0",
+            }
+          }
           viewBox="0 0 133 32"
           width="133px"
         >
@@ -1023,15 +1579,21 @@ exports[`Storyshots Branding Branding 1`] = `
           </g>
         </svg>
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iDtevk"
+          className="c16"
           width="100%"
         >
           <div
-            class="Branding__Line-ranqri-1 gfZuug"
+            className="c7"
           />
           <span
-            class="BrandingText-nluvkd-0 TxcJr"
-            style="margin-left:4px;margin-right:"
+            className="c6"
+            size="medium"
+            style={
+              Object {
+                "marginLeft": "4px",
+                "marginRight": false,
+              }
+            }
           >
             Right Align
           </span>
@@ -1039,14 +1601,20 @@ exports[`Storyshots Branding Branding 1`] = `
       </div>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iPsInh"
+      className="c12"
     >
       <div
-        class="Branding__BrandingWrap-ranqri-0 kLCNLY Branding-ranqri-2 kQRWHN"
+        className="c3 "
+        size="large"
       >
         <svg
           height="48px"
-          style="display:block"
+          style={
+            Object {
+              "display": "block",
+              "margin": null,
+            }
+          }
           viewBox="0 0 133 32"
           width="200px"
         >
@@ -1080,23 +1648,35 @@ exports[`Storyshots Branding Branding 1`] = `
           </g>
         </svg>
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 exzrEz"
+          className="c8"
           width="100%"
         >
           <span
-            class="BrandingText-nluvkd-0 TxcJr"
-            style="margin-left:;margin-right:4px"
+            className="c6"
+            size="large"
+            style={
+              Object {
+                "marginLeft": false,
+                "marginRight": "4px",
+              }
+            }
           >
             Left Align
           </span>
         </div>
       </div>
       <div
-        class="Branding__BrandingWrap-ranqri-0 yiUfZ Branding-ranqri-2 kQRWHN"
+        className="c17 "
+        size="large"
       >
         <svg
           height="48px"
-          style="display:block"
+          style={
+            Object {
+              "display": "block",
+              "margin": null,
+            }
+          }
           viewBox="0 0 133 32"
           width="200px"
         >
@@ -1130,23 +1710,35 @@ exports[`Storyshots Branding Branding 1`] = `
           </g>
         </svg>
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 kBVTzS"
+          className="c18"
           width="100%"
         >
           <span
-            class="BrandingText-nluvkd-0 TxcJr"
-            style="margin-left:4px;margin-right:4px"
+            className="c6"
+            size="large"
+            style={
+              Object {
+                "marginLeft": "4px",
+                "marginRight": "4px",
+              }
+            }
           >
             Center Align
           </span>
         </div>
       </div>
       <div
-        class="Branding__BrandingWrap-ranqri-0 jTTNBD Branding-ranqri-2 kQRWHN"
+        className="c19 "
+        size="large"
       >
         <svg
           height="48px"
-          style="display:block"
+          style={
+            Object {
+              "display": "block",
+              "margin": null,
+            }
+          }
           viewBox="0 0 133 32"
           width="200px"
         >
@@ -1180,12 +1772,18 @@ exports[`Storyshots Branding Branding 1`] = `
           </g>
         </svg>
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 eEHFdc"
+          className="c20"
           width="100%"
         >
           <span
-            class="BrandingText-nluvkd-0 TxcJr"
-            style="margin-left:4px;margin-right:"
+            className="c6"
+            size="large"
+            style={
+              Object {
+                "marginLeft": "4px",
+                "marginRight": false,
+              }
+            }
           >
             Right Align
           </span>
@@ -1193,14 +1791,20 @@ exports[`Storyshots Branding Branding 1`] = `
       </div>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iPsInh"
+      className="c12"
     >
       <div
-        class="Branding__BrandingWrap-ranqri-0 kLCNLY Branding-ranqri-2 kQRWHN"
+        className="c3 "
+        size="large"
       >
         <svg
           height="48px"
-          style="display:block"
+          style={
+            Object {
+              "display": "block",
+              "margin": null,
+            }
+          }
           viewBox="0 0 133 32"
           width="200px"
         >
@@ -1234,26 +1838,38 @@ exports[`Storyshots Branding Branding 1`] = `
           </g>
         </svg>
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 exzrEz"
+          className="c8"
           width="100%"
         >
           <span
-            class="BrandingText-nluvkd-0 TxcJr"
-            style="margin-left:;margin-right:4px"
+            className="c6"
+            size="large"
+            style={
+              Object {
+                "marginLeft": false,
+                "marginRight": "4px",
+              }
+            }
           >
             Left Align
           </span>
           <div
-            class="Branding__Line-ranqri-1 gfZuug"
+            className="c7"
           />
         </div>
       </div>
       <div
-        class="Branding__BrandingWrap-ranqri-0 yiUfZ Branding-ranqri-2 kQRWHN"
+        className="c17 "
+        size="large"
       >
         <svg
           height="48px"
-          style="display:block"
+          style={
+            Object {
+              "display": "block",
+              "margin": null,
+            }
+          }
           viewBox="0 0 133 32"
           width="200px"
         >
@@ -1287,29 +1903,41 @@ exports[`Storyshots Branding Branding 1`] = `
           </g>
         </svg>
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 kBVTzS"
+          className="c18"
           width="100%"
         >
           <div
-            class="Branding__Line-ranqri-1 gfZuug"
+            className="c7"
           />
           <span
-            class="BrandingText-nluvkd-0 TxcJr"
-            style="margin-left:4px;margin-right:4px"
+            className="c6"
+            size="large"
+            style={
+              Object {
+                "marginLeft": "4px",
+                "marginRight": "4px",
+              }
+            }
           >
             Center Align
           </span>
           <div
-            class="Branding__Line-ranqri-1 gfZuug"
+            className="c7"
           />
         </div>
       </div>
       <div
-        class="Branding__BrandingWrap-ranqri-0 jTTNBD Branding-ranqri-2 kQRWHN"
+        className="c19 "
+        size="large"
       >
         <svg
           height="48px"
-          style="display:block"
+          style={
+            Object {
+              "display": "block",
+              "margin": null,
+            }
+          }
           viewBox="0 0 133 32"
           width="200px"
         >
@@ -1343,15 +1971,21 @@ exports[`Storyshots Branding Branding 1`] = `
           </g>
         </svg>
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 eEHFdc"
+          className="c20"
           width="100%"
         >
           <div
-            class="Branding__Line-ranqri-1 gfZuug"
+            className="c7"
           />
           <span
-            class="BrandingText-nluvkd-0 TxcJr"
-            style="margin-left:4px;margin-right:"
+            className="c6"
+            size="large"
+            style={
+              Object {
+                "marginLeft": "4px",
+                "marginRight": false,
+              }
+            }
           >
             Right Align
           </span>

--- a/components/src/Breadcrumbs/__snapshots__/Breadcrumbs.story.storyshot
+++ b/components/src/Breadcrumbs/__snapshots__/Breadcrumbs.story.storyshot
@@ -1,42 +1,143 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Breadcrumbs Breadcrumbs 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c6 {
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c4 {
+  color: #00438f;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c4:hover {
+  cursor: pointer;
+  color: #002b5c;
+}
+
+.c3 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  color: #434d59;
+}
+
+.c3 a:visited {
+  color: #00438f;
+}
+
+.c5 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  color: #434d59;
+  padding-left: 8px;
+  padding-right: 8px;
+}
+
+.c5 a:visited {
+  color: #00438f;
+}
+
+.c2 {
+  margin: 0;
+  padding: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <nav
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+      className="Box-sc-1qu1edy-0 c1"
     >
       <ol
-        class="Breadcrumbs__StyledOl-sc-1l75jcp-1 huaGZO"
+        className="c2"
       >
         <li
-          class="Breadcrumbs__StyledLi-sc-1l75jcp-0 dYpvAr"
+          className="c3"
         >
           <a
-            class="Link-sc-1lpx3d0-0 hcsgot"
+            className="c4"
             color="darkBlue"
-            font-size="medium"
+            fontSize="medium"
             href="/"
           >
             Home
           </a>
         </li>
         <li
-          aria-hidden="true"
-          class="Breadcrumbs__StyledLi-sc-1l75jcp-0 cLdMxg seperator"
+          aria-hidden={true}
+          className="c5 seperator"
         >
           <svg
-            aria-hidden="true"
-            class="Icon-fc7twp-0 dkBAgY"
+            aria-hidden={true}
+            className="c6"
             color="currentColor"
             fill="currentColor"
-            focusable="false"
+            focusable={false}
             height="24px"
             icon="rightArrow"
+            size="24px"
+            title={null}
             viewBox="0 0 24 24"
             width="24px"
           >
@@ -46,29 +147,31 @@ exports[`Storyshots Breadcrumbs Breadcrumbs 1`] = `
           </svg>
         </li>
         <li
-          class="Breadcrumbs__StyledLi-sc-1l75jcp-0 dYpvAr"
+          className="c3"
         >
           <a
-            class="Link-sc-1lpx3d0-0 hcsgot"
+            className="c4"
             color="darkBlue"
-            font-size="medium"
+            fontSize="medium"
             href="/Tenants"
           >
             Tenants
           </a>
         </li>
         <li
-          aria-hidden="true"
-          class="Breadcrumbs__StyledLi-sc-1l75jcp-0 cLdMxg seperator"
+          aria-hidden={true}
+          className="c5 seperator"
         >
           <svg
-            aria-hidden="true"
-            class="Icon-fc7twp-0 dkBAgY"
+            aria-hidden={true}
+            className="c6"
             color="currentColor"
             fill="currentColor"
-            focusable="false"
+            focusable={false}
             height="24px"
             icon="rightArrow"
+            size="24px"
+            title={null}
             viewBox="0 0 24 24"
             width="24px"
           >
@@ -84,42 +187,151 @@ exports[`Storyshots Breadcrumbs Breadcrumbs 1`] = `
 `;
 
 exports[`Storyshots Breadcrumbs without link 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c6 {
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c7 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: #00438f;
+}
+
+.c4 {
+  color: #00438f;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c4:hover {
+  cursor: pointer;
+  color: #002b5c;
+}
+
+.c3 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  color: #434d59;
+}
+
+.c3 a:visited {
+  color: #00438f;
+}
+
+.c5 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  color: #434d59;
+  padding-left: 8px;
+  padding-right: 8px;
+}
+
+.c5 a:visited {
+  color: #00438f;
+}
+
+.c2 {
+  margin: 0;
+  padding: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <nav
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+      className="Box-sc-1qu1edy-0 c1"
     >
       <ol
-        class="Breadcrumbs__StyledOl-sc-1l75jcp-1 huaGZO"
+        className="c2"
       >
         <li
-          class="Breadcrumbs__StyledLi-sc-1l75jcp-0 dYpvAr"
+          className="c3"
         >
           <a
-            class="Link-sc-1lpx3d0-0 hcsgot"
+            className="c4"
             color="darkBlue"
-            font-size="medium"
+            fontSize="medium"
             href="/"
           >
             Home
           </a>
         </li>
         <li
-          aria-hidden="true"
-          class="Breadcrumbs__StyledLi-sc-1l75jcp-0 cLdMxg seperator"
+          aria-hidden={true}
+          className="c5 seperator"
         >
           <svg
-            aria-hidden="true"
-            class="Icon-fc7twp-0 dkBAgY"
+            aria-hidden={true}
+            className="c6"
             color="currentColor"
             fill="currentColor"
-            focusable="false"
+            focusable={false}
             height="24px"
             icon="rightArrow"
+            size="24px"
+            title={null}
             viewBox="0 0 24 24"
             width="24px"
           >
@@ -129,29 +341,31 @@ exports[`Storyshots Breadcrumbs without link 1`] = `
           </svg>
         </li>
         <li
-          class="Breadcrumbs__StyledLi-sc-1l75jcp-0 dYpvAr"
+          className="c3"
         >
           <a
-            class="Link-sc-1lpx3d0-0 hcsgot"
+            className="c4"
             color="darkBlue"
-            font-size="medium"
+            fontSize="medium"
             href="/Tenants"
           >
             Tenants
           </a>
         </li>
         <li
-          aria-hidden="true"
-          class="Breadcrumbs__StyledLi-sc-1l75jcp-0 cLdMxg seperator"
+          aria-hidden={true}
+          className="c5 seperator"
         >
           <svg
-            aria-hidden="true"
-            class="Icon-fc7twp-0 dkBAgY"
+            aria-hidden={true}
+            className="c6"
             color="currentColor"
             fill="currentColor"
-            focusable="false"
+            focusable={false}
             height="24px"
             icon="rightArrow"
+            size="24px"
+            title={null}
             viewBox="0 0 24 24"
             width="24px"
           >
@@ -161,28 +375,31 @@ exports[`Storyshots Breadcrumbs without link 1`] = `
           </svg>
         </li>
         <li
-          class="Breadcrumbs__StyledLi-sc-1l75jcp-0 dYpvAr"
+          className="c3"
         >
           <p
-            class="Text-sc-1wu7vpu-0 kNhVLU"
+            className="c7"
             color="darkBlue"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Current Tenant
           </p>
         </li>
         <li
-          aria-hidden="true"
-          class="Breadcrumbs__StyledLi-sc-1l75jcp-0 cLdMxg seperator"
+          aria-hidden={true}
+          className="c5 seperator"
         >
           <svg
-            aria-hidden="true"
-            class="Icon-fc7twp-0 dkBAgY"
+            aria-hidden={true}
+            className="c6"
             color="currentColor"
             fill="currentColor"
-            focusable="false"
+            focusable={false}
             height="24px"
             icon="rightArrow"
+            size="24px"
+            title={null}
             viewBox="0 0 24 24"
             width="24px"
           >

--- a/components/src/Button/__snapshots__/Button.story.storyshot
+++ b/components/src/Button/__snapshots__/Button.story.storyshot
@@ -1,15 +1,122 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Buttons As a link 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c1:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c1:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
+.c2 {
+  color: #ffffff;
+  border-color: #216beb;
+  background-color: #216beb;
+}
+
+.c2:hover {
+  background-color: #1254c7;
+  border-color: #1254c7;
+}
+
+.c2:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #216beb;
+}
+
+.c2:focus:hover {
+  background-color: #1254c7;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <a
-      class="Button__WrapperButton-sc-1omxup2-0 hkfOQr PrimaryButton-qz78sb-0 cGyyDq"
+      className="c1 c2"
+      disabled={false}
       href="/"
+      size="medium"
     >
       Create project
     </a>
@@ -18,14 +125,99 @@ exports[`Storyshots Buttons As a link 1`] = `
 `;
 
 exports[`Storyshots Buttons Button 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c1:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c1:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
-      class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+      className="c1"
+      disabled={false}
+      size="medium"
     >
       Create project
     </button>
@@ -34,14 +226,121 @@ exports[`Storyshots Buttons Button 1`] = `
 `;
 
 exports[`Storyshots Buttons DangerButton 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c1:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c1:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
+.c2 {
+  color: #ffffff;
+  border-color: #cc1439;
+  background-color: #cc1439;
+}
+
+.c2:hover {
+  background-color: #9e0f2c;
+  border-color: #9e0f2c;
+}
+
+.c2:focus {
+  outline: none;
+  background-color: #cc1439;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c2:focus:hover {
+  background-color: #9e0f2c;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
-      class="Button__WrapperButton-sc-1omxup2-0 hkfOQr DangerButton-sc-1220u5k-0 ehzMsl"
+      className="c1 c2"
+      disabled={false}
+      size="medium"
     >
       Delete project
     </button>
@@ -50,14 +349,121 @@ exports[`Storyshots Buttons DangerButton 1`] = `
 `;
 
 exports[`Storyshots Buttons PrimaryButton 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c1:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c1:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
+.c2 {
+  color: #ffffff;
+  border-color: #216beb;
+  background-color: #216beb;
+}
+
+.c2:hover {
+  background-color: #1254c7;
+  border-color: #1254c7;
+}
+
+.c2:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #216beb;
+}
+
+.c2:focus:hover {
+  background-color: #1254c7;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
-      class="Button__WrapperButton-sc-1omxup2-0 hkfOQr PrimaryButton-qz78sb-0 cGyyDq"
+      className="c1 c2"
+      disabled={false}
+      size="medium"
     >
       Create project
     </button>
@@ -66,14 +472,105 @@ exports[`Storyshots Buttons PrimaryButton 1`] = `
 `;
 
 exports[`Storyshots Buttons QuietButton 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c1:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c1:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
+.c2 {
+  color: #216beb;
+  border-color: transparent;
+  background-color: transparent;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
-      class="Button__WrapperButton-sc-1omxup2-0 hkfOQr QuietButton-sc-1l5k8i4-0 eAbPwX"
+      className="c1 c2"
+      disabled={false}
+      size="medium"
     >
       Create project
     </button>
@@ -82,15 +579,112 @@ exports[`Storyshots Buttons QuietButton 1`] = `
 `;
 
 exports[`Storyshots Buttons Set to disabled 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: default;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c1:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c1:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
+.c2 {
+  color: #ffffff;
+  border-color: #216beb;
+  background-color: #216beb;
+}
+
+.c2:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #216beb;
+}
+
+.c2:focus:hover {
+  background-color: #1254c7;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
-      class="Button__WrapperButton-sc-1omxup2-0 gfuNnn PrimaryButton-qz78sb-0 hcOEwE"
-      disabled=""
+      className="c1 c2"
+      disabled={true}
+      size="medium"
     >
       Create project
     </button>
@@ -99,14 +693,121 @@ exports[`Storyshots Buttons Set to disabled 1`] = `
 `;
 
 exports[`Storyshots Buttons Set to full width 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c1:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c1:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
+.c2 {
+  color: #ffffff;
+  border-color: #216beb;
+  background-color: #216beb;
+}
+
+.c2:hover {
+  background-color: #1254c7;
+  border-color: #1254c7;
+}
+
+.c2:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #216beb;
+}
+
+.c2:focus:hover {
+  background-color: #1254c7;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
-      class="Button__WrapperButton-sc-1omxup2-0 bkRlmc PrimaryButton-qz78sb-0 cGyyDq"
+      className="c1 c2"
+      disabled={false}
+      size="medium"
     >
       Create project
     </button>
@@ -115,24 +816,123 @@ exports[`Storyshots Buttons Set to full width 1`] = `
 `;
 
 exports[`Storyshots Buttons With a selected Icon 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c2 {
+  margin-right: 4px;
+  color: currentColor;
+  min-width: 1.14285714em;
+}
+
+.c3 {
+  margin-left: 4px;
+  color: currentColor;
+  min-width: 1.14285714em;
+}
+
+.c1 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c1:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c1:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
-      class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+      className="c1"
+      disabled={false}
+      size="medium"
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 iVDunr"
+        aria-hidden={true}
+        className="c2"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="1.14285714em"
         icon="add"
         mr="half"
+        size="1.14285714em"
+        title={null}
         viewBox="0 0 24 24"
         width="1.14285714em"
       >
@@ -143,18 +943,22 @@ exports[`Storyshots Buttons With a selected Icon 1`] = `
       Create project
     </button>
     <button
-      class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+      className="c1"
+      disabled={false}
+      size="medium"
     >
       Create project
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 ffVnNY"
+        aria-hidden={true}
+        className="c3"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="1.14285714em"
         icon="add"
         ml="half"
+        size="1.14285714em"
+        title={null}
         viewBox="0 0 24 24"
         width="1.14285714em"
       >
@@ -168,24 +972,229 @@ exports[`Storyshots Buttons With a selected Icon 1`] = `
 `;
 
 exports[`Storyshots Buttons With a selected size 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 14px;
+  line-height: 1.14285714;
+  padding: 3px 8px;
+}
+
+.c1:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c1:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
+.c2 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c2:hover {
+  background-color: #e1ebfa;
+}
+
+.c2:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c2:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c2:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c2:disabled {
+  opacity: .5;
+}
+
+.c3 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 20px;
+  line-height: 1.2;
+  padding: 15px 24px;
+}
+
+.c3:hover {
+  background-color: #e1ebfa;
+}
+
+.c3:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c3:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c3:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c3:disabled {
+  opacity: .5;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
-      class="Button__WrapperButton-sc-1omxup2-0 hSnlTw"
+      className="c1"
+      disabled={false}
+      size="small"
     >
       Create project
     </button>
     <button
-      class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+      className="c2"
+      disabled={false}
+      size="medium"
     >
       Create project
     </button>
     <button
-      class="Button__WrapperButton-sc-1omxup2-0 bDgRPA"
+      className="c3"
+      disabled={false}
+      size="large"
     >
       Create project
     </button>

--- a/components/src/Button/__snapshots__/ControlIcon.story.storyshot
+++ b/components/src/Button/__snapshots__/ControlIcon.story.storyshot
@@ -1,25 +1,87 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots ControlIcon Control Icon 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c2 {
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c1 {
+  background: transparent;
+  border: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px;
+  border-radius: 50%;
+  color: #434d59;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c1:hover:enabled {
+  cursor: pointer;
+  color: #122b47;
+  background-color: #e4e7eb;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
       aria-label="close"
-      class="ControlIcon__StyledButton-sc-1h83lvi-0 cCdEvo"
+      className="c1"
+      disabled={false}
+      onClick={[Function]}
       type="button"
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 efirdb"
+        aria-hidden={true}
+        className="c2"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="32px"
         icon="close"
+        size="32px"
+        title={null}
         viewBox="0 0 24 24"
         width="32px"
       >
@@ -33,26 +95,87 @@ exports[`Storyshots ControlIcon Control Icon 1`] = `
 `;
 
 exports[`Storyshots ControlIcon Disabled 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c2 {
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c1 {
+  background: transparent;
+  border: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px;
+  border-radius: 50%;
+  color: #c0c8d1;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c1:hover:enabled {
+  cursor: pointer;
+  color: #122b47;
+  background-color: #e4e7eb;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
       aria-label="close"
-      class="ControlIcon__StyledButton-sc-1h83lvi-0 lkZGcS"
-      disabled=""
+      className="c1"
+      disabled={true}
+      onClick={[Function]}
       type="button"
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 efirdb"
+        aria-hidden={true}
+        className="c2"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="32px"
         icon="close"
+        size="32px"
+        title={null}
         viewBox="0 0 24 24"
         width="32px"
       >
@@ -66,25 +189,87 @@ exports[`Storyshots ControlIcon Disabled 1`] = `
 `;
 
 exports[`Storyshots ControlIcon Toggled 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c2 {
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c1 {
+  background: transparent;
+  border: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px;
+  border-radius: 50%;
+  color: #00438f;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c1:hover:enabled {
+  cursor: pointer;
+  color: #122b47;
+  background-color: #e4e7eb;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
       aria-label="close"
-      class="ControlIcon__StyledButton-sc-1h83lvi-0 jjnZya"
+      className="c1"
+      disabled={false}
+      onClick={[Function]}
       type="button"
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 efirdb"
+        aria-hidden={true}
+        className="c2"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="32px"
         icon="close"
+        size="32px"
+        title={null}
         viewBox="0 0 24 24"
         width="32px"
       >

--- a/components/src/Button/__snapshots__/IconicButton.story.storyshot
+++ b/components/src/Button/__snapshots__/IconicButton.story.storyshot
@@ -1,26 +1,143 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots IconicButton set to disabled 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  padding: 4px;
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c5 {
+  margin-right: 4px;
+  margin-left: 4px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c1 {
+  background: transparent;
+  border: none;
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px 0px;
+  color: #00438f;
+  cursor: default;
+}
+
+.c1 .c2 {
+  border-radius: 50%;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c1 .c4 {
+  display: block;
+  font-weight: 500;
+  text-align: left;
+}
+
+.c1 .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 0;
+}
+
+.c1:hover .c2 {
+  background-color: #e1ebfa;
+}
+
+.c1:hover .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c1:active .c2 {
+  -webkit-transform: scale(0.875);
+  -ms-transform: scale(0.875);
+  transform: scale(0.875);
+  -webkit-transition: .2s ease-in;
+  transition: .2s ease-in;
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
+.c1:disabled:hover .c2,
+.c1:disabled:active .c2 {
+  background: none;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus .c2 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c1:focus .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
       aria-label="Cancel"
-      class="IconicButton__WrapperButton-sc-1u3dojp-1 kezjjz IconicButton-sc-1u3dojp-2 gZASNp"
-      disabled=""
+      className="c1 "
+      disabled={true}
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 cwKdbD"
+        aria-hidden={true}
+        className="c2 c3"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="32px"
         icon="cancel"
         p="half"
+        size="32px"
+        title={null}
         viewBox="0 0 24 24"
         width="32px"
       >
@@ -29,27 +146,30 @@ exports[`Storyshots IconicButton set to disabled 1`] = `
         />
       </svg>
       <p
-        class="Text-sc-1wu7vpu-0 hHlnON"
+        className="c4 c5"
         color="currentColor"
-        font-size="medium"
+        disabled={false}
+        fontSize="medium"
       >
         Cancel
       </p>
     </button>
     <button
       aria-label="Lock"
-      class="IconicButton__WrapperButton-sc-1u3dojp-1 kezjjz IconicButton-sc-1u3dojp-2 gZASNp"
-      disabled=""
+      className="c1 "
+      disabled={true}
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 cwKdbD"
+        aria-hidden={true}
+        className="c2 c3"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="32px"
         icon="lock"
         p="half"
+        size="32px"
+        title={null}
         viewBox="0 0 24 24"
         width="32px"
       >
@@ -58,9 +178,10 @@ exports[`Storyshots IconicButton set to disabled 1`] = `
         />
       </svg>
       <p
-        class="Text-sc-1wu7vpu-0 hHlnON"
+        className="c4 c5"
         color="currentColor"
-        font-size="medium"
+        disabled={false}
+        fontSize="medium"
       >
         Lock
       </p>
@@ -70,25 +191,146 @@ exports[`Storyshots IconicButton set to disabled 1`] = `
 `;
 
 exports[`Storyshots IconicButton with a hidden label 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  padding: 4px;
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c5 {
+  white-space: nowrap;
+  ont-size: 14px;
+  line-height: 1.14285714;
+  color: #f0f2f5;
+  background-color: rgba(18,43,71,0.85);
+  border-radius: 4px;
+  margin-top: 4px;
+  padding: 4px 8px;
+  pointer-events: none;
+}
+
+.c1 {
+  background: transparent;
+  border: none;
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px 0px;
+  color: #00438f;
+  cursor: pointer;
+  margin-left: 48px;
+}
+
+.c1 .c2 {
+  border-radius: 50%;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c1 .Text-sc-1wu7vpu-0 {
+  display: block;
+  font-weight: 500;
+  text-align: left;
+}
+
+.c1 .c4 {
+  opacity: 0;
+}
+
+.c1:hover .c2 {
+  background-color: #e1ebfa;
+}
+
+.c1:hover .c4 {
+  opacity: 1;
+}
+
+.c1:active .c2 {
+  -webkit-transform: scale(0.875);
+  -ms-transform: scale(0.875);
+  transform: scale(0.875);
+  -webkit-transition: .2s ease-in;
+  transition: .2s ease-in;
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
+.c1:disabled:hover .c2,
+.c1:disabled:active .c2 {
+  background: none;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus .c2 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c1:focus .c4 {
+  opacity: 1;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
       aria-label="Hidden Label"
-      class="IconicButton__WrapperButton-sc-1u3dojp-1 kKACSq IconicButton-sc-1u3dojp-2 gZASNp"
+      className="c1 "
+      disabled={false}
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 cwKdbD"
+        aria-hidden={true}
+        className="c2 c3"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="32px"
         icon="user"
         p="half"
+        size="32px"
+        title={null}
         viewBox="0 0 24 24"
         width="32px"
       >
@@ -97,8 +339,16 @@ exports[`Storyshots IconicButton with a hidden label 1`] = `
         />
       </svg>
       <div
-        class="IconicButton__HoverText-sc-1u3dojp-0 hUWvcf"
-        style="position:absolute;top:0;left:0;opacity:0;pointer-events:none"
+        className="c4 c5"
+        style={
+          Object {
+            "left": 0,
+            "opacity": 0,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "top": 0,
+          }
+        }
       >
         Hidden Label
       </div>
@@ -108,25 +358,143 @@ exports[`Storyshots IconicButton with a hidden label 1`] = `
 `;
 
 exports[`Storyshots IconicButton with a long label 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  padding: 4px;
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c5 {
+  margin-right: 4px;
+  margin-left: 4px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c1 {
+  background: transparent;
+  border: none;
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px 0px;
+  color: #00438f;
+  cursor: pointer;
+}
+
+.c1 .c2 {
+  border-radius: 50%;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c1 .c4 {
+  display: block;
+  font-weight: 500;
+  text-align: left;
+}
+
+.c1 .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 0;
+}
+
+.c1:hover .c2 {
+  background-color: #e1ebfa;
+}
+
+.c1:hover .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c1:active .c2 {
+  -webkit-transform: scale(0.875);
+  -ms-transform: scale(0.875);
+  transform: scale(0.875);
+  -webkit-transition: .2s ease-in;
+  transition: .2s ease-in;
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
+.c1:disabled:hover .c2,
+.c1:disabled:active .c2 {
+  background: none;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus .c2 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c1:focus .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
       aria-label="I am an Iconic Button with a really really really long label"
-      class="IconicButton__WrapperButton-sc-1u3dojp-1 UMPof IconicButton-sc-1u3dojp-2 gZASNp"
+      className="c1 "
+      disabled={false}
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 cwKdbD"
+        aria-hidden={true}
+        className="c2 c3"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="32px"
         icon="user"
         p="half"
+        size="32px"
+        title={null}
         viewBox="0 0 24 24"
         width="32px"
       >
@@ -135,9 +503,10 @@ exports[`Storyshots IconicButton with a long label 1`] = `
         />
       </svg>
       <p
-        class="Text-sc-1wu7vpu-0 hHlnON"
+        className="c4 c5"
         color="currentColor"
-        font-size="medium"
+        disabled={false}
+        fontSize="medium"
       >
         I am an Iconic Button with a really really really long label
       </p>
@@ -147,25 +516,143 @@ exports[`Storyshots IconicButton with a long label 1`] = `
 `;
 
 exports[`Storyshots IconicButton with label 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  padding: 4px;
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c5 {
+  margin-right: 4px;
+  margin-left: 4px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c1 {
+  background: transparent;
+  border: none;
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px 0px;
+  color: #00438f;
+  cursor: pointer;
+}
+
+.c1 .c2 {
+  border-radius: 50%;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c1 .c4 {
+  display: block;
+  font-weight: 500;
+  text-align: left;
+}
+
+.c1 .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 0;
+}
+
+.c1:hover .c2 {
+  background-color: #e1ebfa;
+}
+
+.c1:hover .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c1:active .c2 {
+  -webkit-transform: scale(0.875);
+  -ms-transform: scale(0.875);
+  transform: scale(0.875);
+  -webkit-transition: .2s ease-in;
+  transition: .2s ease-in;
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
+.c1:disabled:hover .c2,
+.c1:disabled:active .c2 {
+  background: none;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus .c2 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c1:focus .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
       aria-label="Delete"
-      class="IconicButton__WrapperButton-sc-1u3dojp-1 UMPof IconicButton-sc-1u3dojp-2 gZASNp"
+      className="c1 "
+      disabled={false}
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 cwKdbD"
+        aria-hidden={true}
+        className="c2 c3"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="32px"
         icon="delete"
         p="half"
+        size="32px"
+        title={null}
         viewBox="0 0 24 24"
         width="32px"
       >
@@ -174,9 +661,10 @@ exports[`Storyshots IconicButton with label 1`] = `
         />
       </svg>
       <p
-        class="Text-sc-1wu7vpu-0 hHlnON"
+        className="c4 c5"
         color="currentColor"
-        font-size="medium"
+        disabled={false}
+        fontSize="medium"
       >
         Delete
       </p>
@@ -186,24 +674,133 @@ exports[`Storyshots IconicButton with label 1`] = `
 `;
 
 exports[`Storyshots IconicButton without a label 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  padding: 4px;
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c1 {
+  background: transparent;
+  border: none;
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px 0px;
+  color: #00438f;
+  cursor: pointer;
+}
+
+.c1 .c2 {
+  border-radius: 50%;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c1 .Text-sc-1wu7vpu-0 {
+  display: block;
+  font-weight: 500;
+  text-align: left;
+}
+
+.c1 .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 0;
+}
+
+.c1:hover .c2 {
+  background-color: #e1ebfa;
+}
+
+.c1:hover .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c1:active .c2 {
+  -webkit-transform: scale(0.875);
+  -ms-transform: scale(0.875);
+  transform: scale(0.875);
+  -webkit-transition: .2s ease-in;
+  transition: .2s ease-in;
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
+.c1:disabled:hover .c2,
+.c1:disabled:active .c2 {
+  background: none;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus .c2 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c1:focus .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
-      class="IconicButton__WrapperButton-sc-1u3dojp-1 UMPof IconicButton-sc-1u3dojp-2 gZASNp"
+      aria-label={null}
+      className="c1 "
+      disabled={false}
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 cwKdbD"
+        aria-hidden={true}
+        className="c2 c3"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="32px"
         icon="delete"
         p="half"
+        size="32px"
+        title={null}
         viewBox="0 0 24 24"
         width="32px"
       >

--- a/components/src/ButtonGroup/__snapshots__/ButtonGroup.story.storyshot
+++ b/components/src/ButtonGroup/__snapshots__/ButtonGroup.story.storyshot
@@ -1,31 +1,171 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots ButtonGroup ButtonGroup 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  background-color: #f0f2f5;
+  padding: 16px;
+  width: 500px;
+}
+
+.c3 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c3:hover {
+  background-color: #e1ebfa;
+}
+
+.c3:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c3:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c3:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c3:disabled {
+  opacity: .5;
+}
+
+.c4 {
+  color: #ffffff;
+  border-color: #216beb;
+  background-color: #216beb;
+}
+
+.c4:hover {
+  background-color: #1254c7;
+  border-color: #1254c7;
+}
+
+.c4:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #216beb;
+}
+
+.c4:focus:hover {
+  background-color: #1254c7;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-bottom: -8px;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c2 button {
+  margin-bottom: 8px;
+}
+
+.c2 button:not(:last-child) {
+  margin-right: 8px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 kmQbtL"
+      className="c1"
       width="500px"
     >
       <div
-        class="ButtonGroup-xkz195-0 dtwRCO"
+        className="c2"
       >
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr PrimaryButton-qz78sb-0 cGyyDq"
+          className="c3 c4"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+          className="c3"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+          className="c3"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
@@ -36,51 +176,314 @@ exports[`Storyshots ButtonGroup ButtonGroup 1`] = `
 `;
 
 exports[`Storyshots ButtonGroup more button types 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  background-color: #f0f2f5;
+  padding: 16px;
+  width: 600px;
+}
+
+.c9 {
+  padding: 4px;
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c11 {
+  margin-right: 4px;
+  margin-left: 4px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c3 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c3:hover {
+  background-color: #e1ebfa;
+}
+
+.c3:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c3:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c3:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c3:disabled {
+  opacity: .5;
+}
+
+.c4 {
+  color: #ffffff;
+  border-color: #216beb;
+  background-color: #216beb;
+}
+
+.c4:hover {
+  background-color: #1254c7;
+  border-color: #1254c7;
+}
+
+.c4:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #216beb;
+}
+
+.c4:focus:hover {
+  background-color: #1254c7;
+}
+
+.c5 {
+  color: #ffffff;
+  border-color: #cc1439;
+  background-color: #cc1439;
+}
+
+.c5:hover {
+  background-color: #9e0f2c;
+  border-color: #9e0f2c;
+}
+
+.c5:focus {
+  outline: none;
+  background-color: #cc1439;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c5:focus:hover {
+  background-color: #9e0f2c;
+}
+
+.c6 {
+  color: #216beb;
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c7 {
+  background: transparent;
+  border: none;
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px 0px;
+  color: #00438f;
+  cursor: pointer;
+}
+
+.c7 .c8 {
+  border-radius: 50%;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c7 .c10 {
+  display: block;
+  font-weight: 500;
+  text-align: left;
+}
+
+.c7 .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 0;
+}
+
+.c7:hover .c8 {
+  background-color: #e1ebfa;
+}
+
+.c7:hover .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c7:active .c8 {
+  -webkit-transform: scale(0.875);
+  -ms-transform: scale(0.875);
+  transform: scale(0.875);
+  -webkit-transition: .2s ease-in;
+  transition: .2s ease-in;
+}
+
+.c7:disabled {
+  opacity: .5;
+}
+
+.c7:disabled:hover .c8,
+.c7:disabled:active .c8 {
+  background: none;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus .c8 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-bottom: -8px;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c2 button {
+  margin-bottom: 8px;
+}
+
+.c2 button:not(:last-child) {
+  margin-right: 8px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 aJDrU"
+      className="c1"
       width="600px"
     >
       <div
-        class="ButtonGroup-xkz195-0 dtwRCO"
+        className="c2"
       >
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr PrimaryButton-qz78sb-0 cGyyDq"
+          className="c3 c4"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr DangerButton-sc-1220u5k-0 ehzMsl"
+          className="c3 c5"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+          className="c3"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr QuietButton-sc-1l5k8i4-0 eAbPwX"
+          className="c3 c6"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
         <button
-          class="IconicButton__WrapperButton-sc-1u3dojp-1 UMPof IconicButton-sc-1u3dojp-2 gZASNp"
+          aria-label={null}
+          className="c7 "
+          disabled={false}
         >
           <svg
-            aria-hidden="true"
-            class="Icon-fc7twp-0 cwKdbD"
+            aria-hidden={true}
+            className="c8 c9"
             color="currentColor"
             fill="currentColor"
-            focusable="false"
+            focusable={false}
             height="32px"
             icon="menu"
             p="half"
+            size="32px"
+            title={null}
             viewBox="0 0 24 24"
             width="32px"
           >
@@ -91,17 +494,20 @@ exports[`Storyshots ButtonGroup more button types 1`] = `
         </button>
         <button
           aria-label="Button"
-          class="IconicButton__WrapperButton-sc-1u3dojp-1 UMPof IconicButton-sc-1u3dojp-2 gZASNp"
+          className="c7 "
+          disabled={false}
         >
           <svg
-            aria-hidden="true"
-            class="Icon-fc7twp-0 cwKdbD"
+            aria-hidden={true}
+            className="c8 c9"
             color="currentColor"
             fill="currentColor"
-            focusable="false"
+            focusable={false}
             height="32px"
             icon="menu"
             p="half"
+            size="32px"
+            title={null}
             viewBox="0 0 24 24"
             width="32px"
           >
@@ -110,9 +516,10 @@ exports[`Storyshots ButtonGroup more button types 1`] = `
             />
           </svg>
           <p
-            class="Text-sc-1wu7vpu-0 hHlnON"
+            className="c10 c11"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Button
           </p>
@@ -124,31 +531,171 @@ exports[`Storyshots ButtonGroup more button types 1`] = `
 `;
 
 exports[`Storyshots ButtonGroup with alignment right 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  background-color: #f0f2f5;
+  padding: 16px;
+  width: 500px;
+}
+
+.c3 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c3:hover {
+  background-color: #e1ebfa;
+}
+
+.c3:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c3:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c3:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c3:disabled {
+  opacity: .5;
+}
+
+.c4 {
+  color: #ffffff;
+  border-color: #216beb;
+  background-color: #216beb;
+}
+
+.c4:hover {
+  background-color: #1254c7;
+  border-color: #1254c7;
+}
+
+.c4:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #216beb;
+}
+
+.c4:focus:hover {
+  background-color: #1254c7;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-bottom: -8px;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c2 button {
+  margin-bottom: 8px;
+}
+
+.c2 button:not(:first-child) {
+  margin-left: 8px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 kmQbtL"
+      className="c1"
       width="500px"
     >
       <div
-        class="ButtonGroup-xkz195-0 blsMJq"
+        className="c2"
       >
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr PrimaryButton-qz78sb-0 cGyyDq"
+          className="c3 c4"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+          className="c3"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+          className="c3"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
@@ -159,26 +706,164 @@ exports[`Storyshots ButtonGroup with alignment right 1`] = `
 `;
 
 exports[`Storyshots ButtonGroup with alignment spaced 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  background-color: #f0f2f5;
+  padding: 16px;
+  width: 500px;
+}
+
+.c3 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c3:hover {
+  background-color: #e1ebfa;
+}
+
+.c3:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c3:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c3:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c3:disabled {
+  opacity: .5;
+}
+
+.c4 {
+  color: #ffffff;
+  border-color: #216beb;
+  background-color: #216beb;
+}
+
+.c4:hover {
+  background-color: #1254c7;
+  border-color: #1254c7;
+}
+
+.c4:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #216beb;
+}
+
+.c4:focus:hover {
+  background-color: #1254c7;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-bottom: -8px;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c2 button {
+  margin-bottom: 8px;
+}
+
+.c2 button:not(:last-child) {
+  margin-right: 8px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 kmQbtL"
+      className="c1"
       width="500px"
     >
       <div
-        class="ButtonGroup-xkz195-0 hCnVmX"
+        className="c2"
       >
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr PrimaryButton-qz78sb-0 cGyyDq"
+          className="c3 c4"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+          className="c3"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
@@ -189,123 +874,303 @@ exports[`Storyshots ButtonGroup with alignment spaced 1`] = `
 `;
 
 exports[`Storyshots ButtonGroup wrapping buttons 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  background-color: #f0f2f5;
+  padding: 16px;
+}
+
+.c4 {
+  background-color: #f0f2f5;
+  padding: 16px;
+  margin-top: 16px;
+}
+
+.c3 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c3:hover {
+  background-color: #e1ebfa;
+}
+
+.c3:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c3:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c3:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c3:disabled {
+  opacity: .5;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-bottom: -8px;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c2 button {
+  margin-bottom: 8px;
+}
+
+.c2 button:not(:last-child) {
+  margin-right: 8px;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-bottom: -8px;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c5 button {
+  margin-bottom: 8px;
+}
+
+.c5 button:not(:first-child) {
+  margin-left: 8px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 hkwtTx"
+      className="c1"
     >
       <div
-        class="ButtonGroup-xkz195-0 dtwRCO"
+        className="c2"
       >
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+          className="c3"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+          className="c3"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+          className="c3"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+          className="c3"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+          className="c3"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+          className="c3"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+          className="c3"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+          className="c3"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+          className="c3"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+          className="c3"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
       </div>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 uuGzP"
+      className="c4"
     >
       <div
-        class="ButtonGroup-xkz195-0 blsMJq"
+        className="c5"
       >
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+          className="c3"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+          className="c3"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+          className="c3"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+          className="c3"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+          className="c3"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+          className="c3"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+          className="c3"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+          className="c3"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+          className="c3"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>
         <button
-          class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+          className="c3"
+          disabled={false}
+          size="medium"
         >
           Button
         </button>

--- a/components/src/Card/__snapshots__/Card.story.storyshot
+++ b/components/src/Card/__snapshots__/Card.story.storyshot
@@ -1,14 +1,51 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Card Card 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  background-color: #f0f2f5;
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-left: 16px;
+  padding-right: 16px;
+  border-radius: 4px;
+  box-shadow: 0px 0px 3px 0px rgba(1,30,56,0.2);
+  position: relative;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
+      className="Box-sc-1qu1edy-0 c1"
     >
       I am a card.
     </div>
@@ -17,27 +54,72 @@ exports[`Storyshots Card Card 1`] = `
 `;
 
 exports[`Storyshots Card Cardset 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  background-color: #f0f2f5;
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-left: 16px;
+  padding-right: 16px;
+  border-radius: 4px;
+  box-shadow: 0px 0px 3px 0px rgba(1,30,56,0.2);
+  position: relative;
+}
+
+.c1 .c2 {
+  margin-bottom: 8px;
+}
+
+.c1 .c2:last-child {
+  margin-bottom: 0px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj CardSet-sc-143b99f-0 hByntb"
+      className="c1"
     >
       <div
-        class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
+        className="c2 c3"
       >
         I am a 1st card in a cardset.
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
+        className="c2 c3"
       >
         I am a 2nd card in a cardset.
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
+        className="c2 c3"
       >
         I am a 3rd card in a cardset.
       </div>
@@ -47,14 +129,53 @@ exports[`Storyshots Card Cardset 1`] = `
 `;
 
 exports[`Storyshots Card Custom card 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  background-color: #011e38;
+  color: #ffffff;
+  padding: 8px;
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-left: 16px;
+  padding-right: 16px;
+  border-radius: 2px;
+  box-shadow: 0px 0px 3px 0px rgba(1,30,56,0.2);
+  position: relative;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 bdKSSm"
+      className="Box-sc-1qu1edy-0 c1"
       color="white"
     >
       I am a custom card.

--- a/components/src/Checkbox/__snapshots__/Checkbox.story.storyshot
+++ b/components/src/Checkbox/__snapshots__/Checkbox.story.storyshot
@@ -1,33 +1,151 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Checkbox Checkbox 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c7 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c2 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c5 {
+  min-width: 16px;
+  height: 16px;
+  border-radius: 2px;
+  border: solid 1px;
+  position: relative;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c5:before {
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  width: 3px;
+  height: 9px;
+  border: solid #ffffff;
+  border-radius: 1px;
+  border-width: 0 3px 3px 0;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.c3 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c3:focus + .c4 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c3:checked + .c4 {
+  border-color: #00438f;
+  background-color: #00438f;
+}
+
+.c3:checked + .c4:before {
+  display: block;
+}
+
+.c3:not(:checked) + .c4 {
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+}
+
+.c1 {
+  padding: 4px 0;
+}
+
+.c1 .c6 {
+  margin-left: 8px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+      className="c1"
     >
       <label
-        class="ClickInputLabel-j2axnv-0 kemUmZ"
+        className="c2"
+        disabled={false}
       >
         <input
-          aria-invalid="false"
-          aria-required="false"
-          class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+          aria-invalid={false}
+          aria-required={false}
+          className="c3 c1"
+          disabled={false}
           id="checkbox"
+          required={false}
           type="checkbox"
         />
         <div
-          class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+          className="c4 c5"
           data-testid="visual-checkbox"
+          disabled={false}
         />
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c6 c7"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           I am a checkbox
         </p>
@@ -38,27 +156,137 @@ exports[`Storyshots Checkbox Checkbox 1`] = `
 `;
 
 exports[`Storyshots Checkbox Checkbox with no label 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c2 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c5 {
+  min-width: 16px;
+  height: 16px;
+  border-radius: 2px;
+  border: solid 1px;
+  position: relative;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c5:before {
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  width: 3px;
+  height: 9px;
+  border: solid #ffffff;
+  border-radius: 1px;
+  border-width: 0 3px 3px 0;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.c3 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c3:focus + .c4 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c3:checked + .c4 {
+  border-color: #00438f;
+  background-color: #00438f;
+}
+
+.c3:checked + .c4:before {
+  display: block;
+}
+
+.c3:not(:checked) + .c4 {
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+}
+
+.c1 {
+  padding: 4px 0;
+}
+
+.c1 .Text-sc-1wu7vpu-0 {
+  margin-left: 8px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+      className="c1"
     >
       <label
-        class="ClickInputLabel-j2axnv-0 kemUmZ"
+        className="c2"
+        disabled={false}
       >
         <input
-          aria-invalid="false"
-          aria-required="false"
-          class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+          aria-invalid={false}
+          aria-required={false}
+          className="c3 c1"
+          disabled={false}
+          id={null}
+          required={false}
           type="checkbox"
         />
         <div
-          class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+          className="c4 c5"
           data-testid="visual-checkbox"
+          disabled={false}
         />
       </label>
     </div>
@@ -67,34 +295,152 @@ exports[`Storyshots Checkbox Checkbox with no label 1`] = `
 `;
 
 exports[`Storyshots Checkbox Set to defaultChecked 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c7 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c2 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c5 {
+  min-width: 16px;
+  height: 16px;
+  border-radius: 2px;
+  border: solid 1px;
+  position: relative;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c5:before {
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  width: 3px;
+  height: 9px;
+  border: solid #ffffff;
+  border-radius: 1px;
+  border-width: 0 3px 3px 0;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.c3 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c3:focus + .c4 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c3:checked + .c4 {
+  border-color: #00438f;
+  background-color: #00438f;
+}
+
+.c3:checked + .c4:before {
+  display: block;
+}
+
+.c3:not(:checked) + .c4 {
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+}
+
+.c1 {
+  padding: 4px 0;
+}
+
+.c1 .c6 {
+  margin-left: 8px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+      className="c1"
     >
       <label
-        class="ClickInputLabel-j2axnv-0 kemUmZ"
+        className="c2"
+        disabled={false}
       >
         <input
-          aria-invalid="false"
-          aria-required="false"
-          checked=""
-          class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+          aria-invalid={false}
+          aria-required={false}
+          className="c3 c1"
+          defaultChecked={true}
+          disabled={false}
           id="checkbox"
+          required={false}
           type="checkbox"
         />
         <div
-          class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+          className="c4 c5"
           data-testid="visual-checkbox"
+          disabled={false}
         />
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c6 c7"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           I am checked by default
         </p>
@@ -105,69 +451,184 @@ exports[`Storyshots Checkbox Set to defaultChecked 1`] = `
 `;
 
 exports[`Storyshots Checkbox Set to disabled 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c7 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+  opacity: 0.3333;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c5 {
+  min-width: 16px;
+  height: 16px;
+  border-radius: 2px;
+  border: solid 1px;
+  position: relative;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c5:before {
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  width: 3px;
+  height: 9px;
+  border: solid #ffffff;
+  border-radius: 1px;
+  border-width: 0 3px 3px 0;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.c3 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c3:focus + .c4 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c3:checked + .c4 {
+  border-color: #e4e7eb;
+  background-color: #e4e7eb;
+}
+
+.c3:checked + .c4:before {
+  display: block;
+}
+
+.c3:not(:checked) + .c4 {
+  border-color: #e4e7eb;
+  background-color: #f0f2f5;
+}
+
+.c1 {
+  padding: 4px 0;
+}
+
+.c1 .c6 {
+  margin-left: 8px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+      className="c1"
     >
       <label
-        class="ClickInputLabel-j2axnv-0 kjxgat"
-        disabled=""
+        className="c2"
+        disabled={true}
       >
         <input
-          aria-invalid="false"
-          aria-required="false"
-          class="Checkbox__CheckboxInput-sc-1nm58f1-1 jdAeaf Checkbox-sc-1nm58f1-2 eJJycu"
-          disabled=""
+          aria-invalid={false}
+          aria-required={false}
+          className="c3 c1"
+          disabled={true}
           id="checkbox-1"
+          required={false}
           type="checkbox"
         />
         <div
-          class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+          className="c4 c5"
           data-testid="visual-checkbox"
-          disabled=""
+          disabled={true}
         />
         <p
-          class="Text-sc-1wu7vpu-0 hdrQgs"
+          className="c6 c7"
           color="currentColor"
-          disabled=""
-          font-size="medium"
+          disabled={true}
+          fontSize="medium"
         >
           I am disabled
         </p>
       </label>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+      className="c1"
     >
       <label
-        class="ClickInputLabel-j2axnv-0 kjxgat"
-        disabled=""
+        className="c2"
+        disabled={true}
       >
         <input
-          aria-invalid="false"
-          aria-required="false"
-          checked=""
-          class="Checkbox__CheckboxInput-sc-1nm58f1-1 jdAeaf Checkbox-sc-1nm58f1-2 eJJycu"
-          disabled=""
+          aria-invalid={false}
+          aria-required={false}
+          checked={true}
+          className="c3 c1"
+          disabled={true}
           id="checkbox-2"
+          required={false}
           type="checkbox"
         />
         <div
-          checked=""
-          class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+          checked={true}
+          className="c4 c5"
           data-testid="visual-checkbox"
-          disabled=""
+          disabled={true}
         />
         <p
-          class="Text-sc-1wu7vpu-0 hdrQgs"
+          className="c6 c7"
           color="currentColor"
-          disabled=""
-          font-size="medium"
+          disabled={true}
+          fontSize="medium"
         >
           I am disabled
         </p>
@@ -178,60 +639,183 @@ exports[`Storyshots Checkbox Set to disabled 1`] = `
 `;
 
 exports[`Storyshots Checkbox Set to error 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c7 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c2 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c5 {
+  min-width: 16px;
+  height: 16px;
+  border-radius: 2px;
+  border: solid 1px;
+  position: relative;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c5:before {
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  width: 3px;
+  height: 9px;
+  border: solid #ffffff;
+  border-radius: 1px;
+  border-width: 0 3px 3px 0;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.c3 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c3:focus + .c4 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c3:checked + .c4 {
+  border-color: #cc1439;
+  background-color: #cc1439;
+}
+
+.c3:checked + .c4:before {
+  display: block;
+}
+
+.c3:not(:checked) + .c4 {
+  border-color: #cc1439;
+  background-color: #ffffff;
+}
+
+.c1 {
+  padding: 4px 0;
+}
+
+.c1 .c6 {
+  margin-left: 8px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+      className="c1"
     >
       <label
-        class="ClickInputLabel-j2axnv-0 kemUmZ"
+        className="c2"
+        disabled={false}
       >
         <input
-          aria-invalid="true"
-          aria-required="false"
-          class="Checkbox__CheckboxInput-sc-1nm58f1-1 iWambR Checkbox-sc-1nm58f1-2 eJJycu"
+          aria-invalid={true}
+          aria-required={false}
+          className="c3 c1"
+          disabled={false}
           id="checkbox"
+          required={false}
           type="checkbox"
         />
         <div
-          class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+          className="c4 c5"
           data-testid="visual-checkbox"
+          disabled={false}
         />
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c6 c7"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           I am error
         </p>
       </label>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+      className="c1"
     >
       <label
-        class="ClickInputLabel-j2axnv-0 kemUmZ"
+        className="c2"
+        disabled={false}
       >
         <input
-          aria-invalid="true"
-          aria-required="false"
-          checked=""
-          class="Checkbox__CheckboxInput-sc-1nm58f1-1 iWambR Checkbox-sc-1nm58f1-2 eJJycu"
+          aria-invalid={true}
+          aria-required={false}
+          className="c3 c1"
+          defaultChecked={true}
+          disabled={false}
           id="checkbox"
+          required={false}
           type="checkbox"
         />
         <div
-          class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+          className="c4 c5"
           data-testid="visual-checkbox"
+          disabled={false}
         />
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c6 c7"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           I am error
         </p>
@@ -242,34 +826,151 @@ exports[`Storyshots Checkbox Set to error 1`] = `
 `;
 
 exports[`Storyshots Checkbox Set to required 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c7 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c2 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c5 {
+  min-width: 16px;
+  height: 16px;
+  border-radius: 2px;
+  border: solid 1px;
+  position: relative;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c5:before {
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  width: 3px;
+  height: 9px;
+  border: solid #ffffff;
+  border-radius: 1px;
+  border-width: 0 3px 3px 0;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.c3 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c3:focus + .c4 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c3:checked + .c4 {
+  border-color: #00438f;
+  background-color: #00438f;
+}
+
+.c3:checked + .c4:before {
+  display: block;
+}
+
+.c3:not(:checked) + .c4 {
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+}
+
+.c1 {
+  padding: 4px 0;
+}
+
+.c1 .c6 {
+  margin-left: 8px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+      className="c1"
     >
       <label
-        class="ClickInputLabel-j2axnv-0 kemUmZ"
+        className="c2"
+        disabled={false}
       >
         <input
-          aria-invalid="false"
-          aria-required="true"
-          class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+          aria-invalid={false}
+          aria-required={true}
+          className="c3 c1"
+          disabled={false}
           id="checkbox"
-          required=""
+          required={true}
           type="checkbox"
         />
         <div
-          class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+          className="c4 c5"
           data-testid="visual-checkbox"
+          disabled={false}
         />
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c6 c7"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           I am a checkbox
         </p>
@@ -280,59 +981,188 @@ exports[`Storyshots Checkbox Set to required 1`] = `
 `;
 
 exports[`Storyshots Checkbox With state 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c7 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c2 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c5 {
+  min-width: 16px;
+  height: 16px;
+  border-radius: 2px;
+  border: solid 1px;
+  position: relative;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c5:before {
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  width: 3px;
+  height: 9px;
+  border: solid #ffffff;
+  border-radius: 1px;
+  border-width: 0 3px 3px 0;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.c3 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c3:focus + .c4 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c3:checked + .c4 {
+  border-color: #00438f;
+  background-color: #00438f;
+}
+
+.c3:checked + .c4:before {
+  display: block;
+}
+
+.c3:not(:checked) + .c4 {
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+}
+
+.c1 {
+  padding: 4px 0;
+}
+
+.c1 .c6 {
+  margin-left: 8px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+      className="c1"
     >
       <label
-        class="ClickInputLabel-j2axnv-0 kemUmZ"
+        className="c2"
+        disabled={false}
       >
         <input
-          aria-invalid="false"
-          aria-required="false"
-          class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+          aria-invalid={false}
+          aria-required={false}
+          checked={false}
+          className="c3 c1"
+          disabled={false}
           id="checkbox-1"
+          onChange={[Function]}
+          required={false}
           type="checkbox"
         />
         <div
-          class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+          checked={false}
+          className="c4 c5"
           data-testid="visual-checkbox"
+          disabled={false}
         />
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c6 c7"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           I am controlled and checked
         </p>
       </label>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+      className="c1"
     >
       <label
-        class="ClickInputLabel-j2axnv-0 kemUmZ"
+        className="c2"
+        disabled={false}
       >
         <input
-          aria-invalid="false"
-          aria-required="false"
-          class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+          aria-invalid={false}
+          aria-required={false}
+          checked={false}
+          className="c3 c1"
+          disabled={false}
           id="checkbox-2"
+          onChange={[Function]}
+          required={false}
           type="checkbox"
         />
         <div
-          class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+          checked={false}
+          className="c4 c5"
           data-testid="visual-checkbox"
+          disabled={false}
         />
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c6 c7"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           I am controlled and unchecked
         </p>
@@ -343,125 +1173,334 @@ exports[`Storyshots Checkbox With state 1`] = `
 `;
 
 exports[`Storyshots Checkbox indeterminate 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c7 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c11 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+  opacity: 0.3333;
+}
+
+.c2 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c9 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c5 {
+  min-width: 16px;
+  height: 16px;
+  border-radius: 2px;
+  border: solid 1px;
+  position: relative;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c5:before {
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  width: 3px;
+  height: 9px;
+  border: solid #ffffff;
+  border-width: 0 3px 0 0;
+  -webkit-transform: rotate(90deg) translateX(1px);
+  -ms-transform: rotate(90deg) translateX(1px);
+  transform: rotate(90deg) translateX(1px);
+  border-radius: 0;
+}
+
+.c3 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c3:focus + .c4 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c3:checked + .c4 {
+  border-color: #00438f;
+  background-color: #00438f;
+}
+
+.c3:checked + .c4:before {
+  display: block;
+}
+
+.c3:not(:checked) + .c4 {
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+}
+
+.c8 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c8:focus + .c4 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c8:checked + .c4 {
+  border-color: #cc1439;
+  background-color: #cc1439;
+}
+
+.c8:checked + .c4:before {
+  display: block;
+}
+
+.c8:not(:checked) + .c4 {
+  border-color: #cc1439;
+  background-color: #ffffff;
+}
+
+.c10 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c10:focus + .c4 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c10:checked + .c4 {
+  border-color: #e4e7eb;
+  background-color: #e4e7eb;
+}
+
+.c10:checked + .c4:before {
+  display: block;
+}
+
+.c10:not(:checked) + .c4 {
+  border-color: #e4e7eb;
+  background-color: #f0f2f5;
+}
+
+.c1 {
+  padding: 4px 0;
+}
+
+.c1 .c6 {
+  margin-left: 8px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+      className="c1"
     >
       <label
-        class="ClickInputLabel-j2axnv-0 kemUmZ"
+        className="c2"
+        disabled={false}
       >
         <input
-          aria-invalid="false"
-          aria-required="false"
-          checked=""
-          class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+          aria-invalid={false}
+          aria-required={false}
+          checked={true}
+          className="c3 c1"
+          disabled={false}
           id="checkbox"
-          readonly=""
+          readOnly={true}
+          required={false}
           type="checkbox"
         />
         <div
-          checked=""
-          class="Checkbox__VisualCheckbox-sc-1nm58f1-0 vVWOc"
+          checked={true}
+          className="c4 c5"
           data-testid="visual-checkbox"
+          disabled={false}
         />
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c6 c7"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           I am an indeterminate checkbox
         </p>
       </label>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+      className="c1"
     >
       <label
-        class="ClickInputLabel-j2axnv-0 kemUmZ"
+        className="c2"
+        disabled={false}
       >
         <input
-          aria-invalid="false"
-          aria-required="false"
-          class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+          aria-invalid={false}
+          aria-required={false}
+          checked={false}
+          className="c3 c1"
+          disabled={false}
           id="checkbox"
-          readonly=""
+          readOnly={true}
+          required={false}
           type="checkbox"
         />
         <div
-          class="Checkbox__VisualCheckbox-sc-1nm58f1-0 vVWOc"
+          checked={false}
+          className="c4 c5"
           data-testid="visual-checkbox"
+          disabled={false}
         />
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c6 c7"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           I am a unchecked indeterminate checkbox
         </p>
       </label>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+      className="c1"
     >
       <label
-        class="ClickInputLabel-j2axnv-0 kemUmZ"
+        className="c2"
+        disabled={false}
       >
         <input
-          aria-invalid="true"
-          aria-required="false"
-          checked=""
-          class="Checkbox__CheckboxInput-sc-1nm58f1-1 iWambR Checkbox-sc-1nm58f1-2 eJJycu"
+          aria-invalid={true}
+          aria-required={false}
+          checked={true}
+          className="c8 c1"
+          disabled={false}
           id="checkbox"
-          readonly=""
+          readOnly={true}
+          required={false}
           type="checkbox"
         />
         <div
-          checked=""
-          class="Checkbox__VisualCheckbox-sc-1nm58f1-0 vVWOc"
+          checked={true}
+          className="c4 c5"
           data-testid="visual-checkbox"
+          disabled={false}
         />
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c6 c7"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           I am an indeterminate checkbox with an error
         </p>
       </label>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+      className="c1"
     >
       <label
-        class="ClickInputLabel-j2axnv-0 kjxgat"
-        disabled=""
+        className="c9"
+        disabled={true}
       >
         <input
-          aria-invalid="false"
-          aria-required="false"
-          checked=""
-          class="Checkbox__CheckboxInput-sc-1nm58f1-1 jdAeaf Checkbox-sc-1nm58f1-2 eJJycu"
-          disabled=""
+          aria-invalid={false}
+          aria-required={false}
+          checked={true}
+          className="c10 c1"
+          disabled={true}
           id="checkbox"
-          readonly=""
+          readOnly={true}
+          required={false}
           type="checkbox"
         />
         <div
-          checked=""
-          class="Checkbox__VisualCheckbox-sc-1nm58f1-0 vVWOc"
+          checked={true}
+          className="c4 c5"
           data-testid="visual-checkbox"
-          disabled=""
+          disabled={true}
         />
         <p
-          class="Text-sc-1wu7vpu-0 hdrQgs"
+          className="c6 c11"
           color="currentColor"
-          disabled=""
-          font-size="medium"
+          disabled={true}
+          fontSize="medium"
         >
           I am a disabled indeterminate checkbox
         </p>

--- a/components/src/Checkbox/__snapshots__/CheckboxGroup.story.storyshot
+++ b/components/src/Checkbox/__snapshots__/CheckboxGroup.story.storyshot
@@ -1,100 +1,252 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots CheckboxGroup CheckboxGroup 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c10 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c5 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c1 {
+  padding: 0;
+  border: 0;
+  margin: 0;
+  width: 100%;
+}
+
+.c1 legend {
+  padding: 0;
+}
+
+.c8 {
+  min-width: 16px;
+  height: 16px;
+  border-radius: 2px;
+  border: solid 1px;
+  position: relative;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c8:before {
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  width: 3px;
+  height: 9px;
+  border: solid #ffffff;
+  border-radius: 1px;
+  border-width: 0 3px 3px 0;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.c6 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c6:focus + .c7 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c6:checked + .c7 {
+  border-color: #00438f;
+  background-color: #00438f;
+}
+
+.c6:checked + .c7:before {
+  display: block;
+}
+
+.c6:not(:checked) + .c7 {
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+}
+
+.c4 {
+  padding: 4px 0;
+}
+
+.c4 .c9 {
+  margin-left: 8px;
+}
+
+.c3 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c2 {
+  margin-bottom: 8px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <fieldset
-      class="Fieldset-sc-9aoml1-0 eiFgjk CheckboxGroup-sc-16y7xr8-2 bfgHHz"
+      className="c1 "
     >
       <legend
-        class="CheckboxGroup__Legend-sc-16y7xr8-1 FZknE"
+        className="c2"
       >
         <span
-          class="CheckboxGroup__LabelText-sc-16y7xr8-0 srOjp"
+          className="c3"
         >
           Setting Selection
         </span>
       </legend>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+        className="c4"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c5"
+          disabled={false}
         >
           <input
-            aria-invalid="false"
-            aria-required="false"
-            class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+            aria-invalid={false}
+            aria-required={false}
+            className="c6 c4"
+            disabled={false}
+            id={null}
             name="settingSelection"
+            required={false}
             type="checkbox"
             value="a"
           />
           <div
-            class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+            className="c7 c8"
             data-testid="visual-checkbox"
+            disabled={false}
           />
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c9 c10"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Option A
           </p>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+        className="c4"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c5"
+          disabled={false}
         >
           <input
-            aria-invalid="false"
-            aria-required="false"
-            class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+            aria-invalid={false}
+            aria-required={false}
+            className="c6 c4"
+            disabled={false}
+            id={null}
             name="settingSelection"
+            required={false}
             type="checkbox"
             value="b"
           />
           <div
-            class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+            className="c7 c8"
             data-testid="visual-checkbox"
+            disabled={false}
           />
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c9 c10"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Option B
           </p>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+        className="c4"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c5"
+          disabled={false}
         >
           <input
-            aria-invalid="false"
-            aria-required="false"
-            class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+            aria-invalid={false}
+            aria-required={false}
+            className="c6 c4"
+            disabled={false}
+            id={null}
             name="settingSelection"
+            required={false}
             type="checkbox"
             value="c"
           />
           <div
-            class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+            className="c7 c8"
             data-testid="visual-checkbox"
+            disabled={false}
           />
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c9 c10"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Option C
           </p>
@@ -106,118 +258,294 @@ exports[`Storyshots CheckboxGroup CheckboxGroup 1`] = `
 `;
 
 exports[`Storyshots CheckboxGroup CheckboxGroup with all props 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c5 {
+  margin-left: 8px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #434d59;
+}
+
+.c12 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c8 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c6 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+  font-size: 14px;
+  line-height: 1.71428571;
+}
+
+.c6 .Link-sc-1lpx3d0-0 {
+  font-size: 14px;
+}
+
+.c1 {
+  padding: 0;
+  border: 0;
+  margin: 0;
+  width: 100%;
+}
+
+.c1 legend {
+  padding: 0;
+}
+
+.c11 {
+  min-width: 16px;
+  height: 16px;
+  border-radius: 2px;
+  border: solid 1px;
+  position: relative;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c11:before {
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  width: 3px;
+  height: 9px;
+  border: solid #ffffff;
+  border-radius: 1px;
+  border-width: 0 3px 3px 0;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.c9 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c9:focus + .c10 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c9:checked + .c10 {
+  border-color: #00438f;
+  background-color: #00438f;
+}
+
+.c9:checked + .c10:before {
+  display: block;
+}
+
+.c9:not(:checked) + .c10 {
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+}
+
+.c7 {
+  padding: 4px 0;
+}
+
+.c7 .c4 {
+  margin-left: 8px;
+}
+
+.c3 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c2 {
+  margin-bottom: 8px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <fieldset
-      class="Fieldset-sc-9aoml1-0 eiFgjk CheckboxGroup-sc-16y7xr8-2 bfgHHz"
+      className="c1 "
     >
       <legend
-        class="CheckboxGroup__Legend-sc-16y7xr8-1 FZknE"
+        className="c2"
       >
         <span
-          class="CheckboxGroup__LabelText-sc-16y7xr8-0 srOjp"
+          className="c3"
         >
           Setting Selection
         </span>
         <span
-          class="Text-sc-1wu7vpu-0 bphWXP"
+          className="c4 c5"
           color="darkGrey"
-          font-size="12px"
+          disabled={false}
+          fontSize="12px"
         >
           (Required)
         </span>
       </legend>
       <p
-        class="Text-sc-1wu7vpu-0 HelpText__HelpTextContent-sc-1jzmq2g-0 feAJVX"
+        className="c4 c6"
         color="currentColor"
-        font-size="medium"
+        disabled={false}
+        fontSize="medium"
       >
         Select a setting from the menu below:
       </p>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+        className="c7"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c8"
+          disabled={false}
         >
           <input
-            aria-invalid="false"
-            aria-required="true"
-            checked=""
-            class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+            aria-invalid={false}
+            aria-required={true}
+            className="c9 c7"
+            defaultChecked={true}
+            disabled={false}
+            id={null}
             name="settingSelection"
-            required=""
+            required={true}
             type="checkbox"
             value="a"
           />
           <div
-            class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+            className="c10 c11"
             data-testid="visual-checkbox"
+            disabled={false}
           />
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c4 c12"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Option A
           </p>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+        className="c7"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c8"
+          disabled={false}
         >
           <input
-            aria-invalid="false"
-            aria-required="true"
-            class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+            aria-invalid={false}
+            aria-required={true}
+            className="c9 c7"
+            defaultChecked={false}
+            disabled={false}
+            id={null}
             name="settingSelection"
-            required=""
+            required={true}
             type="checkbox"
             value="b"
           />
           <div
-            class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+            className="c10 c11"
             data-testid="visual-checkbox"
+            disabled={false}
           />
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c4 c12"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Option B
           </p>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+        className="c7"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c8"
+          disabled={false}
         >
           <input
-            aria-invalid="false"
-            aria-required="true"
-            class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+            aria-invalid={false}
+            aria-required={true}
+            className="c9 c7"
+            defaultChecked={false}
+            disabled={false}
+            id={null}
             name="settingSelection"
-            required=""
+            required={true}
             type="checkbox"
             value="c"
           />
           <div
-            class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+            className="c10 c11"
             data-testid="visual-checkbox"
+            disabled={false}
           />
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c4 c12"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Option C
           </p>
@@ -229,102 +557,261 @@ exports[`Storyshots CheckboxGroup CheckboxGroup with all props 1`] = `
 `;
 
 exports[`Storyshots CheckboxGroup Controlled 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c10 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c5 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c1 {
+  padding: 0;
+  border: 0;
+  margin: 0;
+  width: 100%;
+}
+
+.c1 legend {
+  padding: 0;
+}
+
+.c8 {
+  min-width: 16px;
+  height: 16px;
+  border-radius: 2px;
+  border: solid 1px;
+  position: relative;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c8:before {
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  width: 3px;
+  height: 9px;
+  border: solid #ffffff;
+  border-radius: 1px;
+  border-width: 0 3px 3px 0;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.c6 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c6:focus + .c7 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c6:checked + .c7 {
+  border-color: #00438f;
+  background-color: #00438f;
+}
+
+.c6:checked + .c7:before {
+  display: block;
+}
+
+.c6:not(:checked) + .c7 {
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+}
+
+.c4 {
+  padding: 4px 0;
+}
+
+.c4 .c9 {
+  margin-left: 8px;
+}
+
+.c3 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c2 {
+  margin-bottom: 8px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <fieldset
-      class="Fieldset-sc-9aoml1-0 eiFgjk CheckboxGroup-sc-16y7xr8-2 bfgHHz"
+      className="c1 "
     >
       <legend
-        class="CheckboxGroup__Legend-sc-16y7xr8-1 FZknE"
+        className="c2"
       >
         <span
-          class="CheckboxGroup__LabelText-sc-16y7xr8-0 srOjp"
+          className="c3"
         >
           Setting Selection
         </span>
       </legend>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+        className="c4"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c5"
+          disabled={false}
         >
           <input
-            aria-invalid="false"
-            aria-required="false"
-            checked=""
-            class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+            aria-invalid={false}
+            aria-required={false}
+            checked={true}
+            className="c6 c4"
+            disabled={false}
+            id={null}
             name="settingSelection"
+            onChange={[Function]}
+            required={false}
             type="checkbox"
             value="a"
           />
           <div
-            checked=""
-            class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+            checked={true}
+            className="c7 c8"
             data-testid="visual-checkbox"
+            disabled={false}
           />
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c9 c10"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Option A
           </p>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+        className="c4"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c5"
+          disabled={false}
         >
           <input
-            aria-invalid="false"
-            aria-required="false"
-            class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+            aria-invalid={false}
+            aria-required={false}
+            checked={false}
+            className="c6 c4"
+            disabled={false}
+            id={null}
             name="settingSelection"
+            onChange={[Function]}
+            required={false}
             type="checkbox"
             value="b"
           />
           <div
-            class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+            checked={false}
+            className="c7 c8"
             data-testid="visual-checkbox"
+            disabled={false}
           />
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c9 c10"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Option B
           </p>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+        className="c4"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c5"
+          disabled={false}
         >
           <input
-            aria-invalid="false"
-            aria-required="false"
-            class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+            aria-invalid={false}
+            aria-required={false}
+            checked={false}
+            className="c6 c4"
+            disabled={false}
+            id={null}
             name="settingSelection"
+            onChange={[Function]}
+            required={false}
             type="checkbox"
             value="c"
           />
           <div
-            class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+            checked={false}
+            className="c7 c8"
             data-testid="visual-checkbox"
+            disabled={false}
           />
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c9 c10"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Option C
           </p>
@@ -336,113 +823,255 @@ exports[`Storyshots CheckboxGroup Controlled 1`] = `
 `;
 
 exports[`Storyshots CheckboxGroup Set to disabled 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c10 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+  opacity: 0.3333;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c1 {
+  padding: 0;
+  border: 0;
+  margin: 0;
+  width: 100%;
+}
+
+.c1 legend {
+  padding: 0;
+}
+
+.c8 {
+  min-width: 16px;
+  height: 16px;
+  border-radius: 2px;
+  border: solid 1px;
+  position: relative;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c8:before {
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  width: 3px;
+  height: 9px;
+  border: solid #ffffff;
+  border-radius: 1px;
+  border-width: 0 3px 3px 0;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.c6 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c6:focus + .c7 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c6:checked + .c7 {
+  border-color: #e4e7eb;
+  background-color: #e4e7eb;
+}
+
+.c6:checked + .c7:before {
+  display: block;
+}
+
+.c6:not(:checked) + .c7 {
+  border-color: #e4e7eb;
+  background-color: #f0f2f5;
+}
+
+.c4 {
+  padding: 4px 0;
+}
+
+.c4 .c9 {
+  margin-left: 8px;
+}
+
+.c3 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c2 {
+  margin-bottom: 8px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <fieldset
-      class="Fieldset-sc-9aoml1-0 eiFgjk CheckboxGroup-sc-16y7xr8-2 bfgHHz"
+      className="c1 "
     >
       <legend
-        class="CheckboxGroup__Legend-sc-16y7xr8-1 FZknE"
+        className="c2"
       >
         <span
-          class="CheckboxGroup__LabelText-sc-16y7xr8-0 srOjp"
+          className="c3"
         >
           Setting Selection
         </span>
       </legend>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+        className="c4"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kjxgat"
-          disabled=""
+          className="c5"
+          disabled={true}
         >
           <input
-            aria-invalid="false"
-            aria-required="false"
-            checked=""
-            class="Checkbox__CheckboxInput-sc-1nm58f1-1 jdAeaf Checkbox-sc-1nm58f1-2 eJJycu"
-            disabled=""
+            aria-invalid={false}
+            aria-required={false}
+            className="c6 c4"
+            defaultChecked={true}
+            disabled={true}
+            id={null}
             name="settingSelection"
+            required={false}
             type="checkbox"
             value="a"
           />
           <div
-            class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+            className="c7 c8"
             data-testid="visual-checkbox"
-            disabled=""
+            disabled={true}
           />
           <p
-            class="Text-sc-1wu7vpu-0 hdrQgs"
+            className="c9 c10"
             color="currentColor"
-            disabled=""
-            font-size="medium"
+            disabled={true}
+            fontSize="medium"
           >
             Option A
           </p>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+        className="c4"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kjxgat"
-          disabled=""
+          className="c5"
+          disabled={true}
         >
           <input
-            aria-invalid="false"
-            aria-required="false"
-            class="Checkbox__CheckboxInput-sc-1nm58f1-1 jdAeaf Checkbox-sc-1nm58f1-2 eJJycu"
-            disabled=""
+            aria-invalid={false}
+            aria-required={false}
+            className="c6 c4"
+            defaultChecked={false}
+            disabled={true}
+            id={null}
             name="settingSelection"
+            required={false}
             type="checkbox"
             value="b"
           />
           <div
-            class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+            className="c7 c8"
             data-testid="visual-checkbox"
-            disabled=""
+            disabled={true}
           />
           <p
-            class="Text-sc-1wu7vpu-0 hdrQgs"
+            className="c9 c10"
             color="currentColor"
-            disabled=""
-            font-size="medium"
+            disabled={true}
+            fontSize="medium"
           >
             Option B
           </p>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+        className="c4"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kjxgat"
-          disabled=""
+          className="c5"
+          disabled={true}
         >
           <input
-            aria-invalid="false"
-            aria-required="false"
-            class="Checkbox__CheckboxInput-sc-1nm58f1-1 jdAeaf Checkbox-sc-1nm58f1-2 eJJycu"
-            disabled=""
+            aria-invalid={false}
+            aria-required={false}
+            className="c6 c4"
+            defaultChecked={false}
+            disabled={true}
+            id={null}
             name="settingSelection"
+            required={false}
             type="checkbox"
             value="c"
           />
           <div
-            class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+            className="c7 c8"
             data-testid="visual-checkbox"
-            disabled=""
+            disabled={true}
           />
           <p
-            class="Text-sc-1wu7vpu-0 hdrQgs"
+            className="c9 c10"
             color="currentColor"
-            disabled=""
-            font-size="medium"
+            disabled={true}
+            fontSize="medium"
           >
             Option C
           </p>
@@ -454,119 +1083,317 @@ exports[`Storyshots CheckboxGroup Set to disabled 1`] = `
 `;
 
 exports[`Storyshots CheckboxGroup with error list 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c11 {
+  color: #cc1439;
+  margin-top: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c12 {
+  margin-right: 8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c10 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c5 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c16 {
+  margin-bottom: 8px;
+  color: currentColor;
+}
+
+.c16:last-child {
+  margin-bottom: 0;
+}
+
+.c14 {
+  color: currentColor;
+  margin: 0;
+  padding-left: 18px;
+}
+
+.c14 .c15 {
+  margin-bottom: 0;
+}
+
+.c13 .c9 {
+  margin-bottom: 8px;
+}
+
+.c13 > *:last-child {
+  margin-bottom: 0;
+}
+
+.c1 {
+  padding: 0;
+  border: 0;
+  margin: 0;
+  width: 100%;
+}
+
+.c1 legend {
+  padding: 0;
+}
+
+.c8 {
+  min-width: 16px;
+  height: 16px;
+  border-radius: 2px;
+  border: solid 1px;
+  position: relative;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c8:before {
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  width: 3px;
+  height: 9px;
+  border: solid #ffffff;
+  border-radius: 1px;
+  border-width: 0 3px 3px 0;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.c6 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c6:focus + .c7 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c6:checked + .c7 {
+  border-color: #cc1439;
+  background-color: #cc1439;
+}
+
+.c6:checked + .c7:before {
+  display: block;
+}
+
+.c6:not(:checked) + .c7 {
+  border-color: #cc1439;
+  background-color: #ffffff;
+}
+
+.c4 {
+  padding: 4px 0;
+}
+
+.c4 .c9 {
+  margin-left: 8px;
+}
+
+.c3 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c2 {
+  margin-bottom: 8px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <fieldset
-      class="Fieldset-sc-9aoml1-0 eiFgjk CheckboxGroup-sc-16y7xr8-2 bfgHHz"
+      className="c1 "
     >
       <legend
-        class="CheckboxGroup__Legend-sc-16y7xr8-1 FZknE"
+        className="c2"
       >
         <span
-          class="CheckboxGroup__LabelText-sc-16y7xr8-0 srOjp"
+          className="c3"
         >
           Setting Selection
         </span>
       </legend>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+        className="c4"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c5"
+          disabled={false}
         >
           <input
-            aria-invalid="true"
-            aria-required="false"
-            checked=""
-            class="Checkbox__CheckboxInput-sc-1nm58f1-1 iWambR Checkbox-sc-1nm58f1-2 eJJycu"
+            aria-invalid={true}
+            aria-required={false}
+            className="c6 c4"
+            defaultChecked={true}
+            disabled={false}
+            id={null}
             name="settingSelection"
+            required={false}
             type="checkbox"
             value="a"
           />
           <div
-            class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+            className="c7 c8"
             data-testid="visual-checkbox"
+            disabled={false}
           />
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c9 c10"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Option A
           </p>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+        className="c4"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c5"
+          disabled={false}
         >
           <input
-            aria-invalid="true"
-            aria-required="false"
-            class="Checkbox__CheckboxInput-sc-1nm58f1-1 iWambR Checkbox-sc-1nm58f1-2 eJJycu"
+            aria-invalid={true}
+            aria-required={false}
+            className="c6 c4"
+            defaultChecked={false}
+            disabled={false}
+            id={null}
             name="settingSelection"
+            required={false}
             type="checkbox"
             value="b"
           />
           <div
-            class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+            className="c7 c8"
             data-testid="visual-checkbox"
+            disabled={false}
           />
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c9 c10"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Option B
           </p>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+        className="c4"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c5"
+          disabled={false}
         >
           <input
-            aria-invalid="true"
-            aria-required="false"
-            class="Checkbox__CheckboxInput-sc-1nm58f1-1 iWambR Checkbox-sc-1nm58f1-2 eJJycu"
+            aria-invalid={true}
+            aria-required={false}
+            className="c6 c4"
+            defaultChecked={false}
+            disabled={false}
+            id={null}
             name="settingSelection"
+            required={false}
             type="checkbox"
             value="c"
           />
           <div
-            class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+            className="c7 c8"
             data-testid="visual-checkbox"
+            disabled={false}
           />
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c9 c10"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Option C
           </p>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 ycNbA"
+        className="c11"
         color="red"
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 QuoIa"
+          aria-hidden={true}
+          className="c12"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="error"
           mr="x1"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -575,27 +1402,28 @@ exports[`Storyshots CheckboxGroup with error list 1`] = `
           />
         </svg>
         <div
-          class="InlineValidation__Wrapper-sc-1jic7dw-0 kqhCKM"
+          className="c13"
         >
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c9 c10"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Please select an option
           </p>
           <ul
-            class="List-sc-1cqkmnl-0 diqcEx"
+            className="c14"
             color="currentColor"
           >
             <li
-              class="ListItem-qqenhw-0 gzsWDK"
+              className="c15 c16"
               color="currentColor"
             >
               Error message 1
             </li>
             <li
-              class="ListItem-qqenhw-0 gzsWDK"
+              className="c15 c16"
               color="currentColor"
             >
               Error message 2
@@ -609,119 +1437,298 @@ exports[`Storyshots CheckboxGroup with error list 1`] = `
 `;
 
 exports[`Storyshots CheckboxGroup with error message 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c11 {
+  color: #cc1439;
+  margin-top: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c12 {
+  margin-right: 8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c10 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c5 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c13 .c9 {
+  margin-bottom: 8px;
+}
+
+.c13 > *:last-child {
+  margin-bottom: 0;
+}
+
+.c1 {
+  padding: 0;
+  border: 0;
+  margin: 0;
+  width: 100%;
+}
+
+.c1 legend {
+  padding: 0;
+}
+
+.c8 {
+  min-width: 16px;
+  height: 16px;
+  border-radius: 2px;
+  border: solid 1px;
+  position: relative;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c8:before {
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  width: 3px;
+  height: 9px;
+  border: solid #ffffff;
+  border-radius: 1px;
+  border-width: 0 3px 3px 0;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.c6 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c6:focus + .c7 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c6:checked + .c7 {
+  border-color: #cc1439;
+  background-color: #cc1439;
+}
+
+.c6:checked + .c7:before {
+  display: block;
+}
+
+.c6:not(:checked) + .c7 {
+  border-color: #cc1439;
+  background-color: #ffffff;
+}
+
+.c4 {
+  padding: 4px 0;
+}
+
+.c4 .c9 {
+  margin-left: 8px;
+}
+
+.c3 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c2 {
+  margin-bottom: 8px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <fieldset
-      class="Fieldset-sc-9aoml1-0 eiFgjk CheckboxGroup-sc-16y7xr8-2 bfgHHz"
+      className="c1 "
     >
       <legend
-        class="CheckboxGroup__Legend-sc-16y7xr8-1 FZknE"
+        className="c2"
       >
         <span
-          class="CheckboxGroup__LabelText-sc-16y7xr8-0 srOjp"
+          className="c3"
         >
           Setting Selection
         </span>
       </legend>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+        className="c4"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c5"
+          disabled={false}
         >
           <input
-            aria-invalid="true"
-            aria-required="false"
-            checked=""
-            class="Checkbox__CheckboxInput-sc-1nm58f1-1 iWambR Checkbox-sc-1nm58f1-2 eJJycu"
+            aria-invalid={true}
+            aria-required={false}
+            className="c6 c4"
+            defaultChecked={true}
+            disabled={false}
+            id={null}
             name="settingSelection"
+            required={false}
             type="checkbox"
             value="a"
           />
           <div
-            class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+            className="c7 c8"
             data-testid="visual-checkbox"
+            disabled={false}
           />
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c9 c10"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Option A
           </p>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+        className="c4"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c5"
+          disabled={false}
         >
           <input
-            aria-invalid="true"
-            aria-required="false"
-            class="Checkbox__CheckboxInput-sc-1nm58f1-1 iWambR Checkbox-sc-1nm58f1-2 eJJycu"
+            aria-invalid={true}
+            aria-required={false}
+            className="c6 c4"
+            defaultChecked={false}
+            disabled={false}
+            id={null}
             name="settingSelection"
+            required={false}
             type="checkbox"
             value="b"
           />
           <div
-            class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+            className="c7 c8"
             data-testid="visual-checkbox"
+            disabled={false}
           />
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c9 c10"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Option B
           </p>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+        className="c4"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c5"
+          disabled={false}
         >
           <input
-            aria-invalid="true"
-            aria-required="false"
-            class="Checkbox__CheckboxInput-sc-1nm58f1-1 iWambR Checkbox-sc-1nm58f1-2 eJJycu"
+            aria-invalid={true}
+            aria-required={false}
+            className="c6 c4"
+            defaultChecked={false}
+            disabled={false}
+            id={null}
             name="settingSelection"
+            required={false}
             type="checkbox"
             value="c"
           />
           <div
-            class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+            className="c7 c8"
             data-testid="visual-checkbox"
+            disabled={false}
           />
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c9 c10"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Option C
           </p>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 ycNbA"
+        className="c11"
         color="red"
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 QuoIa"
+          aria-hidden={true}
+          className="c12"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="error"
           mr="x1"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -730,12 +1737,13 @@ exports[`Storyshots CheckboxGroup with error message 1`] = `
           />
         </svg>
         <div
-          class="InlineValidation__Wrapper-sc-1jic7dw-0 kqhCKM"
+          className="c13"
         >
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c9 c10"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Please select an option
           </p>

--- a/components/src/DatePicker/__snapshots__/DatePicker.story.storyshot
+++ b/components/src/DatePicker/__snapshots__/DatePicker.story.storyshot
@@ -1,59 +1,196 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots DatePicker default 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 16px;
+  position: absolute;
+  right: 8px;
+  color: #434d59;
+  bottom: 50%;
+  -webkit-transform: translateY(50%);
+  -ms-transform: translateY(50%);
+  transform: translateY(50%);
+  pointer-events: none;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
+      className="c1  nds-date-picker"
     >
       <div
-        class="react-datepicker-wrapper"
+        className="react-datepicker-wrapper"
       >
         <div
-          class="react-datepicker__input-container"
+          className="react-datepicker__input-container"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c2 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c3"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c4"
               >
                 Expiry Date
               </span>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="select a date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="DD Mon YYYY"
+                  required={false}
                   value="01 Jan 2019"
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -72,59 +209,196 @@ exports[`Storyshots DatePicker default 1`] = `
 `;
 
 exports[`Storyshots DatePicker with custom date format 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 16px;
+  position: absolute;
+  right: 8px;
+  color: #434d59;
+  bottom: 50%;
+  -webkit-transform: translateY(50%);
+  -ms-transform: translateY(50%);
+  transform: translateY(50%);
+  pointer-events: none;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
+      className="c1  nds-date-picker"
     >
       <div
-        class="react-datepicker-wrapper"
+        className="react-datepicker-wrapper"
       >
         <div
-          class="react-datepicker__input-container"
+          className="react-datepicker__input-container"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c2 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c3"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c4"
               >
                 Expiry Date
               </span>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="select a date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="MMMM d, yyyy"
+                  required={false}
                   value="January 1, 2019"
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -143,59 +417,196 @@ exports[`Storyshots DatePicker with custom date format 1`] = `
 `;
 
 exports[`Storyshots DatePicker with custom locale 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 16px;
+  position: absolute;
+  right: 8px;
+  color: #434d59;
+  bottom: 50%;
+  -webkit-transform: translateY(50%);
+  -ms-transform: translateY(50%);
+  transform: translateY(50%);
+  pointer-events: none;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
+      className="c1  nds-date-picker"
     >
       <div
-        class="react-datepicker-wrapper"
+        className="react-datepicker-wrapper"
       >
         <div
-          class="react-datepicker__input-container"
+          className="react-datepicker__input-container"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c2 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c3"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c4"
               >
                 Expiry Date
               </span>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="select a date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="DD Mon YYYY"
+                  required={false}
                   value="10 Jul 2019"
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -214,59 +625,196 @@ exports[`Storyshots DatePicker with custom locale 1`] = `
 `;
 
 exports[`Storyshots DatePicker with custom placeholder 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 16px;
+  position: absolute;
+  right: 8px;
+  color: #434d59;
+  bottom: 50%;
+  -webkit-transform: translateY(50%);
+  -ms-transform: translateY(50%);
+  transform: translateY(50%);
+  pointer-events: none;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
+      className="c1  nds-date-picker"
     >
       <div
-        class="react-datepicker-wrapper"
+        className="react-datepicker-wrapper"
       >
         <div
-          class="react-datepicker__input-container"
+          className="react-datepicker__input-container"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c2 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c3"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c4"
               >
                 Expiry Date
               </span>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="select a date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="Month day, year"
+                  required={false}
                   value=""
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -285,59 +833,227 @@ exports[`Storyshots DatePicker with custom placeholder 1`] = `
 `;
 
 exports[`Storyshots DatePicker with error state 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c9 {
+  color: #cc1439;
+  margin-top: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c10 {
+  margin-right: 8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c13 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c11 .c12 {
+  margin-bottom: 8px;
+}
+
+.c11 > *:last-child {
+  margin-bottom: 0;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #cc1439;
+  border-color: #cc1439;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 16px;
+  position: absolute;
+  right: 8px;
+  color: #434d59;
+  bottom: 50%;
+  -webkit-transform: translateY(50%);
+  -ms-transform: translateY(50%);
+  transform: translateY(50%);
+  pointer-events: none;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
+      className="c1  nds-date-picker"
     >
       <div
-        class="react-datepicker-wrapper"
+        className="react-datepicker-wrapper"
       >
         <div
-          class="react-datepicker__input-container"
+          className="react-datepicker__input-container"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c2 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c3"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c4"
               >
                 Expiry Date
               </span>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="true"
+                  aria-invalid={true}
                   aria-label="select a date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 jMjRjb"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="MMMM d, yyyy"
+                  required={false}
                   value=""
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -351,18 +1067,20 @@ exports[`Storyshots DatePicker with error state 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 ycNbA"
+        className="c9"
         color="red"
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 QuoIa"
+          aria-hidden={true}
+          className="c10"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="error"
           mr="x1"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -371,12 +1089,13 @@ exports[`Storyshots DatePicker with error state 1`] = `
           />
         </svg>
         <div
-          class="InlineValidation__Wrapper-sc-1jic7dw-0 kqhCKM"
+          className="c11"
         >
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c12 c13"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             The date is invalid
           </p>
@@ -388,59 +1107,196 @@ exports[`Storyshots DatePicker with error state 1`] = `
 `;
 
 exports[`Storyshots DatePicker with min and max date 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 16px;
+  position: absolute;
+  right: 8px;
+  color: #434d59;
+  bottom: 50%;
+  -webkit-transform: translateY(50%);
+  -ms-transform: translateY(50%);
+  transform: translateY(50%);
+  pointer-events: none;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
+      className="c1  nds-date-picker"
     >
       <div
-        class="react-datepicker-wrapper"
+        className="react-datepicker-wrapper"
       >
         <div
-          class="react-datepicker__input-container"
+          className="react-datepicker__input-container"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c2 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c3"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c4"
               >
                 Expiry Date
               </span>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="select a date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="DD Mon YYYY"
+                  required={false}
                   value="05 Jan 2019"
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >

--- a/components/src/DateRange/__snapshots__/DateRange.story.storyshot
+++ b/components/src/DateRange/__snapshots__/DateRange.story.storyshot
@@ -1,64 +1,228 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots DateRange customizing input props 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c9 {
+  padding-left: 4px;
+  padding-right: 4px;
+  max-height: 38px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c10 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c1 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c2 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c4 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 16px;
+  position: absolute;
+  right: 8px;
+  color: #434d59;
+  bottom: 50%;
+  -webkit-transform: translateY(50%);
+  -ms-transform: translateY(50%);
+  transform: translateY(50%);
+  pointer-events: none;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      className="c1 "
       color="black"
-      style="display:block"
+      style={
+        Object {
+          "display": "block",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
+        className=""
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          className="c2"
         >
           Date range
         </span>
       </div>
     </label>
     <div
-      class="Box-sc-1qu1edy-0 iyjdMT"
+      className="c3"
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
+        className="c4  nds-date-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select a start date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="From (Mon YYYY)"
+                  required={false}
                   value=""
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -72,48 +236,56 @@ exports[`Storyshots DateRange customizing input props 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hYUuLW"
+        className="c9"
       >
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c10"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           -
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
+        className="c4  nds-date-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select an end date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="To (Mon YYYY)"
+                  required={false}
                   value=""
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -132,64 +304,228 @@ exports[`Storyshots DateRange customizing input props 1`] = `
 `;
 
 exports[`Storyshots DateRange default 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c9 {
+  padding-left: 4px;
+  padding-right: 4px;
+  max-height: 38px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c10 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c1 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c2 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c4 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 16px;
+  position: absolute;
+  right: 8px;
+  color: #434d59;
+  bottom: 50%;
+  -webkit-transform: translateY(50%);
+  -ms-transform: translateY(50%);
+  transform: translateY(50%);
+  pointer-events: none;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      className="c1 "
       color="black"
-      style="display:block"
+      style={
+        Object {
+          "display": "block",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
+        className=""
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          className="c2"
         >
           Date range
         </span>
       </div>
     </label>
     <div
-      class="Box-sc-1qu1edy-0 iyjdMT"
+      className="c3"
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
+        className="c4  nds-date-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select a start date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="DD Mon YYYY"
+                  required={false}
                   value=""
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -203,48 +539,56 @@ exports[`Storyshots DateRange default 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hYUuLW"
+        className="c9"
       >
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c10"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           -
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
+        className="c4  nds-date-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select an end date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="DD Mon YYYY"
+                  required={false}
                   value=""
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -263,64 +607,228 @@ exports[`Storyshots DateRange default 1`] = `
 `;
 
 exports[`Storyshots DateRange default start and end date 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c9 {
+  padding-left: 4px;
+  padding-right: 4px;
+  max-height: 38px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c10 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c1 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c2 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c4 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 16px;
+  position: absolute;
+  right: 8px;
+  color: #434d59;
+  bottom: 50%;
+  -webkit-transform: translateY(50%);
+  -ms-transform: translateY(50%);
+  transform: translateY(50%);
+  pointer-events: none;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      className="c1 "
       color="black"
-      style="display:block"
+      style={
+        Object {
+          "display": "block",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
+        className=""
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          className="c2"
         >
           Date range
         </span>
       </div>
     </label>
     <div
-      class="Box-sc-1qu1edy-0 iyjdMT"
+      className="c3"
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
+        className="c4  nds-date-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select a start date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="DD Mon YYYY"
+                  required={false}
                   value="01 Jan 2019"
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -334,48 +842,56 @@ exports[`Storyshots DateRange default start and end date 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hYUuLW"
+        className="c9"
       >
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c10"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           -
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
+        className="c4  nds-date-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select an end date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="DD Mon YYYY"
+                  required={false}
                   value="05 Jan 2019"
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -394,64 +910,228 @@ exports[`Storyshots DateRange default start and end date 1`] = `
 `;
 
 exports[`Storyshots DateRange disabled range validation 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c9 {
+  padding-left: 4px;
+  padding-right: 4px;
+  max-height: 38px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c10 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c1 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c2 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c4 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 16px;
+  position: absolute;
+  right: 8px;
+  color: #434d59;
+  bottom: 50%;
+  -webkit-transform: translateY(50%);
+  -ms-transform: translateY(50%);
+  transform: translateY(50%);
+  pointer-events: none;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      className="c1 "
       color="black"
-      style="display:block"
+      style={
+        Object {
+          "display": "block",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
+        className=""
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          className="c2"
         >
           Date range
         </span>
       </div>
     </label>
     <div
-      class="Box-sc-1qu1edy-0 iyjdMT"
+      className="c3"
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
+        className="c4  nds-date-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select a start date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="DD Mon YYYY"
+                  required={false}
                   value="10 Sep 2019"
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -465,48 +1145,56 @@ exports[`Storyshots DateRange disabled range validation 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hYUuLW"
+        className="c9"
       >
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c10"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           -
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
+        className="c4  nds-date-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select an end date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="DD Mon YYYY"
+                  required={false}
                   value="05 Jul 2019"
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -525,65 +1213,296 @@ exports[`Storyshots DateRange disabled range validation 1`] = `
 `;
 
 exports[`Storyshots DateRange individual input error 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c9 {
+  color: #cc1439;
+  margin-top: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c14 {
+  padding-left: 4px;
+  padding-right: 4px;
+  max-height: 38px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c10 {
+  margin-right: 8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c13 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c11 .c12 {
+  margin-bottom: 8px;
+}
+
+.c11 > *:last-child {
+  margin-bottom: 0;
+}
+
+.c1 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c2 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c4 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #cc1439;
+  border-color: #cc1439;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c15 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c15:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c15:focus ~ svg {
+  fill: #00438f;
+}
+
+.c15::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c15::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c15:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c15::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 16px;
+  position: absolute;
+  right: 8px;
+  color: #434d59;
+  bottom: 50%;
+  -webkit-transform: translateY(50%);
+  -ms-transform: translateY(50%);
+  transform: translateY(50%);
+  pointer-events: none;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      className="c1 "
       color="black"
-      style="display:block"
+      style={
+        Object {
+          "display": "block",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
+        className=""
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          className="c2"
         >
           Date range
         </span>
       </div>
     </label>
     <div
-      class="Box-sc-1qu1edy-0 iyjdMT"
+      className="c3"
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
+        className="c4  nds-date-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="true"
+                  aria-invalid={true}
                   aria-label="Select a start date"
-                  aria-required="true"
-                  class="InputField__StyledInput-sc-6cu4mg-0 jMjRjb"
+                  aria-required={true}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="DD Mon YYYY"
-                  required=""
+                  required={true}
                   value=""
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -596,18 +1515,20 @@ exports[`Storyshots DateRange individual input error 1`] = `
           </div>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 ycNbA"
+          className="c9"
           color="red"
         >
           <svg
-            aria-hidden="true"
-            class="Icon-fc7twp-0 QuoIa"
+            aria-hidden={true}
+            className="c10"
             color="currentColor"
             fill="currentColor"
-            focusable="false"
+            focusable={false}
             height="24px"
             icon="error"
             mr="x1"
+            size="24px"
+            title={null}
             viewBox="0 0 24 24"
             width="24px"
           >
@@ -616,12 +1537,13 @@ exports[`Storyshots DateRange individual input error 1`] = `
             />
           </svg>
           <div
-            class="InlineValidation__Wrapper-sc-1jic7dw-0 kqhCKM"
+            className="c11"
           >
             <p
-              class="Text-sc-1wu7vpu-0 RbfMK"
+              className="c12 c13"
               color="currentColor"
-              font-size="medium"
+              disabled={false}
+              fontSize="medium"
             >
               Start date is required
             </p>
@@ -629,48 +1551,56 @@ exports[`Storyshots DateRange individual input error 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hYUuLW"
+        className="c14"
       >
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c12 c13"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           -
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
+        className="c4  nds-date-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select an end date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c15"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="DD Mon YYYY"
+                  required={false}
                   value="10 Sep 2019"
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -689,64 +1619,250 @@ exports[`Storyshots DateRange individual input error 1`] = `
 `;
 
 exports[`Storyshots DateRange with custom error 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c9 {
+  padding-left: 4px;
+  padding-right: 4px;
+  max-height: 38px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c12 {
+  color: #cc1439;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c13 {
+  margin-right: 8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c11 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c14 .c10 {
+  margin-bottom: 8px;
+}
+
+.c14 > *:last-child {
+  margin-bottom: 0;
+}
+
+.c1 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c2 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c4 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 16px;
+  position: absolute;
+  right: 8px;
+  color: #434d59;
+  bottom: 50%;
+  -webkit-transform: translateY(50%);
+  -ms-transform: translateY(50%);
+  transform: translateY(50%);
+  pointer-events: none;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      className="c1 "
       color="black"
-      style="display:block"
+      style={
+        Object {
+          "display": "block",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
+        className=""
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          className="c2"
         >
           Date range
         </span>
       </div>
     </label>
     <div
-      class="Box-sc-1qu1edy-0 iyjdMT"
+      className="c3"
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
+        className="c4  nds-date-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select a start date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="DD Mon YYYY"
+                  required={false}
                   value="05 Jul 2019"
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -760,48 +1876,56 @@ exports[`Storyshots DateRange with custom error 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hYUuLW"
+        className="c9"
       >
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c10 c11"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           -
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
+        className="c4  nds-date-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select an end date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="DD Mon YYYY"
+                  required={false}
                   value="10 Sep 2019"
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -816,18 +1940,20 @@ exports[`Storyshots DateRange with custom error 1`] = `
       </div>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 bXREHd"
+      className="c12"
       color="red"
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 QuoIa"
+        aria-hidden={true}
+        className="c13"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="error"
         mr="x1"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -836,12 +1962,13 @@ exports[`Storyshots DateRange with custom error 1`] = `
         />
       </svg>
       <div
-        class="InlineValidation__Wrapper-sc-1jic7dw-0 kqhCKM"
+        className="c14"
       >
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c10 c11"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           This range conflicts with another range
         </p>
@@ -852,64 +1979,246 @@ exports[`Storyshots DateRange with custom error 1`] = `
 `;
 
 exports[`Storyshots DateRange with default start and end times 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c11 {
+  padding-left: 4px;
+  padding-right: 4px;
+  max-height: 38px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c12 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c1 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c2 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c4 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 16px;
+  position: absolute;
+  right: 8px;
+  color: #434d59;
+  bottom: 50%;
+  -webkit-transform: translateY(50%);
+  -ms-transform: translateY(50%);
+  transform: translateY(50%);
+  pointer-events: none;
+}
+
+.c10 {
+  color: currentColor;
+  min-width: 22px;
+  color: #434d59;
+}
+
+.c10:hover {
+  color: #434d59;
+}
+
+.c9 {
+  margin-left: 8px;
+}
+
+.c13 {
+  margin-right: 8px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      className="c1 "
       color="black"
-      style="display:block"
+      style={
+        Object {
+          "display": "block",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
+        className=""
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          className="c2"
         >
           Date range
         </span>
       </div>
     </label>
     <div
-      class="Box-sc-1qu1edy-0 iyjdMT"
+      className="c3"
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
+        className="c4  nds-date-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select a start date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="DD Mon YYYY"
+                  required={false}
                   value="05 Jul 2019"
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -923,25 +2232,28 @@ exports[`Storyshots DateRange with default start and end times 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+        className="c4"
       >
         <div
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker DateRange__StyledStartTime-sc-1m2eund-0 bMhikq css-2b097c-container"
+            className="nds-time-picker c9 css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1liu8yu-Control"
+                className=" css-1liu8yu-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-r447wv-singleValue"
+                    className=" css-r447wv-singleValue"
                   >
                     03:30 AM
                   </div>
@@ -949,50 +2261,87 @@ exports[`Storyshots DateRange with default start and end times 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
                           aria-label="Select a start time"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
                           id="react-select-4-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      aria-hidden={true}
+                      className="Icon-fc7twp-0 c10"
                       color="currentColor"
                       fill="currentColor"
-                      focusable="false"
+                      focusable={false}
                       height="22px"
                       icon="queryBuilder"
+                      size="22px"
+                      title={null}
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -1008,36 +2357,40 @@ exports[`Storyshots DateRange with default start and end times 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hYUuLW"
+        className="c11"
       >
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c12"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           -
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+        className="c4"
       >
         <div
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker DateRange__StyledEndTime-sc-1m2eund-1 clTvEf css-2b097c-container"
+            className="nds-time-picker c13 css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1liu8yu-Control"
+                className=" css-1liu8yu-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-r447wv-singleValue"
+                    className=" css-r447wv-singleValue"
                   >
                     01:30 PM
                   </div>
@@ -1045,50 +2398,87 @@ exports[`Storyshots DateRange with default start and end times 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
                           aria-label="Select an end time"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
                           id="react-select-5-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      aria-hidden={true}
+                      className="Icon-fc7twp-0 c10"
                       color="currentColor"
                       fill="currentColor"
-                      focusable="false"
+                      focusable={false}
                       height="22px"
                       icon="queryBuilder"
+                      size="22px"
+                      title={null}
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -1104,37 +2494,44 @@ exports[`Storyshots DateRange with default start and end times 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
+        className="c4  nds-date-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select an end date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="DD Mon YYYY"
+                  required={false}
                   value="10 Sep 2019"
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -1153,64 +2550,246 @@ exports[`Storyshots DateRange with default start and end times 1`] = `
 `;
 
 exports[`Storyshots DateRange with time error 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c11 {
+  padding-left: 4px;
+  padding-right: 4px;
+  max-height: 38px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c12 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c1 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c2 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c4 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 16px;
+  position: absolute;
+  right: 8px;
+  color: #434d59;
+  bottom: 50%;
+  -webkit-transform: translateY(50%);
+  -ms-transform: translateY(50%);
+  transform: translateY(50%);
+  pointer-events: none;
+}
+
+.c10 {
+  color: currentColor;
+  min-width: 22px;
+  color: #434d59;
+}
+
+.c10:hover {
+  color: #434d59;
+}
+
+.c9 {
+  margin-left: 8px;
+}
+
+.c13 {
+  margin-right: 8px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      className="c1 "
       color="black"
-      style="display:block"
+      style={
+        Object {
+          "display": "block",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
+        className=""
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          className="c2"
         >
           Date range
         </span>
       </div>
     </label>
     <div
-      class="Box-sc-1qu1edy-0 iyjdMT"
+      className="c3"
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
+        className="c4  nds-date-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select a start date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="DD Mon YYYY"
+                  required={false}
                   value="05 Jul 2019"
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -1224,25 +2803,28 @@ exports[`Storyshots DateRange with time error 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+        className="c4"
       >
         <div
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker DateRange__StyledStartTime-sc-1m2eund-0 bMhikq css-2b097c-container"
+            className="nds-time-picker c9 css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1liu8yu-Control"
+                className=" css-1liu8yu-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-r447wv-singleValue"
+                    className=" css-r447wv-singleValue"
                   >
                     01:30 PM
                   </div>
@@ -1250,50 +2832,87 @@ exports[`Storyshots DateRange with time error 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
                           aria-label="Select a start time"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
                           id="react-select-6-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      aria-hidden={true}
+                      className="Icon-fc7twp-0 c10"
                       color="currentColor"
                       fill="currentColor"
-                      focusable="false"
+                      focusable={false}
                       height="22px"
                       icon="queryBuilder"
+                      size="22px"
+                      title={null}
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -1309,36 +2928,40 @@ exports[`Storyshots DateRange with time error 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hYUuLW"
+        className="c11"
       >
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c12"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           -
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+        className="c4"
       >
         <div
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker DateRange__StyledEndTime-sc-1m2eund-1 clTvEf css-2b097c-container"
+            className="nds-time-picker c13 css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1liu8yu-Control"
+                className=" css-1liu8yu-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-r447wv-singleValue"
+                    className=" css-r447wv-singleValue"
                   >
                     10:30 AM
                   </div>
@@ -1346,50 +2969,87 @@ exports[`Storyshots DateRange with time error 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
                           aria-label="Select an end time"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
                           id="react-select-7-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      aria-hidden={true}
+                      className="Icon-fc7twp-0 c10"
                       color="currentColor"
                       fill="currentColor"
-                      focusable="false"
+                      focusable={false}
                       height="22px"
                       icon="queryBuilder"
+                      size="22px"
+                      title={null}
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -1405,37 +3065,44 @@ exports[`Storyshots DateRange with time error 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
+        className="c4  nds-date-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select an end date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="DD Mon YYYY"
+                  required={false}
                   value="05 Jul 2019"
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -1454,64 +3121,246 @@ exports[`Storyshots DateRange with time error 1`] = `
 `;
 
 exports[`Storyshots DateRange with times 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c11 {
+  padding-left: 4px;
+  padding-right: 4px;
+  max-height: 38px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c12 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c1 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c2 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c4 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 16px;
+  position: absolute;
+  right: 8px;
+  color: #434d59;
+  bottom: 50%;
+  -webkit-transform: translateY(50%);
+  -ms-transform: translateY(50%);
+  transform: translateY(50%);
+  pointer-events: none;
+}
+
+.c10 {
+  color: currentColor;
+  min-width: 22px;
+  color: #434d59;
+}
+
+.c10:hover {
+  color: #434d59;
+}
+
+.c9 {
+  margin-left: 8px;
+}
+
+.c13 {
+  margin-right: 8px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      className="c1 "
       color="black"
-      style="display:block"
+      style={
+        Object {
+          "display": "block",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
+        className=""
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          className="c2"
         >
           Date range
         </span>
       </div>
     </label>
     <div
-      class="Box-sc-1qu1edy-0 iyjdMT"
+      className="c3"
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
+        className="c4  nds-date-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select a start date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="DD Mon YYYY"
+                  required={false}
                   value="01 Jan 2019"
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -1525,25 +3374,28 @@ exports[`Storyshots DateRange with times 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+        className="c4"
       >
         <div
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker DateRange__StyledStartTime-sc-1m2eund-0 bMhikq css-2b097c-container"
+            className="nds-time-picker c9 css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1liu8yu-Control"
+                className=" css-1liu8yu-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    className=" css-1yhx6vz-Placeholder"
                   >
                     HH:MM
                   </div>
@@ -1551,50 +3403,87 @@ exports[`Storyshots DateRange with times 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
                           aria-label="Select a start time"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
                           id="react-select-2-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      aria-hidden={true}
+                      className="Icon-fc7twp-0 c10"
                       color="currentColor"
                       fill="currentColor"
-                      focusable="false"
+                      focusable={false}
                       height="22px"
                       icon="queryBuilder"
+                      size="22px"
+                      title={null}
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -1610,36 +3499,40 @@ exports[`Storyshots DateRange with times 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hYUuLW"
+        className="c11"
       >
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c12"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           -
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+        className="c4"
       >
         <div
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker DateRange__StyledEndTime-sc-1m2eund-1 clTvEf css-2b097c-container"
+            className="nds-time-picker c13 css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1liu8yu-Control"
+                className=" css-1liu8yu-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    className=" css-1yhx6vz-Placeholder"
                   >
                     HH:MM
                   </div>
@@ -1647,50 +3540,87 @@ exports[`Storyshots DateRange with times 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
                           aria-label="Select an end time"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
                           id="react-select-3-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      aria-hidden={true}
+                      className="Icon-fc7twp-0 c10"
                       color="currentColor"
                       fill="currentColor"
-                      focusable="false"
+                      focusable={false}
                       height="22px"
                       icon="queryBuilder"
+                      size="22px"
+                      title={null}
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -1706,37 +3636,44 @@ exports[`Storyshots DateRange with times 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
+        className="c4  nds-date-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select an end date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="DD Mon YYYY"
+                  required={false}
                   value="05 Jan 2019"
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >

--- a/components/src/DropdownMenu/__snapshots__/DropdownMenu.story.storyshot
+++ b/components/src/DropdownMenu/__snapshots__/DropdownMenu.story.storyshot
@@ -1,28 +1,140 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots DropdownMenu DropdownMenu 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  padding: 4px;
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c1 {
+  background: transparent;
+  border: none;
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px 0px;
+  color: #00438f;
+  cursor: pointer;
+}
+
+.c1 .c2 {
+  border-radius: 50%;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c1 .Text-sc-1wu7vpu-0 {
+  display: block;
+  font-weight: 500;
+  text-align: left;
+}
+
+.c1 .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 0;
+}
+
+.c1:hover .c2 {
+  background-color: #e1ebfa;
+}
+
+.c1:hover .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c1:active .c2 {
+  -webkit-transform: scale(0.875);
+  -ms-transform: scale(0.875);
+  transform: scale(0.875);
+  -webkit-transition: .2s ease-in;
+  transition: .2s ease-in;
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
+.c1:disabled:hover .c2,
+.c1:disabled:active .c2 {
+  background: none;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus .c2 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c1:focus .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
-      aria-expanded="false"
-      aria-haspopup="true"
+      aria-describedby={null}
+      aria-expanded={false}
+      aria-haspopup={true}
       aria-label="open dropdown"
-      class="IconicButton__WrapperButton-sc-1u3dojp-1 UMPof IconicButton-sc-1u3dojp-2 gZASNp"
+      className="c1 "
+      disabled={null}
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
       type="button"
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 cwKdbD"
+        aria-hidden={true}
+        className="c2 c3"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="32px"
         icon="more"
         p="half"
+        size="32px"
+        title={null}
         viewBox="0 0 24 24"
         width="32px"
       >
@@ -36,29 +148,140 @@ exports[`Storyshots DropdownMenu DropdownMenu 1`] = `
 `;
 
 exports[`Storyshots DropdownMenu Set to disabled 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  padding: 4px;
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c1 {
+  background: transparent;
+  border: none;
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px 0px;
+  color: #00438f;
+  cursor: default;
+}
+
+.c1 .c2 {
+  border-radius: 50%;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c1 .Text-sc-1wu7vpu-0 {
+  display: block;
+  font-weight: 500;
+  text-align: left;
+}
+
+.c1 .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 0;
+}
+
+.c1:hover .c2 {
+  background-color: #e1ebfa;
+}
+
+.c1:hover .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c1:active .c2 {
+  -webkit-transform: scale(0.875);
+  -ms-transform: scale(0.875);
+  transform: scale(0.875);
+  -webkit-transition: .2s ease-in;
+  transition: .2s ease-in;
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
+.c1:disabled:hover .c2,
+.c1:disabled:active .c2 {
+  background: none;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus .c2 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c1:focus .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
-      aria-expanded="false"
-      aria-haspopup="true"
+      aria-describedby={null}
+      aria-expanded={false}
+      aria-haspopup={true}
       aria-label="open dropdown"
-      class="IconicButton__WrapperButton-sc-1u3dojp-1 kezjjz IconicButton-sc-1u3dojp-2 gZASNp"
-      disabled=""
+      className="c1 "
+      disabled={true}
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
       type="button"
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 cwKdbD"
+        aria-hidden={true}
+        className="c2 c3"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="32px"
         icon="more"
         p="half"
+        size="32px"
+        title={null}
         viewBox="0 0 24 24"
         width="32px"
       >
@@ -72,28 +295,302 @@ exports[`Storyshots DropdownMenu Set to disabled 1`] = `
 `;
 
 exports[`Storyshots DropdownMenu set to defaultOpen 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  padding: 4px;
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c8 {
+  position: absolute;
+  height: 8px;
+  width: 8px;
+  margin: 12px;
+  margin-top: -7px;
+  top: 0;
+}
+
+.c8:before {
+  border-style: solid;
+  content: '';
+  display: block;
+  height: 0;
+  margin: auto;
+  position: absolute;
+  width: 0;
+}
+
+.c8:after {
+  border-style: solid;
+  content: '';
+  display: block;
+  height: 0;
+  margin: auto;
+  position: absolute;
+  width: 0;
+}
+
+.c8:before {
+  border-color: transparent transparent #f0f2f5 transparent;
+  border-width: 0 8px 8px 8px;
+}
+
+.c8:after {
+  border-color: transparent transparent #f0f2f5 transparent;
+  border-width: 0 8px 8px 8px;
+  left: -4px;
+}
+
+.c8:before {
+  top: -2px;
+  left: -4px;
+}
+
+.c8:after {
+  left: -4px;
+}
+
+.c1 {
+  background: transparent;
+  border: none;
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px 0px;
+  color: #00438f;
+  cursor: pointer;
+}
+
+.c1 .c2 {
+  border-radius: 50%;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c1 .Text-sc-1wu7vpu-0 {
+  display: block;
+  font-weight: 500;
+  text-align: left;
+}
+
+.c1 .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 0;
+}
+
+.c1:hover .c2 {
+  background-color: #e1ebfa;
+}
+
+.c1:hover .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c1:active .c2 {
+  -webkit-transform: scale(0.875);
+  -ms-transform: scale(0.875);
+  transform: scale(0.875);
+  -webkit-transition: .2s ease-in;
+  transition: .2s ease-in;
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
+.c1:disabled:hover .c2,
+.c1:disabled:active .c2 {
+  background: none;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus .c2 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c1:focus .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c4 {
+  background-color: #f0f2f5;
+  background-color: #f0f2f5;
+  border-radius: 4px;
+  border-top: 1px solid #f0f2f5;
+  border-bottom: 1px solid #f0f2f5;
+  box-shadow: 0px 0px 3px 0px rgba(1,30,56,0.2);
+  padding: 7px 0;
+  z-index: 100;
+  margin-top: 4px;
+}
+
+.c6 {
+  color: #00438f;
+  display: block;
+  width: 100%;
+  cursor: pointer;
+  border: none;
+  text-align: left;
+  background-color: transparent;
+  line-height: 1.5;
+  font-size: 16px;
+  -webkit-transition: .2s;
+  transition: .2s;
+  padding: 8px 16px 8px 12px;
+  border-left: 4px solid transparent;
+}
+
+.c6:hover {
+  color: #00438f;
+  background-color: #e4e7eb;
+}
+
+.c6:focus {
+  outline: none;
+  color: #00438f;
+  background-color: #e4e7eb;
+  border-left: 4px solid #216beb;
+}
+
+.c6:disabled {
+  opacity: .5;
+}
+
+.c5 {
+  display: block;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border-color: transparent;
+  background-color: transparent;
+  line-height: 1.5;
+  font-size: 16px;
+  -webkit-transition: .2s;
+  transition: .2s;
+  color: #00438f;
+  padding: 8px 16px 8px 12px;
+  border-left: 4px solid transparent;
+}
+
+.c5:hover {
+  color: #00438f;
+  background-color: #e4e7eb;
+}
+
+.c5:visited {
+  color: #00438f;
+}
+
+.c5:focus {
+  outline: none;
+  color: #00438f;
+  background-color: #e4e7eb;
+  border-left: 4px solid #216beb;
+}
+
+.c5:disabled {
+  opacity: .5;
+}
+
+.c7 * {
+  color: #00438f;
+  display: block;
+  width: 100%;
+  cursor: pointer;
+  border: none;
+  text-align: left;
+  background-color: transparent;
+  line-height: 1.5;
+  -webkit-transition: .2s;
+  transition: .2s;
+  font-size: 16px;
+  padding: 8px 16px;
+}
+
+.c7 *:hover,
+.c7 *:focus {
+  outline: none;
+  color: #00438f;
+  background-color: #e4e7eb;
+}
+
+.c7 *:disabled {
+  opacity: .5;
+}
+
+.c7 *:visited {
+  color: #00438f;
+}
+
+.c7 *:active {
+  color: #00438f;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
-      aria-expanded="true"
-      aria-haspopup="true"
+      aria-describedby={null}
+      aria-expanded={true}
+      aria-haspopup={true}
       aria-label="close dropdown"
-      class="IconicButton__WrapperButton-sc-1u3dojp-1 UMPof IconicButton-sc-1u3dojp-2 gZASNp"
+      className="c1 "
+      disabled={null}
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
       type="button"
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 cwKdbD"
+        aria-hidden={true}
+        className="c2 c3"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="32px"
         icon="more"
         p="half"
+        size="32px"
+        title={null}
         viewBox="0 0 24 24"
         width="32px"
       >
@@ -103,36 +600,55 @@ exports[`Storyshots DropdownMenu set to defaultOpen 1`] = `
       </svg>
     </button>
     <div
-      class="Box-sc-1qu1edy-0 DropdownMenuContainer-sc-3zczz8-0 fcJZzO  nds-popper-pop-up"
-      open=""
-      style="position:absolute;top:0;left:0;opacity:0;pointer-events:none"
+      className="Box-sc-1qu1edy-0 c4  nds-popper-pop-up"
+      id={null}
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      open={true}
+      style={
+        Object {
+          "left": 0,
+          "opacity": 0,
+          "pointerEvents": "none",
+          "position": "absolute",
+          "top": 0,
+        }
+      }
     >
       <a
-        class="DropdownLink-sc-1myz2tl-0 kCziCp"
+        className="c5"
         color="darkBlue"
         href="/"
       >
         Dropdown Link
       </a>
       <button
-        class="DropdownButton-sc-15i1gee-0 cGihZp"
+        className="c6"
         color="darkBlue"
+        disabled={false}
+        onClick={[Function]}
       >
         Dropdown Button
       </button>
       <div
-        class="DropdownItem-sc-17fo530-0 doIexv"
+        className="c7"
         color="darkBlue"
       >
         <a
           href="/"
-          style="text-decoration:none"
+          style={
+            Object {
+              "textDecoration": "none",
+            }
+          }
         >
           Custom Link Component
         </a>
       </div>
       <div
-        class="PopperArrow-sc-1bcgj4w-0 dGhVUx"
+        className="c8"
+        style={Object {}}
       />
     </div>
   </div>
@@ -140,28 +656,140 @@ exports[`Storyshots DropdownMenu set to defaultOpen 1`] = `
 `;
 
 exports[`Storyshots DropdownMenu with button closing menu 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  padding: 4px;
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c1 {
+  background: transparent;
+  border: none;
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px 0px;
+  color: #00438f;
+  cursor: pointer;
+}
+
+.c1 .c2 {
+  border-radius: 50%;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c1 .Text-sc-1wu7vpu-0 {
+  display: block;
+  font-weight: 500;
+  text-align: left;
+}
+
+.c1 .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 0;
+}
+
+.c1:hover .c2 {
+  background-color: #e1ebfa;
+}
+
+.c1:hover .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c1:active .c2 {
+  -webkit-transform: scale(0.875);
+  -ms-transform: scale(0.875);
+  transform: scale(0.875);
+  -webkit-transition: .2s ease-in;
+  transition: .2s ease-in;
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
+.c1:disabled:hover .c2,
+.c1:disabled:active .c2 {
+  background: none;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus .c2 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c1:focus .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
-      aria-expanded="false"
-      aria-haspopup="true"
+      aria-describedby={null}
+      aria-expanded={false}
+      aria-haspopup={true}
       aria-label="open dropdown"
-      class="IconicButton__WrapperButton-sc-1u3dojp-1 UMPof IconicButton-sc-1u3dojp-2 gZASNp"
+      className="c1 "
+      disabled={null}
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
       type="button"
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 cwKdbD"
+        aria-hidden={true}
+        className="c2 c3"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="32px"
         icon="more"
         p="half"
+        size="32px"
+        title={null}
         viewBox="0 0 24 24"
         width="32px"
       >
@@ -175,28 +803,268 @@ exports[`Storyshots DropdownMenu with button closing menu 1`] = `
 `;
 
 exports[`Storyshots DropdownMenu with custom colors 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  padding: 4px;
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c7 {
+  position: absolute;
+  height: 8px;
+  width: 8px;
+  margin: 12px;
+  margin-top: -7px;
+  top: 0;
+}
+
+.c7:before {
+  border-style: solid;
+  content: '';
+  display: block;
+  height: 0;
+  margin: auto;
+  position: absolute;
+  width: 0;
+}
+
+.c7:after {
+  border-style: solid;
+  content: '';
+  display: block;
+  height: 0;
+  margin: auto;
+  position: absolute;
+  width: 0;
+}
+
+.c7:before {
+  border-color: transparent transparent #122b47 transparent;
+  border-width: 0 8px 8px 8px;
+}
+
+.c7:after {
+  border-color: transparent transparent #122b47 transparent;
+  border-width: 0 8px 8px 8px;
+  left: -4px;
+}
+
+.c7:before {
+  top: -2px;
+  left: -4px;
+}
+
+.c7:after {
+  left: -4px;
+}
+
+.c1 {
+  background: transparent;
+  border: none;
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px 0px;
+  color: #00438f;
+  cursor: pointer;
+}
+
+.c1 .c2 {
+  border-radius: 50%;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c1 .Text-sc-1wu7vpu-0 {
+  display: block;
+  font-weight: 500;
+  text-align: left;
+}
+
+.c1 .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 0;
+}
+
+.c1:hover .c2 {
+  background-color: #e1ebfa;
+}
+
+.c1:hover .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c1:active .c2 {
+  -webkit-transform: scale(0.875);
+  -ms-transform: scale(0.875);
+  transform: scale(0.875);
+  -webkit-transition: .2s ease-in;
+  transition: .2s ease-in;
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
+.c1:disabled:hover .c2,
+.c1:disabled:active .c2 {
+  background: none;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus .c2 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c1:focus .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c4 {
+  background-color: #122b47;
+  background-color: #122b47;
+  border-radius: 4px;
+  border-top: 1px solid #122b47;
+  border-bottom: 1px solid #122b47;
+  box-shadow: 0px 0px 3px 0px rgba(1,30,56,0.2);
+  padding: 7px 0;
+  z-index: 100;
+  margin-top: 4px;
+}
+
+.c6 {
+  color: #ffffff;
+  display: block;
+  width: 100%;
+  cursor: pointer;
+  border: none;
+  text-align: left;
+  background-color: transparent;
+  line-height: 1.5;
+  font-size: 16px;
+  -webkit-transition: .2s;
+  transition: .2s;
+  padding: 8px 16px 8px 12px;
+  border-left: 4px solid transparent;
+}
+
+.c6:hover {
+  color: #ffffff;
+  background-color: #011e38;
+}
+
+.c6:focus {
+  outline: none;
+  color: #ffffff;
+  background-color: #011e38;
+  border-left: 4px solid #216beb;
+}
+
+.c6:disabled {
+  opacity: .5;
+}
+
+.c5 {
+  display: block;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border-color: transparent;
+  background-color: transparent;
+  line-height: 1.5;
+  font-size: 16px;
+  -webkit-transition: .2s;
+  transition: .2s;
+  color: #ffffff;
+  padding: 8px 16px 8px 12px;
+  border-left: 4px solid transparent;
+}
+
+.c5:hover {
+  color: #ffffff;
+  background-color: #011e38;
+}
+
+.c5:visited {
+  color: #ffffff;
+}
+
+.c5:focus {
+  outline: none;
+  color: #ffffff;
+  background-color: #011e38;
+  border-left: 4px solid #216beb;
+}
+
+.c5:disabled {
+  opacity: .5;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
-      aria-expanded="true"
-      aria-haspopup="true"
+      aria-describedby={null}
+      aria-expanded={true}
+      aria-haspopup={true}
       aria-label="close dropdown"
-      class="IconicButton__WrapperButton-sc-1u3dojp-1 UMPof IconicButton-sc-1u3dojp-2 gZASNp"
+      className="c1 "
+      disabled={null}
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
       type="button"
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 cwKdbD"
+        aria-hidden={true}
+        className="c2 c3"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="32px"
         icon="more"
         p="half"
+        size="32px"
+        title={null}
         viewBox="0 0 24 24"
         width="32px"
       >
@@ -206,25 +1074,40 @@ exports[`Storyshots DropdownMenu with custom colors 1`] = `
       </svg>
     </button>
     <div
-      class="Box-sc-1qu1edy-0 DropdownMenuContainer-sc-3zczz8-0 gCpwvi  nds-popper-pop-up"
-      open=""
-      style="position:absolute;top:0;left:0;opacity:0;pointer-events:none"
+      className="Box-sc-1qu1edy-0 c4  nds-popper-pop-up"
+      id={null}
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      open={true}
+      style={
+        Object {
+          "left": 0,
+          "opacity": 0,
+          "pointerEvents": "none",
+          "position": "absolute",
+          "top": 0,
+        }
+      }
     >
       <a
-        class="DropdownLink-sc-1myz2tl-0 fzJAwh"
+        className="c5"
         color="white"
         href="/"
       >
         Dropdown Link
       </a>
       <button
-        class="DropdownButton-sc-15i1gee-0 djNVKc"
+        className="c6"
         color="white"
+        disabled={false}
+        onClick={[Function]}
       >
         Dropdown Button
       </button>
       <div
-        class="PopperArrow-sc-1bcgj4w-0 duKylJ"
+        className="c7"
+        style={Object {}}
       />
     </div>
   </div>
@@ -232,28 +1115,140 @@ exports[`Storyshots DropdownMenu with custom colors 1`] = `
 `;
 
 exports[`Storyshots DropdownMenu with custom item 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  padding: 4px;
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c1 {
+  background: transparent;
+  border: none;
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px 0px;
+  color: #00438f;
+  cursor: pointer;
+}
+
+.c1 .c2 {
+  border-radius: 50%;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c1 .Text-sc-1wu7vpu-0 {
+  display: block;
+  font-weight: 500;
+  text-align: left;
+}
+
+.c1 .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 0;
+}
+
+.c1:hover .c2 {
+  background-color: #e1ebfa;
+}
+
+.c1:hover .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c1:active .c2 {
+  -webkit-transform: scale(0.875);
+  -ms-transform: scale(0.875);
+  transform: scale(0.875);
+  -webkit-transition: .2s ease-in;
+  transition: .2s ease-in;
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
+.c1:disabled:hover .c2,
+.c1:disabled:active .c2 {
+  background: none;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus .c2 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c1:focus .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
-      aria-expanded="false"
-      aria-haspopup="true"
+      aria-describedby={null}
+      aria-expanded={false}
+      aria-haspopup={true}
       aria-label="open dropdown"
-      class="IconicButton__WrapperButton-sc-1u3dojp-1 UMPof IconicButton-sc-1u3dojp-2 gZASNp"
+      className="c1 "
+      disabled={null}
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
       type="button"
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 cwKdbD"
+        aria-hidden={true}
+        className="c2 c3"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="32px"
         icon="more"
         p="half"
+        size="32px"
+        title={null}
         viewBox="0 0 24 24"
         width="32px"
       >
@@ -267,17 +1262,106 @@ exports[`Storyshots DropdownMenu with custom item 1`] = `
 `;
 
 exports[`Storyshots DropdownMenu with custom trigger 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c1:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c1:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
-      aria-expanded="false"
-      aria-haspopup="true"
+      aria-describedby={null}
+      aria-expanded={false}
+      aria-haspopup={true}
       aria-label="open dropdown"
-      class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+      className="c1"
+      disabled={null}
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      size="medium"
       type="button"
     >
       Custom Trigger

--- a/components/src/FieldLabel/__snapshots__/FieldLabel.story.storyshot
+++ b/components/src/FieldLabel/__snapshots__/FieldLabel.story.storyshot
@@ -1,23 +1,64 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots FieldLabel FieldLabel 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c2 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      className="c1 "
       color="black"
-      style="display:block"
+      style={
+        Object {
+          "display": "block",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
+        className=""
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          className="c2"
         >
           Default label
         </span>
@@ -28,36 +69,106 @@ exports[`Storyshots FieldLabel FieldLabel 1`] = `
 `;
 
 exports[`Storyshots FieldLabel with HelpText 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c5 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c5:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
+.c3 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+  font-size: 14px;
+  line-height: 1.71428571;
+}
+
+.c3 .c4 {
+  font-size: 14px;
+}
+
+.c1 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c2 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      className="c1 "
       color="black"
-      style="display:block"
+      style={
+        Object {
+          "display": "block",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
+        className=""
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          className="c2"
         >
           Default label
         </span>
         <p
-          class="Text-sc-1wu7vpu-0 HelpText__HelpTextContent-sc-1jzmq2g-0 feAJVX"
+          className="Text-sc-1wu7vpu-0 c3"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           I am help text. I can be a string or a node that includes a 
           <a
-            class="Link-sc-1lpx3d0-0 gxbSxg"
+            className="c4 c5"
             color="blue"
-            font-size="medium"
+            fontSize="medium"
             href="http://nulogy.design"
           >
             link
@@ -71,30 +182,81 @@ exports[`Storyshots FieldLabel with HelpText 1`] = `
 `;
 
 exports[`Storyshots FieldLabel with RequirementText 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-left: 8px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #434d59;
+}
+
+.c1 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c2 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      className="c1 "
       color="black"
-      style="display:block"
+      style={
+        Object {
+          "display": "block",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
+        className=""
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          className="c2"
         >
           Default label
         </span>
         <span
-          class="Text-sc-1wu7vpu-0 bphWXP"
+          className="c3"
           color="darkGrey"
-          font-size="12px"
+          disabled={false}
+          fontSize="12px"
         >
           (Required)
         </span>
@@ -105,37 +267,103 @@ exports[`Storyshots FieldLabel with RequirementText 1`] = `
 `;
 
 exports[`Storyshots FieldLabel with all additional text 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-left: 8px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #434d59;
+}
+
+.c4 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+  font-size: 14px;
+  line-height: 1.71428571;
+}
+
+.c4 .Link-sc-1lpx3d0-0 {
+  font-size: 14px;
+}
+
+.c1 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c2 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      className="c1 "
       color="black"
-      style="display:block"
+      style={
+        Object {
+          "display": "block",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
+        className=""
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          className="c2"
         >
           Default label
         </span>
         <span
-          class="Text-sc-1wu7vpu-0 bphWXP"
+          className="c3"
           color="darkGrey"
-          font-size="12px"
+          disabled={false}
+          fontSize="12px"
         >
           (Required)
         </span>
         <p
-          class="Text-sc-1wu7vpu-0 HelpText__HelpTextContent-sc-1jzmq2g-0 feAJVX"
+          className="c4"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           I am help text. I can give more details on the input below!
         </p>
@@ -146,56 +374,200 @@ exports[`Storyshots FieldLabel with all additional text 1`] = `
 `;
 
 exports[`Storyshots FieldLabel with associated custom input component 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c2 {
+  margin-bottom: 8px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c4 {
+  margin-left: 8px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #434d59;
+}
+
+.c5 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+  font-size: 14px;
+  line-height: 1.71428571;
+}
+
+.c5 .Link-sc-1lpx3d0-0 {
+  font-size: 14px;
+}
+
+.c1 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c3 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c6 {
+  width: 100%;
+}
+
+.c9 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c9:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c9:focus ~ svg {
+  fill: #00438f;
+}
+
+.c9::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c9::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c9:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c9::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      className="c1 "
       color="black"
-      style="display:block"
+      style={
+        Object {
+          "display": "block",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 ilQgHG"
+        className="c2"
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          className="c3"
         >
           Default label
         </span>
         <span
-          class="Text-sc-1wu7vpu-0 bphWXP"
+          className="c4"
           color="darkGrey"
-          font-size="12px"
+          disabled={false}
+          fontSize="12px"
         >
           (Required)
         </span>
         <p
-          class="Text-sc-1wu7vpu-0 HelpText__HelpTextContent-sc-1jzmq2g-0 feAJVX"
+          className="c5"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           I am help text. I can give more details on the input below!
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+        className="c6"
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+          className="c7"
         >
           <div
-            class="Box-sc-1qu1edy-0 hxUhcg"
+            className="c8"
             display="flex"
           >
             <input
-              aria-invalid="false"
-              aria-required="false"
-              class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+              aria-invalid={false}
+              aria-required={false}
+              className="c9"
+              disabled={false}
               id="input1"
+              required={false}
             />
           </div>
         </div>

--- a/components/src/Flex/__snapshots__/Flex.story.storyshot
+++ b/components/src/Flex/__snapshots__/Flex.story.storyshot
@@ -1,43 +1,113 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Flex Flex 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
-      style="box-sizing:content-box;padding:24px;background:#f0f2f5;min-height:400px"
+      className="c1"
+      style={
+        Object {
+          "background": "#f0f2f5",
+          "boxSizing": "content-box",
+          "minHeight": "400px",
+          "padding": "24px",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         1
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         2
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         3
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         4
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         5
       </div>
@@ -47,52 +117,131 @@ exports[`Storyshots Flex Flex 1`] = `
 `;
 
 exports[`Storyshots Flex IE11 minHeight solution 1 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  height: 400px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c2 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hWMBMD"
+      className="c1"
       height="400px"
-      style="box-sizing:content-box;padding:24px;background:#f0f2f5"
+      style={
+        Object {
+          "background": "#f0f2f5",
+          "boxSizing": "content-box",
+          "padding": "24px",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         1
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         2
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         3
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         4
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         5
       </div>
     </div>
     <p
-      class="Text-sc-1wu7vpu-0 RbfMK"
+      className="c2"
       color="currentColor"
-      font-size="medium"
+      disabled={false}
+      fontSize="medium"
     >
       This solution involves using height instead min-height.
     </p>
@@ -101,55 +250,144 @@ exports[`Storyshots Flex IE11 minHeight solution 1 1`] = `
 `;
 
 exports[`Storyshots Flex IE11 minHeight solution 2 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 eeiLmV"
+      className="c1"
     >
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
-        style="box-sizing:content-box;padding:24px;background:#f0f2f5;min-height:400px"
+        className="c2"
+        style={
+          Object {
+            "background": "#f0f2f5",
+            "boxSizing": "content-box",
+            "minHeight": "400px",
+            "padding": "24px",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
-          style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+          className=""
+          style={
+            Object {
+              "background": "#c0c8d1",
+              "outline": "2px dotted #434d59",
+              "padding": "48px",
+            }
+          }
         >
           1
         </div>
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
-          style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+          className=""
+          style={
+            Object {
+              "background": "#c0c8d1",
+              "outline": "2px dotted #434d59",
+              "padding": "48px",
+            }
+          }
         >
           2
         </div>
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
-          style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+          className=""
+          style={
+            Object {
+              "background": "#c0c8d1",
+              "outline": "2px dotted #434d59",
+              "padding": "48px",
+            }
+          }
         >
           3
         </div>
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
-          style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+          className=""
+          style={
+            Object {
+              "background": "#c0c8d1",
+              "outline": "2px dotted #434d59",
+              "padding": "48px",
+            }
+          }
         >
           4
         </div>
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
-          style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+          className=""
+          style={
+            Object {
+              "background": "#c0c8d1",
+              "outline": "2px dotted #434d59",
+              "padding": "48px",
+            }
+          }
         >
           5
         </div>
       </div>
     </div>
     <p
-      class="Text-sc-1wu7vpu-0 RbfMK"
+      className="c3"
       color="currentColor"
-      font-size="medium"
+      disabled={false}
+      fontSize="medium"
     >
       This solution involves wrapping Flex element with another Flex element with column direction..
     </p>
@@ -158,48 +396,148 @@ exports[`Storyshots Flex IE11 minHeight solution 2 1`] = `
 `;
 
 exports[`Storyshots Flex With custom order 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c2 {
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+}
+
+.c3 {
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
+}
+
+.c4 {
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+}
+
+.c5 {
+  -webkit-order: 5;
+  -ms-flex-order: 5;
+  order: 5;
+}
+
+.c6 {
+  -webkit-order: 4;
+  -ms-flex-order: 4;
+  order: 4;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
-      style="box-sizing:content-box;padding:24px;background:#f0f2f5;min-height:400px"
+      className="c1"
+      style={
+        Object {
+          "background": "#f0f2f5",
+          "boxSizing": "content-box",
+          "minHeight": "400px",
+          "padding": "24px",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jeXUhB"
+        className="c2"
         order="1"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         1
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jpYpSf"
+        className="c3"
         order="3"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         2
       </div>
       <div
-        class="Box-sc-1qu1edy-0 frZDCe"
+        className="c4"
         order="2"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         3
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jjupVN"
+        className="c5"
         order="5"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         4
       </div>
       <div
-        class="Box-sc-1qu1edy-0 flvDFM"
+        className="c6"
         order="4"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         5
       </div>
@@ -209,43 +547,117 @@ exports[`Storyshots Flex With custom order 1`] = `
 `;
 
 exports[`Storyshots Flex alignItems set to center 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 geyRYt"
-      style="box-sizing:content-box;padding:24px;background:#f0f2f5;min-height:400px"
+      className="c1"
+      style={
+        Object {
+          "background": "#f0f2f5",
+          "boxSizing": "content-box",
+          "minHeight": "400px",
+          "padding": "24px",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         1
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         2
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         3
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         4
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         5
       </div>
@@ -255,43 +667,117 @@ exports[`Storyshots Flex alignItems set to center 1`] = `
 `;
 
 exports[`Storyshots Flex alignItems set to flex-end 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 cPBChj"
-      style="box-sizing:content-box;padding:24px;background:#f0f2f5;min-height:400px"
+      className="c1"
+      style={
+        Object {
+          "background": "#f0f2f5",
+          "boxSizing": "content-box",
+          "minHeight": "400px",
+          "padding": "24px",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         1
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         2
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         3
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         4
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         5
       </div>
@@ -301,43 +787,117 @@ exports[`Storyshots Flex alignItems set to flex-end 1`] = `
 `;
 
 exports[`Storyshots Flex alignItems set to flex-start 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
-      style="box-sizing:content-box;padding:24px;background:#f0f2f5;min-height:400px"
+      className="c1"
+      style={
+        Object {
+          "background": "#f0f2f5",
+          "boxSizing": "content-box",
+          "minHeight": "400px",
+          "padding": "24px",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         1
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         2
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         3
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         4
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         5
       </div>
@@ -347,43 +907,117 @@ exports[`Storyshots Flex alignItems set to flex-start 1`] = `
 `;
 
 exports[`Storyshots Flex alignItems set to stretch (default) 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fMZgiV"
-      style="box-sizing:content-box;padding:24px;background:#f0f2f5;min-height:400px"
+      className="c1"
+      style={
+        Object {
+          "background": "#f0f2f5",
+          "boxSizing": "content-box",
+          "minHeight": "400px",
+          "padding": "24px",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         1
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         2
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         3
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         4
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         5
       </div>
@@ -393,43 +1027,116 @@ exports[`Storyshots Flex alignItems set to stretch (default) 1`] = `
 `;
 
 exports[`Storyshots Flex flexDirection set to column 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 eeiLmV"
-      style="box-sizing:content-box;padding:24px;background:#f0f2f5;min-height:400px"
+      className="c1"
+      style={
+        Object {
+          "background": "#f0f2f5",
+          "boxSizing": "content-box",
+          "minHeight": "400px",
+          "padding": "24px",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         1
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         2
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         3
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         4
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         5
       </div>
@@ -439,43 +1146,116 @@ exports[`Storyshots Flex flexDirection set to column 1`] = `
 `;
 
 exports[`Storyshots Flex flexDirection set to column-reverse 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column-reverse;
+  -ms-flex-direction: column-reverse;
+  flex-direction: column-reverse;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 jIvELE"
-      style="box-sizing:content-box;padding:24px;background:#f0f2f5;min-height:400px"
+      className="c1"
+      style={
+        Object {
+          "background": "#f0f2f5",
+          "boxSizing": "content-box",
+          "minHeight": "400px",
+          "padding": "24px",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         1
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         2
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         3
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         4
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         5
       </div>
@@ -485,43 +1265,116 @@ exports[`Storyshots Flex flexDirection set to column-reverse 1`] = `
 `;
 
 exports[`Storyshots Flex flexDirection set to row-reverse 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row-reverse;
+  -ms-flex-direction: row-reverse;
+  flex-direction: row-reverse;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 YzlTQ"
-      style="box-sizing:content-box;padding:24px;background:#f0f2f5;min-height:400px"
+      className="c1"
+      style={
+        Object {
+          "background": "#f0f2f5",
+          "boxSizing": "content-box",
+          "minHeight": "400px",
+          "padding": "24px",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         1
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         2
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         3
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         4
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         5
       </div>
@@ -531,59 +1384,148 @@ exports[`Storyshots Flex flexDirection set to row-reverse 1`] = `
 `;
 
 exports[`Storyshots Flex flexWrap set to no-wrap (default) 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  width: 500px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 hLZXXF"
-      width="500"
+      className="c1"
+      width={500}
     >
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 cJTmbP"
-        style="box-sizing:content-box;padding:24px;background:#f0f2f5;min-height:400px"
+        className="c2"
+        style={
+          Object {
+            "background": "#f0f2f5",
+            "boxSizing": "content-box",
+            "minHeight": "400px",
+            "padding": "24px",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
-          style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+          className=""
+          style={
+            Object {
+              "background": "#c0c8d1",
+              "outline": "2px dotted #434d59",
+              "padding": "48px",
+            }
+          }
         >
           1
         </div>
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
-          style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+          className=""
+          style={
+            Object {
+              "background": "#c0c8d1",
+              "outline": "2px dotted #434d59",
+              "padding": "48px",
+            }
+          }
         >
           2
         </div>
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
-          style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+          className=""
+          style={
+            Object {
+              "background": "#c0c8d1",
+              "outline": "2px dotted #434d59",
+              "padding": "48px",
+            }
+          }
         >
           3
         </div>
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
-          style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+          className=""
+          style={
+            Object {
+              "background": "#c0c8d1",
+              "outline": "2px dotted #434d59",
+              "padding": "48px",
+            }
+          }
         >
           4
         </div>
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
-          style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+          className=""
+          style={
+            Object {
+              "background": "#c0c8d1",
+              "outline": "2px dotted #434d59",
+              "padding": "48px",
+            }
+          }
         >
           5
         </div>
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
-          style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+          className=""
+          style={
+            Object {
+              "background": "#c0c8d1",
+              "outline": "2px dotted #434d59",
+              "padding": "48px",
+            }
+          }
         >
           6
         </div>
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
-          style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+          className=""
+          style={
+            Object {
+              "background": "#c0c8d1",
+              "outline": "2px dotted #434d59",
+              "padding": "48px",
+            }
+          }
         >
           7
         </div>
@@ -594,59 +1536,148 @@ exports[`Storyshots Flex flexWrap set to no-wrap (default) 1`] = `
 `;
 
 exports[`Storyshots Flex flexWrap set to wrap 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  width: 500px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 hLZXXF"
-      width="500"
+      className="c1"
+      width={500}
     >
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 kKfTwu"
-        style="box-sizing:content-box;padding:24px;background:#f0f2f5;min-height:400px"
+        className="c2"
+        style={
+          Object {
+            "background": "#f0f2f5",
+            "boxSizing": "content-box",
+            "minHeight": "400px",
+            "padding": "24px",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
-          style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+          className=""
+          style={
+            Object {
+              "background": "#c0c8d1",
+              "outline": "2px dotted #434d59",
+              "padding": "48px",
+            }
+          }
         >
           1
         </div>
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
-          style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+          className=""
+          style={
+            Object {
+              "background": "#c0c8d1",
+              "outline": "2px dotted #434d59",
+              "padding": "48px",
+            }
+          }
         >
           2
         </div>
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
-          style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+          className=""
+          style={
+            Object {
+              "background": "#c0c8d1",
+              "outline": "2px dotted #434d59",
+              "padding": "48px",
+            }
+          }
         >
           3
         </div>
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
-          style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+          className=""
+          style={
+            Object {
+              "background": "#c0c8d1",
+              "outline": "2px dotted #434d59",
+              "padding": "48px",
+            }
+          }
         >
           4
         </div>
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
-          style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+          className=""
+          style={
+            Object {
+              "background": "#c0c8d1",
+              "outline": "2px dotted #434d59",
+              "padding": "48px",
+            }
+          }
         >
           5
         </div>
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
-          style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+          className=""
+          style={
+            Object {
+              "background": "#c0c8d1",
+              "outline": "2px dotted #434d59",
+              "padding": "48px",
+            }
+          }
         >
           6
         </div>
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
-          style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+          className=""
+          style={
+            Object {
+              "background": "#c0c8d1",
+              "outline": "2px dotted #434d59",
+              "padding": "48px",
+            }
+          }
         >
           7
         </div>
@@ -657,59 +1688,148 @@ exports[`Storyshots Flex flexWrap set to wrap 1`] = `
 `;
 
 exports[`Storyshots Flex flexWrap set to wrap-reverse 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  width: 500px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap-reverse;
+  -ms-flex-wrap: wrap-reverse;
+  flex-wrap: wrap-reverse;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 hLZXXF"
-      width="500"
+      className="c1"
+      width={500}
     >
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbhWTT"
-        style="box-sizing:content-box;padding:24px;background:#f0f2f5;min-height:400px"
+        className="c2"
+        style={
+          Object {
+            "background": "#f0f2f5",
+            "boxSizing": "content-box",
+            "minHeight": "400px",
+            "padding": "24px",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
-          style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+          className=""
+          style={
+            Object {
+              "background": "#c0c8d1",
+              "outline": "2px dotted #434d59",
+              "padding": "48px",
+            }
+          }
         >
           1
         </div>
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
-          style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+          className=""
+          style={
+            Object {
+              "background": "#c0c8d1",
+              "outline": "2px dotted #434d59",
+              "padding": "48px",
+            }
+          }
         >
           2
         </div>
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
-          style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+          className=""
+          style={
+            Object {
+              "background": "#c0c8d1",
+              "outline": "2px dotted #434d59",
+              "padding": "48px",
+            }
+          }
         >
           3
         </div>
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
-          style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+          className=""
+          style={
+            Object {
+              "background": "#c0c8d1",
+              "outline": "2px dotted #434d59",
+              "padding": "48px",
+            }
+          }
         >
           4
         </div>
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
-          style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+          className=""
+          style={
+            Object {
+              "background": "#c0c8d1",
+              "outline": "2px dotted #434d59",
+              "padding": "48px",
+            }
+          }
         >
           5
         </div>
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
-          style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+          className=""
+          style={
+            Object {
+              "background": "#c0c8d1",
+              "outline": "2px dotted #434d59",
+              "padding": "48px",
+            }
+          }
         >
           6
         </div>
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
-          style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+          className=""
+          style={
+            Object {
+              "background": "#c0c8d1",
+              "outline": "2px dotted #434d59",
+              "padding": "48px",
+            }
+          }
         >
           7
         </div>
@@ -720,43 +1840,117 @@ exports[`Storyshots Flex flexWrap set to wrap-reverse 1`] = `
 `;
 
 exports[`Storyshots Flex justifyContent set to center 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iIgIah"
-      style="box-sizing:content-box;padding:24px;background:#f0f2f5;min-height:400px"
+      className="c1"
+      style={
+        Object {
+          "background": "#f0f2f5",
+          "boxSizing": "content-box",
+          "minHeight": "400px",
+          "padding": "24px",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         1
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         2
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         3
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         4
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         5
       </div>
@@ -766,43 +1960,117 @@ exports[`Storyshots Flex justifyContent set to center 1`] = `
 `;
 
 exports[`Storyshots Flex justifyContent set to flex-end 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 dTSZwr"
-      style="box-sizing:content-box;padding:24px;background:#f0f2f5;min-height:400px"
+      className="c1"
+      style={
+        Object {
+          "background": "#f0f2f5",
+          "boxSizing": "content-box",
+          "minHeight": "400px",
+          "padding": "24px",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         1
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         2
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         3
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         4
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         5
       </div>
@@ -812,43 +2080,117 @@ exports[`Storyshots Flex justifyContent set to flex-end 1`] = `
 `;
 
 exports[`Storyshots Flex justifyContent set to flex-start (default) 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 dDCzDc"
-      style="box-sizing:content-box;padding:24px;background:#f0f2f5;min-height:400px"
+      className="c1"
+      style={
+        Object {
+          "background": "#f0f2f5",
+          "boxSizing": "content-box",
+          "minHeight": "400px",
+          "padding": "24px",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         1
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         2
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         3
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         4
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         5
       </div>
@@ -858,43 +2200,117 @@ exports[`Storyshots Flex justifyContent set to flex-start (default) 1`] = `
 `;
 
 exports[`Storyshots Flex justifyContent set to space-around 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iCANLs"
-      style="box-sizing:content-box;padding:24px;background:#f0f2f5;min-height:400px"
+      className="c1"
+      style={
+        Object {
+          "background": "#f0f2f5",
+          "boxSizing": "content-box",
+          "minHeight": "400px",
+          "padding": "24px",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         1
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         2
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         3
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         4
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         5
       </div>
@@ -904,43 +2320,117 @@ exports[`Storyshots Flex justifyContent set to space-around 1`] = `
 `;
 
 exports[`Storyshots Flex justifyContent set to space-between 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hBnJSV"
-      style="box-sizing:content-box;padding:24px;background:#f0f2f5;min-height:400px"
+      className="c1"
+      style={
+        Object {
+          "background": "#f0f2f5",
+          "boxSizing": "content-box",
+          "minHeight": "400px",
+          "padding": "24px",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         1
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         2
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         3
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         4
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         5
       </div>
@@ -950,43 +2440,117 @@ exports[`Storyshots Flex justifyContent set to space-between 1`] = `
 `;
 
 exports[`Storyshots Flex justifyContent set to space-evenly 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: space-evenly;
+  -webkit-justify-content: space-evenly;
+  -ms-flex-pack: space-evenly;
+  justify-content: space-evenly;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hVgYgW"
-      style="box-sizing:content-box;padding:24px;background:#f0f2f5;min-height:400px"
+      className="c1"
+      style={
+        Object {
+          "background": "#f0f2f5",
+          "boxSizing": "content-box",
+          "minHeight": "400px",
+          "padding": "24px",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         1
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         2
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         3
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         4
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
-        style="padding:48px;background:#c0c8d1;outline:2px dotted #434d59"
+        className=""
+        style={
+          Object {
+            "background": "#c0c8d1",
+            "outline": "2px dotted #434d59",
+            "padding": "48px",
+          }
+        }
       >
         5
       </div>

--- a/components/src/Form/__snapshots__/Form.story.storyshot
+++ b/components/src/Form/__snapshots__/Form.story.storyshot
@@ -1,35 +1,803 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Form Demo form 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c8 {
+  margin-right: auto;
+}
+
+.c22 {
+  margin-bottom: 8px;
+}
+
+.c25 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c4 {
+  background-color: #fae6ea;
+  padding: 16px;
+  border-radius: 4px;
+  border-left-width: half;
+  border-left-color: #cc1439;
+  border-left-style: solid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c24 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c30 {
+  color: #cc1439;
+  margin-top: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c7 {
+  margin-right: 8px;
+  color: #cc1439;
+  min-width: 24px;
+}
+
+.c31 {
+  margin-right: 8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c10 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c11 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c27 {
+  margin-left: 8px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #434d59;
+}
+
+.c45 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+  opacity: 0.3333;
+}
+
+.c57 {
+  margin-bottom: 0px;
+  margin-left: 8px;
+  margin-top: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c60 {
+  margin-bottom: 0px;
+  margin-left: 8px;
+  margin-top: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+  opacity: 0.3333;
+}
+
+.c3 {
+  margin-top: 0;
+  margin-bottom: 16px;
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.23076923;
+}
+
+.c39 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c43 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c14 {
+  margin-bottom: 8px;
+  color: currentColor;
+}
+
+.c14:last-child {
+  margin-bottom: 0;
+}
+
+.c12 {
+  color: currentColor;
+  margin: 0;
+}
+
+.c12 .c13 {
+  margin-bottom: 0;
+}
+
+.c32 .c9 {
+  margin-bottom: 8px;
+}
+
+.c32 > *:last-child {
+  margin-bottom: 0;
+}
+
+.c6 .Link-sc-1lpx3d0-0 {
+  color: #011e38;
+}
+
+.c28 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+  font-size: 14px;
+  line-height: 1.71428571;
+}
+
+.c28 .Link-sc-1lpx3d0-0 {
+  font-size: 14px;
+}
+
+.c21 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c23 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c20 {
+  width: 100%;
+}
+
+.c35 {
+  padding: 0;
+  border: 0;
+  margin: 0;
+  width: 100%;
+}
+
+.c35 legend {
+  padding: 0;
+}
+
+.c18 {
+  margin-top: 0;
+  margin-bottom: 8px;
+  font-weight: 500;
+  font-size: 20px;
+  line-height: 1.2;
+}
+
+.c16 {
+  width: 100%;
+  padding: 0;
+  margin: 0;
+  border: none;
+}
+
+.c16 .c17 {
+  padding: 0;
+  margin-bottom: 24px;
+}
+
+.c16 .c19,
+.c16 .c34 {
+  margin-bottom: 24px;
+}
+
+.c16 .c19:last-child,
+.c16 .c34:last-child {
+  margin-bottom: 0;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c1 .c2 {
+  margin-bottom: 48px;
+}
+
+.c1 .c5 {
+  margin-bottom: 48px;
+}
+
+.c1 .c19,
+.c1 .c34 {
+  margin-bottom: 24px;
+}
+
+.c1 .c19:last-child,
+.c1 .c34:last-child {
+  margin-bottom: 0;
+}
+
+.c1 .c15 {
+  margin-bottom: 48px;
+}
+
+.c1 .c15:last-child {
+  margin-bottom: 0;
+}
+
+.c26 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c26:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c26:focus ~ svg {
+  fill: #00438f;
+}
+
+.c26::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c26::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c26:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c26::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c29 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #cc1439;
+  border-color: #cc1439;
+}
+
+.c29:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c29:focus ~ svg {
+  fill: #00438f;
+}
+
+.c29::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c29::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c29:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c29::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c33 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: rgba(1,30,56,0.3333);
+  border-color: #e4e7eb;
+  background-color: #f0f2f5;
+}
+
+.c33:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c33:focus ~ svg {
+  fill: #00438f;
+}
+
+.c33::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c33::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c33:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c33::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c42 {
+  min-width: 16px;
+  height: 16px;
+  border-radius: 2px;
+  border: solid 1px;
+  position: relative;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c42:before {
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  width: 3px;
+  height: 9px;
+  border: solid #ffffff;
+  border-radius: 1px;
+  border-width: 0 3px 3px 0;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.c40 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c40:focus + .c41 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c40:checked + .c41 {
+  border-color: #00438f;
+  background-color: #00438f;
+}
+
+.c40:checked + .c41:before {
+  display: block;
+}
+
+.c40:not(:checked) + .c41 {
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+}
+
+.c44 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c44:focus + .c41 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c44:checked + .c41 {
+  border-color: #e4e7eb;
+  background-color: #e4e7eb;
+}
+
+.c44:checked + .c41:before {
+  display: block;
+}
+
+.c44:not(:checked) + .c41 {
+  border-color: #e4e7eb;
+  background-color: #f0f2f5;
+}
+
+.c38 {
+  padding: 4px 0;
+}
+
+.c38 .c9 {
+  margin-left: 8px;
+}
+
+.c37 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c36 {
+  margin-bottom: 8px;
+}
+
+.c49 {
+  min-width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  border-radius: 50%;
+  border: solid 1px;
+  position: relative;
+  top: 4px;
+}
+
+.c49:before {
+  cursor: pointer;
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  top: 4px;
+  width: 2px;
+  height: 2px;
+  background: #ffffff;
+  border: 2px solid #ffffff;
+  border-radius: 50%;
+}
+
+.c51 {
+  min-width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  border-radius: 50%;
+  border: solid 1px;
+  position: relative;
+  top: 4px;
+}
+
+.c51:before {
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  top: 4px;
+  width: 2px;
+  height: 2px;
+  background: #ffffff;
+  border: 2px solid #ffffff;
+  border-radius: 50%;
+}
+
+.c47 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c47:focus + .c48 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c47:checked + .c48 {
+  border-color: #cc1439;
+  background-color: #cc1439;
+}
+
+.c47:checked + .c48:before {
+  display: block;
+}
+
+.c47:not(:checked) + .c48 {
+  border-color: #cc1439;
+  background-color: #ffffff;
+}
+
+.c50 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c50:focus + .c48 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c50:checked + .c48 {
+  border-color: #e4e7eb;
+  background-color: #e4e7eb;
+}
+
+.c50:checked + .c48:before {
+  display: block;
+}
+
+.c50:not(:checked) + .c48 {
+  border-color: #e4e7eb;
+  background-color: #f0f2f5;
+}
+
+.c46 {
+  padding: 4px 0;
+}
+
+.c56 {
+  position: absolute;
+  height: 24px;
+  width: 48px;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: #e4e7eb;
+  border-radius: 12px;
+  -webkit-transition: .2s ease;
+  transition: .2s ease;
+  cursor: pointer;
+}
+
+.c56:before {
+  content: '';
+  position: absolute;
+  height: 24px;
+  width: 24px;
+  left: 0px;
+  top: 0px;
+  border-radius: 50%;
+  box-sizing: border-box;
+  border: solid 1px;
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+  -webkit-transition: .2s ease;
+  transition: .2s ease;
+}
+
+.c59 {
+  position: absolute;
+  height: 24px;
+  width: 48px;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: #e4e7eb;
+  border-radius: 12px;
+  -webkit-transition: .2s ease;
+  transition: .2s ease;
+}
+
+.c59:before {
+  content: '';
+  position: absolute;
+  height: 24px;
+  width: 24px;
+  left: 0px;
+  top: 0px;
+  border-radius: 50%;
+  box-sizing: border-box;
+  border: solid 1px;
+  border-color: #e4e7eb;
+  background-color: #f0f2f5;
+  -webkit-transition: .2s ease;
+  transition: .2s ease;
+}
+
+.c53 {
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  min-width: 48px;
+  min-height: 24px;
+}
+
+.c53 input {
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+}
+
+.c54:checked + .c55:before {
+  -webkit-transform: translateX(24px);
+  -ms-transform: translateX(24px);
+  transform: translateX(24px);
+  background-color: #00438f;
+  border-color: #00438f;
+}
+
+.c54:checked + .c55 {
+  background-color: #e1ebfa;
+}
+
+.c54:focus + .c55:before {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c58:checked + .c55:before {
+  -webkit-transform: translateX(24px);
+  -ms-transform: translateX(24px);
+  transform: translateX(24px);
+  background-color: #e4e7eb;
+  border-color: #f0f2f5;
+}
+
+.c58:checked + .c55 {
+  background-color: #f0f2f5;
+}
+
+.c52 {
+  padding: 4px 0;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <form
-      class="Form-n70q8u-0 laLzBn"
+      className="c1"
     >
       <h2
-        class="Text-sc-1wu7vpu-0-h2 heWDlS"
-        font-size="larger"
-        font-weight="medium"
+        className="c2 c3"
+        fontSize="larger"
+        fontWeight="medium"
       >
         Job 324400
       </h2>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 gjRpuy Alert-u8lbe-0 kjZZUq"
+        className="c4 c5 c6"
         role="alert"
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 ewGQci"
+          aria-hidden={true}
+          className="c7"
           color="red"
           fill="#cc1439"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="error"
           mr="x1"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -38,41 +806,43 @@ exports[`Storyshots Form Demo form 1`] = `
           />
         </svg>
         <div
-          class="Box-sc-1qu1edy-0 iDnpba"
+          className="c8"
         >
           <p
-            class="Text-sc-1wu7vpu-0 dFPjNj"
+            className="c9 c10"
             color="currentColor"
-            font-size="medium"
-            font-weight="bold"
+            disabled={false}
+            fontSize="medium"
+            fontWeight="bold"
           >
             Errors have occured ...
           </p>
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c9 c11"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Instructions and description of errors
           </p>
           <ul
-            class="List-sc-1cqkmnl-0 gfYBVm"
+            className="c12"
             color="currentColor"
           >
             <li
-              class="ListItem-qqenhw-0 gzsWDK"
+              className="c13 c14"
               color="currentColor"
             >
               Affected field
             </li>
             <li
-              class="ListItem-qqenhw-0 gzsWDK"
+              className="c13 c14"
               color="currentColor"
             >
               Unmet criteria
             </li>
             <li
-              class="ListItem-qqenhw-0 gzsWDK"
+              className="c13 c14"
               color="currentColor"
             >
               <a
@@ -85,114 +855,132 @@ exports[`Storyshots Form Demo form 1`] = `
         </div>
       </div>
       <fieldset
-        class="FormSection-sc-5yud6c-1 cJYtnA"
+        className="c15 c16"
       >
         <legend
-          class="Text-sc-1wu7vpu-0-h3 Headings__SubsectionTitle-igpciy-0 FormSection__FormSectionTitle-sc-5yud6c-0 gaHdwg"
-          font-size="large"
-          font-weight="medium"
+          className="c9-h3 Headings__SubsectionTitle-igpciy-0 c17 c18"
+          fontSize="large"
+          fontWeight="medium"
         >
           Job Information
         </legend>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c19 c20"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c21 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c22"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c23"
               >
                 Project
               </span>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c24"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c25"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-invalid={false}
+                  aria-required={false}
+                  className="c26"
+                  disabled={false}
                   id="project"
                   placeholder="Project 128703"
+                  required={false}
                 />
               </div>
             </div>
           </label>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c19 c20"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c21 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c22"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c23"
               >
                 Project description
               </span>
               <span
-                class="Text-sc-1wu7vpu-0 bphWXP"
+                className="c9 c27"
                 color="darkGrey"
-                font-size="12px"
+                disabled={false}
+                fontSize="12px"
               >
                 (Optional)
               </span>
               <p
-                class="Text-sc-1wu7vpu-0 HelpText__HelpTextContent-sc-1jzmq2g-0 feAJVX"
+                className="c9 c28"
                 color="currentColor"
-                font-size="medium"
+                disabled={false}
+                fontSize="medium"
               >
                 Project description helps identify the project.
               </p>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c24"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c25"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-invalid={false}
+                  aria-required={false}
+                  className="c26"
+                  disabled={false}
                   id="project-description"
+                  required={false}
                 />
               </div>
             </div>
           </label>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c19 c20"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c21 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c22"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c23"
               >
                 Project status
               </span>
@@ -201,19 +989,22 @@ exports[`Storyshots Form Demo form 1`] = `
               data-testid="select-container"
             >
               <div
-                class=" css-2b097c-container"
+                className=" css-2b097c-container"
+                onKeyDown={[Function]}
               >
                 <div
                   data-testid="select-control"
                 >
                   <div
-                    class=" css-1liu8yu-Control"
+                    className=" css-1liu8yu-Control"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <div
-                      class=" css-7zc8my"
+                      className=" css-7zc8my"
                     >
                       <div
-                        class=" css-1yhx6vz-Placeholder"
+                        className=" css-1yhx6vz-Placeholder"
                       >
                         Select...
                       </div>
@@ -221,48 +1012,83 @@ exports[`Storyshots Form Demo form 1`] = `
                         data-testid="select-input"
                       >
                         <div
-                          class="css-17yls17-Input"
+                          className="css-17yls17-Input"
                         >
                           <div
-                            class=""
-                            style="display:inline-block"
+                            className=""
+                            style={
+                              Object {
+                                "display": "inline-block",
+                              }
+                            }
                           >
                             <input
                               aria-autocomplete="list"
-                              autocapitalize="none"
-                              autocomplete="off"
-                              autocorrect="off"
+                              autoCapitalize="none"
+                              autoComplete="off"
+                              autoCorrect="off"
+                              disabled={null}
                               id="project-status"
-                              spellcheck="false"
-                              style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                              tabindex="0"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              spellCheck="false"
+                              style={
+                                Object {
+                                  "background": 0,
+                                  "border": 0,
+                                  "boxSizing": "content-box",
+                                  "color": "inherit",
+                                  "fontSize": "inherit",
+                                  "label": "input",
+                                  "opacity": 1,
+                                  "outline": 0,
+                                  "padding": 0,
+                                  "width": "1px",
+                                }
+                              }
+                              tabIndex="0"
                               type="text"
                               value=""
                             />
                             <div
-                              style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                            />
+                              style={
+                                Object {
+                                  "height": 0,
+                                  "left": 0,
+                                  "overflow": "scroll",
+                                  "position": "absolute",
+                                  "top": 0,
+                                  "visibility": "hidden",
+                                  "whiteSpace": "pre",
+                                }
+                              }
+                            >
+                              
+                            </div>
                           </div>
                         </div>
                       </div>
                     </div>
                     <div
-                      class=" css-173cxbq-IndicatorsContainer"
+                      className=" css-173cxbq-IndicatorsContainer"
                     >
                       <span
-                        class=" css-4z5mi-indicatorSeparator"
+                        className=" css-4z5mi-indicatorSeparator"
                       />
                       <div
                         aria-hidden="true"
-                        class=" css-19phze7-indicatorContainer"
+                        className=" css-19phze7-indicatorContainer"
+                        onMouseDown={[Function]}
+                        onTouchEnd={[Function]}
                       >
                         <svg
                           aria-hidden="true"
-                          class="css-6q0nyr-Svg"
+                          className="css-6q0nyr-Svg"
                           focusable="false"
-                          height="20"
+                          height={20}
                           viewBox="0 0 20 20"
-                          width="20"
+                          width={20}
                         >
                           <path
                             d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
@@ -277,53 +1103,61 @@ exports[`Storyshots Form Demo form 1`] = `
           </label>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c19 c20"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c21 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c22"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c23"
               >
                 Item code
               </span>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c24"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c25"
                 display="flex"
               >
                 <input
-                  aria-invalid="true"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 jMjRjb"
+                  aria-invalid={true}
+                  aria-required={false}
+                  className="c29"
+                  defaultValue="WS2SB6"
+                  disabled={false}
                   id="item-code"
-                  value="WS2SB6"
+                  required={false}
                 />
               </div>
             </div>
           </label>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 ycNbA"
+            className="c30"
             color="red"
           >
             <svg
-              aria-hidden="true"
-              class="Icon-fc7twp-0 QuoIa"
+              aria-hidden={true}
+              className="c31"
               color="currentColor"
               fill="currentColor"
-              focusable="false"
+              focusable={false}
               height="24px"
               icon="error"
               mr="x1"
+              size="24px"
+              title={null}
               viewBox="0 0 24 24"
               width="24px"
             >
@@ -332,12 +1166,13 @@ exports[`Storyshots Form Demo form 1`] = `
               />
             </svg>
             <div
-              class="InlineValidation__Wrapper-sc-1jic7dw-0 kqhCKM"
+              className="c32"
             >
               <p
-                class="Text-sc-1wu7vpu-0 RbfMK"
+                className="c9 c11"
                 color="currentColor"
-                font-size="medium"
+                disabled={false}
+                fontSize="medium"
               >
                 Item WS2SB6 does not exist.
               </p>
@@ -345,280 +1180,320 @@ exports[`Storyshots Form Demo form 1`] = `
           </div>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c19 c20"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c21 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c22"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c23"
               >
                 Eaches expected on Job
               </span>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c24"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c25"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-invalid={false}
+                  aria-required={false}
+                  className="c26"
+                  disabled={false}
                   id="eaches-expected"
                   placeholder="2 000"
+                  required={false}
                 />
               </div>
             </div>
           </label>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c19 c20"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c21 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c22"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c23"
               >
                 Eaches remaining on Project
               </span>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c24"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c25"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 fdcdYd"
-                  disabled=""
+                  aria-invalid={false}
+                  aria-required={false}
+                  className="c33"
+                  defaultValue="18 000"
+                  disabled={true}
                   id="eaches-remaining"
-                  value="18 000"
+                  required={false}
                 />
               </div>
             </div>
           </label>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c19 c20"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c21 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c22"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c23"
               >
                 Scheduled start
               </span>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c24"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c25"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-invalid={false}
+                  aria-required={false}
+                  className="c26"
+                  disabled={false}
                   id="scheduled-start"
                   placeholder="MMM-DD-YYYY"
+                  required={false}
                 />
               </div>
             </div>
           </label>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c19 c20"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c21 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c22"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c23"
               >
                 Scheduled end
               </span>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c24"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c25"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-invalid={false}
+                  aria-required={false}
+                  className="c26"
+                  disabled={false}
                   id="scheduled-end"
                   placeholder="MMM-DD-YYYY"
+                  required={false}
                 />
               </div>
             </div>
           </label>
         </div>
         <fieldset
-          class="Fieldset-sc-9aoml1-0 eiFgjk CheckboxGroup-sc-16y7xr8-2 bfgHHz"
+          className="c34 c35 "
         >
           <legend
-            class="CheckboxGroup__Legend-sc-16y7xr8-1 FZknE"
+            className="c36"
           >
             <span
-              class="CheckboxGroup__LabelText-sc-16y7xr8-0 srOjp"
+              className="c37"
             >
               Line Lead
             </span>
             <span
-              class="Text-sc-1wu7vpu-0 bphWXP"
+              className="c9 c27"
               color="darkGrey"
-              font-size="12px"
+              disabled={false}
+              fontSize="12px"
             >
               (Optional)
             </span>
           </legend>
           <div
-            class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+            className="c38"
           >
             <label
-              class="ClickInputLabel-j2axnv-0 kemUmZ"
+              className="c39"
+              disabled={false}
             >
               <input
-                aria-invalid="false"
-                aria-required="false"
-                class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                aria-invalid={false}
+                aria-required={false}
+                className="c40 c38"
+                disabled={false}
+                id={null}
                 name="linelead"
+                required={false}
                 type="checkbox"
                 value="christiaan"
               />
               <div
-                class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                className="c41 c42"
                 data-testid="visual-checkbox"
+                disabled={false}
               />
               <p
-                class="Text-sc-1wu7vpu-0 RbfMK"
+                className="c9 c11"
                 color="currentColor"
-                font-size="medium"
+                disabled={false}
+                fontSize="medium"
               >
                 Christiaan Oostenbrug
               </p>
             </label>
           </div>
           <div
-            class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+            className="c38"
           >
             <label
-              class="ClickInputLabel-j2axnv-0 kemUmZ"
+              className="c39"
+              disabled={false}
             >
               <input
-                aria-invalid="false"
-                aria-required="false"
-                class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                aria-invalid={false}
+                aria-required={false}
+                className="c40 c38"
+                disabled={false}
+                id={null}
                 name="linelead"
+                required={false}
                 type="checkbox"
                 value="matt"
               />
               <div
-                class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                className="c41 c42"
                 data-testid="visual-checkbox"
+                disabled={false}
               />
               <p
-                class="Text-sc-1wu7vpu-0 RbfMK"
+                className="c9 c11"
                 color="currentColor"
-                font-size="medium"
+                disabled={false}
+                fontSize="medium"
               >
                 Matt Dunn
               </p>
             </label>
           </div>
           <div
-            class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+            className="c38"
           >
             <label
-              class="ClickInputLabel-j2axnv-0 kjxgat"
-              disabled=""
+              className="c43"
+              disabled={true}
             >
               <input
-                aria-invalid="false"
-                aria-required="false"
-                class="Checkbox__CheckboxInput-sc-1nm58f1-1 jdAeaf Checkbox-sc-1nm58f1-2 eJJycu"
-                disabled=""
+                aria-invalid={false}
+                aria-required={false}
+                className="c44 c38"
+                disabled={true}
+                id={null}
                 name="linelead"
+                required={false}
                 type="checkbox"
                 value="clemens"
               />
               <div
-                class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                className="c41 c42"
                 data-testid="visual-checkbox"
-                disabled=""
+                disabled={true}
               />
               <p
-                class="Text-sc-1wu7vpu-0 hdrQgs"
+                className="c9 c45"
                 color="currentColor"
-                disabled=""
-                font-size="medium"
+                disabled={true}
+                fontSize="medium"
               >
                 Clemens Park
               </p>
             </label>
           </div>
           <div
-            class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+            className="c38"
           >
             <label
-              class="ClickInputLabel-j2axnv-0 kjxgat"
-              disabled=""
+              className="c43"
+              disabled={true}
             >
               <input
-                aria-invalid="false"
-                aria-required="false"
-                class="Checkbox__CheckboxInput-sc-1nm58f1-1 jdAeaf Checkbox-sc-1nm58f1-2 eJJycu"
-                disabled=""
+                aria-invalid={false}
+                aria-required={false}
+                className="c44 c38"
+                disabled={true}
+                id={null}
                 name="linelead"
+                required={false}
                 type="checkbox"
                 value="nikola"
               />
               <div
-                class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                className="c41 c42"
                 data-testid="visual-checkbox"
-                disabled=""
+                disabled={true}
               />
               <p
-                class="Text-sc-1wu7vpu-0 hdrQgs"
+                className="c9 c45"
                 color="currentColor"
-                disabled=""
-                font-size="medium"
+                disabled={true}
+                fontSize="medium"
               >
                 Nikola Pejcic
               </p>
@@ -626,114 +1501,146 @@ exports[`Storyshots Form Demo form 1`] = `
           </div>
         </fieldset>
         <fieldset
-          class="Fieldset-sc-9aoml1-0 eiFgjk RadioGroup-pgv2w1-0 hFKzrk"
+          className="c34 c35 "
           id="reconcile"
         >
           <legend
-            style="margin-bottom:8px"
+            style={
+              Object {
+                "marginBottom": "8px",
+              }
+            }
           >
             <span
-              style="font-size:14px;font-weight:600;line-height:1.71428571"
+              style={
+                Object {
+                  "fontSize": "14px",
+                  "fontWeight": "600",
+                  "lineHeight": "1.71428571",
+                }
+              }
             >
               Reconcile
             </span>
           </legend>
           <div
-            class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+            className="c46"
           >
             <label
-              class="ClickInputLabel-j2axnv-0 kemUmZ"
+              className="c39"
+              disabled={false}
             >
               <input
-                aria-invalid="true"
-                aria-required="false"
-                checked=""
-                class="Radio__RadioInput-sc-82dpxx-1 iSoGgh Radio-sc-82dpxx-2 jeIhWi"
+                aria-invalid={true}
+                aria-required={false}
+                className="c47 c46"
+                defaultChecked={true}
+                disabled={false}
+                id={null}
                 name="settingSelection"
+                required={false}
                 type="radio"
                 value="yes"
               />
               <div
-                class="Radio__VisualRadio-sc-82dpxx-0 cMunLd"
+                className="c48 c49"
+                disabled={false}
               />
               <span
-                class="Text-sc-1wu7vpu-0 RbfMK"
+                className="c9 c11"
                 color="currentColor"
-                font-size="medium"
+                disabled={false}
+                fontSize="medium"
               >
-                 Yes 
+                 
+                Yes
+                 
               </span>
             </label>
           </div>
           <div
-            class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+            className="c46"
           >
             <label
-              class="ClickInputLabel-j2axnv-0 kemUmZ"
+              className="c39"
+              disabled={false}
             >
               <input
-                aria-invalid="true"
-                aria-required="false"
-                class="Radio__RadioInput-sc-82dpxx-1 iSoGgh Radio-sc-82dpxx-2 jeIhWi"
+                aria-invalid={true}
+                aria-required={false}
+                className="c47 c46"
+                disabled={false}
+                id={null}
                 name="settingSelection"
+                required={false}
                 type="radio"
                 value="no"
               />
               <div
-                class="Radio__VisualRadio-sc-82dpxx-0 cMunLd"
+                className="c48 c49"
+                disabled={false}
               />
               <span
-                class="Text-sc-1wu7vpu-0 RbfMK"
+                className="c9 c11"
                 color="currentColor"
-                font-size="medium"
+                disabled={false}
+                fontSize="medium"
               >
-                 No 
+                 
+                No
+                 
               </span>
             </label>
           </div>
           <div
-            class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+            className="c46"
           >
             <label
-              class="ClickInputLabel-j2axnv-0 kjxgat"
-              disabled=""
+              className="c43"
+              disabled={true}
             >
               <input
-                aria-invalid="true"
-                aria-required="false"
-                class="Radio__RadioInput-sc-82dpxx-1 hBtCEn Radio-sc-82dpxx-2 jeIhWi"
-                disabled=""
+                aria-invalid={true}
+                aria-required={false}
+                className="c50 c46"
+                disabled={true}
+                id={null}
                 name="settingSelection"
+                required={false}
                 type="radio"
                 value="maybe"
               />
               <div
-                class="Radio__VisualRadio-sc-82dpxx-0 bCyppR"
-                disabled=""
+                className="c48 c51"
+                disabled={true}
               />
               <span
-                class="Text-sc-1wu7vpu-0 hdrQgs"
+                className="c9 c45"
                 color="currentColor"
-                disabled=""
-                font-size="medium"
+                disabled={true}
+                fontSize="medium"
               >
-                 Maybe 
+                 
+                Maybe
+                 
               </span>
             </label>
           </div>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 ycNbA"
+            className="c30"
             color="red"
           >
             <svg
-              aria-hidden="true"
-              class="Icon-fc7twp-0 QuoIa"
+              aria-hidden={true}
+              className="c31"
               color="currentColor"
               fill="currentColor"
-              focusable="false"
+              focusable={false}
               height="24px"
               icon="error"
               mr="x1"
+              size="24px"
+              title={null}
               viewBox="0 0 24 24"
               width="24px"
             >
@@ -742,12 +1649,13 @@ exports[`Storyshots Form Demo form 1`] = `
               />
             </svg>
             <div
-              class="InlineValidation__Wrapper-sc-1jic7dw-0 kqhCKM"
+              className="c32"
             >
               <p
-                class="Text-sc-1wu7vpu-0 RbfMK"
+                className="c9 c11"
                 color="currentColor"
-                font-size="medium"
+                disabled={false}
+                fontSize="medium"
               >
                 Only yes can be selected...
               </p>
@@ -755,43 +1663,57 @@ exports[`Storyshots Form Demo form 1`] = `
           </div>
         </fieldset>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle__StyledToggle-sc-1oqd206-0 tNttj"
+          className="c19 c20 c52"
         >
           <div
             id="Job Visibility-label"
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c22"
             >
               <span
-                style="font-size:14px;font-weight:600;line-height:1.71428571"
+                style={
+                  Object {
+                    "fontSize": "14px",
+                    "fontWeight": "600",
+                    "lineHeight": "1.71428571",
+                  }
+                }
               >
                 Job Visibility
               </span>
             </div>
             <div
-              class="ClickInputLabel-j2axnv-0 kemUmZ"
+              className="c39"
+              disabled={false}
+              onClick={[Function]}
             >
               <div
-                class="ToggleButton__Switch-asgrb8-1 hOMJxD"
+                className="c53"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-labelledby="Job Visibility-label"
-                  aria-required="false"
-                  class="ToggleButton__ToggleInput-asgrb8-2 lcDvtB"
+                  aria-required={false}
+                  className="c54"
+                  disabled={false}
                   id="job-visibility"
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  required={false}
                   type="checkbox"
                   value="on"
                 />
                 <span
-                  class="ToggleButton__Slider-asgrb8-0 bLvWmF"
+                  className="c55 c56"
+                  disabled={false}
                 />
               </div>
               <p
-                class="Text-sc-1wu7vpu-0 cOGezP"
+                className="c9 c57"
                 color="currentColor"
-                font-size="medium"
+                disabled={false}
+                fontSize="medium"
               >
                 Hidden
               </p>
@@ -800,63 +1722,71 @@ exports[`Storyshots Form Demo form 1`] = `
         </div>
       </fieldset>
       <fieldset
-        class="FormSection-sc-5yud6c-1 cJYtnA"
+        className="c15 c16"
       >
         <legend
-          class="Text-sc-1wu7vpu-0-h3 Headings__SubsectionTitle-igpciy-0 FormSection__FormSectionTitle-sc-5yud6c-0 gaHdwg"
-          font-size="large"
-          font-weight="medium"
+          className="c9-h3 Headings__SubsectionTitle-igpciy-0 c17 c18"
+          fontSize="large"
+          fontWeight="medium"
         >
           Rejects
         </legend>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c19 c20"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c21 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c22"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c23"
               >
                 Item
               </span>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c24"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c25"
                 display="flex"
               >
                 <input
-                  aria-invalid="true"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 jMjRjb"
+                  aria-invalid={true}
+                  aria-required={false}
+                  className="c29"
+                  defaultValue="235432"
+                  disabled={false}
                   id="items"
-                  value="235432"
+                  required={false}
                 />
               </div>
             </div>
           </label>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 ycNbA"
+            className="c30"
             color="red"
           >
             <svg
-              aria-hidden="true"
-              class="Icon-fc7twp-0 QuoIa"
+              aria-hidden={true}
+              className="c31"
               color="currentColor"
               fill="currentColor"
-              focusable="false"
+              focusable={false}
               height="24px"
               icon="error"
               mr="x1"
+              size="24px"
+              title={null}
               viewBox="0 0 24 24"
               width="24px"
             >
@@ -865,12 +1795,13 @@ exports[`Storyshots Form Demo form 1`] = `
               />
             </svg>
             <div
-              class="InlineValidation__Wrapper-sc-1jic7dw-0 kqhCKM"
+              className="c32"
             >
               <p
-                class="Text-sc-1wu7vpu-0 RbfMK"
+                className="c9 c11"
                 color="currentColor"
-                font-size="medium"
+                disabled={false}
+                fontSize="medium"
               >
                 Item 235432 is not a valid entry
               </p>
@@ -878,82 +1809,98 @@ exports[`Storyshots Form Demo form 1`] = `
           </div>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c19 c20"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c21 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c22"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c23"
               >
                 Quantity
               </span>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c24"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c25"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-invalid={false}
+                  aria-required={false}
+                  className="c26"
+                  disabled={false}
                   id="quantity"
+                  required={false}
                 />
               </div>
             </div>
           </label>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle__StyledToggle-sc-1oqd206-0 tNttj"
+          className="c19 c20 c52"
         >
           <div
             id="Reject visibility-label"
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c22"
             >
               <span
-                style="font-size:14px;font-weight:600;line-height:1.71428571"
+                style={
+                  Object {
+                    "fontSize": "14px",
+                    "fontWeight": "600",
+                    "lineHeight": "1.71428571",
+                  }
+                }
               >
                 Reject visibility
               </span>
             </div>
             <div
-              class="ClickInputLabel-j2axnv-0 kjxgat"
-              disabled=""
+              className="c43"
+              disabled={true}
+              onClick={[Function]}
             >
               <div
-                class="ToggleButton__Switch-asgrb8-1 hOMJxD"
+                className="c53"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-labelledby="Reject visibility-label"
-                  aria-required="false"
-                  class="ToggleButton__ToggleInput-asgrb8-2 gajnWZ"
-                  disabled=""
+                  aria-required={false}
+                  className="c58"
+                  disabled={true}
                   id="reject-visibility"
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  required={false}
                   type="checkbox"
                   value="on"
                 />
                 <span
-                  class="ToggleButton__Slider-asgrb8-0 bQpZex"
-                  disabled=""
+                  className="c55 c59"
+                  disabled={true}
                 />
               </div>
               <p
-                class="Text-sc-1wu7vpu-0 jVsGHh"
+                className="c9 c60"
                 color="currentColor"
-                disabled=""
-                font-size="medium"
+                disabled={true}
+                fontSize="medium"
               >
                 Hidden
               </p>
@@ -967,144 +1914,339 @@ exports[`Storyshots Form Demo form 1`] = `
 `;
 
 exports[`Storyshots Form Form 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c7 {
+  margin-bottom: 8px;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c13 {
+  margin-left: 8px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #434d59;
+}
+
+.c3 {
+  margin-top: 0;
+  margin-bottom: 16px;
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.23076923;
+}
+
+.c14 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+  font-size: 14px;
+  line-height: 1.71428571;
+}
+
+.c14 .Link-sc-1lpx3d0-0 {
+  font-size: 14px;
+}
+
+.c6 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c8 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c5 {
+  width: 100%;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c1 .c2 {
+  margin-bottom: 48px;
+}
+
+.c1 .Alert-u8lbe-0 {
+  margin-bottom: 48px;
+}
+
+.c1 .c4,
+.c1 .Fieldset-sc-9aoml1-0 {
+  margin-bottom: 24px;
+}
+
+.c1 .c4:last-child,
+.c1 .Fieldset-sc-9aoml1-0:last-child {
+  margin-bottom: 0;
+}
+
+.c1 .FormSection-sc-5yud6c-1 {
+  margin-bottom: 48px;
+}
+
+.c1 .FormSection-sc-5yud6c-1:last-child {
+  margin-bottom: 0;
+}
+
+.c11 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c11:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c11:focus ~ svg {
+  fill: #00438f;
+}
+
+.c11::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c11::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c11:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c11::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <form
-      class="Form-n70q8u-0 laLzBn"
+      className="c1"
     >
       <h2
-        class="Text-sc-1wu7vpu-0-h2 heWDlS"
-        font-size="larger"
-        font-weight="medium"
+        className="c2 c3"
+        fontSize="larger"
+        fontWeight="medium"
       >
         New Profile
       </h2>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+        className="c4 c5"
       >
         <label
-          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+          className="c6 "
           color="black"
-          style="display:block"
+          style={
+            Object {
+              "display": "block",
+            }
+          }
         >
           <div
-            class="Box-sc-1qu1edy-0 ilQgHG"
+            className="c7"
             data-testid="field-label"
           >
             <span
-              class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+              className="c8"
             >
               Name
             </span>
           </div>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+            className="c9"
           >
             <div
-              class="Box-sc-1qu1edy-0 hxUhcg"
+              className="c10"
               display="flex"
             >
               <input
-                aria-invalid="false"
-                aria-required="false"
-                class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                aria-invalid={false}
+                aria-required={false}
+                className="c11"
+                disabled={false}
                 id="name"
+                required={false}
               />
             </div>
           </div>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+        className="c4 c5"
       >
         <label
-          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+          className="c6 "
           color="black"
-          style="display:block"
+          style={
+            Object {
+              "display": "block",
+            }
+          }
         >
           <div
-            class="Box-sc-1qu1edy-0 ilQgHG"
+            className="c7"
             data-testid="field-label"
           >
             <span
-              class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+              className="c8"
             >
               Date of birth
             </span>
             <span
-              class="Text-sc-1wu7vpu-0 bphWXP"
+              className="c12 c13"
               color="darkGrey"
-              font-size="12px"
+              disabled={false}
+              fontSize="12px"
             >
               (Optional)
             </span>
             <p
-              class="Text-sc-1wu7vpu-0 HelpText__HelpTextContent-sc-1jzmq2g-0 feAJVX"
+              className="c12 c14"
               color="currentColor"
-              font-size="medium"
+              disabled={false}
+              fontSize="medium"
             >
               Enter a date below
             </p>
           </div>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+            className="c9"
           >
             <div
-              class="Box-sc-1qu1edy-0 hxUhcg"
+              className="c10"
               display="flex"
             >
               <input
-                aria-invalid="false"
-                aria-required="false"
-                class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                aria-invalid={false}
+                aria-required={false}
+                className="c11"
+                disabled={false}
                 id="birthdate"
                 placeholder="DD-MM-YYYY"
+                required={false}
               />
             </div>
           </div>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+        className="c4 c5"
       >
         <label
-          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+          className="c6 "
           color="black"
-          style="display:block"
+          style={
+            Object {
+              "display": "block",
+            }
+          }
         >
           <div
-            class="Box-sc-1qu1edy-0 ilQgHG"
+            className="c7"
             data-testid="field-label"
           >
             <span
-              class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+              className="c8"
             >
               Place of birth
             </span>
             <span
-              class="Text-sc-1wu7vpu-0 bphWXP"
+              className="c12 c13"
               color="darkGrey"
-              font-size="12px"
+              disabled={false}
+              fontSize="12px"
             >
               (Optional)
             </span>
           </div>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+            className="c9"
           >
             <div
-              class="Box-sc-1qu1edy-0 hxUhcg"
+              className="c10"
               display="flex"
             >
               <input
-                aria-invalid="false"
-                aria-required="false"
-                class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                aria-invalid={false}
+                aria-required={false}
+                className="c11"
+                disabled={false}
                 id="birthplace"
+                required={false}
               />
             </div>
           </div>
@@ -1116,154 +2258,379 @@ exports[`Storyshots Form Form 1`] = `
 `;
 
 exports[`Storyshots Form With form sections 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c11 {
+  margin-bottom: 8px;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c17 {
+  margin-left: 8px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #434d59;
+}
+
+.c3 {
+  margin-top: 0;
+  margin-bottom: 16px;
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.23076923;
+}
+
+.c18 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+  font-size: 14px;
+  line-height: 1.71428571;
+}
+
+.c18 .Link-sc-1lpx3d0-0 {
+  font-size: 14px;
+}
+
+.c10 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c12 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c9 {
+  width: 100%;
+}
+
+.c7 {
+  margin-top: 0;
+  margin-bottom: 8px;
+  font-weight: 500;
+  font-size: 20px;
+  line-height: 1.2;
+}
+
+.c5 {
+  width: 100%;
+  padding: 0;
+  margin: 0;
+  border: none;
+}
+
+.c5 .c6 {
+  padding: 0;
+  margin-bottom: 24px;
+}
+
+.c5 .c8,
+.c5 .Fieldset-sc-9aoml1-0 {
+  margin-bottom: 24px;
+}
+
+.c5 .c8:last-child,
+.c5 .Fieldset-sc-9aoml1-0:last-child {
+  margin-bottom: 0;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c1 .c2 {
+  margin-bottom: 48px;
+}
+
+.c1 .Alert-u8lbe-0 {
+  margin-bottom: 48px;
+}
+
+.c1 .c8,
+.c1 .Fieldset-sc-9aoml1-0 {
+  margin-bottom: 24px;
+}
+
+.c1 .c8:last-child,
+.c1 .Fieldset-sc-9aoml1-0:last-child {
+  margin-bottom: 0;
+}
+
+.c1 .c4 {
+  margin-bottom: 48px;
+}
+
+.c1 .c4:last-child {
+  margin-bottom: 0;
+}
+
+.c15 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c15:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c15:focus ~ svg {
+  fill: #00438f;
+}
+
+.c15::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c15::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c15:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c15::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <form
-      class="Form-n70q8u-0 laLzBn"
+      className="c1"
     >
       <h2
-        class="Text-sc-1wu7vpu-0-h2 heWDlS"
-        font-size="larger"
-        font-weight="medium"
+        className="c2 c3"
+        fontSize="larger"
+        fontWeight="medium"
       >
         New Profile
       </h2>
       <fieldset
-        class="FormSection-sc-5yud6c-1 cJYtnA"
+        className="c4 c5"
       >
         <legend
-          class="Text-sc-1wu7vpu-0-h3 Headings__SubsectionTitle-igpciy-0 FormSection__FormSectionTitle-sc-5yud6c-0 gaHdwg"
-          font-size="large"
-          font-weight="medium"
+          className="c16-h3 Headings__SubsectionTitle-igpciy-0 c6 c7"
+          fontSize="large"
+          fontWeight="medium"
         >
           Personal Information
         </legend>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c8 c9"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c10 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c11"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c12"
               >
                 Name
               </span>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c13"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c14"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-invalid={false}
+                  aria-required={false}
+                  className="c15"
+                  disabled={false}
                   id="name"
+                  required={false}
                 />
               </div>
             </div>
           </label>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c8 c9"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c10 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c11"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c12"
               >
                 Date of birth
               </span>
               <span
-                class="Text-sc-1wu7vpu-0 bphWXP"
+                className="c16 c17"
                 color="darkGrey"
-                font-size="12px"
+                disabled={false}
+                fontSize="12px"
               >
                 (Optional)
               </span>
               <p
-                class="Text-sc-1wu7vpu-0 HelpText__HelpTextContent-sc-1jzmq2g-0 feAJVX"
+                className="c16 c18"
                 color="currentColor"
-                font-size="medium"
+                disabled={false}
+                fontSize="medium"
               >
                 Enter a date below
               </p>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c13"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c14"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-invalid={false}
+                  aria-required={false}
+                  className="c15"
+                  disabled={false}
                   id="birthdate"
                   placeholder="DD-MM-YYYY"
+                  required={false}
                 />
               </div>
             </div>
           </label>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c8 c9"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c10 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c11"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c12"
               >
                 Place of birth
               </span>
               <span
-                class="Text-sc-1wu7vpu-0 bphWXP"
+                className="c16 c17"
                 color="darkGrey"
-                font-size="12px"
+                disabled={false}
+                fontSize="12px"
               >
                 (Optional)
               </span>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c13"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c14"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-invalid={false}
+                  aria-required={false}
+                  className="c15"
+                  disabled={false}
                   id="birthplace"
+                  required={false}
                 />
               </div>
             </div>
@@ -1271,80 +2638,92 @@ exports[`Storyshots Form With form sections 1`] = `
         </div>
       </fieldset>
       <fieldset
-        class="FormSection-sc-5yud6c-1 cJYtnA"
+        className="c4 c5"
       >
         <legend
-          class="Text-sc-1wu7vpu-0-h3 Headings__SubsectionTitle-igpciy-0 FormSection__FormSectionTitle-sc-5yud6c-0 gaHdwg"
-          font-size="large"
-          font-weight="medium"
+          className="c16-h3 Headings__SubsectionTitle-igpciy-0 c6 c7"
+          fontSize="large"
+          fontWeight="medium"
         >
           General Information
         </legend>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c8 c9"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c10 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c11"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c12"
               >
                 Gender
               </span>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c13"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c14"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-invalid={false}
+                  aria-required={false}
+                  className="c15"
+                  disabled={false}
                   id="gender"
+                  required={false}
                 />
               </div>
             </div>
           </label>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c8 c9"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c10 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c11"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c12"
               >
                 Occupation
               </span>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c13"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c14"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-invalid={false}
+                  aria-required={false}
+                  className="c15"
+                  disabled={false}
                   id="occupation"
+                  required={false}
                 />
               </div>
             </div>
@@ -1357,147 +2736,364 @@ exports[`Storyshots Form With form sections 1`] = `
 `;
 
 exports[`Storyshots Form With form sections without titles 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c9 {
+  margin-bottom: 8px;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c15 {
+  margin-left: 8px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #434d59;
+}
+
+.c3 {
+  margin-top: 0;
+  margin-bottom: 16px;
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.23076923;
+}
+
+.c16 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+  font-size: 14px;
+  line-height: 1.71428571;
+}
+
+.c16 .Link-sc-1lpx3d0-0 {
+  font-size: 14px;
+}
+
+.c8 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c10 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c7 {
+  width: 100%;
+}
+
+.c5 {
+  width: 100%;
+  padding: 0;
+  margin: 0;
+  border: none;
+}
+
+.c5 .FormSection__FormSectionTitle-sc-5yud6c-0 {
+  padding: 0;
+  margin-bottom: 0;
+}
+
+.c5 .c6,
+.c5 .Fieldset-sc-9aoml1-0 {
+  margin-bottom: 24px;
+}
+
+.c5 .c6:last-child,
+.c5 .Fieldset-sc-9aoml1-0:last-child {
+  margin-bottom: 0;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c1 .c2 {
+  margin-bottom: 48px;
+}
+
+.c1 .Alert-u8lbe-0 {
+  margin-bottom: 48px;
+}
+
+.c1 .c6,
+.c1 .Fieldset-sc-9aoml1-0 {
+  margin-bottom: 24px;
+}
+
+.c1 .c6:last-child,
+.c1 .Fieldset-sc-9aoml1-0:last-child {
+  margin-bottom: 0;
+}
+
+.c1 .c4 {
+  margin-bottom: 48px;
+}
+
+.c1 .c4:last-child {
+  margin-bottom: 0;
+}
+
+.c13 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c13:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c13:focus ~ svg {
+  fill: #00438f;
+}
+
+.c13::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c13::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c13:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c13::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <form
-      class="Form-n70q8u-0 laLzBn"
+      className="c1"
     >
       <h2
-        class="Text-sc-1wu7vpu-0-h2 heWDlS"
-        font-size="larger"
-        font-weight="medium"
+        className="c2 c3"
+        fontSize="larger"
+        fontWeight="medium"
       >
         New Profile
       </h2>
       <fieldset
-        class="FormSection-sc-5yud6c-1 klMAvm"
+        className="c4 c5"
       >
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c6 c7"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c8 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c9"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c10"
               >
                 Name
               </span>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c11"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c12"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-invalid={false}
+                  aria-required={false}
+                  className="c13"
+                  disabled={false}
                   id="name"
+                  required={false}
                 />
               </div>
             </div>
           </label>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c6 c7"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c8 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c9"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c10"
               >
                 Date of birth
               </span>
               <span
-                class="Text-sc-1wu7vpu-0 bphWXP"
+                className="c14 c15"
                 color="darkGrey"
-                font-size="12px"
+                disabled={false}
+                fontSize="12px"
               >
                 (Optional)
               </span>
               <p
-                class="Text-sc-1wu7vpu-0 HelpText__HelpTextContent-sc-1jzmq2g-0 feAJVX"
+                className="c14 c16"
                 color="currentColor"
-                font-size="medium"
+                disabled={false}
+                fontSize="medium"
               >
                 Enter a date below
               </p>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c11"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c12"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-invalid={false}
+                  aria-required={false}
+                  className="c13"
+                  disabled={false}
                   id="birthdate"
                   placeholder="DD-MM-YYYY"
+                  required={false}
                 />
               </div>
             </div>
           </label>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c6 c7"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c8 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c9"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c10"
               >
                 Place of birth
               </span>
               <span
-                class="Text-sc-1wu7vpu-0 bphWXP"
+                className="c14 c15"
                 color="darkGrey"
-                font-size="12px"
+                disabled={false}
+                fontSize="12px"
               >
                 (Optional)
               </span>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c11"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c12"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-invalid={false}
+                  aria-required={false}
+                  className="c13"
+                  disabled={false}
                   id="birthplace"
+                  required={false}
                 />
               </div>
             </div>
@@ -1505,73 +3101,85 @@ exports[`Storyshots Form With form sections without titles 1`] = `
         </div>
       </fieldset>
       <fieldset
-        class="FormSection-sc-5yud6c-1 klMAvm"
+        className="c4 c5"
       >
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c6 c7"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c8 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c9"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c10"
               >
                 Gender
               </span>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c11"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c12"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-invalid={false}
+                  aria-required={false}
+                  className="c13"
+                  disabled={false}
                   id="gender"
+                  required={false}
                 />
               </div>
             </div>
           </label>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c6 c7"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c8 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c9"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c10"
               >
                 Occupation
               </span>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c11"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c12"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-invalid={false}
+                  aria-required={false}
+                  className="c13"
+                  disabled={false}
                   id="occupation"
+                  required={false}
                 />
               </div>
             </div>
@@ -1584,137 +3192,324 @@ exports[`Storyshots Form With form sections without titles 1`] = `
 `;
 
 exports[`Storyshots Form Without title 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c5 {
+  margin-bottom: 8px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c11 {
+  margin-left: 8px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #434d59;
+}
+
+.c12 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+  font-size: 14px;
+  line-height: 1.71428571;
+}
+
+.c12 .Link-sc-1lpx3d0-0 {
+  font-size: 14px;
+}
+
+.c4 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c6 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c3 {
+  width: 100%;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c1 .c10-h2 {
+  margin-bottom: 0;
+}
+
+.c1 .Alert-u8lbe-0 {
+  margin-bottom: 48px;
+}
+
+.c1 .c2,
+.c1 .Fieldset-sc-9aoml1-0 {
+  margin-bottom: 24px;
+}
+
+.c1 .c2:last-child,
+.c1 .Fieldset-sc-9aoml1-0:last-child {
+  margin-bottom: 0;
+}
+
+.c1 .FormSection-sc-5yud6c-1 {
+  margin-bottom: 48px;
+}
+
+.c1 .FormSection-sc-5yud6c-1:last-child {
+  margin-bottom: 0;
+}
+
+.c9 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c9:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c9:focus ~ svg {
+  fill: #00438f;
+}
+
+.c9::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c9::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c9:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c9::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <form
-      class="Form-n70q8u-0 ilQSyT"
+      className="c1"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+        className="c2 c3"
       >
         <label
-          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+          className="c4 "
           color="black"
-          style="display:block"
+          style={
+            Object {
+              "display": "block",
+            }
+          }
         >
           <div
-            class="Box-sc-1qu1edy-0 ilQgHG"
+            className="c5"
             data-testid="field-label"
           >
             <span
-              class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+              className="c6"
             >
               Name
             </span>
           </div>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+            className="c7"
           >
             <div
-              class="Box-sc-1qu1edy-0 hxUhcg"
+              className="c8"
               display="flex"
             >
               <input
-                aria-invalid="false"
-                aria-required="false"
-                class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                aria-invalid={false}
+                aria-required={false}
+                className="c9"
+                disabled={false}
                 id="name"
+                required={false}
               />
             </div>
           </div>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+        className="c2 c3"
       >
         <label
-          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+          className="c4 "
           color="black"
-          style="display:block"
+          style={
+            Object {
+              "display": "block",
+            }
+          }
         >
           <div
-            class="Box-sc-1qu1edy-0 ilQgHG"
+            className="c5"
             data-testid="field-label"
           >
             <span
-              class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+              className="c6"
             >
               Date of birth
             </span>
             <span
-              class="Text-sc-1wu7vpu-0 bphWXP"
+              className="c10 c11"
               color="darkGrey"
-              font-size="12px"
+              disabled={false}
+              fontSize="12px"
             >
               (Optional)
             </span>
             <p
-              class="Text-sc-1wu7vpu-0 HelpText__HelpTextContent-sc-1jzmq2g-0 feAJVX"
+              className="c10 c12"
               color="currentColor"
-              font-size="medium"
+              disabled={false}
+              fontSize="medium"
             >
               Enter a date below
             </p>
           </div>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+            className="c7"
           >
             <div
-              class="Box-sc-1qu1edy-0 hxUhcg"
+              className="c8"
               display="flex"
             >
               <input
-                aria-invalid="false"
-                aria-required="false"
-                class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                aria-invalid={false}
+                aria-required={false}
+                className="c9"
+                disabled={false}
                 id="birthdate"
                 placeholder="DD-MM-YYYY"
+                required={false}
               />
             </div>
           </div>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+        className="c2 c3"
       >
         <label
-          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+          className="c4 "
           color="black"
-          style="display:block"
+          style={
+            Object {
+              "display": "block",
+            }
+          }
         >
           <div
-            class="Box-sc-1qu1edy-0 ilQgHG"
+            className="c5"
             data-testid="field-label"
           >
             <span
-              class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+              className="c6"
             >
               Place of birth
             </span>
             <span
-              class="Text-sc-1wu7vpu-0 bphWXP"
+              className="c10 c11"
               color="darkGrey"
-              font-size="12px"
+              disabled={false}
+              fontSize="12px"
             >
               (Optional)
             </span>
           </div>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+            className="c7"
           >
             <div
-              class="Box-sc-1qu1edy-0 hxUhcg"
+              className="c8"
               display="flex"
             >
               <input
-                aria-invalid="false"
-                aria-required="false"
-                class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                aria-invalid={false}
+                aria-required={false}
+                className="c9"
+                disabled={false}
                 id="birthplace"
+                required={false}
               />
             </div>
           </div>

--- a/components/src/Icon/__snapshots__/Icon.story.storyshot
+++ b/components/src/Icon/__snapshots__/Icon.story.storyshot
@@ -1,27 +1,79 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Icon InlineIcon 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c2 {
+  position: absolute;
+  top: 0;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  position: relative;
+  height: 1em;
+  width: 1.25em;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <p
-      style="font-size:1em"
+      style={
+        Object {
+          "fontSize": "1em",
+        }
+      }
     >
-      @1em:  
+      @
+      1
+      em:  
       <span
-        class="Icon__IconContainer-fc7twp-2 jzPWAQ"
+        className="c1"
       >
         <svg
-          aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          aria-hidden={true}
+          className="c2"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="1.25em"
           icon="accessTime"
+          size="1.25em"
+          title={null}
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -34,16 +86,18 @@ exports[`Storyshots Icon InlineIcon 1`] = `
         </svg>
       </span>
       <span
-        class="Icon__IconContainer-fc7twp-2 jzPWAQ"
+        className="c1"
       >
         <svg
-          aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          aria-hidden={true}
+          className="c2"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="1.25em"
           icon="add"
+          size="1.25em"
+          title={null}
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -53,16 +107,18 @@ exports[`Storyshots Icon InlineIcon 1`] = `
         </svg>
       </span>
       <span
-        class="Icon__IconContainer-fc7twp-2 jzPWAQ"
+        className="c1"
       >
         <svg
-          aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          aria-hidden={true}
+          className="c2"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="1.25em"
           icon="addCircleOutline"
+          size="1.25em"
+          title={null}
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -72,16 +128,18 @@ exports[`Storyshots Icon InlineIcon 1`] = `
         </svg>
       </span>
       <span
-        class="Icon__IconContainer-fc7twp-2 jzPWAQ"
+        className="c1"
       >
         <svg
-          aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          aria-hidden={true}
+          className="c2"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="1.25em"
           icon="arrowForward"
+          size="1.25em"
+          title={null}
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -91,16 +149,18 @@ exports[`Storyshots Icon InlineIcon 1`] = `
         </svg>
       </span>
       <span
-        class="Icon__IconContainer-fc7twp-2 jzPWAQ"
+        className="c1"
       >
         <svg
-          aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          aria-hidden={true}
+          className="c2"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="1.25em"
           icon="block"
+          size="1.25em"
+          title={null}
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -110,13 +170,14 @@ exports[`Storyshots Icon InlineIcon 1`] = `
         </svg>
       </span>
       <span
-        class="Icon__IconContainer-fc7twp-2 jzPWAQ"
+        className="c1"
       >
         <svg
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
-          focusable="false"
+          className="c2"
+          focusable={false}
           height="1.25em"
           icon="loading"
+          title={null}
           viewBox="0 0 38 38"
           width="1.25em"
           xmlns="http://www.w3.org/2000/svg"
@@ -131,23 +192,23 @@ exports[`Storyshots Icon InlineIcon 1`] = `
             >
               <stop
                 offset="0%"
-                stop-color="currentColor"
-                stop-opacity="0"
+                stopColor="currentColor"
+                stopOpacity="0"
               />
               <stop
                 offset="63.146%"
-                stop-color="currentColor"
-                stop-opacity=".631"
+                stopColor="currentColor"
+                stopOpacity=".631"
               />
               <stop
                 offset="100%"
-                stop-color="currentColor"
+                stopColor="currentColor"
               />
             </linearGradient>
           </defs>
           <g
             fill="none"
-            fill-rule="evenodd"
+            fillRule="evenodd"
           >
             <g
               transform="translate(1 1)"
@@ -156,7 +217,7 @@ exports[`Storyshots Icon InlineIcon 1`] = `
                 d="M36 18c0-9.94-8.06-18-18-18"
                 id="Oval-2"
                 stroke="url(#random-id-1)"
-                stroke-width="2"
+                strokeWidth="2"
               >
                 <animateTransform
                   attributeName="transform"
@@ -188,20 +249,28 @@ exports[`Storyshots Icon InlineIcon 1`] = `
       </span>
     </p>
     <p
-      style="font-size:2em"
+      style={
+        Object {
+          "fontSize": "2em",
+        }
+      }
     >
-      @2em:  
+      @
+      2
+      em:  
       <span
-        class="Icon__IconContainer-fc7twp-2 jzPWAQ"
+        className="c1"
       >
         <svg
-          aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          aria-hidden={true}
+          className="c2"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="1.25em"
           icon="accessTime"
+          size="1.25em"
+          title={null}
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -214,16 +283,18 @@ exports[`Storyshots Icon InlineIcon 1`] = `
         </svg>
       </span>
       <span
-        class="Icon__IconContainer-fc7twp-2 jzPWAQ"
+        className="c1"
       >
         <svg
-          aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          aria-hidden={true}
+          className="c2"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="1.25em"
           icon="add"
+          size="1.25em"
+          title={null}
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -233,16 +304,18 @@ exports[`Storyshots Icon InlineIcon 1`] = `
         </svg>
       </span>
       <span
-        class="Icon__IconContainer-fc7twp-2 jzPWAQ"
+        className="c1"
       >
         <svg
-          aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          aria-hidden={true}
+          className="c2"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="1.25em"
           icon="addCircleOutline"
+          size="1.25em"
+          title={null}
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -252,16 +325,18 @@ exports[`Storyshots Icon InlineIcon 1`] = `
         </svg>
       </span>
       <span
-        class="Icon__IconContainer-fc7twp-2 jzPWAQ"
+        className="c1"
       >
         <svg
-          aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          aria-hidden={true}
+          className="c2"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="1.25em"
           icon="arrowForward"
+          size="1.25em"
+          title={null}
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -271,16 +346,18 @@ exports[`Storyshots Icon InlineIcon 1`] = `
         </svg>
       </span>
       <span
-        class="Icon__IconContainer-fc7twp-2 jzPWAQ"
+        className="c1"
       >
         <svg
-          aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          aria-hidden={true}
+          className="c2"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="1.25em"
           icon="block"
+          size="1.25em"
+          title={null}
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -290,13 +367,14 @@ exports[`Storyshots Icon InlineIcon 1`] = `
         </svg>
       </span>
       <span
-        class="Icon__IconContainer-fc7twp-2 jzPWAQ"
+        className="c1"
       >
         <svg
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
-          focusable="false"
+          className="c2"
+          focusable={false}
           height="1.25em"
           icon="loading"
+          title={null}
           viewBox="0 0 38 38"
           width="1.25em"
           xmlns="http://www.w3.org/2000/svg"
@@ -311,23 +389,23 @@ exports[`Storyshots Icon InlineIcon 1`] = `
             >
               <stop
                 offset="0%"
-                stop-color="currentColor"
-                stop-opacity="0"
+                stopColor="currentColor"
+                stopOpacity="0"
               />
               <stop
                 offset="63.146%"
-                stop-color="currentColor"
-                stop-opacity=".631"
+                stopColor="currentColor"
+                stopOpacity=".631"
               />
               <stop
                 offset="100%"
-                stop-color="currentColor"
+                stopColor="currentColor"
               />
             </linearGradient>
           </defs>
           <g
             fill="none"
-            fill-rule="evenodd"
+            fillRule="evenodd"
           >
             <g
               transform="translate(1 1)"
@@ -336,7 +414,7 @@ exports[`Storyshots Icon InlineIcon 1`] = `
                 d="M36 18c0-9.94-8.06-18-18-18"
                 id="Oval-2"
                 stroke="url(#random-id-2)"
-                stroke-width="2"
+                strokeWidth="2"
               >
                 <animateTransform
                   attributeName="transform"
@@ -368,20 +446,28 @@ exports[`Storyshots Icon InlineIcon 1`] = `
       </span>
     </p>
     <p
-      style="font-size:3em"
+      style={
+        Object {
+          "fontSize": "3em",
+        }
+      }
     >
-      @3em:  
+      @
+      3
+      em:  
       <span
-        class="Icon__IconContainer-fc7twp-2 jzPWAQ"
+        className="c1"
       >
         <svg
-          aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          aria-hidden={true}
+          className="c2"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="1.25em"
           icon="accessTime"
+          size="1.25em"
+          title={null}
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -394,16 +480,18 @@ exports[`Storyshots Icon InlineIcon 1`] = `
         </svg>
       </span>
       <span
-        class="Icon__IconContainer-fc7twp-2 jzPWAQ"
+        className="c1"
       >
         <svg
-          aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          aria-hidden={true}
+          className="c2"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="1.25em"
           icon="add"
+          size="1.25em"
+          title={null}
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -413,16 +501,18 @@ exports[`Storyshots Icon InlineIcon 1`] = `
         </svg>
       </span>
       <span
-        class="Icon__IconContainer-fc7twp-2 jzPWAQ"
+        className="c1"
       >
         <svg
-          aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          aria-hidden={true}
+          className="c2"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="1.25em"
           icon="addCircleOutline"
+          size="1.25em"
+          title={null}
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -432,16 +522,18 @@ exports[`Storyshots Icon InlineIcon 1`] = `
         </svg>
       </span>
       <span
-        class="Icon__IconContainer-fc7twp-2 jzPWAQ"
+        className="c1"
       >
         <svg
-          aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          aria-hidden={true}
+          className="c2"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="1.25em"
           icon="arrowForward"
+          size="1.25em"
+          title={null}
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -451,16 +543,18 @@ exports[`Storyshots Icon InlineIcon 1`] = `
         </svg>
       </span>
       <span
-        class="Icon__IconContainer-fc7twp-2 jzPWAQ"
+        className="c1"
       >
         <svg
-          aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          aria-hidden={true}
+          className="c2"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="1.25em"
           icon="block"
+          size="1.25em"
+          title={null}
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -470,13 +564,14 @@ exports[`Storyshots Icon InlineIcon 1`] = `
         </svg>
       </span>
       <span
-        class="Icon__IconContainer-fc7twp-2 jzPWAQ"
+        className="c1"
       >
         <svg
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
-          focusable="false"
+          className="c2"
+          focusable={false}
           height="1.25em"
           icon="loading"
+          title={null}
           viewBox="0 0 38 38"
           width="1.25em"
           xmlns="http://www.w3.org/2000/svg"
@@ -491,23 +586,23 @@ exports[`Storyshots Icon InlineIcon 1`] = `
             >
               <stop
                 offset="0%"
-                stop-color="currentColor"
-                stop-opacity="0"
+                stopColor="currentColor"
+                stopOpacity="0"
               />
               <stop
                 offset="63.146%"
-                stop-color="currentColor"
-                stop-opacity=".631"
+                stopColor="currentColor"
+                stopOpacity=".631"
               />
               <stop
                 offset="100%"
-                stop-color="currentColor"
+                stopColor="currentColor"
               />
             </linearGradient>
           </defs>
           <g
             fill="none"
-            fill-rule="evenodd"
+            fillRule="evenodd"
           >
             <g
               transform="translate(1 1)"
@@ -516,7 +611,7 @@ exports[`Storyshots Icon InlineIcon 1`] = `
                 d="M36 18c0-9.94-8.06-18-18-18"
                 id="Oval-2"
                 stroke="url(#random-id-3)"
-                stroke-width="2"
+                strokeWidth="2"
               >
                 <animateTransform
                   attributeName="transform"
@@ -548,20 +643,28 @@ exports[`Storyshots Icon InlineIcon 1`] = `
       </span>
     </p>
     <p
-      style="font-size:4em"
+      style={
+        Object {
+          "fontSize": "4em",
+        }
+      }
     >
-      @4em:  
+      @
+      4
+      em:  
       <span
-        class="Icon__IconContainer-fc7twp-2 jzPWAQ"
+        className="c1"
       >
         <svg
-          aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          aria-hidden={true}
+          className="c2"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="1.25em"
           icon="accessTime"
+          size="1.25em"
+          title={null}
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -574,16 +677,18 @@ exports[`Storyshots Icon InlineIcon 1`] = `
         </svg>
       </span>
       <span
-        class="Icon__IconContainer-fc7twp-2 jzPWAQ"
+        className="c1"
       >
         <svg
-          aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          aria-hidden={true}
+          className="c2"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="1.25em"
           icon="add"
+          size="1.25em"
+          title={null}
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -593,16 +698,18 @@ exports[`Storyshots Icon InlineIcon 1`] = `
         </svg>
       </span>
       <span
-        class="Icon__IconContainer-fc7twp-2 jzPWAQ"
+        className="c1"
       >
         <svg
-          aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          aria-hidden={true}
+          className="c2"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="1.25em"
           icon="addCircleOutline"
+          size="1.25em"
+          title={null}
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -612,16 +719,18 @@ exports[`Storyshots Icon InlineIcon 1`] = `
         </svg>
       </span>
       <span
-        class="Icon__IconContainer-fc7twp-2 jzPWAQ"
+        className="c1"
       >
         <svg
-          aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          aria-hidden={true}
+          className="c2"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="1.25em"
           icon="arrowForward"
+          size="1.25em"
+          title={null}
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -631,16 +740,18 @@ exports[`Storyshots Icon InlineIcon 1`] = `
         </svg>
       </span>
       <span
-        class="Icon__IconContainer-fc7twp-2 jzPWAQ"
+        className="c1"
       >
         <svg
-          aria-hidden="true"
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
+          aria-hidden={true}
+          className="c2"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="1.25em"
           icon="block"
+          size="1.25em"
+          title={null}
           viewBox="0 0 24 24"
           width="1.25em"
         >
@@ -650,13 +761,14 @@ exports[`Storyshots Icon InlineIcon 1`] = `
         </svg>
       </span>
       <span
-        class="Icon__IconContainer-fc7twp-2 jzPWAQ"
+        className="c1"
       >
         <svg
-          class="Icon__CenteredIcon-fc7twp-1 dKjNdn"
-          focusable="false"
+          className="c2"
+          focusable={false}
           height="1.25em"
           icon="loading"
+          title={null}
           viewBox="0 0 38 38"
           width="1.25em"
           xmlns="http://www.w3.org/2000/svg"
@@ -671,23 +783,23 @@ exports[`Storyshots Icon InlineIcon 1`] = `
             >
               <stop
                 offset="0%"
-                stop-color="currentColor"
-                stop-opacity="0"
+                stopColor="currentColor"
+                stopOpacity="0"
               />
               <stop
                 offset="63.146%"
-                stop-color="currentColor"
-                stop-opacity=".631"
+                stopColor="currentColor"
+                stopOpacity=".631"
               />
               <stop
                 offset="100%"
-                stop-color="currentColor"
+                stopColor="currentColor"
               />
             </linearGradient>
           </defs>
           <g
             fill="none"
-            fill-rule="evenodd"
+            fillRule="evenodd"
           >
             <g
               transform="translate(1 1)"
@@ -696,7 +808,7 @@ exports[`Storyshots Icon InlineIcon 1`] = `
                 d="M36 18c0-9.94-8.06-18-18-18"
                 id="Oval-2"
                 stroke="url(#random-id-4)"
-                stroke-width="2"
+                strokeWidth="2"
               >
                 <animateTransform
                   attributeName="transform"
@@ -732,23 +844,76 @@ exports[`Storyshots Icon InlineIcon 1`] = `
 `;
 
 exports[`Storyshots Icon With a color 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  color: #cc1439;
+  min-width: 24px;
+}
+
+.c2 {
+  color: #ffbb00;
+  min-width: 24px;
+}
+
+.c3 {
+  color: #008059;
+  min-width: 24px;
+}
+
+.c4 {
+  color: #216beb;
+  min-width: 24px;
+}
+
+.c5 {
+  color: #122b47;
+  min-width: 24px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj"
+      className=""
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 fjiVCY"
+        aria-hidden={true}
+        className="c1"
         color="#cc1439"
         fill="#cc1439"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="accessTime"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -760,13 +925,15 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 fjiVCY"
+        aria-hidden={true}
+        className="c1"
         color="#cc1439"
         fill="#cc1439"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="add"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -775,13 +942,15 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 fjiVCY"
+        aria-hidden={true}
+        className="c1"
         color="#cc1439"
         fill="#cc1439"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="addCircleOutline"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -790,13 +959,15 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 fjiVCY"
+        aria-hidden={true}
+        className="c1"
         color="#cc1439"
         fill="#cc1439"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="arrowForward"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -805,13 +976,15 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 fjiVCY"
+        aria-hidden={true}
+        className="c1"
         color="#cc1439"
         fill="#cc1439"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="block"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -820,10 +993,11 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        class="Icon-fc7twp-0 fjiVCY"
-        focusable="false"
+        className="c1"
+        focusable={false}
         height="24px"
         icon="loading"
+        title={null}
         viewBox="0 0 38 38"
         width="24px"
         xmlns="http://www.w3.org/2000/svg"
@@ -838,23 +1012,23 @@ exports[`Storyshots Icon With a color 1`] = `
           >
             <stop
               offset="0%"
-              stop-color="#cc1439"
-              stop-opacity="0"
+              stopColor="#cc1439"
+              stopOpacity="0"
             />
             <stop
               offset="63.146%"
-              stop-color="#cc1439"
-              stop-opacity=".631"
+              stopColor="#cc1439"
+              stopOpacity=".631"
             />
             <stop
               offset="100%"
-              stop-color="#cc1439"
+              stopColor="#cc1439"
             />
           </linearGradient>
         </defs>
         <g
           fill="none"
-          fill-rule="evenodd"
+          fillRule="evenodd"
         >
           <g
             transform="translate(1 1)"
@@ -863,7 +1037,7 @@ exports[`Storyshots Icon With a color 1`] = `
               d="M36 18c0-9.94-8.06-18-18-18"
               id="Oval-2"
               stroke="url(#random-id-5)"
-              stroke-width="2"
+              strokeWidth="2"
             >
               <animateTransform
                 attributeName="transform"
@@ -894,16 +1068,18 @@ exports[`Storyshots Icon With a color 1`] = `
       </svg>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj"
+      className=""
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 fGpDPz"
+        aria-hidden={true}
+        className="c2"
         color="#ffbb00"
         fill="#ffbb00"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="accessTime"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -915,13 +1091,15 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 fGpDPz"
+        aria-hidden={true}
+        className="c2"
         color="#ffbb00"
         fill="#ffbb00"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="add"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -930,13 +1108,15 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 fGpDPz"
+        aria-hidden={true}
+        className="c2"
         color="#ffbb00"
         fill="#ffbb00"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="addCircleOutline"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -945,13 +1125,15 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 fGpDPz"
+        aria-hidden={true}
+        className="c2"
         color="#ffbb00"
         fill="#ffbb00"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="arrowForward"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -960,13 +1142,15 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 fGpDPz"
+        aria-hidden={true}
+        className="c2"
         color="#ffbb00"
         fill="#ffbb00"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="block"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -975,10 +1159,11 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        class="Icon-fc7twp-0 fGpDPz"
-        focusable="false"
+        className="c2"
+        focusable={false}
         height="24px"
         icon="loading"
+        title={null}
         viewBox="0 0 38 38"
         width="24px"
         xmlns="http://www.w3.org/2000/svg"
@@ -993,23 +1178,23 @@ exports[`Storyshots Icon With a color 1`] = `
           >
             <stop
               offset="0%"
-              stop-color="#ffbb00"
-              stop-opacity="0"
+              stopColor="#ffbb00"
+              stopOpacity="0"
             />
             <stop
               offset="63.146%"
-              stop-color="#ffbb00"
-              stop-opacity=".631"
+              stopColor="#ffbb00"
+              stopOpacity=".631"
             />
             <stop
               offset="100%"
-              stop-color="#ffbb00"
+              stopColor="#ffbb00"
             />
           </linearGradient>
         </defs>
         <g
           fill="none"
-          fill-rule="evenodd"
+          fillRule="evenodd"
         >
           <g
             transform="translate(1 1)"
@@ -1018,7 +1203,7 @@ exports[`Storyshots Icon With a color 1`] = `
               d="M36 18c0-9.94-8.06-18-18-18"
               id="Oval-2"
               stroke="url(#random-id-6)"
-              stroke-width="2"
+              strokeWidth="2"
             >
               <animateTransform
                 attributeName="transform"
@@ -1049,16 +1234,18 @@ exports[`Storyshots Icon With a color 1`] = `
       </svg>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj"
+      className=""
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 fAXHND"
+        aria-hidden={true}
+        className="c3"
         color="#008059"
         fill="#008059"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="accessTime"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1070,13 +1257,15 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 fAXHND"
+        aria-hidden={true}
+        className="c3"
         color="#008059"
         fill="#008059"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="add"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1085,13 +1274,15 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 fAXHND"
+        aria-hidden={true}
+        className="c3"
         color="#008059"
         fill="#008059"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="addCircleOutline"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1100,13 +1291,15 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 fAXHND"
+        aria-hidden={true}
+        className="c3"
         color="#008059"
         fill="#008059"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="arrowForward"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1115,13 +1308,15 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 fAXHND"
+        aria-hidden={true}
+        className="c3"
         color="#008059"
         fill="#008059"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="block"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1130,10 +1325,11 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        class="Icon-fc7twp-0 fAXHND"
-        focusable="false"
+        className="c3"
+        focusable={false}
         height="24px"
         icon="loading"
+        title={null}
         viewBox="0 0 38 38"
         width="24px"
         xmlns="http://www.w3.org/2000/svg"
@@ -1148,23 +1344,23 @@ exports[`Storyshots Icon With a color 1`] = `
           >
             <stop
               offset="0%"
-              stop-color="#008059"
-              stop-opacity="0"
+              stopColor="#008059"
+              stopOpacity="0"
             />
             <stop
               offset="63.146%"
-              stop-color="#008059"
-              stop-opacity=".631"
+              stopColor="#008059"
+              stopOpacity=".631"
             />
             <stop
               offset="100%"
-              stop-color="#008059"
+              stopColor="#008059"
             />
           </linearGradient>
         </defs>
         <g
           fill="none"
-          fill-rule="evenodd"
+          fillRule="evenodd"
         >
           <g
             transform="translate(1 1)"
@@ -1173,7 +1369,7 @@ exports[`Storyshots Icon With a color 1`] = `
               d="M36 18c0-9.94-8.06-18-18-18"
               id="Oval-2"
               stroke="url(#random-id-7)"
-              stroke-width="2"
+              strokeWidth="2"
             >
               <animateTransform
                 attributeName="transform"
@@ -1204,16 +1400,18 @@ exports[`Storyshots Icon With a color 1`] = `
       </svg>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj"
+      className=""
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 cQdNwL"
+        aria-hidden={true}
+        className="c4"
         color="#216beb"
         fill="#216beb"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="accessTime"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1225,13 +1423,15 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 cQdNwL"
+        aria-hidden={true}
+        className="c4"
         color="#216beb"
         fill="#216beb"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="add"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1240,13 +1440,15 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 cQdNwL"
+        aria-hidden={true}
+        className="c4"
         color="#216beb"
         fill="#216beb"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="addCircleOutline"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1255,13 +1457,15 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 cQdNwL"
+        aria-hidden={true}
+        className="c4"
         color="#216beb"
         fill="#216beb"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="arrowForward"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1270,13 +1474,15 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 cQdNwL"
+        aria-hidden={true}
+        className="c4"
         color="#216beb"
         fill="#216beb"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="block"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1285,10 +1491,11 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        class="Icon-fc7twp-0 cQdNwL"
-        focusable="false"
+        className="c4"
+        focusable={false}
         height="24px"
         icon="loading"
+        title={null}
         viewBox="0 0 38 38"
         width="24px"
         xmlns="http://www.w3.org/2000/svg"
@@ -1303,23 +1510,23 @@ exports[`Storyshots Icon With a color 1`] = `
           >
             <stop
               offset="0%"
-              stop-color="#216beb"
-              stop-opacity="0"
+              stopColor="#216beb"
+              stopOpacity="0"
             />
             <stop
               offset="63.146%"
-              stop-color="#216beb"
-              stop-opacity=".631"
+              stopColor="#216beb"
+              stopOpacity=".631"
             />
             <stop
               offset="100%"
-              stop-color="#216beb"
+              stopColor="#216beb"
             />
           </linearGradient>
         </defs>
         <g
           fill="none"
-          fill-rule="evenodd"
+          fillRule="evenodd"
         >
           <g
             transform="translate(1 1)"
@@ -1328,7 +1535,7 @@ exports[`Storyshots Icon With a color 1`] = `
               d="M36 18c0-9.94-8.06-18-18-18"
               id="Oval-2"
               stroke="url(#random-id-8)"
-              stroke-width="2"
+              strokeWidth="2"
             >
               <animateTransform
                 attributeName="transform"
@@ -1359,16 +1566,18 @@ exports[`Storyshots Icon With a color 1`] = `
       </svg>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj"
+      className=""
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 ckNWkf"
+        aria-hidden={true}
+        className="c5"
         color="#122b47"
         fill="#122b47"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="accessTime"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1380,13 +1589,15 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 ckNWkf"
+        aria-hidden={true}
+        className="c5"
         color="#122b47"
         fill="#122b47"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="add"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1395,13 +1606,15 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 ckNWkf"
+        aria-hidden={true}
+        className="c5"
         color="#122b47"
         fill="#122b47"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="addCircleOutline"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1410,13 +1623,15 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 ckNWkf"
+        aria-hidden={true}
+        className="c5"
         color="#122b47"
         fill="#122b47"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="arrowForward"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1425,13 +1640,15 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 ckNWkf"
+        aria-hidden={true}
+        className="c5"
         color="#122b47"
         fill="#122b47"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="block"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1440,10 +1657,11 @@ exports[`Storyshots Icon With a color 1`] = `
         />
       </svg>
       <svg
-        class="Icon-fc7twp-0 ckNWkf"
-        focusable="false"
+        className="c5"
+        focusable={false}
         height="24px"
         icon="loading"
+        title={null}
         viewBox="0 0 38 38"
         width="24px"
         xmlns="http://www.w3.org/2000/svg"
@@ -1458,23 +1676,23 @@ exports[`Storyshots Icon With a color 1`] = `
           >
             <stop
               offset="0%"
-              stop-color="#122b47"
-              stop-opacity="0"
+              stopColor="#122b47"
+              stopOpacity="0"
             />
             <stop
               offset="63.146%"
-              stop-color="#122b47"
-              stop-opacity=".631"
+              stopColor="#122b47"
+              stopOpacity=".631"
             />
             <stop
               offset="100%"
-              stop-color="#122b47"
+              stopColor="#122b47"
             />
           </linearGradient>
         </defs>
         <g
           fill="none"
-          fill-rule="evenodd"
+          fillRule="evenodd"
         >
           <g
             transform="translate(1 1)"
@@ -1483,7 +1701,7 @@ exports[`Storyshots Icon With a color 1`] = `
               d="M36 18c0-9.94-8.06-18-18-18"
               id="Oval-2"
               stroke="url(#random-id-9)"
-              stroke-width="2"
+              strokeWidth="2"
             >
               <animateTransform
                 attributeName="transform"
@@ -1518,23 +1736,66 @@ exports[`Storyshots Icon With a color 1`] = `
 `;
 
 exports[`Storyshots Icon With a size 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  color: currentColor;
+  min-width: 8px;
+}
+
+.c2 {
+  color: currentColor;
+  min-width: 16px;
+}
+
+.c3 {
+  color: currentColor;
+  min-width: 24px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj"
+      className=""
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 HAgHa"
+        aria-hidden={true}
+        className="c1"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="8px"
         icon="accessTime"
+        size="8px"
+        title={null}
         viewBox="0 0 24 24"
         width="8px"
       >
@@ -1546,13 +1807,15 @@ exports[`Storyshots Icon With a size 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 HAgHa"
+        aria-hidden={true}
+        className="c1"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="8px"
         icon="add"
+        size="8px"
+        title={null}
         viewBox="0 0 24 24"
         width="8px"
       >
@@ -1561,13 +1824,15 @@ exports[`Storyshots Icon With a size 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 HAgHa"
+        aria-hidden={true}
+        className="c1"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="8px"
         icon="addCircleOutline"
+        size="8px"
+        title={null}
         viewBox="0 0 24 24"
         width="8px"
       >
@@ -1576,13 +1841,15 @@ exports[`Storyshots Icon With a size 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 HAgHa"
+        aria-hidden={true}
+        className="c1"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="8px"
         icon="arrowForward"
+        size="8px"
+        title={null}
         viewBox="0 0 24 24"
         width="8px"
       >
@@ -1591,13 +1858,15 @@ exports[`Storyshots Icon With a size 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 HAgHa"
+        aria-hidden={true}
+        className="c1"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="8px"
         icon="block"
+        size="8px"
+        title={null}
         viewBox="0 0 24 24"
         width="8px"
       >
@@ -1606,10 +1875,11 @@ exports[`Storyshots Icon With a size 1`] = `
         />
       </svg>
       <svg
-        class="Icon-fc7twp-0 HAgHa"
-        focusable="false"
+        className="c1"
+        focusable={false}
         height="8px"
         icon="loading"
+        title={null}
         viewBox="0 0 38 38"
         width="8px"
         xmlns="http://www.w3.org/2000/svg"
@@ -1624,23 +1894,23 @@ exports[`Storyshots Icon With a size 1`] = `
           >
             <stop
               offset="0%"
-              stop-color="currentColor"
-              stop-opacity="0"
+              stopColor="currentColor"
+              stopOpacity="0"
             />
             <stop
               offset="63.146%"
-              stop-color="currentColor"
-              stop-opacity=".631"
+              stopColor="currentColor"
+              stopOpacity=".631"
             />
             <stop
               offset="100%"
-              stop-color="currentColor"
+              stopColor="currentColor"
             />
           </linearGradient>
         </defs>
         <g
           fill="none"
-          fill-rule="evenodd"
+          fillRule="evenodd"
         >
           <g
             transform="translate(1 1)"
@@ -1649,7 +1919,7 @@ exports[`Storyshots Icon With a size 1`] = `
               d="M36 18c0-9.94-8.06-18-18-18"
               id="Oval-2"
               stroke="url(#random-id-10)"
-              stroke-width="2"
+              strokeWidth="2"
             >
               <animateTransform
                 attributeName="transform"
@@ -1680,16 +1950,18 @@ exports[`Storyshots Icon With a size 1`] = `
       </svg>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj"
+      className=""
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 fvcdOB"
+        aria-hidden={true}
+        className="c2"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="16px"
         icon="accessTime"
+        size="16px"
+        title={null}
         viewBox="0 0 24 24"
         width="16px"
       >
@@ -1701,13 +1973,15 @@ exports[`Storyshots Icon With a size 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 fvcdOB"
+        aria-hidden={true}
+        className="c2"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="16px"
         icon="add"
+        size="16px"
+        title={null}
         viewBox="0 0 24 24"
         width="16px"
       >
@@ -1716,13 +1990,15 @@ exports[`Storyshots Icon With a size 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 fvcdOB"
+        aria-hidden={true}
+        className="c2"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="16px"
         icon="addCircleOutline"
+        size="16px"
+        title={null}
         viewBox="0 0 24 24"
         width="16px"
       >
@@ -1731,13 +2007,15 @@ exports[`Storyshots Icon With a size 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 fvcdOB"
+        aria-hidden={true}
+        className="c2"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="16px"
         icon="arrowForward"
+        size="16px"
+        title={null}
         viewBox="0 0 24 24"
         width="16px"
       >
@@ -1746,13 +2024,15 @@ exports[`Storyshots Icon With a size 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 fvcdOB"
+        aria-hidden={true}
+        className="c2"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="16px"
         icon="block"
+        size="16px"
+        title={null}
         viewBox="0 0 24 24"
         width="16px"
       >
@@ -1761,10 +2041,11 @@ exports[`Storyshots Icon With a size 1`] = `
         />
       </svg>
       <svg
-        class="Icon-fc7twp-0 fvcdOB"
-        focusable="false"
+        className="c2"
+        focusable={false}
         height="16px"
         icon="loading"
+        title={null}
         viewBox="0 0 38 38"
         width="16px"
         xmlns="http://www.w3.org/2000/svg"
@@ -1779,23 +2060,23 @@ exports[`Storyshots Icon With a size 1`] = `
           >
             <stop
               offset="0%"
-              stop-color="currentColor"
-              stop-opacity="0"
+              stopColor="currentColor"
+              stopOpacity="0"
             />
             <stop
               offset="63.146%"
-              stop-color="currentColor"
-              stop-opacity=".631"
+              stopColor="currentColor"
+              stopOpacity=".631"
             />
             <stop
               offset="100%"
-              stop-color="currentColor"
+              stopColor="currentColor"
             />
           </linearGradient>
         </defs>
         <g
           fill="none"
-          fill-rule="evenodd"
+          fillRule="evenodd"
         >
           <g
             transform="translate(1 1)"
@@ -1804,7 +2085,7 @@ exports[`Storyshots Icon With a size 1`] = `
               d="M36 18c0-9.94-8.06-18-18-18"
               id="Oval-2"
               stroke="url(#random-id-11)"
-              stroke-width="2"
+              strokeWidth="2"
             >
               <animateTransform
                 attributeName="transform"
@@ -1835,16 +2116,18 @@ exports[`Storyshots Icon With a size 1`] = `
       </svg>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj"
+      className=""
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 dkBAgY"
+        aria-hidden={true}
+        className="c3"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="accessTime"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1856,13 +2139,15 @@ exports[`Storyshots Icon With a size 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 dkBAgY"
+        aria-hidden={true}
+        className="c3"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="add"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1871,13 +2156,15 @@ exports[`Storyshots Icon With a size 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 dkBAgY"
+        aria-hidden={true}
+        className="c3"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="addCircleOutline"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1886,13 +2173,15 @@ exports[`Storyshots Icon With a size 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 dkBAgY"
+        aria-hidden={true}
+        className="c3"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="arrowForward"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1901,13 +2190,15 @@ exports[`Storyshots Icon With a size 1`] = `
         />
       </svg>
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 dkBAgY"
+        aria-hidden={true}
+        className="c3"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="block"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -1916,10 +2207,11 @@ exports[`Storyshots Icon With a size 1`] = `
         />
       </svg>
       <svg
-        class="Icon-fc7twp-0 dkBAgY"
-        focusable="false"
+        className="c3"
+        focusable={false}
         height="24px"
         icon="loading"
+        title={null}
         viewBox="0 0 38 38"
         width="24px"
         xmlns="http://www.w3.org/2000/svg"
@@ -1934,23 +2226,23 @@ exports[`Storyshots Icon With a size 1`] = `
           >
             <stop
               offset="0%"
-              stop-color="currentColor"
-              stop-opacity="0"
+              stopColor="currentColor"
+              stopOpacity="0"
             />
             <stop
               offset="63.146%"
-              stop-color="currentColor"
-              stop-opacity=".631"
+              stopColor="currentColor"
+              stopOpacity=".631"
             />
             <stop
               offset="100%"
-              stop-color="currentColor"
+              stopColor="currentColor"
             />
           </linearGradient>
         </defs>
         <g
           fill="none"
-          fill-rule="evenodd"
+          fillRule="evenodd"
         >
           <g
             transform="translate(1 1)"
@@ -1959,7 +2251,7 @@ exports[`Storyshots Icon With a size 1`] = `
               d="M36 18c0-9.94-8.06-18-18-18"
               id="Oval-2"
               stroke="url(#random-id-12)"
-              stroke-width="2"
+              strokeWidth="2"
             >
               <animateTransform
                 attributeName="transform"
@@ -1994,23 +2286,63 @@ exports[`Storyshots Icon With a size 1`] = `
 `;
 
 exports[`Storyshots Icon With accessibility title 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  padding: 16px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c2 {
+  color: currentColor;
+  min-width: 24px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 beovZS"
+      className="Box-sc-1qu1edy-0 c1"
     >
       <svg
-        aria-hidden="false"
-        class="Icon-fc7twp-0 dkBAgY"
+        aria-hidden={false}
+        className="c2"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="user"
+        size="24px"
         title="User account"
         viewBox="0 0 24 24"
         width="24px"
@@ -2022,16 +2354,18 @@ exports[`Storyshots Icon With accessibility title 1`] = `
        This has a title attribute so it will be read by assistive devices.
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 beovZS"
+      className="Box-sc-1qu1edy-0 c1"
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 dkBAgY"
+        aria-hidden={true}
+        className="c2"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="user"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -2046,28 +2380,113 @@ exports[`Storyshots Icon With accessibility title 1`] = `
 `;
 
 exports[`Storyshots Icon With added margin 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  margin: 24px;
+}
+
+.c2 {
+  background-color: #e4e7eb;
+  margin: 24px;
+}
+
+.c3 {
+  margin: 16px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c4 {
+  margin-top: 16px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c5 {
+  margin-right: 16px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c6 {
+  margin-bottom: 16px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c7 {
+  margin-left: 16px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c8 {
+  margin-left: 16px;
+  margin-right: 16px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c9 {
+  margin-top: 16px;
+  margin-bottom: 16px;
+  color: currentColor;
+  min-width: 24px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 bPFBWy"
+      className="c1"
     >
       <div
-        class="Box-sc-1qu1edy-0 SsrzS"
-        style="display:inline-block"
+        className="c2"
+        style={
+          Object {
+            "display": "inline-block",
+          }
+        }
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 bCFepo"
+          aria-hidden={true}
+          className="c3"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="delete"
           m="x2"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -2077,18 +2496,24 @@ exports[`Storyshots Icon With added margin 1`] = `
         </svg>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 SsrzS"
-        style="display:inline-block"
+        className="c2"
+        style={
+          Object {
+            "display": "inline-block",
+          }
+        }
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 hAhxEu"
+          aria-hidden={true}
+          className="c4"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="delete"
           mt="x2"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -2098,18 +2523,24 @@ exports[`Storyshots Icon With added margin 1`] = `
         </svg>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 SsrzS"
-        style="display:inline-block"
+        className="c2"
+        style={
+          Object {
+            "display": "inline-block",
+          }
+        }
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 gezant"
+          aria-hidden={true}
+          className="c5"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="delete"
           mr="x2"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -2119,18 +2550,24 @@ exports[`Storyshots Icon With added margin 1`] = `
         </svg>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 SsrzS"
-        style="display:inline-block"
+        className="c2"
+        style={
+          Object {
+            "display": "inline-block",
+          }
+        }
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 iCRWbe"
+          aria-hidden={true}
+          className="c6"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="delete"
           mb="x2"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -2140,18 +2577,24 @@ exports[`Storyshots Icon With added margin 1`] = `
         </svg>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 SsrzS"
-        style="display:inline-block"
+        className="c2"
+        style={
+          Object {
+            "display": "inline-block",
+          }
+        }
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 ZEcAK"
+          aria-hidden={true}
+          className="c7"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="delete"
           ml="x2"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -2161,18 +2604,24 @@ exports[`Storyshots Icon With added margin 1`] = `
         </svg>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 SsrzS"
-        style="display:inline-block"
+        className="c2"
+        style={
+          Object {
+            "display": "inline-block",
+          }
+        }
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 bdShWb"
+          aria-hidden={true}
+          className="c8"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="delete"
           mx="x2"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -2182,18 +2631,24 @@ exports[`Storyshots Icon With added margin 1`] = `
         </svg>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 SsrzS"
-        style="display:inline-block"
+        className="c2"
+        style={
+          Object {
+            "display": "inline-block",
+          }
+        }
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 iHUtzQ"
+          aria-hidden={true}
+          className="c9"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="delete"
           my="x2"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >

--- a/components/src/Input/__snapshots__/Input.story.storyshot
+++ b/components/src/Input/__snapshots__/Input.story.storyshot
@@ -1,41 +1,162 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Input Input 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Input
           </span>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+          className="c5"
         >
           <div
-            class="Box-sc-1qu1edy-0 hxUhcg"
+            className="c6"
             display="flex"
           >
             <input
-              aria-invalid="false"
-              aria-required="false"
-              class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+              aria-invalid={false}
+              aria-required={false}
+              className="c7"
+              disabled={false}
+              onBlur={[Function]}
+              onChange={[Function]}
+              required={false}
             />
           </div>
         </div>
@@ -46,42 +167,162 @@ exports[`Storyshots Input Input 1`] = `
 `;
 
 exports[`Storyshots Input set to disabled 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: rgba(1,30,56,0.3333);
+  border-color: #e4e7eb;
+  background-color: #f0f2f5;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Set to disabled
           </span>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+          className="c5"
         >
           <div
-            class="Box-sc-1qu1edy-0 hxUhcg"
+            className="c6"
             display="flex"
           >
             <input
-              aria-invalid="false"
-              aria-required="false"
-              class="InputField__StyledInput-sc-6cu4mg-0 fdcdYd"
-              disabled=""
+              aria-invalid={false}
+              aria-required={false}
+              className="c7"
+              disabled={true}
+              onBlur={[Function]}
+              required={false}
             />
           </div>
         </div>
@@ -92,59 +333,298 @@ exports[`Storyshots Input set to disabled 1`] = `
 `;
 
 exports[`Storyshots Input set to required 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c7 {
+  margin-bottom: 8px;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c3 {
+  margin-top: 0;
+  margin-bottom: 16px;
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.23076923;
+}
+
+.c12 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c12:hover {
+  background-color: #e1ebfa;
+}
+
+.c12:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c12:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c12:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c12:disabled {
+  opacity: .5;
+}
+
+.c13 {
+  color: #ffffff;
+  border-color: #216beb;
+  background-color: #216beb;
+}
+
+.c13:hover {
+  background-color: #1254c7;
+  border-color: #1254c7;
+}
+
+.c13:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #216beb;
+}
+
+.c13:focus:hover {
+  background-color: #1254c7;
+}
+
+.c6 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c8 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c5 {
+  width: 100%;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c1 .c2 {
+  margin-bottom: 48px;
+}
+
+.c1 .Alert-u8lbe-0 {
+  margin-bottom: 48px;
+}
+
+.c1 .c4,
+.c1 .Fieldset-sc-9aoml1-0 {
+  margin-bottom: 24px;
+}
+
+.c1 .c4:last-child,
+.c1 .Fieldset-sc-9aoml1-0:last-child {
+  margin-bottom: 0;
+}
+
+.c1 .FormSection-sc-5yud6c-1 {
+  margin-bottom: 48px;
+}
+
+.c1 .FormSection-sc-5yud6c-1:last-child {
+  margin-bottom: 0;
+}
+
+.c11 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c11:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c11:focus ~ svg {
+  fill: #00438f;
+}
+
+.c11::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c11::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c11:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c11::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <form
-      class="Form-n70q8u-0 laLzBn"
+      className="c1"
     >
       <h2
-        class="Text-sc-1wu7vpu-0-h2 heWDlS"
-        font-size="larger"
-        font-weight="medium"
+        className="c2 c3"
+        fontSize="larger"
+        fontWeight="medium"
       >
         Required field example
       </h2>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+        className="c4 c5"
       >
         <label
-          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+          className="c6 "
           color="black"
-          style="display:block"
+          style={
+            Object {
+              "display": "block",
+            }
+          }
         >
           <div
-            class="Box-sc-1qu1edy-0 ilQgHG"
+            className="c7"
             data-testid="field-label"
           >
             <span
-              class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+              className="c8"
             >
               Label
             </span>
           </div>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+            className="c9"
           >
             <div
-              class="Box-sc-1qu1edy-0 hxUhcg"
+              className="c10"
               display="flex"
             >
               <input
-                aria-invalid="false"
-                aria-required="true"
-                class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
-                required=""
+                aria-invalid={false}
+                aria-required={true}
+                className="c11"
+                disabled={false}
+                onBlur={[Function]}
+                onChange={[Function]}
+                required={true}
               />
             </div>
           </div>
         </label>
       </div>
       <button
-        class="Button__WrapperButton-sc-1omxup2-0 hkfOQr PrimaryButton-qz78sb-0 cGyyDq"
+        className="c12 c13"
+        disabled={false}
+        size="medium"
       >
         Send
       </button>
@@ -154,49 +634,286 @@ exports[`Storyshots Input set to required 1`] = `
 `;
 
 exports[`Storyshots Input with a affix (prefix and suffix) 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c11 {
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-left: 8px;
+}
+
+.c17 {
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-left: 8px;
+  width: 360px;
+}
+
+.c18 {
+  padding-top: 8px;
+  padding-right: 8px;
+  padding-bottom: 8px;
+}
+
+.c19 {
+  padding-top: 8px;
+  padding-right: 8px;
+  padding-bottom: 8px;
+  width: 360px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c13 {
+  margin-top: 0;
+  margin-bottom: 0;
+  text-align: left;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c20 {
+  margin-top: 0;
+  margin-bottom: 0;
+  text-align: right;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c3 {
+  margin-top: 0;
+  margin-bottom: 16px;
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.23076923;
+}
+
+.c7 {
+  width: 100%;
+}
+
+.c16 {
+  margin-top: 0;
+  margin-bottom: 8px;
+  font-weight: 500;
+  font-size: 20px;
+  line-height: 1.2;
+}
+
+.c5 {
+  width: 100%;
+  padding: 0;
+  margin: 0;
+  border: none;
+}
+
+.c5 .c15 {
+  padding: 0;
+  margin-bottom: 0;
+}
+
+.c5 .c6,
+.c5 .Fieldset-sc-9aoml1-0 {
+  margin-bottom: 24px;
+}
+
+.c5 .c6:last-child,
+.c5 .Fieldset-sc-9aoml1-0:last-child {
+  margin-bottom: 0;
+}
+
+.c14 {
+  width: 100%;
+  padding: 0;
+  margin: 0;
+  border: none;
+}
+
+.c14 .c15 {
+  padding: 0;
+  margin-bottom: 24px;
+}
+
+.c14 .c6,
+.c14 .Fieldset-sc-9aoml1-0 {
+  margin-bottom: 24px;
+}
+
+.c14 .c6:last-child,
+.c14 .Fieldset-sc-9aoml1-0:last-child {
+  margin-bottom: 0;
+}
+
+.c1 {
+  margin-bottom: 48px;
+  width: 100%;
+}
+
+.c1 .c2 {
+  margin-bottom: 48px;
+}
+
+.c1 .Alert-u8lbe-0 {
+  margin-bottom: 48px;
+}
+
+.c1 .c6,
+.c1 .Fieldset-sc-9aoml1-0 {
+  margin-bottom: 24px;
+}
+
+.c1 .c6:last-child,
+.c1 .Fieldset-sc-9aoml1-0:last-child {
+  margin-bottom: 0;
+}
+
+.c1 .c4 {
+  margin-bottom: 48px;
+}
+
+.c1 .c4:last-child {
+  margin-bottom: 0;
+}
+
+.c10 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c10:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c10:focus ~ svg {
+  fill: #00438f;
+}
+
+.c10::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c10::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c10:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c10::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <form
-      class="Form-n70q8u-0 fuhEdK"
+      className="c1"
       mb="x6"
     >
       <h2
-        class="Text-sc-1wu7vpu-0-h2 heWDlS"
-        font-size="larger"
-        font-weight="medium"
+        className="c2 c3"
+        fontSize="larger"
+        fontWeight="medium"
       >
         Suffix
       </h2>
       <fieldset
-        class="FormSection-sc-5yud6c-1 klMAvm"
+        className="c4 c5"
       >
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c6 c7"
         >
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+            className="c8"
           >
             <div
-              class="Box-sc-1qu1edy-0 hxUhcg"
+              className="c9"
               display="flex"
             >
               <input
-                aria-invalid="false"
-                aria-required="false"
-                class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                aria-invalid={false}
+                aria-required={false}
+                className="c10"
+                disabled={false}
+                required={false}
               />
             </div>
             <div
-              class="Box-sc-1qu1edy-0 gtRBwd"
+              className="c11"
+              width={null}
             >
               <p
-                class="Text-sc-1wu7vpu-0 eEDmVF"
+                className="c12 c13"
                 color="currentColor"
-                font-size="medium"
+                disabled={false}
+                fontSize="medium"
               >
                 Eaches
               </p>
@@ -204,28 +921,32 @@ exports[`Storyshots Input with a affix (prefix and suffix) 1`] = `
           </div>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c6 c7"
         >
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+            className="c8"
           >
             <div
-              class="Box-sc-1qu1edy-0 hxUhcg"
+              className="c9"
               display="flex"
             >
               <input
-                aria-invalid="false"
-                aria-required="false"
-                class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                aria-invalid={false}
+                aria-required={false}
+                className="c10"
+                disabled={false}
+                required={false}
               />
             </div>
             <div
-              class="Box-sc-1qu1edy-0 gtRBwd"
+              className="c11"
+              width={null}
             >
               <p
-                class="Text-sc-1wu7vpu-0 eEDmVF"
+                className="c12 c13"
                 color="currentColor"
-                font-size="medium"
+                disabled={false}
+                fontSize="medium"
               >
                 Pallets and boxes
               </p>
@@ -234,39 +955,42 @@ exports[`Storyshots Input with a affix (prefix and suffix) 1`] = `
         </div>
       </fieldset>
       <fieldset
-        class="FormSection-sc-5yud6c-1 cJYtnA"
+        className="c4 c14"
       >
         <legend
-          class="Text-sc-1wu7vpu-0-h3 Headings__SubsectionTitle-igpciy-0 FormSection__FormSectionTitle-sc-5yud6c-0 gaHdwg"
-          font-size="large"
-          font-weight="medium"
+          className="c12-h3 Headings__SubsectionTitle-igpciy-0 c15 c16"
+          fontSize="large"
+          fontWeight="medium"
         >
           With Custom Width
         </legend>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c6 c7"
         >
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+            className="c8"
           >
             <div
-              class="Box-sc-1qu1edy-0 hxUhcg"
+              className="c9"
               display="flex"
             >
               <input
-                aria-invalid="false"
-                aria-required="false"
-                class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                aria-invalid={false}
+                aria-required={false}
+                className="c10"
+                disabled={false}
+                required={false}
               />
             </div>
             <div
-              class="Box-sc-1qu1edy-0 fehlWH"
+              className="c17"
               width="360px"
             >
               <p
-                class="Text-sc-1wu7vpu-0 eEDmVF"
+                className="c12 c13"
                 color="currentColor"
-                font-size="medium"
+                disabled={false}
+                fontSize="medium"
               >
                 Eaches
               </p>
@@ -274,29 +998,32 @@ exports[`Storyshots Input with a affix (prefix and suffix) 1`] = `
           </div>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c6 c7"
         >
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+            className="c8"
           >
             <div
-              class="Box-sc-1qu1edy-0 hxUhcg"
+              className="c9"
               display="flex"
             >
               <input
-                aria-invalid="false"
-                aria-required="false"
-                class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                aria-invalid={false}
+                aria-required={false}
+                className="c10"
+                disabled={false}
+                required={false}
               />
             </div>
             <div
-              class="Box-sc-1qu1edy-0 fehlWH"
+              className="c17"
               width="360px"
             >
               <p
-                class="Text-sc-1wu7vpu-0 eEDmVF"
+                className="c12 c13"
                 color="currentColor"
-                font-size="medium"
+                disabled={false}
+                fontSize="medium"
               >
                 Pallets and boxes
               </p>
@@ -306,215 +1033,235 @@ exports[`Storyshots Input with a affix (prefix and suffix) 1`] = `
       </fieldset>
     </form>
     <form
-      class="Form-n70q8u-0 fuhEdK"
+      className="c1"
       mb="x6"
     >
       <h2
-        class="Text-sc-1wu7vpu-0-h2 heWDlS"
-        font-size="larger"
-        font-weight="medium"
+        className="c2 c3"
+        fontSize="larger"
+        fontWeight="medium"
       >
         Prefix
       </h2>
       <fieldset
-        class="FormSection-sc-5yud6c-1 klMAvm"
+        className="c4 c5"
       >
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c6 c7"
         >
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+            className="c8"
           >
             <div
-              class="Box-sc-1qu1edy-0 cujNNu"
+              className="c18"
+              width={null}
             >
               <p
-                class="Text-sc-1wu7vpu-0 eEDmVF"
+                className="c12 c13"
                 color="currentColor"
-                font-size="medium"
+                disabled={false}
+                fontSize="medium"
               >
                 Eaches
               </p>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 hxUhcg"
+              className="c9"
               display="flex"
             >
               <input
-                aria-invalid="false"
-                aria-required="false"
-                class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                aria-invalid={false}
+                aria-required={false}
+                className="c10"
+                disabled={false}
+                required={false}
               />
             </div>
           </div>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c6 c7"
         >
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+            className="c8"
           >
             <div
-              class="Box-sc-1qu1edy-0 cujNNu"
+              className="c18"
+              width={null}
             >
               <p
-                class="Text-sc-1wu7vpu-0 eEDmVF"
+                className="c12 c13"
                 color="currentColor"
-                font-size="medium"
+                disabled={false}
+                fontSize="medium"
               >
                 Pallets and boxes
               </p>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 hxUhcg"
+              className="c9"
               display="flex"
             >
               <input
-                aria-invalid="false"
-                aria-required="false"
-                class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                aria-invalid={false}
+                aria-required={false}
+                className="c10"
+                disabled={false}
+                required={false}
               />
             </div>
           </div>
         </div>
       </fieldset>
       <fieldset
-        class="FormSection-sc-5yud6c-1 cJYtnA"
+        className="c4 c14"
       >
         <legend
-          class="Text-sc-1wu7vpu-0-h3 Headings__SubsectionTitle-igpciy-0 FormSection__FormSectionTitle-sc-5yud6c-0 gaHdwg"
-          font-size="large"
-          font-weight="medium"
+          className="c12-h3 Headings__SubsectionTitle-igpciy-0 c15 c16"
+          fontSize="large"
+          fontWeight="medium"
         >
           With Custom Width
         </legend>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c6 c7"
         >
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+            className="c8"
           >
             <div
-              class="Box-sc-1qu1edy-0 hEsaBU"
+              className="c19"
               width="360px"
             >
               <p
-                class="Text-sc-1wu7vpu-0 eEDmVF"
+                className="c12 c13"
                 color="currentColor"
-                font-size="medium"
+                disabled={false}
+                fontSize="medium"
               >
                 Eaches
               </p>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 hxUhcg"
+              className="c9"
               display="flex"
             >
               <input
-                aria-invalid="false"
-                aria-required="false"
-                class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                aria-invalid={false}
+                aria-required={false}
+                className="c10"
+                disabled={false}
+                required={false}
               />
             </div>
           </div>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c6 c7"
         >
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+            className="c8"
           >
             <div
-              class="Box-sc-1qu1edy-0 hEsaBU"
+              className="c19"
               width="360px"
             >
               <p
-                class="Text-sc-1wu7vpu-0 eEDmVF"
+                className="c12 c13"
                 color="currentColor"
-                font-size="medium"
+                disabled={false}
+                fontSize="medium"
               >
                 Pallets and boxes
               </p>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 hxUhcg"
+              className="c9"
               display="flex"
             >
               <input
-                aria-invalid="false"
-                aria-required="false"
-                class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                aria-invalid={false}
+                aria-required={false}
+                className="c10"
+                disabled={false}
+                required={false}
               />
             </div>
           </div>
         </div>
       </fieldset>
       <fieldset
-        class="FormSection-sc-5yud6c-1 cJYtnA"
+        className="c4 c14"
       >
         <legend
-          class="Text-sc-1wu7vpu-0-h3 Headings__SubsectionTitle-igpciy-0 FormSection__FormSectionTitle-sc-5yud6c-0 gaHdwg"
-          font-size="large"
-          font-weight="medium"
+          className="c12-h3 Headings__SubsectionTitle-igpciy-0 c15 c16"
+          fontSize="large"
+          fontWeight="medium"
         >
           With right alignment
         </legend>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c6 c7"
         >
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+            className="c8"
           >
             <div
-              class="Box-sc-1qu1edy-0 hEsaBU"
+              className="c19"
               width="360px"
             >
               <p
-                class="Text-sc-1wu7vpu-0 edyTXm"
+                className="c12 c20"
                 color="currentColor"
-                font-size="medium"
+                disabled={false}
+                fontSize="medium"
               >
                 Eaches
               </p>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 hxUhcg"
+              className="c9"
               display="flex"
             >
               <input
-                aria-invalid="false"
-                aria-required="false"
-                class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                aria-invalid={false}
+                aria-required={false}
+                className="c10"
+                disabled={false}
+                required={false}
               />
             </div>
           </div>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+          className="c6 c7"
         >
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+            className="c8"
           >
             <div
-              class="Box-sc-1qu1edy-0 hEsaBU"
+              className="c19"
               width="360px"
             >
               <p
-                class="Text-sc-1wu7vpu-0 edyTXm"
+                className="c12 c20"
                 color="currentColor"
-                font-size="medium"
+                disabled={false}
+                fontSize="medium"
               >
                 Pallets and boxes
               </p>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 hxUhcg"
+              className="c9"
               display="flex"
             >
               <input
-                aria-invalid="false"
-                aria-required="false"
-                class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                aria-invalid={false}
+                aria-required={false}
+                className="c10"
+                disabled={false}
+                required={false}
               />
             </div>
           </div>
@@ -522,50 +1269,56 @@ exports[`Storyshots Input with a affix (prefix and suffix) 1`] = `
       </fieldset>
     </form>
     <form
-      class="Form-n70q8u-0 fuhEdK"
+      className="c1"
       mb="x6"
     >
       <h2
-        class="Text-sc-1wu7vpu-0-h2 heWDlS"
-        font-size="larger"
-        font-weight="medium"
+        className="c2 c3"
+        fontSize="larger"
+        fontWeight="medium"
       >
         Prefix and Suffix
       </h2>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+        className="c6 c7"
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+          className="c8"
         >
           <div
-            class="Box-sc-1qu1edy-0 cujNNu"
+            className="c18"
+            width={null}
           >
             <p
-              class="Text-sc-1wu7vpu-0 eEDmVF"
+              className="c12 c13"
               color="currentColor"
-              font-size="medium"
+              disabled={false}
+              fontSize="medium"
             >
               Quantity
             </p>
           </div>
           <div
-            class="Box-sc-1qu1edy-0 hxUhcg"
+            className="c9"
             display="flex"
           >
             <input
-              aria-invalid="false"
-              aria-required="false"
-              class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+              aria-invalid={false}
+              aria-required={false}
+              className="c10"
+              disabled={false}
+              required={false}
             />
           </div>
           <div
-            class="Box-sc-1qu1edy-0 gtRBwd"
+            className="c11"
+            width={null}
           >
             <p
-              class="Text-sc-1wu7vpu-0 eEDmVF"
+              className="c12 c13"
               color="currentColor"
-              font-size="medium"
+              disabled={false}
+              fontSize="medium"
             >
               Eaches
             </p>
@@ -578,57 +1331,202 @@ exports[`Storyshots Input with a affix (prefix and suffix) 1`] = `
 `;
 
 exports[`Storyshots Input with all props 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c5 {
+  margin-left: 8px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #434d59;
+}
+
+.c6 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+  font-size: 14px;
+  line-height: 1.71428571;
+}
+
+.c6 .Link-sc-1lpx3d0-0 {
+  font-size: 14px;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c9 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c9:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c9:focus ~ svg {
+  fill: #00438f;
+}
+
+.c9::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c9::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c9:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c9::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Input
           </span>
           <span
-            class="Text-sc-1wu7vpu-0 bphWXP"
+            className="c5"
             color="darkGrey"
-            font-size="12px"
+            disabled={false}
+            fontSize="12px"
           >
             Required
           </span>
           <p
-            class="Text-sc-1wu7vpu-0 HelpText__HelpTextContent-sc-1jzmq2g-0 feAJVX"
+            className="c6"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Additional help text
           </p>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+          className="c7"
         >
           <div
-            class="Box-sc-1qu1edy-0 hxUhcg"
+            className="c8"
             display="flex"
           >
             <input
-              aria-invalid="false"
-              aria-required="true"
-              class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+              aria-invalid={false}
+              aria-required={true}
+              className="c9"
+              disabled={false}
+              onBlur={[Function]}
+              onChange={[Function]}
               placeholder="Placeholder"
-              required=""
+              required={true}
             />
           </div>
         </div>
@@ -639,42 +1537,163 @@ exports[`Storyshots Input with all props 1`] = `
 `;
 
 exports[`Storyshots Input with custom ID 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Label
           </span>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+          className="c5"
         >
           <div
-            class="Box-sc-1qu1edy-0 hxUhcg"
+            className="c6"
             display="flex"
           >
             <input
-              aria-invalid="false"
-              aria-required="false"
-              class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+              aria-invalid={false}
+              aria-required={false}
+              className="c7"
+              disabled={false}
               id="my-own-id"
+              onBlur={[Function]}
+              onChange={[Function]}
+              required={false}
             />
           </div>
         </div>
@@ -685,58 +1704,231 @@ exports[`Storyshots Input with custom ID 1`] = `
 `;
 
 exports[`Storyshots Input with error list  1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c8 {
+  color: #cc1439;
+  margin-top: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c9 {
+  margin-right: 8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c12 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c15 {
+  margin-bottom: 8px;
+  color: currentColor;
+}
+
+.c15:last-child {
+  margin-bottom: 0;
+}
+
+.c13 {
+  color: currentColor;
+  margin: 0;
+  padding-left: 18px;
+}
+
+.c13 .c14 {
+  margin-bottom: 0;
+}
+
+.c10 .c11 {
+  margin-bottom: 8px;
+}
+
+.c10 > *:last-child {
+  margin-bottom: 0;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #cc1439;
+  border-color: #cc1439;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Label
           </span>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+          className="c5"
         >
           <div
-            class="Box-sc-1qu1edy-0 hxUhcg"
+            className="c6"
             display="flex"
           >
             <input
-              aria-invalid="true"
-              aria-required="false"
-              class="InputField__StyledInput-sc-6cu4mg-0 jMjRjb"
+              aria-invalid={true}
+              aria-required={false}
+              className="c7"
+              disabled={false}
+              onBlur={[Function]}
+              onChange={[Function]}
+              required={false}
             />
           </div>
         </div>
       </label>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 ycNbA"
+        className="c8"
         color="red"
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 QuoIa"
+          aria-hidden={true}
+          className="c9"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="error"
           mr="x1"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -745,27 +1937,28 @@ exports[`Storyshots Input with error list  1`] = `
           />
         </svg>
         <div
-          class="InlineValidation__Wrapper-sc-1jic7dw-0 kqhCKM"
+          className="c10"
         >
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c11 c12"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Error message
           </p>
           <ul
-            class="List-sc-1cqkmnl-0 diqcEx"
+            className="c13"
             color="currentColor"
           >
             <li
-              class="ListItem-qqenhw-0 gzsWDK"
+              className="c14 c15"
               color="currentColor"
             >
               Error message 1
             </li>
             <li
-              class="ListItem-qqenhw-0 gzsWDK"
+              className="c14 c15"
               color="currentColor"
             >
               Error message 2
@@ -779,58 +1972,212 @@ exports[`Storyshots Input with error list  1`] = `
 `;
 
 exports[`Storyshots Input with error message 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c8 {
+  color: #cc1439;
+  margin-top: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c9 {
+  margin-right: 8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c12 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c10 .c11 {
+  margin-bottom: 8px;
+}
+
+.c10 > *:last-child {
+  margin-bottom: 0;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #cc1439;
+  border-color: #cc1439;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Label
           </span>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+          className="c5"
         >
           <div
-            class="Box-sc-1qu1edy-0 hxUhcg"
+            className="c6"
             display="flex"
           >
             <input
-              aria-invalid="true"
-              aria-required="false"
-              class="InputField__StyledInput-sc-6cu4mg-0 jMjRjb"
+              aria-invalid={true}
+              aria-required={false}
+              className="c7"
+              disabled={false}
+              onBlur={[Function]}
+              onChange={[Function]}
+              required={false}
             />
           </div>
         </div>
       </label>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 ycNbA"
+        className="c8"
         color="red"
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 QuoIa"
+          aria-hidden={true}
+          className="c9"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="error"
           mr="x1"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -839,12 +2186,13 @@ exports[`Storyshots Input with error message 1`] = `
           />
         </svg>
         <div
-          class="InlineValidation__Wrapper-sc-1jic7dw-0 kqhCKM"
+          className="c10"
         >
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c11 c12"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Error message
           </p>

--- a/components/src/Link/__snapshots__/Link.story.storyshot
+++ b/components/src/Link/__snapshots__/Link.story.storyshot
@@ -1,16 +1,57 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Link As a <button> 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  padding: 0;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c1:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
-      class="Link-sc-1lpx3d0-0 cLSnCY"
+      className="c1"
       color="blue"
-      font-size="medium"
+      fontSize="medium"
     >
       Link
     </button>
@@ -19,16 +60,56 @@ exports[`Storyshots Link As a <button> 1`] = `
 `;
 
 exports[`Storyshots Link Link  1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c1:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <a
-      class="Link-sc-1lpx3d0-0 gxbSxg"
+      className="c1"
       color="blue"
-      font-size="medium"
+      fontSize="medium"
       href="http://nulogy.design"
     >
       Link
@@ -38,16 +119,56 @@ exports[`Storyshots Link Link  1`] = `
 `;
 
 exports[`Storyshots Link With a different color 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  color: #011e38;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c1:hover {
+  cursor: pointer;
+  color: #cc1439;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <a
-      class="Link-sc-1lpx3d0-0 cpcHzb"
+      className="c1"
       color="black"
-      font-size="medium"
+      fontSize="medium"
       href="http://nulogy.design"
     >
       Link
@@ -57,16 +178,56 @@ exports[`Storyshots Link With a different color 1`] = `
 `;
 
 exports[`Storyshots Link With a different size 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  color: #011e38;
+  font-size: 20px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c1:hover {
+  cursor: pointer;
+  color: #000306;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <a
-      class="Link-sc-1lpx3d0-0 jFBEBU"
+      className="c1"
       color="black"
-      font-size="large"
+      fontSize="large"
       href="http://nulogy.design"
     >
       Link
@@ -76,16 +237,56 @@ exports[`Storyshots Link With a different size 1`] = `
 `;
 
 exports[`Storyshots Link Without underline 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c1:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <a
-      class="Link-sc-1lpx3d0-0 clvBNI"
+      className="c1"
       color="blue"
-      font-size="medium"
+      fontSize="medium"
       href="http://nulogy.design"
     >
       Link
@@ -95,16 +296,56 @@ exports[`Storyshots Link Without underline 1`] = `
 `;
 
 exports[`Storyshots Link with custom font size 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  color: #216beb;
+  font-size: 14px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c1:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <a
-      class="Link-sc-1lpx3d0-0 eELETS"
+      className="c1"
       color="blue"
-      font-size="small"
+      fontSize="small"
       href="http://nulogy.design"
     >
       Link

--- a/components/src/List/__snapshots__/List.story.storyshot
+++ b/components/src/List/__snapshots__/List.story.storyshot
@@ -1,30 +1,74 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots List List 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+  color: currentColor;
+}
+
+.c3:last-child {
+  margin-bottom: 0;
+}
+
+.c1 {
+  color: currentColor;
+  margin: 0;
+}
+
+.c1 .c2 {
+  margin-bottom: 8px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <ul
-      class="List-sc-1cqkmnl-0 jrhpm"
+      className="c1"
       color="currentColor"
     >
       <li
-        class="ListItem-qqenhw-0 gzsWDK"
+        className="c2 c3"
         color="currentColor"
       >
         List Item 1
       </li>
       <li
-        class="ListItem-qqenhw-0 gzsWDK"
+        className="c2 c3"
         color="currentColor"
       >
         List Item 2 that is really really really really really really really really really long
       </li>
       <li
-        class="ListItem-qqenhw-0 gzsWDK"
+        className="c2 c3"
         color="currentColor"
       >
         List Item 3
@@ -35,30 +79,74 @@ exports[`Storyshots List List 1`] = `
 `;
 
 exports[`Storyshots List With compact spacing 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+  color: currentColor;
+}
+
+.c3:last-child {
+  margin-bottom: 0;
+}
+
+.c1 {
+  color: currentColor;
+  margin: 0;
+}
+
+.c1 .c2 {
+  margin-bottom: 0;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <ul
-      class="List-sc-1cqkmnl-0 gfYBVm"
+      className="c1"
       color="currentColor"
     >
       <li
-        class="ListItem-qqenhw-0 gzsWDK"
+        className="c2 c3"
         color="currentColor"
       >
         List Item 1
       </li>
       <li
-        class="ListItem-qqenhw-0 gzsWDK"
+        className="c2 c3"
         color="currentColor"
       >
         List Item 2 that is really really really really really really really really really long
       </li>
       <li
-        class="ListItem-qqenhw-0 gzsWDK"
+        className="c2 c3"
         color="currentColor"
       >
         List Item 3
@@ -69,30 +157,74 @@ exports[`Storyshots List With compact spacing 1`] = `
 `;
 
 exports[`Storyshots List With custom colour 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+  color: currentColor;
+}
+
+.c3:last-child {
+  margin-bottom: 0;
+}
+
+.c1 {
+  color: #cc1439;
+  margin: 0;
+}
+
+.c1 .c2 {
+  margin-bottom: 8px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <ul
-      class="List-sc-1cqkmnl-0 cIngjC"
+      className="c1"
       color="red"
     >
       <li
-        class="ListItem-qqenhw-0 gzsWDK"
+        className="c2 c3"
         color="currentColor"
       >
         List Item 1
       </li>
       <li
-        class="ListItem-qqenhw-0 gzsWDK"
+        className="c2 c3"
         color="currentColor"
       >
         List Item 2 that is really really really really really really really really really long
       </li>
       <li
-        class="ListItem-qqenhw-0 gzsWDK"
+        className="c2 c3"
         color="currentColor"
       >
         List Item 3
@@ -103,33 +235,89 @@ exports[`Storyshots List With custom colour 1`] = `
 `;
 
 exports[`Storyshots List With custom font size and line height 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+  color: currentColor;
+}
+
+.c3:last-child {
+  margin-bottom: 0;
+}
+
+.c4 {
+  margin-bottom: 8px;
+  color: currentColor;
+  font-size: 20px;
+}
+
+.c4:last-child {
+  margin-bottom: 0;
+}
+
+.c1 {
+  color: currentColor;
+  font-size: 14px;
+  line-height: 1.71428571;
+  margin: 0;
+}
+
+.c1 .c2 {
+  margin-bottom: 8px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <ul
-      class="List-sc-1cqkmnl-0 dPxgHI"
+      className="c1"
       color="currentColor"
-      font-size="small"
+      fontSize="small"
     >
       <li
-        class="ListItem-qqenhw-0 gzsWDK"
+        className="c2 c3"
         color="currentColor"
       >
         List Item 1
       </li>
       <li
-        class="ListItem-qqenhw-0 gzsWDK"
+        className="c2 c3"
         color="currentColor"
       >
         List Item 2 that is really really really really really really really really really long
       </li>
       <li
-        class="ListItem-qqenhw-0 deWKnu"
+        className="c2 c4"
         color="currentColor"
-        font-size="large"
+        fontSize="large"
       >
         Larger List Item 3
       </li>
@@ -139,30 +327,75 @@ exports[`Storyshots List With custom font size and line height 1`] = `
 `;
 
 exports[`Storyshots List With left alignment 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+  color: currentColor;
+}
+
+.c3:last-child {
+  margin-bottom: 0;
+}
+
+.c1 {
+  color: currentColor;
+  margin: 0;
+  padding-left: 18px;
+}
+
+.c1 .c2 {
+  margin-bottom: 8px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <ul
-      class="List-sc-1cqkmnl-0 joVEnl"
+      className="c1"
       color="currentColor"
     >
       <li
-        class="ListItem-qqenhw-0 gzsWDK"
+        className="c2 c3"
         color="currentColor"
       >
         List Item 1
       </li>
       <li
-        class="ListItem-qqenhw-0 gzsWDK"
+        className="c2 c3"
         color="currentColor"
       >
         List Item 2 that is really really really really really really really really really long
       </li>
       <li
-        class="ListItem-qqenhw-0 gzsWDK"
+        className="c2 c3"
         color="currentColor"
       >
         List Item 3

--- a/components/src/LoadingAnimation/__snapshots__/LoadingAnimation.story.storyshot
+++ b/components/src/LoadingAnimation/__snapshots__/LoadingAnimation.story.storyshot
@@ -1,11 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots LoadingAnimation Active 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <svg
       height="24px"
@@ -159,11 +185,37 @@ exports[`Storyshots LoadingAnimation Active 1`] = `
 `;
 
 exports[`Storyshots LoadingAnimation Inactive 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <svg
       height="24px"
@@ -317,28 +369,210 @@ exports[`Storyshots LoadingAnimation Inactive 1`] = `
 `;
 
 exports[`Storyshots LoadingAnimation Page example - active 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c4 {
+  margin-bottom: 8px;
+}
+
+.c2 {
+  margin: auto;
+  margin-bottom: 32px;
+  -webkit-box-flex: 2;
+  -webkit-flex-grow: 2;
+  -ms-flex-positive: 2;
+  flex-grow: 2;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 2;
+  -webkit-flex-grow: 2;
+  -ms-flex-positive: 2;
+  flex-grow: 2;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c6 {
+  margin-bottom: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c3 {
+  margin-bottom: 16px;
+  margin-top: 0;
+  font-weight: 500;
+  text-align: right;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c5 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 14px;
+  line-height: 1.5;
+  color: #434d59;
+}
+
+.c7 {
+  background: transparent;
+  border: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px;
+  border-radius: 50%;
+  color: #c0c8d1;
+  margin-right: 8px;
+}
+
+.c7:focus {
+  outline: none;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:hover:enabled {
+  cursor: pointer;
+  color: #122b47;
+  background-color: #e4e7eb;
+}
+
+.c9 {
+  background: transparent;
+  border: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px;
+  border-radius: 50%;
+  color: #434d59;
+}
+
+.c9:focus {
+  outline: none;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c9:hover:enabled {
+  cursor: pointer;
+  color: #122b47;
+  background-color: #e4e7eb;
+}
+
+.c1 {
+  position: fixed;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1000;
+  background-color: rgba(255,255,255,0.95);
+}
+
+@media screen and (min-width:0px) {
+  .c1 {
+    margin: 16px;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c1 {
+    margin: 24px;
+  }
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 Overlay-spdky8-0 eOwUiE"
+      className="c1"
     >
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 gsptzN"
+        className="c2"
       >
         <p
-          class="Text-sc-1wu7vpu-0 kyRgWL"
+          className="c3"
           color="currentColor"
-          font-size="medium"
-          font-weight="medium"
+          disabled={false}
+          fontSize="medium"
+          fontWeight="medium"
         >
           1/4
         </p>
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c4"
         >
           <svg
             height="24px"
@@ -489,30 +723,34 @@ exports[`Storyshots LoadingAnimation Page example - active 1`] = `
           </svg>
         </div>
         <p
-          class="Text-sc-1wu7vpu-0 keXslM"
+          className="c5"
           color="darkGrey"
-          font-size="small"
+          disabled={false}
+          fontSize="small"
         >
           Applying action ...
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 eRyacc"
+        className="c6"
       >
         <button
           aria-label="Retry"
-          class="ControlIcon__StyledButton-sc-1h83lvi-0 jupSnY"
-          disabled=""
+          className="c7"
+          disabled={true}
+          onClick={null}
           type="button"
         >
           <svg
-            aria-hidden="true"
-            class="Icon-fc7twp-0 efirdb"
+            aria-hidden={true}
+            className="c8"
             color="currentColor"
             fill="currentColor"
-            focusable="false"
+            focusable={false}
             height="32px"
             icon="refresh"
+            size="32px"
+            title={null}
             viewBox="0 0 24 24"
             width="32px"
           >
@@ -523,17 +761,21 @@ exports[`Storyshots LoadingAnimation Page example - active 1`] = `
         </button>
         <button
           aria-label="Abort"
-          class="ControlIcon__StyledButton-sc-1h83lvi-0 cCdEvo"
+          className="c9"
+          disabled={false}
+          onClick={null}
           type="button"
         >
           <svg
-            aria-hidden="true"
-            class="Icon-fc7twp-0 efirdb"
+            aria-hidden={true}
+            className="c8"
             color="currentColor"
             fill="currentColor"
-            focusable="false"
+            focusable={false}
             height="32px"
             icon="close"
+            size="32px"
+            title={null}
             viewBox="0 0 24 24"
             width="32px"
           >
@@ -549,28 +791,238 @@ exports[`Storyshots LoadingAnimation Page example - active 1`] = `
 `;
 
 exports[`Storyshots LoadingAnimation Page example - inactive 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c4 {
+  margin-bottom: 8px;
+}
+
+.c8 {
+  margin-right: auto;
+}
+
+.c2 {
+  margin: auto;
+  margin-bottom: 32px;
+  -webkit-box-flex: 2;
+  -webkit-flex-grow: 2;
+  -ms-flex-positive: 2;
+  flex-grow: 2;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 2;
+  -webkit-flex-grow: 2;
+  -ms-flex-positive: 2;
+  flex-grow: 2;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c6 {
+  background-color: #fcf5e3;
+  padding: 16px;
+  margin-bottom: 16px;
+  border-radius: 4px;
+  border-left-width: half;
+  border-left-color: #ffbb00;
+  border-left-style: solid;
+  position: absolute;
+  bottom: 64px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c9 {
+  margin-bottom: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c11 {
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c3 {
+  margin-bottom: 16px;
+  margin-top: 0;
+  font-weight: 500;
+  text-align: right;
+  font-size: 16px;
+  line-height: 1.5;
+  color: #c0c8d1;
+}
+
+.c5 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 14px;
+  line-height: 1.5;
+  color: #c0c8d1;
+}
+
+.c10 {
+  background: transparent;
+  border: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px;
+  border-radius: 50%;
+  color: #434d59;
+  margin-right: 8px;
+}
+
+.c10:focus {
+  outline: none;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c10:hover:enabled {
+  cursor: pointer;
+  color: #122b47;
+  background-color: #e4e7eb;
+}
+
+.c12 {
+  background: transparent;
+  border: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px;
+  border-radius: 50%;
+  color: #434d59;
+}
+
+.c12:focus {
+  outline: none;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c12:hover:enabled {
+  cursor: pointer;
+  color: #122b47;
+  background-color: #e4e7eb;
+}
+
+.c7 {
+  margin-bottom: 16px;
+}
+
+.c7 .Link-sc-1lpx3d0-0 {
+  color: #011e38;
+}
+
+.c1 {
+  position: fixed;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1000;
+  background-color: rgba(255,255,255,0.95);
+}
+
+@media screen and (min-width:0px) {
+  .c1 {
+    margin: 16px;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c1 {
+    margin: 24px;
+  }
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 Overlay-spdky8-0 eOwUiE"
+      className="c1"
     >
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 gsptzN"
+        className="c2"
       >
         <p
-          class="Text-sc-1wu7vpu-0 gfZztd"
+          className="c3"
           color="grey"
-          font-size="medium"
-          font-weight="medium"
+          disabled={false}
+          fontSize="medium"
+          fontWeight="medium"
         >
           1/4
         </p>
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c4"
         >
           <svg
             height="24px"
@@ -721,39 +1173,44 @@ exports[`Storyshots LoadingAnimation Page example - inactive 1`] = `
           </svg>
         </div>
         <p
-          class="Text-sc-1wu7vpu-0 dJrfVi"
+          className="c5"
           color="grey"
-          font-size="small"
+          disabled={false}
+          fontSize="small"
         >
           Applying action ...
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 bOrzAg Alert-u8lbe-0 yTvFo"
+        className="c6 c7"
         role="alert"
       >
         <div
-          class="Box-sc-1qu1edy-0 iDnpba"
+          className="c8"
         >
           This action takes longer than expected. Try again...
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 eRyacc"
+        className="c9"
       >
         <button
           aria-label="Retry"
-          class="ControlIcon__StyledButton-sc-1h83lvi-0 jlPgHC"
+          className="c10"
+          disabled={false}
+          onClick={null}
           type="button"
         >
           <svg
-            aria-hidden="true"
-            class="Icon-fc7twp-0 efirdb"
+            aria-hidden={true}
+            className="c11"
             color="currentColor"
             fill="currentColor"
-            focusable="false"
+            focusable={false}
             height="32px"
             icon="refresh"
+            size="32px"
+            title={null}
             viewBox="0 0 24 24"
             width="32px"
           >
@@ -764,17 +1221,21 @@ exports[`Storyshots LoadingAnimation Page example - inactive 1`] = `
         </button>
         <button
           aria-label="Abort"
-          class="ControlIcon__StyledButton-sc-1h83lvi-0 cCdEvo"
+          className="c12"
+          disabled={false}
+          onClick={null}
           type="button"
         >
           <svg
-            aria-hidden="true"
-            class="Icon-fc7twp-0 efirdb"
+            aria-hidden={true}
+            className="c11"
             color="currentColor"
             fill="currentColor"
-            focusable="false"
+            focusable={false}
             height="32px"
             icon="close"
+            size="32px"
+            title={null}
             viewBox="0 0 24 24"
             width="32px"
           >

--- a/components/src/Modal/__snapshots__/Modal.story.storyshot
+++ b/components/src/Modal/__snapshots__/Modal.story.storyshot
@@ -1,25 +1,428 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Modal Modal 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 0px;
+  margin-top: 0;
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.23076923;
+}
+
+.c7 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c7:hover {
+  background-color: #e1ebfa;
+}
+
+.c7:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c7:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c7:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c7:disabled {
+  opacity: .5;
+}
+
+.c8 {
+  color: #ffffff;
+  border-color: #216beb;
+  background-color: #216beb;
+}
+
+.c8:hover {
+  background-color: #1254c7;
+  border-color: #1254c7;
+}
+
+.c8:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #216beb;
+}
+
+.c8:focus:hover {
+  background-color: #1254c7;
+}
+
+.c9 {
+  color: #216beb;
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-bottom: -8px;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c6 button {
+  margin-bottom: 8px;
+}
+
+.c6 button:not(:last-child) {
+  margin-right: 8px;
+}
+
+.c4 {
+  margin-top: -64px;
+  margin-bottom: -72px;
+  overflow: auto;
+  padding-top: 88px;
+  padding-bottom: 96px;
+  padding-left: 24px;
+  padding-right: 24px;
+}
+
+.c2 {
+  position: relative;
+  padding: 16px 24px 16px 24px;
+  background-color: rgba(255,255,255,0.9);
+  z-index: 2;
+  border-radius: 4px 4px 0 0;
+}
+
+.c2:after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 8px;
+  right: 8px;
+  display: block;
+  margin: 0 auto;
+  border-bottom: solid 1px #e4e7eb;
+}
+
+.c5 {
+  position: relative;
+  padding: 16px 24px;
+  background-color: rgba(255,255,255,0.9);
+  z-index: 2;
+  border-radius: 0 0 4px 4px;
+}
+
+.c5:after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 8px;
+  right: 8px;
+  display: block;
+  margin: 0 auto;
+  border-bottom: solid 1px #e4e7eb;
+}
+
+.c1 {
+  max-width: 624px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ffffff;
+  border-radius: 4px;
+  box-shadow: 0px 3px 5px 0px rgba(1,30,56,0.1);
+  width: 100%;
+  height: auto;
+  max-height: calc(100vh - 64px);
+  margin: 0px 16px;
+  padding: 0;
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c1 * {
+  box-sizing: border-box;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    width: 100%;
+    max-width: 100%;
+  }
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
-  />
+    className="c0"
+  >
+    <div
+      className="ReactModal__Overlay ReactModal__Overlay--after-open"
+      onClick={[Function]}
+      onMouseDown={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "rgba(18,43,71,0.5)",
+          "bottom": 0,
+          "display": "flex",
+          "justifyContent": "center",
+          "left": 0,
+          "position": "fixed",
+          "right": 0,
+          "top": 0,
+          "zIndex": 1000,
+        }
+      }
+    >
+      <div
+        aria-describedby={null}
+        aria-label={null}
+        aria-labelledby="modal-title"
+        className="ReactModal__Content ReactModal__Content--after-open c1"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="dialog"
+        style={Object {}}
+        tabIndex="-1"
+      >
+        <div
+          className="c2"
+        >
+          <h2
+            className="c3"
+            fontSize="larger"
+            fontWeight="medium"
+            id="modal-title"
+          >
+            Modal Title
+          </h2>
+        </div>
+        <div
+          className="c4"
+        >
+          Content Content Content
+        </div>
+        <div
+          className="c5"
+        >
+          <div
+            className="c6"
+          >
+            <button
+              className="c7 c8"
+              disabled={false}
+              size="medium"
+            >
+              Add job to line
+            </button>
+            <button
+              className="c7 c9"
+              disabled={false}
+              size="medium"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 `;
 
 exports[`Storyshots Modal example controlled modal 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c1:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c1:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
+@media only screen and (max-width:768px) {
+
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div>
       <button
-        class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+        className="c1"
+        disabled={false}
+        onClick={[Function]}
+        size="medium"
       >
         Open Modal
       </button>
@@ -29,81 +432,3432 @@ exports[`Storyshots Modal example controlled modal 1`] = `
 `;
 
 exports[`Storyshots Modal with close button 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c7 {
+  padding: 4px;
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c3 {
+  margin-bottom: 0px;
+  margin-top: 0;
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.23076923;
+}
+
+.c11 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c11:hover {
+  background-color: #e1ebfa;
+}
+
+.c11:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c11:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c11:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c11:disabled {
+  opacity: .5;
+}
+
+.c12 {
+  color: #ffffff;
+  border-color: #216beb;
+  background-color: #216beb;
+}
+
+.c12:hover {
+  background-color: #1254c7;
+  border-color: #1254c7;
+}
+
+.c12:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #216beb;
+}
+
+.c12:focus:hover {
+  background-color: #1254c7;
+}
+
+.c13 {
+  color: #216beb;
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c4 {
+  background: transparent;
+  border: none;
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 0;
+  color: #011e38;
+  cursor: pointer;
+}
+
+.c4 .c6 {
+  border-radius: 50%;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c4:hover .c6 {
+  background-color: #e4e7eb;
+}
+
+.c4:active .c6 {
+  -webkit-transform: scale(0.875);
+  -ms-transform: scale(0.875);
+  transform: scale(0.875);
+  -webkit-transition: .2s ease-in;
+  transition: .2s ease-in;
+}
+
+.c4:disabled {
+  opacity: .5;
+}
+
+.c4:disabled:hover .c6,
+.c4:disabled:active .c6 {
+  background: none;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus .c6 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-bottom: -8px;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c10 button {
+  margin-bottom: 8px;
+}
+
+.c10 button:not(:last-child) {
+  margin-right: 8px;
+}
+
+.c8 {
+  margin-top: -64px;
+  margin-bottom: -72px;
+  overflow: auto;
+  padding-top: 88px;
+  padding-bottom: 96px;
+  padding-left: 24px;
+  padding-right: 24px;
+}
+
+.c2 {
+  position: relative;
+  padding: 16px 64px 16px 24px;
+  background-color: rgba(255,255,255,0.9);
+  z-index: 2;
+  border-radius: 4px 4px 0 0;
+}
+
+.c2:after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 8px;
+  right: 8px;
+  display: block;
+  margin: 0 auto;
+  border-bottom: solid 1px #e4e7eb;
+}
+
+.c9 {
+  position: relative;
+  padding: 16px 24px;
+  background-color: rgba(255,255,255,0.9);
+  z-index: 2;
+  border-radius: 0 0 4px 4px;
+}
+
+.c9:after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 8px;
+  right: 8px;
+  display: block;
+  margin: 0 auto;
+  border-bottom: solid 1px #e4e7eb;
+}
+
+.c5 {
+  position: absolute;
+  top: 12px;
+  right: 16px;
+  z-index: 3;
+}
+
+.c1 {
+  max-width: 624px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ffffff;
+  border-radius: 4px;
+  box-shadow: 0px 3px 5px 0px rgba(1,30,56,0.1);
+  width: 100%;
+  height: auto;
+  max-height: calc(100vh - 64px);
+  margin: 0px 16px;
+  padding: 0;
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c1 * {
+  box-sizing: border-box;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    width: 100%;
+    max-width: 100%;
+  }
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
-  />
+    className="c0"
+  >
+    <div
+      className="ReactModal__Overlay ReactModal__Overlay--after-open"
+      onClick={[Function]}
+      onMouseDown={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "rgba(18,43,71,0.5)",
+          "bottom": 0,
+          "display": "flex",
+          "justifyContent": "center",
+          "left": 0,
+          "position": "fixed",
+          "right": 0,
+          "top": 0,
+          "zIndex": 1000,
+        }
+      }
+    >
+      <div
+        aria-describedby={null}
+        aria-label={null}
+        aria-labelledby="modal-title"
+        className="ReactModal__Content ReactModal__Content--after-open c1"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="dialog"
+        style={Object {}}
+        tabIndex="-1"
+      >
+        <div
+          className="c2"
+        >
+          <h2
+            className="c3"
+            fontSize="larger"
+            fontWeight="medium"
+            id="modal-title"
+          >
+            Modal Title
+          </h2>
+          <button
+            className="c4 CloseButton-sc-1xxxr4t-1 c5"
+            onClick={[Function]}
+          >
+            <svg
+              aria-hidden={true}
+              className="c6 c7"
+              color="currentColor"
+              fill="currentColor"
+              focusable={false}
+              height="32px"
+              icon="close"
+              p="half"
+              size="32px"
+              title={null}
+              viewBox="0 0 24 24"
+              width="32px"
+            >
+              <path
+                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          className="c8"
+        >
+          Content Content Content
+        </div>
+        <div
+          className="c9"
+        >
+          <div
+            className="c10"
+          >
+            <button
+              className="c11 c12"
+              disabled={false}
+              size="medium"
+            >
+              Add job to line
+            </button>
+            <button
+              className="c11 c13"
+              disabled={false}
+              size="medium"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 `;
 
 exports[`Storyshots Modal with custom maxWidth 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 0px;
+  margin-top: 0;
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.23076923;
+}
+
+.c7 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c7:hover {
+  background-color: #e1ebfa;
+}
+
+.c7:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c7:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c7:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c7:disabled {
+  opacity: .5;
+}
+
+.c8 {
+  color: #ffffff;
+  border-color: #216beb;
+  background-color: #216beb;
+}
+
+.c8:hover {
+  background-color: #1254c7;
+  border-color: #1254c7;
+}
+
+.c8:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #216beb;
+}
+
+.c8:focus:hover {
+  background-color: #1254c7;
+}
+
+.c9 {
+  color: #216beb;
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-bottom: -8px;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c6 button {
+  margin-bottom: 8px;
+}
+
+.c6 button:not(:last-child) {
+  margin-right: 8px;
+}
+
+.c4 {
+  margin-top: -64px;
+  margin-bottom: -72px;
+  overflow: auto;
+  padding-top: 88px;
+  padding-bottom: 96px;
+  padding-left: 24px;
+  padding-right: 24px;
+}
+
+.c2 {
+  position: relative;
+  padding: 16px 24px 16px 24px;
+  background-color: rgba(255,255,255,0.9);
+  z-index: 2;
+  border-radius: 4px 4px 0 0;
+}
+
+.c2:after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 8px;
+  right: 8px;
+  display: block;
+  margin: 0 auto;
+  border-bottom: solid 1px #e4e7eb;
+}
+
+.c5 {
+  position: relative;
+  padding: 16px 24px;
+  background-color: rgba(255,255,255,0.9);
+  z-index: 2;
+  border-radius: 0 0 4px 4px;
+}
+
+.c5:after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 8px;
+  right: 8px;
+  display: block;
+  margin: 0 auto;
+  border-bottom: solid 1px #e4e7eb;
+}
+
+.c1 {
+  max-width: 1000px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ffffff;
+  border-radius: 4px;
+  box-shadow: 0px 3px 5px 0px rgba(1,30,56,0.1);
+  width: 100%;
+  height: auto;
+  max-height: calc(100vh - 64px);
+  margin: 0px 16px;
+  padding: 0;
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c1 * {
+  box-sizing: border-box;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    width: 100%;
+    max-width: 100%;
+  }
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
-  />
+    className="c0"
+  >
+    <div
+      className="ReactModal__Overlay ReactModal__Overlay--after-open"
+      onClick={[Function]}
+      onMouseDown={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "rgba(18,43,71,0.5)",
+          "bottom": 0,
+          "display": "flex",
+          "justifyContent": "center",
+          "left": 0,
+          "position": "fixed",
+          "right": 0,
+          "top": 0,
+          "zIndex": 1000,
+        }
+      }
+    >
+      <div
+        aria-describedby={null}
+        aria-label={null}
+        aria-labelledby="modal-title"
+        className="ReactModal__Content ReactModal__Content--after-open c1"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="dialog"
+        style={Object {}}
+        tabIndex="-1"
+      >
+        <div
+          className="c2"
+        >
+          <h2
+            className="c3"
+            fontSize="larger"
+            fontWeight="medium"
+            id="modal-title"
+          >
+            Modal Title
+          </h2>
+        </div>
+        <div
+          className="c4"
+        >
+          Content Content Content
+        </div>
+        <div
+          className="c5"
+        >
+          <div
+            className="c6"
+          >
+            <button
+              className="c7 c8"
+              disabled={false}
+              size="medium"
+            >
+              Add job to line
+            </button>
+            <button
+              className="c7 c9"
+              disabled={false}
+              size="medium"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 `;
 
 exports[`Storyshots Modal with no footerContent 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c7 {
+  padding: 4px;
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c3 {
+  margin-bottom: 0px;
+  margin-top: 0;
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.23076923;
+}
+
+.c4 {
+  background: transparent;
+  border: none;
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 0;
+  color: #011e38;
+  cursor: pointer;
+}
+
+.c4 .c6 {
+  border-radius: 50%;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c4:hover .c6 {
+  background-color: #e4e7eb;
+}
+
+.c4:active .c6 {
+  -webkit-transform: scale(0.875);
+  -ms-transform: scale(0.875);
+  transform: scale(0.875);
+  -webkit-transition: .2s ease-in;
+  transition: .2s ease-in;
+}
+
+.c4:disabled {
+  opacity: .5;
+}
+
+.c4:disabled:hover .c6,
+.c4:disabled:active .c6 {
+  background: none;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.c4:focus {
+  outline: none;
+}
+
+.c4:focus .c6 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c8 {
+  margin-top: -64px;
+  margin-bottom: 0;
+  overflow: auto;
+  padding-top: 88px;
+  padding-bottom: 16px;
+  padding-left: 24px;
+  padding-right: 24px;
+}
+
+.c2 {
+  position: relative;
+  padding: 16px 64px 16px 24px;
+  background-color: rgba(255,255,255,0.9);
+  z-index: 2;
+  border-radius: 4px 4px 0 0;
+}
+
+.c2:after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 8px;
+  right: 8px;
+  display: block;
+  margin: 0 auto;
+  border-bottom: solid 1px #e4e7eb;
+}
+
+.c5 {
+  position: absolute;
+  top: 12px;
+  right: 16px;
+  z-index: 3;
+}
+
+.c1 {
+  max-width: 624px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ffffff;
+  border-radius: 4px;
+  box-shadow: 0px 3px 5px 0px rgba(1,30,56,0.1);
+  width: 100%;
+  height: auto;
+  max-height: calc(100vh - 64px);
+  margin: 0px 16px;
+  padding: 0;
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c1 * {
+  box-sizing: border-box;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    width: 100%;
+    max-width: 100%;
+  }
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
-  />
+    className="c0"
+  >
+    <div
+      className="ReactModal__Overlay ReactModal__Overlay--after-open"
+      onClick={[Function]}
+      onMouseDown={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "rgba(18,43,71,0.5)",
+          "bottom": 0,
+          "display": "flex",
+          "justifyContent": "center",
+          "left": 0,
+          "position": "fixed",
+          "right": 0,
+          "top": 0,
+          "zIndex": 1000,
+        }
+      }
+    >
+      <div
+        aria-describedby={null}
+        aria-label={null}
+        aria-labelledby="modal-title"
+        className="ReactModal__Content ReactModal__Content--after-open c1"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="dialog"
+        style={Object {}}
+        tabIndex="-1"
+      >
+        <div
+          className="c2"
+        >
+          <h2
+            className="c3"
+            fontSize="larger"
+            fontWeight="medium"
+            id="modal-title"
+          >
+            Without footerContent
+          </h2>
+          <button
+            className="c4 CloseButton-sc-1xxxr4t-1 c5"
+            onClick={[Function]}
+          >
+            <svg
+              aria-hidden={true}
+              className="c6 c7"
+              color="currentColor"
+              fill="currentColor"
+              focusable={false}
+              height="32px"
+              icon="close"
+              p="half"
+              size="32px"
+              title={null}
+              viewBox="0 0 24 24"
+              width="32px"
+            >
+              <path
+                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          className="c8"
+        >
+          Content Content Content
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 `;
 
 exports[`Storyshots Modal with no title 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c5 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c5:hover {
+  background-color: #e1ebfa;
+}
+
+.c5:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c5:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c5:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c5:disabled {
+  opacity: .5;
+}
+
+.c6 {
+  color: #ffffff;
+  border-color: #216beb;
+  background-color: #216beb;
+}
+
+.c6:hover {
+  background-color: #1254c7;
+  border-color: #1254c7;
+}
+
+.c6:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #216beb;
+}
+
+.c6:focus:hover {
+  background-color: #1254c7;
+}
+
+.c7 {
+  color: #216beb;
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-bottom: -8px;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c4 button {
+  margin-bottom: 8px;
+}
+
+.c4 button:not(:last-child) {
+  margin-right: 8px;
+}
+
+.c2 {
+  margin-top: -64px;
+  margin-bottom: -72px;
+  overflow: auto;
+  padding-top: 88px;
+  padding-bottom: 96px;
+  padding-left: 24px;
+  padding-right: 24px;
+}
+
+.c3 {
+  position: relative;
+  padding: 16px 24px;
+  background-color: rgba(255,255,255,0.9);
+  z-index: 2;
+  border-radius: 0 0 4px 4px;
+}
+
+.c3:after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 8px;
+  right: 8px;
+  display: block;
+  margin: 0 auto;
+  border-bottom: solid 1px #e4e7eb;
+}
+
+.c1 {
+  max-width: 624px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ffffff;
+  border-radius: 4px;
+  box-shadow: 0px 3px 5px 0px rgba(1,30,56,0.1);
+  width: 100%;
+  height: auto;
+  max-height: calc(100vh - 64px);
+  margin: 0px 16px;
+  padding: 0;
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c1 * {
+  box-sizing: border-box;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    width: 100%;
+    max-width: 100%;
+  }
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
-  />
+    className="c0"
+  >
+    <div
+      className="ReactModal__Overlay ReactModal__Overlay--after-open"
+      onClick={[Function]}
+      onMouseDown={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "rgba(18,43,71,0.5)",
+          "bottom": 0,
+          "display": "flex",
+          "justifyContent": "center",
+          "left": 0,
+          "position": "fixed",
+          "right": 0,
+          "top": 0,
+          "zIndex": 1000,
+        }
+      }
+    >
+      <div
+        aria-describedby={null}
+        aria-label={null}
+        className="ReactModal__Content ReactModal__Content--after-open c1"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="dialog"
+        style={Object {}}
+        tabIndex="-1"
+      >
+        <div
+          className="c2"
+        >
+          Content Content Content
+        </div>
+        <div
+          className="c3"
+        >
+          <div
+            className="c4"
+          >
+            <button
+              className="c5 c6"
+              disabled={false}
+              size="medium"
+            >
+              Add job to line
+            </button>
+            <button
+              className="c5 c7"
+              disabled={false}
+              size="medium"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 `;
 
 exports[`Storyshots Modal with scrolling content 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c5 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c3 {
+  margin-bottom: 0px;
+  margin-top: 0;
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.23076923;
+}
+
+.c8 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c8:hover {
+  background-color: #e1ebfa;
+}
+
+.c8:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c8:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c8:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c8:disabled {
+  opacity: .5;
+}
+
+.c9 {
+  color: #ffffff;
+  border-color: #216beb;
+  background-color: #216beb;
+}
+
+.c9:hover {
+  background-color: #1254c7;
+  border-color: #1254c7;
+}
+
+.c9:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #216beb;
+}
+
+.c9:focus:hover {
+  background-color: #1254c7;
+}
+
+.c10 {
+  color: #216beb;
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-bottom: -8px;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c7 button {
+  margin-bottom: 8px;
+}
+
+.c7 button:not(:last-child) {
+  margin-right: 8px;
+}
+
+.c4 {
+  margin-top: -64px;
+  margin-bottom: -72px;
+  overflow: auto;
+  padding-top: 88px;
+  padding-bottom: 96px;
+  padding-left: 24px;
+  padding-right: 24px;
+}
+
+.c2 {
+  position: relative;
+  padding: 16px 24px 16px 24px;
+  background-color: rgba(255,255,255,0.9);
+  z-index: 2;
+  border-radius: 4px 4px 0 0;
+}
+
+.c2:after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 8px;
+  right: 8px;
+  display: block;
+  margin: 0 auto;
+  border-bottom: solid 1px #e4e7eb;
+}
+
+.c6 {
+  position: relative;
+  padding: 16px 24px;
+  background-color: rgba(255,255,255,0.9);
+  z-index: 2;
+  border-radius: 0 0 4px 4px;
+}
+
+.c6:after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 8px;
+  right: 8px;
+  display: block;
+  margin: 0 auto;
+  border-bottom: solid 1px #e4e7eb;
+}
+
+.c1 {
+  max-width: 624px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ffffff;
+  border-radius: 4px;
+  box-shadow: 0px 3px 5px 0px rgba(1,30,56,0.1);
+  width: 100%;
+  height: auto;
+  max-height: calc(100vh - 64px);
+  margin: 0px 16px;
+  padding: 0;
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c1 * {
+  box-sizing: border-box;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    width: 100%;
+    max-width: 100%;
+  }
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
-  />
+    className="c0"
+  >
+    <div
+      className="ReactModal__Overlay ReactModal__Overlay--after-open"
+      onClick={[Function]}
+      onMouseDown={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "rgba(18,43,71,0.5)",
+          "bottom": 0,
+          "display": "flex",
+          "justifyContent": "center",
+          "left": 0,
+          "position": "fixed",
+          "right": 0,
+          "top": 0,
+          "zIndex": 1000,
+        }
+      }
+    >
+      <div
+        aria-describedby={null}
+        aria-label={null}
+        aria-labelledby="modal-title"
+        className="ReactModal__Content ReactModal__Content--after-open c1"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="dialog"
+        style={Object {}}
+        tabIndex="-1"
+      >
+        <div
+          className="c2"
+        >
+          <h2
+            className="c3"
+            fontSize="larger"
+            fontWeight="medium"
+            id="modal-title"
+          >
+            Modal Title
+          </h2>
+        </div>
+        <div
+          className="c4"
+        >
+          <p
+            className="c5"
+            color="currentColor"
+            disabled={false}
+            fontSize="medium"
+          >
+            Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+          </p>
+          <p
+            className="c5"
+            color="currentColor"
+            disabled={false}
+            fontSize="medium"
+          >
+            Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+          </p>
+          <p
+            className="c5"
+            color="currentColor"
+            disabled={false}
+            fontSize="medium"
+          >
+            Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+          </p>
+          <p
+            className="c5"
+            color="currentColor"
+            disabled={false}
+            fontSize="medium"
+          >
+            Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+          </p>
+          <p
+            className="c5"
+            color="currentColor"
+            disabled={false}
+            fontSize="medium"
+          >
+            Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+          </p>
+          <p
+            className="c5"
+            color="currentColor"
+            disabled={false}
+            fontSize="medium"
+          >
+            Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+          </p>
+        </div>
+        <div
+          className="c6"
+        >
+          <div
+            className="c7"
+          >
+            <button
+              className="c8 c9"
+              disabled={false}
+              size="medium"
+            >
+              Add job to line
+            </button>
+            <button
+              className="c8 c10"
+              disabled={false}
+              size="medium"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 `;
 
 exports[`Storyshots Modal with scrolling content without footer content 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c5 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c3 {
+  margin-bottom: 0px;
+  margin-top: 0;
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.23076923;
+}
+
+.c4 {
+  margin-top: -64px;
+  margin-bottom: 0;
+  overflow: auto;
+  padding-top: 88px;
+  padding-bottom: 16px;
+  padding-left: 24px;
+  padding-right: 24px;
+}
+
+.c2 {
+  position: relative;
+  padding: 16px 24px 16px 24px;
+  background-color: rgba(255,255,255,0.9);
+  z-index: 2;
+  border-radius: 4px 4px 0 0;
+}
+
+.c2:after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 8px;
+  right: 8px;
+  display: block;
+  margin: 0 auto;
+  border-bottom: solid 1px #e4e7eb;
+}
+
+.c1 {
+  max-width: 624px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ffffff;
+  border-radius: 4px;
+  box-shadow: 0px 3px 5px 0px rgba(1,30,56,0.1);
+  width: 100%;
+  height: auto;
+  max-height: calc(100vh - 64px);
+  margin: 0px 16px;
+  padding: 0;
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c1 * {
+  box-sizing: border-box;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    width: 100%;
+    max-width: 100%;
+  }
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
-  />
+    className="c0"
+  >
+    <div
+      className="ReactModal__Overlay ReactModal__Overlay--after-open"
+      onClick={[Function]}
+      onMouseDown={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "rgba(18,43,71,0.5)",
+          "bottom": 0,
+          "display": "flex",
+          "justifyContent": "center",
+          "left": 0,
+          "position": "fixed",
+          "right": 0,
+          "top": 0,
+          "zIndex": 1000,
+        }
+      }
+    >
+      <div
+        aria-describedby={null}
+        aria-label={null}
+        aria-labelledby="modal-title"
+        className="ReactModal__Content ReactModal__Content--after-open c1"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="dialog"
+        style={Object {}}
+        tabIndex="-1"
+      >
+        <div
+          className="c2"
+        >
+          <h2
+            className="c3"
+            fontSize="larger"
+            fontWeight="medium"
+            id="modal-title"
+          >
+            Modal Title
+          </h2>
+        </div>
+        <div
+          className="c4"
+        >
+          <p
+            className="c5"
+            color="currentColor"
+            disabled={false}
+            fontSize="medium"
+          >
+            Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+          </p>
+          <p
+            className="c5"
+            color="currentColor"
+            disabled={false}
+            fontSize="medium"
+          >
+            Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+          </p>
+          <p
+            className="c5"
+            color="currentColor"
+            disabled={false}
+            fontSize="medium"
+          >
+            Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+          </p>
+          <p
+            className="c5"
+            color="currentColor"
+            disabled={false}
+            fontSize="medium"
+          >
+            Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+          </p>
+          <p
+            className="c5"
+            color="currentColor"
+            disabled={false}
+            fontSize="medium"
+          >
+            Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+          </p>
+          <p
+            className="c5"
+            color="currentColor"
+            disabled={false}
+            fontSize="medium"
+          >
+            Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content Content
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 `;
 
 exports[`Storyshots Modal with select 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c14 {
+  margin-bottom: 8px;
+}
+
+.c8 {
+  padding: 4px;
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c4 {
+  margin-bottom: 0px;
+  margin-top: 0;
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.23076923;
+}
+
+.c18 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c18:hover {
+  background-color: #e1ebfa;
+}
+
+.c18:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c18:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c18:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c18:disabled {
+  opacity: .5;
+}
+
+.c19 {
+  color: #ffffff;
+  border-color: #216beb;
+  background-color: #216beb;
+}
+
+.c19:hover {
+  background-color: #1254c7;
+  border-color: #1254c7;
+}
+
+.c19:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #216beb;
+}
+
+.c19:focus:hover {
+  background-color: #1254c7;
+}
+
+.c20 {
+  color: #216beb;
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c5 {
+  background: transparent;
+  border: none;
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 0;
+  color: #011e38;
+  cursor: pointer;
+}
+
+.c5 .c7 {
+  border-radius: 50%;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c5:hover .c7 {
+  background-color: #e4e7eb;
+}
+
+.c5:active .c7 {
+  -webkit-transform: scale(0.875);
+  -ms-transform: scale(0.875);
+  transform: scale(0.875);
+  -webkit-transition: .2s ease-in;
+  transition: .2s ease-in;
+}
+
+.c5:disabled {
+  opacity: .5;
+}
+
+.c5:disabled:hover .c7,
+.c5:disabled:active .c7 {
+  background: none;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus .c7 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c17 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-bottom: -8px;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c17 button {
+  margin-bottom: 8px;
+}
+
+.c17 button:not(:last-child) {
+  margin-right: 8px;
+}
+
+.c13 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c15 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c12 {
+  width: 100%;
+}
+
+.c10 {
+  margin-bottom: 16px;
+  width: 100%;
+}
+
+.c10 .c3 {
+  margin-bottom: 0;
+}
+
+.c10 .Alert-u8lbe-0 {
+  margin-bottom: 48px;
+}
+
+.c10 .c11,
+.c10 .Fieldset-sc-9aoml1-0 {
+  margin-bottom: 24px;
+}
+
+.c10 .c11:last-child,
+.c10 .Fieldset-sc-9aoml1-0:last-child {
+  margin-bottom: 0;
+}
+
+.c10 .FormSection-sc-5yud6c-1 {
+  margin-bottom: 48px;
+}
+
+.c10 .FormSection-sc-5yud6c-1:last-child {
+  margin-bottom: 0;
+}
+
+.c9 {
+  margin-top: -64px;
+  margin-bottom: -72px;
+  overflow: auto;
+  padding-top: 88px;
+  padding-bottom: 96px;
+  padding-left: 24px;
+  padding-right: 24px;
+}
+
+.c2 {
+  position: relative;
+  padding: 16px 64px 16px 24px;
+  background-color: rgba(255,255,255,0.9);
+  z-index: 2;
+  border-radius: 4px 4px 0 0;
+}
+
+.c2:after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 8px;
+  right: 8px;
+  display: block;
+  margin: 0 auto;
+  border-bottom: solid 1px #e4e7eb;
+}
+
+.c16 {
+  position: relative;
+  padding: 16px 24px;
+  background-color: rgba(255,255,255,0.9);
+  z-index: 2;
+  border-radius: 0 0 4px 4px;
+}
+
+.c16:after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 8px;
+  right: 8px;
+  display: block;
+  margin: 0 auto;
+  border-bottom: solid 1px #e4e7eb;
+}
+
+.c6 {
+  position: absolute;
+  top: 12px;
+  right: 16px;
+  z-index: 3;
+}
+
+.c1 {
+  max-width: 456px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ffffff;
+  border-radius: 4px;
+  box-shadow: 0px 3px 5px 0px rgba(1,30,56,0.1);
+  width: 100%;
+  height: auto;
+  max-height: calc(100vh - 64px);
+  margin: 0px 16px;
+  padding: 0;
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c1 * {
+  box-sizing: border-box;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    width: 100%;
+    max-width: 100%;
+  }
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
-  />
+    className="c0"
+  >
+    <div
+      className="ReactModal__Overlay ReactModal__Overlay--after-open"
+      onClick={[Function]}
+      onMouseDown={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "rgba(18,43,71,0.5)",
+          "bottom": 0,
+          "display": "flex",
+          "justifyContent": "center",
+          "left": 0,
+          "position": "fixed",
+          "right": 0,
+          "top": 0,
+          "zIndex": 1000,
+        }
+      }
+    >
+      <div
+        aria-describedby={null}
+        aria-label={null}
+        aria-labelledby="modal-title"
+        className="ReactModal__Content ReactModal__Content--after-open c1"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="dialog"
+        style={Object {}}
+        tabIndex="-1"
+      >
+        <div
+          className="c2"
+        >
+          <h2
+            className="c3 c4"
+            fontSize="larger"
+            fontWeight="medium"
+            id="modal-title"
+          >
+            Edit Profile
+          </h2>
+          <button
+            className="c5 CloseButton-sc-1xxxr4t-1 c6"
+            onClick={[Function]}
+          >
+            <svg
+              aria-hidden={true}
+              className="c7 c8"
+              color="currentColor"
+              fill="currentColor"
+              focusable={false}
+              height="32px"
+              icon="close"
+              p="half"
+              size="32px"
+              title={null}
+              viewBox="0 0 24 24"
+              width="32px"
+            >
+              <path
+                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          className="c9"
+        >
+          <form
+            className="c10"
+            id="myForm"
+            mb="x2"
+          >
+            <div
+              className="c11 c12"
+            >
+              <label
+                className="c13 "
+                color="black"
+                style={
+                  Object {
+                    "display": "block",
+                  }
+                }
+              >
+                <div
+                  className="c14"
+                  data-testid="field-label"
+                >
+                  <span
+                    className="c15"
+                  >
+                    Inventory status
+                  </span>
+                </div>
+                <div
+                  data-testid="select-container"
+                >
+                  <div
+                    className=" css-2b097c-container"
+                    onKeyDown={[Function]}
+                  >
+                    <div
+                      data-testid="select-control"
+                    >
+                      <div
+                        className=" css-1liu8yu-Control"
+                        onMouseDown={[Function]}
+                        onTouchEnd={[Function]}
+                      >
+                        <div
+                          className=" css-7zc8my"
+                        >
+                          <div
+                            className=" css-1yhx6vz-Placeholder"
+                          >
+                            Please select inventory status
+                          </div>
+                          <div
+                            data-testid="select-input"
+                          >
+                            <div
+                              className="css-17yls17-Input"
+                            >
+                              <div
+                                className=""
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                  }
+                                }
+                              >
+                                <input
+                                  aria-autocomplete="list"
+                                  autoCapitalize="none"
+                                  autoComplete="off"
+                                  autoCorrect="off"
+                                  disabled={null}
+                                  id="react-select-9-input"
+                                  onBlur={[Function]}
+                                  onChange={[Function]}
+                                  onFocus={[Function]}
+                                  spellCheck="false"
+                                  style={
+                                    Object {
+                                      "background": 0,
+                                      "border": 0,
+                                      "boxSizing": "content-box",
+                                      "color": "inherit",
+                                      "fontSize": "inherit",
+                                      "label": "input",
+                                      "opacity": 1,
+                                      "outline": 0,
+                                      "padding": 0,
+                                      "width": "1px",
+                                    }
+                                  }
+                                  tabIndex="0"
+                                  type="text"
+                                  value=""
+                                />
+                                <div
+                                  style={
+                                    Object {
+                                      "height": 0,
+                                      "left": 0,
+                                      "overflow": "scroll",
+                                      "position": "absolute",
+                                      "top": 0,
+                                      "visibility": "hidden",
+                                      "whiteSpace": "pre",
+                                    }
+                                  }
+                                >
+                                  
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          className=" css-173cxbq-IndicatorsContainer"
+                        >
+                          <span
+                            className=" css-4z5mi-indicatorSeparator"
+                          />
+                          <div
+                            aria-hidden="true"
+                            className=" css-19phze7-indicatorContainer"
+                            onMouseDown={[Function]}
+                            onTouchEnd={[Function]}
+                          >
+                            <svg
+                              aria-hidden="true"
+                              className="css-6q0nyr-Svg"
+                              focusable="false"
+                              height={20}
+                              viewBox="0 0 20 20"
+                              width={20}
+                            >
+                              <path
+                                d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </label>
+            </div>
+          </form>
+        </div>
+        <div
+          className="c16"
+        >
+          <div
+            className="c17"
+          >
+            <button
+              className="c18 c19"
+              disabled={false}
+              size="medium"
+            >
+              Add job to line
+            </button>
+            <button
+              className="c18 c20"
+              disabled={false}
+              size="medium"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 `;
 
 exports[`Storyshots Modal with select and scrolling content 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c14 {
+  margin-bottom: 8px;
+}
+
+.c17 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c8 {
+  padding: 4px;
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c4 {
+  margin-bottom: 0px;
+  margin-top: 0;
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.23076923;
+}
+
+.c21 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c21:hover {
+  background-color: #e1ebfa;
+}
+
+.c21:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c21:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c21:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c21:disabled {
+  opacity: .5;
+}
+
+.c22 {
+  color: #ffffff;
+  border-color: #216beb;
+  background-color: #216beb;
+}
+
+.c22:hover {
+  background-color: #1254c7;
+  border-color: #1254c7;
+}
+
+.c22:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #216beb;
+}
+
+.c22:focus:hover {
+  background-color: #1254c7;
+}
+
+.c23 {
+  color: #216beb;
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c5 {
+  background: transparent;
+  border: none;
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 0;
+  color: #011e38;
+  cursor: pointer;
+}
+
+.c5 .c7 {
+  border-radius: 50%;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c5:hover .c7 {
+  background-color: #e4e7eb;
+}
+
+.c5:active .c7 {
+  -webkit-transform: scale(0.875);
+  -ms-transform: scale(0.875);
+  transform: scale(0.875);
+  -webkit-transition: .2s ease-in;
+  transition: .2s ease-in;
+}
+
+.c5:disabled {
+  opacity: .5;
+}
+
+.c5:disabled:hover .c7,
+.c5:disabled:active .c7 {
+  background: none;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus .c7 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c20 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-bottom: -8px;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c20 button {
+  margin-bottom: 8px;
+}
+
+.c20 button:not(:last-child) {
+  margin-right: 8px;
+}
+
+.c13 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c15 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c12 {
+  width: 100%;
+}
+
+.c10 {
+  margin-bottom: 16px;
+  width: 100%;
+}
+
+.c10 .c3 {
+  margin-bottom: 0;
+}
+
+.c10 .Alert-u8lbe-0 {
+  margin-bottom: 48px;
+}
+
+.c10 .c11,
+.c10 .Fieldset-sc-9aoml1-0 {
+  margin-bottom: 24px;
+}
+
+.c10 .c11:last-child,
+.c10 .Fieldset-sc-9aoml1-0:last-child {
+  margin-bottom: 0;
+}
+
+.c10 .FormSection-sc-5yud6c-1 {
+  margin-bottom: 48px;
+}
+
+.c10 .FormSection-sc-5yud6c-1:last-child {
+  margin-bottom: 0;
+}
+
+.c18 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c18:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c18:focus ~ svg {
+  fill: #00438f;
+}
+
+.c18::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c18::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c18:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c18::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c9 {
+  margin-top: -64px;
+  margin-bottom: -72px;
+  overflow: auto;
+  padding-top: 88px;
+  padding-bottom: 96px;
+  padding-left: 24px;
+  padding-right: 24px;
+}
+
+.c2 {
+  position: relative;
+  padding: 16px 64px 16px 24px;
+  background-color: rgba(255,255,255,0.9);
+  z-index: 2;
+  border-radius: 4px 4px 0 0;
+}
+
+.c2:after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 8px;
+  right: 8px;
+  display: block;
+  margin: 0 auto;
+  border-bottom: solid 1px #e4e7eb;
+}
+
+.c19 {
+  position: relative;
+  padding: 16px 24px;
+  background-color: rgba(255,255,255,0.9);
+  z-index: 2;
+  border-radius: 0 0 4px 4px;
+}
+
+.c19:after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 8px;
+  right: 8px;
+  display: block;
+  margin: 0 auto;
+  border-bottom: solid 1px #e4e7eb;
+}
+
+.c6 {
+  position: absolute;
+  top: 12px;
+  right: 16px;
+  z-index: 3;
+}
+
+.c1 {
+  max-width: 456px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ffffff;
+  border-radius: 4px;
+  box-shadow: 0px 3px 5px 0px rgba(1,30,56,0.1);
+  width: 100%;
+  height: auto;
+  max-height: calc(100vh - 64px);
+  margin: 0px 16px;
+  padding: 0;
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c1 * {
+  box-sizing: border-box;
+}
+
+@media only screen and (max-width:768px) {
+  .c1 {
+    width: 100%;
+    max-width: 100%;
+  }
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
-  />
+    className="c0"
+  >
+    <div
+      className="ReactModal__Overlay ReactModal__Overlay--after-open"
+      onClick={[Function]}
+      onMouseDown={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "rgba(18,43,71,0.5)",
+          "bottom": 0,
+          "display": "flex",
+          "justifyContent": "center",
+          "left": 0,
+          "position": "fixed",
+          "right": 0,
+          "top": 0,
+          "zIndex": 1000,
+        }
+      }
+    >
+      <div
+        aria-describedby={null}
+        aria-label={null}
+        aria-labelledby="modal-title"
+        className="ReactModal__Content ReactModal__Content--after-open c1"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="dialog"
+        style={Object {}}
+        tabIndex="-1"
+      >
+        <div
+          className="c2"
+        >
+          <h2
+            className="c3 c4"
+            fontSize="larger"
+            fontWeight="medium"
+            id="modal-title"
+          >
+            Edit Profile
+          </h2>
+          <button
+            className="c5 CloseButton-sc-1xxxr4t-1 c6"
+            onClick={[Function]}
+          >
+            <svg
+              aria-hidden={true}
+              className="c7 c8"
+              color="currentColor"
+              fill="currentColor"
+              focusable={false}
+              height="32px"
+              icon="close"
+              p="half"
+              size="32px"
+              title={null}
+              viewBox="0 0 24 24"
+              width="32px"
+            >
+              <path
+                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          className="c9"
+        >
+          <form
+            className="c10"
+            id="myForm"
+            mb="x2"
+          >
+            <div
+              className="c11 c12"
+            >
+              <label
+                className="c13 "
+                color="black"
+                style={
+                  Object {
+                    "display": "block",
+                  }
+                }
+              >
+                <div
+                  className="c14"
+                  data-testid="field-label"
+                >
+                  <span
+                    className="c15"
+                  >
+                    Name
+                  </span>
+                </div>
+                <div
+                  className="c16"
+                >
+                  <div
+                    className="c17"
+                    display="flex"
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-required={false}
+                      className="c18"
+                      disabled={false}
+                      id="name"
+                      name="name"
+                      required={false}
+                    />
+                  </div>
+                </div>
+              </label>
+            </div>
+            <div
+              className="c11 c12"
+            >
+              <label
+                className="c13 "
+                color="black"
+                style={
+                  Object {
+                    "display": "block",
+                  }
+                }
+              >
+                <div
+                  className="c14"
+                  data-testid="field-label"
+                >
+                  <span
+                    className="c15"
+                  >
+                    Age
+                  </span>
+                </div>
+                <div
+                  className="c16"
+                >
+                  <div
+                    className="c17"
+                    display="flex"
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-required={false}
+                      className="c18"
+                      disabled={false}
+                      id="age"
+                      name="age"
+                      required={false}
+                      type="number"
+                    />
+                  </div>
+                </div>
+              </label>
+            </div>
+            <div
+              className="c11 c12"
+            >
+              <label
+                className="c13 "
+                color="black"
+                style={
+                  Object {
+                    "display": "block",
+                  }
+                }
+              >
+                <div
+                  className="c14"
+                  data-testid="field-label"
+                >
+                  <span
+                    className="c15"
+                  >
+                    Name
+                  </span>
+                </div>
+                <div
+                  className="c16"
+                >
+                  <div
+                    className="c17"
+                    display="flex"
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-required={false}
+                      className="c18"
+                      disabled={false}
+                      id="name"
+                      name="name"
+                      required={false}
+                    />
+                  </div>
+                </div>
+              </label>
+            </div>
+            <div
+              className="c11 c12"
+            >
+              <label
+                className="c13 "
+                color="black"
+                style={
+                  Object {
+                    "display": "block",
+                  }
+                }
+              >
+                <div
+                  className="c14"
+                  data-testid="field-label"
+                >
+                  <span
+                    className="c15"
+                  >
+                    Age
+                  </span>
+                </div>
+                <div
+                  className="c16"
+                >
+                  <div
+                    className="c17"
+                    display="flex"
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-required={false}
+                      className="c18"
+                      disabled={false}
+                      id="age"
+                      name="age"
+                      required={false}
+                      type="number"
+                    />
+                  </div>
+                </div>
+              </label>
+            </div>
+            <div
+              className="c11 c12"
+            >
+              <label
+                className="c13 "
+                color="black"
+                style={
+                  Object {
+                    "display": "block",
+                  }
+                }
+              >
+                <div
+                  className="c14"
+                  data-testid="field-label"
+                >
+                  <span
+                    className="c15"
+                  >
+                    Name
+                  </span>
+                </div>
+                <div
+                  className="c16"
+                >
+                  <div
+                    className="c17"
+                    display="flex"
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-required={false}
+                      className="c18"
+                      disabled={false}
+                      id="name"
+                      name="name"
+                      required={false}
+                    />
+                  </div>
+                </div>
+              </label>
+            </div>
+            <div
+              className="c11 c12"
+            >
+              <label
+                className="c13 "
+                color="black"
+                style={
+                  Object {
+                    "display": "block",
+                  }
+                }
+              >
+                <div
+                  className="c14"
+                  data-testid="field-label"
+                >
+                  <span
+                    className="c15"
+                  >
+                    Age
+                  </span>
+                </div>
+                <div
+                  className="c16"
+                >
+                  <div
+                    className="c17"
+                    display="flex"
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-required={false}
+                      className="c18"
+                      disabled={false}
+                      id="age"
+                      name="age"
+                      required={false}
+                      type="number"
+                    />
+                  </div>
+                </div>
+              </label>
+            </div>
+            <div
+              className="c11 c12"
+            >
+              <label
+                className="c13 "
+                color="black"
+                style={
+                  Object {
+                    "display": "block",
+                  }
+                }
+              >
+                <div
+                  className="c14"
+                  data-testid="field-label"
+                >
+                  <span
+                    className="c15"
+                  >
+                    Inventory status
+                  </span>
+                </div>
+                <div
+                  data-testid="select-container"
+                >
+                  <div
+                    className=" css-2b097c-container"
+                    onKeyDown={[Function]}
+                  >
+                    <div
+                      data-testid="select-control"
+                    >
+                      <div
+                        className=" css-1liu8yu-Control"
+                        onMouseDown={[Function]}
+                        onTouchEnd={[Function]}
+                      >
+                        <div
+                          className=" css-7zc8my"
+                        >
+                          <div
+                            className=" css-1yhx6vz-Placeholder"
+                          >
+                            Please select inventory status
+                          </div>
+                          <div
+                            data-testid="select-input"
+                          >
+                            <div
+                              className="css-17yls17-Input"
+                            >
+                              <div
+                                className=""
+                                style={
+                                  Object {
+                                    "display": "inline-block",
+                                  }
+                                }
+                              >
+                                <input
+                                  aria-autocomplete="list"
+                                  autoCapitalize="none"
+                                  autoComplete="off"
+                                  autoCorrect="off"
+                                  disabled={null}
+                                  id="react-select-10-input"
+                                  onBlur={[Function]}
+                                  onChange={[Function]}
+                                  onFocus={[Function]}
+                                  spellCheck="false"
+                                  style={
+                                    Object {
+                                      "background": 0,
+                                      "border": 0,
+                                      "boxSizing": "content-box",
+                                      "color": "inherit",
+                                      "fontSize": "inherit",
+                                      "label": "input",
+                                      "opacity": 1,
+                                      "outline": 0,
+                                      "padding": 0,
+                                      "width": "1px",
+                                    }
+                                  }
+                                  tabIndex="0"
+                                  type="text"
+                                  value=""
+                                />
+                                <div
+                                  style={
+                                    Object {
+                                      "height": 0,
+                                      "left": 0,
+                                      "overflow": "scroll",
+                                      "position": "absolute",
+                                      "top": 0,
+                                      "visibility": "hidden",
+                                      "whiteSpace": "pre",
+                                    }
+                                  }
+                                >
+                                  
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          className=" css-173cxbq-IndicatorsContainer"
+                        >
+                          <span
+                            className=" css-4z5mi-indicatorSeparator"
+                          />
+                          <div
+                            aria-hidden="true"
+                            className=" css-19phze7-indicatorContainer"
+                            onMouseDown={[Function]}
+                            onTouchEnd={[Function]}
+                          >
+                            <svg
+                              aria-hidden="true"
+                              className="css-6q0nyr-Svg"
+                              focusable="false"
+                              height={20}
+                              viewBox="0 0 20 20"
+                              width={20}
+                            >
+                              <path
+                                d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </label>
+            </div>
+          </form>
+        </div>
+        <div
+          className="c19"
+        >
+          <div
+            className="c20"
+          >
+            <button
+              className="c21 c22"
+              disabled={false}
+              size="medium"
+            >
+              Add job to line
+            </button>
+            <button
+              className="c21 c23"
+              disabled={false}
+              size="medium"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 `;

--- a/components/src/MonthPicker/__snapshots__/MonthPicker.story.storyshot
+++ b/components/src/MonthPicker/__snapshots__/MonthPicker.story.storyshot
@@ -1,60 +1,197 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots MonthPicker default 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 16px;
+  position: absolute;
+  right: 8px;
+  color: #434d59;
+  bottom: 50%;
+  -webkit-transform: translateY(50%);
+  -ms-transform: translateY(50%);
+  transform: translateY(50%);
+  pointer-events: none;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-month-picker"
+      className="c1 nds-month-picker"
       data-testid="month-picker"
     >
       <div
-        class="react-datepicker-wrapper"
+        className="react-datepicker-wrapper"
       >
         <div
-          class="react-datepicker__input-container"
+          className="react-datepicker__input-container"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c2 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c3"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c4"
               >
                 Month
               </span>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="select a date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="Mon YYYY"
+                  required={false}
                   value="Jan 2019"
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -73,60 +210,197 @@ exports[`Storyshots MonthPicker default 1`] = `
 `;
 
 exports[`Storyshots MonthPicker with a min and max date 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 16px;
+  position: absolute;
+  right: 8px;
+  color: #434d59;
+  bottom: 50%;
+  -webkit-transform: translateY(50%);
+  -ms-transform: translateY(50%);
+  transform: translateY(50%);
+  pointer-events: none;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-month-picker"
+      className="c1 nds-month-picker"
       data-testid="month-picker"
     >
       <div
-        class="react-datepicker-wrapper"
+        className="react-datepicker-wrapper"
       >
         <div
-          class="react-datepicker__input-container"
+          className="react-datepicker__input-container"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c2 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c3"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c4"
               >
                 Month and Year
               </span>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="select a date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="Mon YYYY"
+                  required={false}
                   value="Jul 2019"
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -145,60 +419,197 @@ exports[`Storyshots MonthPicker with a min and max date 1`] = `
 `;
 
 exports[`Storyshots MonthPicker with custom placeholder 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 16px;
+  position: absolute;
+  right: 8px;
+  color: #434d59;
+  bottom: 50%;
+  -webkit-transform: translateY(50%);
+  -ms-transform: translateY(50%);
+  transform: translateY(50%);
+  pointer-events: none;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-month-picker"
+      className="c1 nds-month-picker"
       data-testid="month-picker"
     >
       <div
-        class="react-datepicker-wrapper"
+        className="react-datepicker-wrapper"
       >
         <div
-          class="react-datepicker__input-container"
+          className="react-datepicker__input-container"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c2 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c3"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c4"
               >
                 Month and Year
               </span>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="select a date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="Month, year"
+                  required={false}
                   value=""
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -217,60 +628,228 @@ exports[`Storyshots MonthPicker with custom placeholder 1`] = `
 `;
 
 exports[`Storyshots MonthPicker with error state 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c9 {
+  color: #cc1439;
+  margin-top: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c10 {
+  margin-right: 8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c13 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c11 .c12 {
+  margin-bottom: 8px;
+}
+
+.c11 > *:last-child {
+  margin-bottom: 0;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #cc1439;
+  border-color: #cc1439;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 16px;
+  position: absolute;
+  right: 8px;
+  color: #434d59;
+  bottom: 50%;
+  -webkit-transform: translateY(50%);
+  -ms-transform: translateY(50%);
+  transform: translateY(50%);
+  pointer-events: none;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-month-picker"
+      className="c1 nds-month-picker"
       data-testid="month-picker"
     >
       <div
-        class="react-datepicker-wrapper"
+        className="react-datepicker-wrapper"
       >
         <div
-          class="react-datepicker__input-container"
+          className="react-datepicker__input-container"
         >
           <label
-            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            className="c2 "
             color="black"
-            style="display:block"
+            style={
+              Object {
+                "display": "block",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 ilQgHG"
+              className="c3"
               data-testid="field-label"
             >
               <span
-                class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                className="c4"
               >
                 Month and Year
               </span>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="true"
+                  aria-invalid={true}
                   aria-label="select a date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 jMjRjb"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="yyyy MMM"
+                  required={false}
                   value=""
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -284,18 +863,20 @@ exports[`Storyshots MonthPicker with error state 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 ycNbA"
+        className="c9"
         color="red"
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 QuoIa"
+          aria-hidden={true}
+          className="c10"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="error"
           mr="x1"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -304,12 +885,13 @@ exports[`Storyshots MonthPicker with error state 1`] = `
           />
         </svg>
         <div
-          class="InlineValidation__Wrapper-sc-1jic7dw-0 kqhCKM"
+          className="c11"
         >
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c12 c13"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             The date is invalid
           </p>

--- a/components/src/MonthRange/__snapshots__/MonthRange.story.storyshot
+++ b/components/src/MonthRange/__snapshots__/MonthRange.story.storyshot
@@ -1,65 +1,229 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots MonthRange customizing input props 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c9 {
+  padding-left: 4px;
+  padding-right: 4px;
+  max-height: 38px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c10 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c1 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c2 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c4 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 16px;
+  position: absolute;
+  right: 8px;
+  color: #434d59;
+  bottom: 50%;
+  -webkit-transform: translateY(50%);
+  -ms-transform: translateY(50%);
+  transform: translateY(50%);
+  pointer-events: none;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      className="c1 "
       color="black"
-      style="display:block"
+      style={
+        Object {
+          "display": "block",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
+        className=""
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          className="c2"
         >
           Month range
         </span>
       </div>
     </label>
     <div
-      class="Box-sc-1qu1edy-0 iyjdMT"
+      className="c3"
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-month-picker"
+        className="c4 nds-month-picker"
         data-testid="month-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select a start date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="From (Mon YYYY)"
+                  required={false}
                   value=""
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -73,49 +237,57 @@ exports[`Storyshots MonthRange customizing input props 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hYUuLW"
+        className="c9"
       >
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c10"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           -
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-month-picker"
+        className="c4 nds-month-picker"
         data-testid="month-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select an end date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="To (Mon YYYY)"
+                  required={false}
                   value=""
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -134,65 +306,229 @@ exports[`Storyshots MonthRange customizing input props 1`] = `
 `;
 
 exports[`Storyshots MonthRange default 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c9 {
+  padding-left: 4px;
+  padding-right: 4px;
+  max-height: 38px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c10 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c1 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c2 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c4 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 16px;
+  position: absolute;
+  right: 8px;
+  color: #434d59;
+  bottom: 50%;
+  -webkit-transform: translateY(50%);
+  -ms-transform: translateY(50%);
+  transform: translateY(50%);
+  pointer-events: none;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      className="c1 "
       color="black"
-      style="display:block"
+      style={
+        Object {
+          "display": "block",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
+        className=""
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          className="c2"
         >
           Month range
         </span>
       </div>
     </label>
     <div
-      class="Box-sc-1qu1edy-0 iyjdMT"
+      className="c3"
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-month-picker"
+        className="c4 nds-month-picker"
         data-testid="month-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select a start date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="Mon YYYY"
+                  required={false}
                   value=""
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -206,49 +542,57 @@ exports[`Storyshots MonthRange default 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hYUuLW"
+        className="c9"
       >
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c10"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           -
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-month-picker"
+        className="c4 nds-month-picker"
         data-testid="month-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select an end date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="Mon YYYY"
+                  required={false}
                   value=""
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -267,65 +611,229 @@ exports[`Storyshots MonthRange default 1`] = `
 `;
 
 exports[`Storyshots MonthRange default start and end date 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c9 {
+  padding-left: 4px;
+  padding-right: 4px;
+  max-height: 38px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c10 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c1 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c2 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c4 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 16px;
+  position: absolute;
+  right: 8px;
+  color: #434d59;
+  bottom: 50%;
+  -webkit-transform: translateY(50%);
+  -ms-transform: translateY(50%);
+  transform: translateY(50%);
+  pointer-events: none;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      className="c1 "
       color="black"
-      style="display:block"
+      style={
+        Object {
+          "display": "block",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
+        className=""
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          className="c2"
         >
           Month range
         </span>
       </div>
     </label>
     <div
-      class="Box-sc-1qu1edy-0 iyjdMT"
+      className="c3"
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-month-picker"
+        className="c4 nds-month-picker"
         data-testid="month-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select a start date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="Mon YYYY"
+                  required={false}
                   value="Jul 2019"
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -339,49 +847,57 @@ exports[`Storyshots MonthRange default start and end date 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hYUuLW"
+        className="c9"
       >
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c10"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           -
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-month-picker"
+        className="c4 nds-month-picker"
         data-testid="month-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select an end date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="Mon YYYY"
+                  required={false}
                   value="Sep 2019"
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -400,65 +916,229 @@ exports[`Storyshots MonthRange default start and end date 1`] = `
 `;
 
 exports[`Storyshots MonthRange disabled range validation 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c9 {
+  padding-left: 4px;
+  padding-right: 4px;
+  max-height: 38px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c10 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c1 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c2 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c4 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 16px;
+  position: absolute;
+  right: 8px;
+  color: #434d59;
+  bottom: 50%;
+  -webkit-transform: translateY(50%);
+  -ms-transform: translateY(50%);
+  transform: translateY(50%);
+  pointer-events: none;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      className="c1 "
       color="black"
-      style="display:block"
+      style={
+        Object {
+          "display": "block",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
+        className=""
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          className="c2"
         >
           Month range
         </span>
       </div>
     </label>
     <div
-      class="Box-sc-1qu1edy-0 iyjdMT"
+      className="c3"
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-month-picker"
+        className="c4 nds-month-picker"
         data-testid="month-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select a start date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="Mon YYYY"
+                  required={false}
                   value="Sep 2019"
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -472,49 +1152,57 @@ exports[`Storyshots MonthRange disabled range validation 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hYUuLW"
+        className="c9"
       >
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c10"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           -
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-month-picker"
+        className="c4 nds-month-picker"
         data-testid="month-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select an end date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="Mon YYYY"
+                  required={false}
                   value="Jul 2019"
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="Icon-fc7twp-0 c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -533,66 +1221,297 @@ exports[`Storyshots MonthRange disabled range validation 1`] = `
 `;
 
 exports[`Storyshots MonthRange individual input error 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c9 {
+  color: #cc1439;
+  margin-top: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c14 {
+  padding-left: 4px;
+  padding-right: 4px;
+  max-height: 38px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c10 {
+  margin-right: 8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c13 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c11 .c12 {
+  margin-bottom: 8px;
+}
+
+.c11 > *:last-child {
+  margin-bottom: 0;
+}
+
+.c1 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c2 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c4 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #cc1439;
+  border-color: #cc1439;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c15 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c15:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c15:focus ~ svg {
+  fill: #00438f;
+}
+
+.c15::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c15::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c15:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c15::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 16px;
+  position: absolute;
+  right: 8px;
+  color: #434d59;
+  bottom: 50%;
+  -webkit-transform: translateY(50%);
+  -ms-transform: translateY(50%);
+  transform: translateY(50%);
+  pointer-events: none;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      className="c1 "
       color="black"
-      style="display:block"
+      style={
+        Object {
+          "display": "block",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
+        className=""
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          className="c2"
         >
           Month range
         </span>
       </div>
     </label>
     <div
-      class="Box-sc-1qu1edy-0 iyjdMT"
+      className="c3"
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-month-picker"
+        className="c4 nds-month-picker"
         data-testid="month-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="true"
+                  aria-invalid={true}
                   aria-label="Select a start date"
-                  aria-required="true"
-                  class="InputField__StyledInput-sc-6cu4mg-0 jMjRjb"
+                  aria-required={true}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="Mon YYYY"
-                  required=""
+                  required={true}
                   value=""
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -605,18 +1524,20 @@ exports[`Storyshots MonthRange individual input error 1`] = `
           </div>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 ycNbA"
+          className="c9"
           color="red"
         >
           <svg
-            aria-hidden="true"
-            class="Icon-fc7twp-0 QuoIa"
+            aria-hidden={true}
+            className="c10"
             color="currentColor"
             fill="currentColor"
-            focusable="false"
+            focusable={false}
             height="24px"
             icon="error"
             mr="x1"
+            size="24px"
+            title={null}
             viewBox="0 0 24 24"
             width="24px"
           >
@@ -625,12 +1546,13 @@ exports[`Storyshots MonthRange individual input error 1`] = `
             />
           </svg>
           <div
-            class="InlineValidation__Wrapper-sc-1jic7dw-0 kqhCKM"
+            className="c11"
           >
             <p
-              class="Text-sc-1wu7vpu-0 RbfMK"
+              className="c12 c13"
               color="currentColor"
-              font-size="medium"
+              disabled={false}
+              fontSize="medium"
             >
               Start date is required
             </p>
@@ -638,49 +1560,57 @@ exports[`Storyshots MonthRange individual input error 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hYUuLW"
+        className="c14"
       >
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c12 c13"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           -
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-month-picker"
+        className="c4 nds-month-picker"
         data-testid="month-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select an end date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c15"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="Mon YYYY"
+                  required={false}
                   value="Sep 2019"
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -699,65 +1629,251 @@ exports[`Storyshots MonthRange individual input error 1`] = `
 `;
 
 exports[`Storyshots MonthRange with custom error 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c9 {
+  padding-left: 4px;
+  padding-right: 4px;
+  max-height: 38px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c12 {
+  color: #cc1439;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c13 {
+  margin-right: 8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c11 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c14 .c10 {
+  margin-bottom: 8px;
+}
+
+.c14 > *:last-child {
+  margin-bottom: 0;
+}
+
+.c1 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c2 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c4 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus ~ svg {
+  fill: #00438f;
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 16px;
+  position: absolute;
+  right: 8px;
+  color: #434d59;
+  bottom: 50%;
+  -webkit-transform: translateY(50%);
+  -ms-transform: translateY(50%);
+  transform: translateY(50%);
+  pointer-events: none;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      className="c1 "
       color="black"
-      style="display:block"
+      style={
+        Object {
+          "display": "block",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
+        className=""
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          className="c2"
         >
           Month range
         </span>
       </div>
     </label>
     <div
-      class="Box-sc-1qu1edy-0 iyjdMT"
+      className="c3"
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-month-picker"
+        className="c4 nds-month-picker"
         data-testid="month-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select a start date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="Mon YYYY"
+                  required={false}
                   value="Jul 2019"
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -771,49 +1887,57 @@ exports[`Storyshots MonthRange with custom error 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hYUuLW"
+        className="c9"
       >
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c10 c11"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           -
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB nds-month-picker"
+        className="c4 nds-month-picker"
         data-testid="month-picker"
       >
         <div
-          class="react-datepicker-wrapper"
+          className="react-datepicker-wrapper"
         >
           <div
-            class="react-datepicker__input-container"
+            className="react-datepicker__input-container"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+              className="c5"
             >
               <div
-                class="Box-sc-1qu1edy-0 hxUhcg"
+                className="c6"
                 display="flex"
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select an end date"
-                  aria-required="false"
-                  class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                  aria-required={false}
+                  className="c7"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="Mon YYYY"
+                  required={false}
                   value="Sep 2019"
                 />
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  aria-hidden={true}
+                  className="c8"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="16px"
                   icon="calendarToday"
+                  size="16px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="16px"
                 >
@@ -828,18 +1952,20 @@ exports[`Storyshots MonthRange with custom error 1`] = `
       </div>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 bXREHd"
+      className="c12"
       color="red"
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 QuoIa"
+        aria-hidden={true}
+        className="c13"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="error"
         mr="x1"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -848,12 +1974,13 @@ exports[`Storyshots MonthRange with custom error 1`] = `
         />
       </svg>
       <div
-        class="InlineValidation__Wrapper-sc-1jic7dw-0 kqhCKM"
+        className="c14"
       >
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c10 c11"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           This range conflicts with another range
         </p>

--- a/components/src/NavBar/__snapshots__/NavBar.story.storyshot
+++ b/components/src/NavBar/__snapshots__/NavBar.story.storyshot
@@ -1,35 +1,381 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots NavBar NavBar 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c12 {
+  margin-right: 8px;
+  max-width: 18em;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-content: flex-end;
+  -ms-flex-line-pack: end;
+  align-content: flex-end;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c9 {
+  padding: 2px;
+  color: #ffffff;
+  min-width: 20px;
+}
+
+.c18 {
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c3 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
+.c4 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding: 2px 0;
+}
+
+.c14 {
+  width: 100%;
+}
+
+.c17 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c17:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c17:focus ~ svg {
+  fill: #00438f;
+}
+
+.c17::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c17::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c17:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c17::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c13 {
+  background: #e1ebfa;
+  border-radius: 4px;
+  height: 40px;
+  min-width: 7em;
+  width: 100%;
+}
+
+.c13 button {
+  padding: 7px;
+  color: #122b47;
+  background: transparent;
+  border: solid 1px transparent;
+  border-radius: 4px;
+  min-width: 40px;
+}
+
+.c13 button:focus {
+  color: #ffffff;
+  background: #1254c7;
+  border: solid 1px #e1ebfa;
+  outline: none;
+  box-shadow: none;
+}
+
+.c13 button svg {
+  display: block;
+}
+
+.c13 Input {
+  color: #122b47;
+  background: transparent;
+  border: solid 1px transparent;
+  border-radius: 4px;
+}
+
+.c13 Input:focus {
+  background: #ffffff;
+  border: solid 1px transparent;
+  box-shadow: none;
+}
+
+.c13 Input::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c13 Input::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c13 Input:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c13 Input::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c13 Input[type='search'] {
+  -webkit-appearance: textfield;
+}
+
+.c13 Input[type='search']::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  color: #ffffff;
+  border: none;
+  background-color: transparent;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  line-height: 1.5;
+  -webkit-transition: background-color .2s;
+  transition: background-color .2s;
+  font-size: 16px;
+  padding: 8px 28px 8px 16px;
+  border-radius: 4px;
+}
+
+.c8:hover,
+.c8:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c8:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c8:disabled {
+  opacity: .5;
+}
+
+.c10 {
+  display: block;
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: none;
+  background-color: transparent;
+  vertical-align: middle;
+  line-height: 1.5;
+  font-size: 16px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c10:hover,
+.c10:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c10:disabled {
+  opacity: .5;
+}
+
+.c10:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c7 div:not(:last-of-type) {
+  margin-right: 8px;
+}
+
+.c2 {
+  background-color: #122b47;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: #122b47;
+  padding: 16px 24px;
+}
+
+.c1 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="NavBarstory__ResetStorybookView-hsfjc-0 jahzXr"
+      className="c1"
     >
       <header
-        class="NavBar-iayrjp-3 bwrKUV"
+        className=""
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 NavBar__NavBarBackground-iayrjp-0 btupnB"
+          className="c2"
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 clvBNI"
+            className="c3"
             color="blue"
-            font-size="medium"
+            fontSize="medium"
             href="/"
-            style="display:block;height:40px"
+            style={
+              Object {
+                "display": "block",
+                "height": "40px",
+              }
+            }
           >
             <div
-              class="Branding__BrandingWrap-ranqri-0 gACiZG Branding-ranqri-2 kQRWHN"
+              className="c4 "
+              size="medium"
             >
               <svg
                 height="32px"
-                style="display:block;margin:2px 0"
+                style={
+                  Object {
+                    "display": "block",
+                    "margin": "2px 0",
+                  }
+                }
                 viewBox="0 0 133 32"
                 width="133px"
               >
@@ -65,33 +411,52 @@ exports[`Storyshots NavBar NavBar 1`] = `
             </div>
           </a>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 cDPANM"
-            style="flex-grow:1;margin:0 0 0 24px"
+            className="c5"
+            style={
+              Object {
+                "flexGrow": "1",
+                "margin": "0 0 0 24px",
+              }
+            }
           >
             <nav
               aria-label="Primary navigation"
-              class="DesktopMenu__Nav-e4dzdq-3 bWwdcq DesktopMenu-e4dzdq-4 irbObu"
-              style="padding-right:24px"
+              className="c6 c7"
+              style={
+                Object {
+                  "paddingRight": "24px",
+                }
+              }
             >
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c8"
                   color="#ffffff"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Dashboard
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    aria-hidden={true}
+                    className="c9"
                     color="#ffffff"
                     fill="#ffffff"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -103,23 +468,33 @@ exports[`Storyshots NavBar NavBar 1`] = `
               </div>
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c8"
                   color="#ffffff"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Inspector
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    aria-hidden={true}
+                    className="c9"
                     color="#ffffff"
                     fill="#ffffff"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -131,23 +506,33 @@ exports[`Storyshots NavBar NavBar 1`] = `
               </div>
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c8"
                   color="#ffffff"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Operations
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    aria-hidden={true}
+                    className="c9"
                     color="#ffffff"
                     fill="#ffffff"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -159,7 +544,7 @@ exports[`Storyshots NavBar NavBar 1`] = `
               </div>
               <div>
                 <a
-                  class="DesktopMenu__MenuLink-e4dzdq-1 kgAySz"
+                  className="c10"
                   color="#ffffff"
                   href="/"
                 >
@@ -168,37 +553,43 @@ exports[`Storyshots NavBar NavBar 1`] = `
               </div>
             </nav>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
-              style="float:right"
+              className="c11"
+              style={
+                Object {
+                  "float": "right",
+                }
+              }
             >
               <div
-                class="Box-sc-1qu1edy-0 eBpgUm"
+                className="c12"
               >
                 <form
-                  class="NavBarSearch-sc-1aq0npd-0 lfszCe"
+                  className="c13"
+                  onSubmit={[Function]}
                 >
                   <div
-                    class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+                    className="c11"
                     role="search"
                   >
                     <div
-                      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+                      className="c14"
                     >
                       <div
-                        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+                        className="c15"
                       >
                         <div
-                          class="Box-sc-1qu1edy-0 hxUhcg"
+                          className="c16"
                           display="flex"
                         >
                           <input
-                            aria-invalid="false"
+                            aria-invalid={false}
                             aria-labelledby="global-search"
-                            aria-required="true"
-                            class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                            aria-required={true}
+                            className="c17"
+                            disabled={false}
                             id="navbar-search"
                             placeholder="Search Nulogy..."
-                            required=""
+                            required={true}
                             type="search"
                           />
                         </div>
@@ -209,13 +600,15 @@ exports[`Storyshots NavBar NavBar 1`] = `
                       id="global-search"
                     >
                       <svg
-                        aria-hidden="true"
-                        class="Icon-fc7twp-0 dkBAgY"
+                        aria-hidden={true}
+                        className="c18"
                         color="currentColor"
                         fill="currentColor"
-                        focusable="false"
+                        focusable={false}
                         height="24px"
                         icon="search"
+                        size="24px"
+                        title={null}
                         viewBox="0 0 24 24"
                         width="24px"
                       >
@@ -229,27 +622,37 @@ exports[`Storyshots NavBar NavBar 1`] = `
               </div>
               <nav
                 aria-label="Secondary navigation"
-                class="DesktopMenu__Nav-e4dzdq-3 bWwdcq DesktopMenu-e4dzdq-4 irbObu"
+                className="c6 c7"
               >
                 <div>
                   <button
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="c8"
                     color="#ffffff"
+                    onBlur={[Function]}
+                    onClick={[Function]}
                     type="button"
                   >
                     User@Nulogy.com
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 hIxIEB"
+                      aria-hidden={true}
+                      className="c9"
                       color="#ffffff"
                       fill="#ffffff"
-                      focusable="false"
+                      focusable={false}
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px;right:8px"
+                      size="20px"
+                      style={
+                        Object {
+                          "position": "absolute",
+                          "right": "8px",
+                          "top": "11px",
+                        }
+                      }
+                      title={null}
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -261,23 +664,33 @@ exports[`Storyshots NavBar NavBar 1`] = `
                 </div>
                 <div>
                   <button
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="c8"
                     color="#ffffff"
+                    onBlur={[Function]}
+                    onClick={[Function]}
                     type="button"
                   >
                     Settings
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 hIxIEB"
+                      aria-hidden={true}
+                      className="c9"
                       color="#ffffff"
                       fill="#ffffff"
-                      focusable="false"
+                      focusable={false}
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px;right:8px"
+                      size="20px"
+                      style={
+                        Object {
+                          "position": "absolute",
+                          "right": "8px",
+                          "top": "11px",
+                        }
+                      }
+                      title={null}
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -298,35 +711,304 @@ exports[`Storyshots NavBar NavBar 1`] = `
 `;
 
 exports[`Storyshots NavBar With alternate themeColor 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c5 {
+  padding-top: 2px;
+  padding-bottom: 2px;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-content: flex-end;
+  -ms-flex-line-pack: end;
+  align-content: flex-end;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c11 {
+  padding: 2px;
+  color: #00438f;
+  min-width: 20px;
+}
+
+.c3 {
+  color: #216beb;
+  margin-top: -8px;
+  margin-bottom: -8px;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
+.c6 {
+  color: #0E77D2;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 500;
+  -webkit-letter-spacing: 0.0333em;
+  -moz-letter-spacing: 0.0333em;
+  -ms-letter-spacing: 0.0333em;
+  letter-spacing: 0.0333em;
+  text-transform: uppercase;
+  font-size: 11px;
+  line-height: 12px;
+  white-space: nowrap;
+}
+
+.c6 active {
+  color: #0E77D2;
+}
+
+.c6 visited {
+  color: #0E77D2;
+}
+
+.c4 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding: 2px 0;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  color: #00438f;
+  border: none;
+  background-color: transparent;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  line-height: 1.5;
+  -webkit-transition: background-color .2s;
+  transition: background-color .2s;
+  font-size: 16px;
+  padding: 8px 28px 8px 16px;
+  border-radius: 4px;
+}
+
+.c10:hover,
+.c10:focus {
+  outline: none;
+  color: #122b47;
+  background-color: #f0f2f5;
+  cursor: pointer;
+}
+
+.c10:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c10:disabled {
+  opacity: .5;
+}
+
+.c13 * {
+  display: block;
+  color: #00438f;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: none;
+  background-color: transparent;
+  vertical-align: middle;
+  line-height: 1.5;
+  font-size: 16px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c13 *:hover,
+.c13 *:focus {
+  outline: none;
+  color: #122b47;
+  background-color: #f0f2f5;
+  cursor: pointer;
+}
+
+.c13 *:disabled {
+  opacity: .5;
+}
+
+.c13 *:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c12 {
+  display: block;
+  color: #00438f;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: none;
+  background-color: transparent;
+  vertical-align: middle;
+  line-height: 1.5;
+  font-size: 16px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c12:hover,
+.c12:focus {
+  outline: none;
+  color: #122b47;
+  background-color: #f0f2f5;
+  cursor: pointer;
+}
+
+.c12:disabled {
+  opacity: .5;
+}
+
+.c12:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c9 div:not(:last-of-type) {
+  margin-right: 8px;
+}
+
+.c2 {
+  background-color: #ffffff;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: #ffffff;
+  padding: 16px 24px;
+}
+
+.c1 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="NavBarstory__ResetStorybookView-hsfjc-0 jahzXr"
+      className="c1"
     >
       <header
-        class="NavBar-iayrjp-3 bwrKUV"
+        className=""
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 NavBar__NavBarBackground-iayrjp-0 hHesXB"
+          className="Box-sc-1qu1edy-0 c2"
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 egQWMc"
+            className="c3"
             color="blue"
-            font-size="medium"
+            fontSize="medium"
             href="/"
-            style="display:block;height:56px"
+            style={
+              Object {
+                "display": "block",
+                "height": "56px",
+              }
+            }
           >
             <div
-              class="Branding__BrandingWrap-ranqri-0 gACiZG Branding-ranqri-2 kQRWHN"
+              className="c4 "
+              size="medium"
             >
               <svg
                 height="32px"
-                style="display:block;margin:2px 0"
+                style={
+                  Object {
+                    "display": "block",
+                    "margin": "2px 0",
+                  }
+                }
                 viewBox="0 0 133 32"
                 width="133px"
               >
@@ -360,12 +1042,18 @@ exports[`Storyshots NavBar With alternate themeColor 1`] = `
                 </g>
               </svg>
               <div
-                class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hfSUkz"
+                className="Box-sc-1qu1edy-0 c5"
                 width="100%"
               >
                 <span
-                  class="BrandingText-nluvkd-0 TxcJr"
-                  style="margin-left:;margin-right:4px"
+                  className="c6"
+                  size="medium"
+                  style={
+                    Object {
+                      "marginLeft": false,
+                      "marginRight": "4px",
+                    }
+                  }
                 >
                   Logo Subtext
                 </span>
@@ -373,33 +1061,52 @@ exports[`Storyshots NavBar With alternate themeColor 1`] = `
             </div>
           </a>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 cDPANM"
-            style="flex-grow:1;margin:0 0 0 24px"
+            className="Box-sc-1qu1edy-0 c7"
+            style={
+              Object {
+                "flexGrow": "1",
+                "margin": "0 0 0 24px",
+              }
+            }
           >
             <nav
               aria-label="Primary navigation"
-              class="DesktopMenu__Nav-e4dzdq-3 bWwdcq DesktopMenu-e4dzdq-4 irbObu"
-              style="padding-right:24px"
+              className="c8 c9"
+              style={
+                Object {
+                  "paddingRight": "24px",
+                }
+              }
             >
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 dZyBSn"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c10"
                   color="#00438f"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Dashboard
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 ldBYos"
+                    aria-hidden={true}
+                    className="c11"
                     color="#00438f"
                     fill="#00438f"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -411,7 +1118,7 @@ exports[`Storyshots NavBar With alternate themeColor 1`] = `
               </div>
               <div>
                 <a
-                  class="DesktopMenu__MenuLink-e4dzdq-1 jvufSB"
+                  className="c12"
                   color="#00438f"
                   href="/"
                 >
@@ -419,7 +1126,7 @@ exports[`Storyshots NavBar With alternate themeColor 1`] = `
                 </a>
               </div>
               <div
-                class="DesktopMenu__ApplyMenuLinkStyles-e4dzdq-0 eWgLiw"
+                className="c13"
                 color="#00438f"
               >
                 <a
@@ -430,8 +1137,12 @@ exports[`Storyshots NavBar With alternate themeColor 1`] = `
               </div>
             </nav>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
-              style="float:right"
+              className="Box-sc-1qu1edy-0 c14"
+              style={
+                Object {
+                  "float": "right",
+                }
+              }
             />
           </div>
         </div>
@@ -442,35 +1153,265 @@ exports[`Storyshots NavBar With alternate themeColor 1`] = `
 `;
 
 exports[`Storyshots NavBar With alternative branding link 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-content: flex-end;
+  -ms-flex-line-pack: end;
+  align-content: flex-end;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c9 {
+  padding: 2px;
+  color: #ffffff;
+  min-width: 20px;
+}
+
+.c3 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
+.c4 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding: 2px 0;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  color: #ffffff;
+  border: none;
+  background-color: transparent;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  line-height: 1.5;
+  -webkit-transition: background-color .2s;
+  transition: background-color .2s;
+  font-size: 16px;
+  padding: 8px 28px 8px 16px;
+  border-radius: 4px;
+}
+
+.c8:hover,
+.c8:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c8:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c8:disabled {
+  opacity: .5;
+}
+
+.c11 * {
+  display: block;
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: none;
+  background-color: transparent;
+  vertical-align: middle;
+  line-height: 1.5;
+  font-size: 16px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c11 *:hover,
+.c11 *:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c11 *:disabled {
+  opacity: .5;
+}
+
+.c11 *:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c10 {
+  display: block;
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: none;
+  background-color: transparent;
+  vertical-align: middle;
+  line-height: 1.5;
+  font-size: 16px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c10:hover,
+.c10:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c10:disabled {
+  opacity: .5;
+}
+
+.c10:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c7 div:not(:last-of-type) {
+  margin-right: 8px;
+}
+
+.c2 {
+  background-color: #122b47;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: #122b47;
+  padding: 16px 24px;
+}
+
+.c1 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="NavBarstory__ResetStorybookView-hsfjc-0 jahzXr"
+      className="c1"
     >
       <header
-        class="NavBar-iayrjp-3 bwrKUV"
+        className=""
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 NavBar__NavBarBackground-iayrjp-0 btupnB"
+          className="Box-sc-1qu1edy-0 c2"
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 clvBNI"
+            className="c3"
             color="blue"
-            font-size="medium"
+            fontSize="medium"
             href="/portal"
-            style="display:block;height:40px"
+            style={
+              Object {
+                "display": "block",
+                "height": "40px",
+              }
+            }
           >
             <div
-              class="Branding__BrandingWrap-ranqri-0 gACiZG Branding-ranqri-2 kQRWHN"
+              className="c4 "
+              size="medium"
             >
               <svg
                 height="32px"
-                style="display:block;margin:2px 0"
+                style={
+                  Object {
+                    "display": "block",
+                    "margin": "2px 0",
+                  }
+                }
                 viewBox="0 0 133 32"
                 width="133px"
               >
@@ -506,33 +1447,52 @@ exports[`Storyshots NavBar With alternative branding link 1`] = `
             </div>
           </a>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 cDPANM"
-            style="flex-grow:1;margin:0 0 0 24px"
+            className="Box-sc-1qu1edy-0 c5"
+            style={
+              Object {
+                "flexGrow": "1",
+                "margin": "0 0 0 24px",
+              }
+            }
           >
             <nav
               aria-label="Primary navigation"
-              class="DesktopMenu__Nav-e4dzdq-3 bWwdcq DesktopMenu-e4dzdq-4 irbObu"
-              style="padding-right:24px"
+              className="c6 c7"
+              style={
+                Object {
+                  "paddingRight": "24px",
+                }
+              }
             >
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c8"
                   color="#ffffff"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Dashboard
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    aria-hidden={true}
+                    className="c9"
                     color="#ffffff"
                     fill="#ffffff"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -544,7 +1504,7 @@ exports[`Storyshots NavBar With alternative branding link 1`] = `
               </div>
               <div>
                 <a
-                  class="DesktopMenu__MenuLink-e4dzdq-1 kgAySz"
+                  className="c10"
                   color="#ffffff"
                   href="/"
                 >
@@ -552,7 +1512,7 @@ exports[`Storyshots NavBar With alternative branding link 1`] = `
                 </a>
               </div>
               <div
-                class="DesktopMenu__ApplyMenuLinkStyles-e4dzdq-0 cMjXYC"
+                className="c11"
                 color="#ffffff"
               >
                 <a
@@ -563,8 +1523,12 @@ exports[`Storyshots NavBar With alternative branding link 1`] = `
               </div>
             </nav>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
-              style="float:right"
+              className="Box-sc-1qu1edy-0 c12"
+              style={
+                Object {
+                  "float": "right",
+                }
+              }
             />
           </div>
         </div>
@@ -575,35 +1539,145 @@ exports[`Storyshots NavBar With alternative branding link 1`] = `
 `;
 
 exports[`Storyshots NavBar With branding only 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-content: flex-end;
+  -ms-flex-line-pack: end;
+  align-content: flex-end;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
+.c4 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding: 2px 0;
+}
+
+.c2 {
+  background-color: #122b47;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: #122b47;
+  padding: 16px 24px;
+}
+
+.c1 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="NavBarstory__ResetStorybookView-hsfjc-0 jahzXr"
+      className="c1"
     >
       <header
-        class="NavBar-iayrjp-3 bwrKUV"
+        className=""
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 NavBar__NavBarBackground-iayrjp-0 btupnB"
+          className="Box-sc-1qu1edy-0 c2"
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 clvBNI"
+            className="c3"
             color="blue"
-            font-size="medium"
+            fontSize="medium"
             href="/"
-            style="display:block;height:40px"
+            style={
+              Object {
+                "display": "block",
+                "height": "40px",
+              }
+            }
           >
             <div
-              class="Branding__BrandingWrap-ranqri-0 gACiZG Branding-ranqri-2 kQRWHN"
+              className="c4 "
+              size="medium"
             >
               <svg
                 height="32px"
-                style="display:block;margin:2px 0"
+                style={
+                  Object {
+                    "display": "block",
+                    "margin": "2px 0",
+                  }
+                }
                 viewBox="0 0 133 32"
                 width="133px"
               >
@@ -639,12 +1713,21 @@ exports[`Storyshots NavBar With branding only 1`] = `
             </div>
           </a>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 cDPANM"
-            style="flex-grow:1;margin:0 0 0 24px"
+            className="Box-sc-1qu1edy-0 c5"
+            style={
+              Object {
+                "flexGrow": "1",
+                "margin": "0 0 0 24px",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
-              style="float:right"
+              className="Box-sc-1qu1edy-0 c6"
+              style={
+                Object {
+                  "float": "right",
+                }
+              }
             />
           </div>
         </div>
@@ -655,35 +1738,413 @@ exports[`Storyshots NavBar With branding only 1`] = `
 `;
 
 exports[`Storyshots NavBar With custom link components 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c13 {
+  margin-right: 8px;
+  max-width: 18em;
+}
+
+.c17 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-content: flex-end;
+  -ms-flex-line-pack: end;
+  align-content: flex-end;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c9 {
+  padding: 2px;
+  color: #ffffff;
+  min-width: 20px;
+}
+
+.c19 {
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c3 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
+.c4 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding: 2px 0;
+}
+
+.c15 {
+  width: 100%;
+}
+
+.c18 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c18:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c18:focus ~ svg {
+  fill: #00438f;
+}
+
+.c18::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c18::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c18:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c18::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c14 {
+  background: #e1ebfa;
+  border-radius: 4px;
+  height: 40px;
+  min-width: 7em;
+  width: 100%;
+}
+
+.c14 button {
+  padding: 7px;
+  color: #122b47;
+  background: transparent;
+  border: solid 1px transparent;
+  border-radius: 4px;
+  min-width: 40px;
+}
+
+.c14 button:focus {
+  color: #ffffff;
+  background: #1254c7;
+  border: solid 1px #e1ebfa;
+  outline: none;
+  box-shadow: none;
+}
+
+.c14 button svg {
+  display: block;
+}
+
+.c14 Input {
+  color: #122b47;
+  background: transparent;
+  border: solid 1px transparent;
+  border-radius: 4px;
+}
+
+.c14 Input:focus {
+  background: #ffffff;
+  border: solid 1px transparent;
+  box-shadow: none;
+}
+
+.c14 Input::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c14 Input::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c14 Input:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c14 Input::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c14 Input[type='search'] {
+  -webkit-appearance: textfield;
+}
+
+.c14 Input[type='search']::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  color: #ffffff;
+  border: none;
+  background-color: transparent;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  line-height: 1.5;
+  -webkit-transition: background-color .2s;
+  transition: background-color .2s;
+  font-size: 16px;
+  padding: 8px 28px 8px 16px;
+  border-radius: 4px;
+}
+
+.c8:hover,
+.c8:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c8:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c8:disabled {
+  opacity: .5;
+}
+
+.c11 * {
+  display: block;
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: none;
+  background-color: transparent;
+  vertical-align: middle;
+  line-height: 1.5;
+  font-size: 16px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c11 *:hover,
+.c11 *:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c11 *:disabled {
+  opacity: .5;
+}
+
+.c11 *:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c10 {
+  display: block;
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: none;
+  background-color: transparent;
+  vertical-align: middle;
+  line-height: 1.5;
+  font-size: 16px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c10:hover,
+.c10:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c10:disabled {
+  opacity: .5;
+}
+
+.c10:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c7 div:not(:last-of-type) {
+  margin-right: 8px;
+}
+
+.c2 {
+  background-color: #122b47;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: #122b47;
+  padding: 16px 24px;
+}
+
+.c1 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="NavBarstory__ResetStorybookView-hsfjc-0 jahzXr"
+      className="c1"
     >
       <header
-        class="NavBar-iayrjp-3 bwrKUV"
+        className=""
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 NavBar__NavBarBackground-iayrjp-0 btupnB"
+          className="c2"
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 clvBNI"
+            className="c3"
             color="blue"
-            font-size="medium"
+            fontSize="medium"
             href="/"
-            style="display:block;height:40px"
+            style={
+              Object {
+                "display": "block",
+                "height": "40px",
+              }
+            }
           >
             <div
-              class="Branding__BrandingWrap-ranqri-0 gACiZG Branding-ranqri-2 kQRWHN"
+              className="c4 "
+              size="medium"
             >
               <svg
                 height="32px"
-                style="display:block;margin:2px 0"
+                style={
+                  Object {
+                    "display": "block",
+                    "margin": "2px 0",
+                  }
+                }
                 viewBox="0 0 133 32"
                 width="133px"
               >
@@ -719,33 +2180,52 @@ exports[`Storyshots NavBar With custom link components 1`] = `
             </div>
           </a>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 cDPANM"
-            style="flex-grow:1;margin:0 0 0 24px"
+            className="c5"
+            style={
+              Object {
+                "flexGrow": "1",
+                "margin": "0 0 0 24px",
+              }
+            }
           >
             <nav
               aria-label="Primary navigation"
-              class="DesktopMenu__Nav-e4dzdq-3 bWwdcq DesktopMenu-e4dzdq-4 irbObu"
-              style="padding-right:24px"
+              className="c6 c7"
+              style={
+                Object {
+                  "paddingRight": "24px",
+                }
+              }
             >
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c8"
                   color="#ffffff"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Dashboard
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    aria-hidden={true}
+                    className="c9"
                     color="#ffffff"
                     fill="#ffffff"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -757,7 +2237,7 @@ exports[`Storyshots NavBar With custom link components 1`] = `
               </div>
               <div>
                 <a
-                  class="DesktopMenu__MenuLink-e4dzdq-1 kgAySz"
+                  className="c10"
                   color="#ffffff"
                   href="/"
                 >
@@ -765,7 +2245,7 @@ exports[`Storyshots NavBar With custom link components 1`] = `
                 </a>
               </div>
               <div
-                class="DesktopMenu__ApplyMenuLinkStyles-e4dzdq-0 cMjXYC"
+                className="c11"
                 color="#ffffff"
               >
                 <a
@@ -776,37 +2256,43 @@ exports[`Storyshots NavBar With custom link components 1`] = `
               </div>
             </nav>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
-              style="float:right"
+              className="c12"
+              style={
+                Object {
+                  "float": "right",
+                }
+              }
             >
               <div
-                class="Box-sc-1qu1edy-0 eBpgUm"
+                className="c13"
               >
                 <form
-                  class="NavBarSearch-sc-1aq0npd-0 lfszCe"
+                  className="c14"
+                  onSubmit={[Function]}
                 >
                   <div
-                    class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+                    className="c12"
                     role="search"
                   >
                     <div
-                      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+                      className="c15"
                     >
                       <div
-                        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+                        className="c16"
                       >
                         <div
-                          class="Box-sc-1qu1edy-0 hxUhcg"
+                          className="c17"
                           display="flex"
                         >
                           <input
-                            aria-invalid="false"
+                            aria-invalid={false}
                             aria-labelledby="global-search"
-                            aria-required="true"
-                            class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                            aria-required={true}
+                            className="c18"
+                            disabled={false}
                             id="navbar-search"
                             placeholder="Search Nulogy..."
-                            required=""
+                            required={true}
                             type="search"
                           />
                         </div>
@@ -817,13 +2303,15 @@ exports[`Storyshots NavBar With custom link components 1`] = `
                       id="global-search"
                     >
                       <svg
-                        aria-hidden="true"
-                        class="Icon-fc7twp-0 dkBAgY"
+                        aria-hidden={true}
+                        className="c19"
                         color="currentColor"
                         fill="currentColor"
-                        focusable="false"
+                        focusable={false}
                         height="24px"
                         icon="search"
+                        size="24px"
+                        title={null}
                         viewBox="0 0 24 24"
                         width="24px"
                       >
@@ -837,27 +2325,37 @@ exports[`Storyshots NavBar With custom link components 1`] = `
               </div>
               <nav
                 aria-label="Secondary navigation"
-                class="DesktopMenu__Nav-e4dzdq-3 bWwdcq DesktopMenu-e4dzdq-4 irbObu"
+                className="c6 c7"
               >
                 <div>
                   <button
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="c8"
                     color="#ffffff"
+                    onBlur={[Function]}
+                    onClick={[Function]}
                     type="button"
                   >
                     User@Nulogy.com
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 hIxIEB"
+                      aria-hidden={true}
+                      className="c9"
                       color="#ffffff"
                       fill="#ffffff"
-                      focusable="false"
+                      focusable={false}
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px;right:8px"
+                      size="20px"
+                      style={
+                        Object {
+                          "position": "absolute",
+                          "right": "8px",
+                          "top": "11px",
+                        }
+                      }
+                      title={null}
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -869,21 +2367,25 @@ exports[`Storyshots NavBar With custom link components 1`] = `
                 </div>
                 <div>
                   <button
-                    aria-expanded="false"
-                    aria-haspopup="true"
+                    aria-expanded={false}
+                    aria-haspopup={true}
                     aria-label="Settings"
-                    class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                    className="c8"
                     color="#ffffff"
+                    onBlur={[Function]}
+                    onClick={[Function]}
                     type="button"
                   >
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 dkBAgY"
+                      aria-hidden={true}
+                      className="c19"
                       color="currentColor"
                       fill="currentColor"
-                      focusable="false"
+                      focusable={false}
                       height="24px"
                       icon="settings"
+                      size="24px"
+                      title={null}
                       viewBox="0 0 20 20"
                       width="24px"
                     >
@@ -892,15 +2394,23 @@ exports[`Storyshots NavBar With custom link components 1`] = `
                       />
                     </svg>
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 hIxIEB"
+                      aria-hidden={true}
+                      className="c9"
                       color="#ffffff"
                       fill="#ffffff"
-                      focusable="false"
+                      focusable={false}
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px;right:8px"
+                      size="20px"
+                      style={
+                        Object {
+                          "position": "absolute",
+                          "right": "8px",
+                          "top": "11px",
+                        }
+                      }
+                      title={null}
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -921,35 +2431,452 @@ exports[`Storyshots NavBar With custom link components 1`] = `
 `;
 
 exports[`Storyshots NavBar With subtext 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c15 {
+  margin-right: 0px;
+  max-width: 18em;
+}
+
+.c19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  padding-top: 2px;
+  padding-bottom: 2px;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-content: flex-end;
+  -ms-flex-line-pack: end;
+  align-content: flex-end;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c11 {
+  padding: 2px;
+  color: #ffffff;
+  min-width: 20px;
+}
+
+.c21 {
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c3 {
+  color: #216beb;
+  margin-top: -8px;
+  margin-bottom: -8px;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
+.c6 {
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 500;
+  -webkit-letter-spacing: 0.0333em;
+  -moz-letter-spacing: 0.0333em;
+  -ms-letter-spacing: 0.0333em;
+  letter-spacing: 0.0333em;
+  text-transform: uppercase;
+  font-size: 11px;
+  line-height: 12px;
+  white-space: nowrap;
+}
+
+.c6 active {
+  color: #ffffff;
+}
+
+.c6 visited {
+  color: #ffffff;
+}
+
+.c4 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding: 2px 0;
+}
+
+.c17 {
+  width: 100%;
+}
+
+.c20 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c20:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c20:focus ~ svg {
+  fill: #00438f;
+}
+
+.c20::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c20::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c20:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c20::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c16 {
+  background: #e1ebfa;
+  border-radius: 4px;
+  height: 40px;
+  min-width: 7em;
+  width: 100%;
+}
+
+.c16 button {
+  padding: 7px;
+  color: #122b47;
+  background: transparent;
+  border: solid 1px transparent;
+  border-radius: 4px;
+  min-width: 40px;
+}
+
+.c16 button:focus {
+  color: #ffffff;
+  background: #1254c7;
+  border: solid 1px #e1ebfa;
+  outline: none;
+  box-shadow: none;
+}
+
+.c16 button svg {
+  display: block;
+}
+
+.c16 Input {
+  color: #122b47;
+  background: transparent;
+  border: solid 1px transparent;
+  border-radius: 4px;
+}
+
+.c16 Input:focus {
+  background: #ffffff;
+  border: solid 1px transparent;
+  box-shadow: none;
+}
+
+.c16 Input::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c16 Input::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c16 Input:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c16 Input::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c16 Input[type='search'] {
+  -webkit-appearance: textfield;
+}
+
+.c16 Input[type='search']::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  color: #ffffff;
+  border: none;
+  background-color: transparent;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  line-height: 1.5;
+  -webkit-transition: background-color .2s;
+  transition: background-color .2s;
+  font-size: 16px;
+  padding: 8px 28px 8px 16px;
+  border-radius: 4px;
+}
+
+.c10:hover,
+.c10:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c10:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c10:disabled {
+  opacity: .5;
+}
+
+.c13 * {
+  display: block;
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: none;
+  background-color: transparent;
+  vertical-align: middle;
+  line-height: 1.5;
+  font-size: 16px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c13 *:hover,
+.c13 *:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c13 *:disabled {
+  opacity: .5;
+}
+
+.c13 *:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c12 {
+  display: block;
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: none;
+  background-color: transparent;
+  vertical-align: middle;
+  line-height: 1.5;
+  font-size: 16px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c12:hover,
+.c12:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c12:disabled {
+  opacity: .5;
+}
+
+.c12:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c9 div:not(:last-of-type) {
+  margin-right: 8px;
+}
+
+.c2 {
+  background-color: #122b47;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: #122b47;
+  padding: 16px 24px;
+}
+
+.c1 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="NavBarstory__ResetStorybookView-hsfjc-0 jahzXr"
+      className="c1"
     >
       <header
-        class="NavBar-iayrjp-3 bwrKUV"
+        className=""
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 NavBar__NavBarBackground-iayrjp-0 btupnB"
+          className="c2"
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 egQWMc"
+            className="c3"
             color="blue"
-            font-size="medium"
+            fontSize="medium"
             href="/"
-            style="display:block;height:56px"
+            style={
+              Object {
+                "display": "block",
+                "height": "56px",
+              }
+            }
           >
             <div
-              class="Branding__BrandingWrap-ranqri-0 gACiZG Branding-ranqri-2 kQRWHN"
+              className="c4 "
+              size="medium"
             >
               <svg
                 height="32px"
-                style="display:block;margin:2px 0"
+                style={
+                  Object {
+                    "display": "block",
+                    "margin": "2px 0",
+                  }
+                }
                 viewBox="0 0 133 32"
                 width="133px"
               >
@@ -983,12 +2910,18 @@ exports[`Storyshots NavBar With subtext 1`] = `
                 </g>
               </svg>
               <div
-                class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hfSUkz"
+                className="c5"
                 width="100%"
               >
                 <span
-                  class="BrandingText-nluvkd-0 klrjtc"
-                  style="margin-left:;margin-right:4px"
+                  className="c6"
+                  size="medium"
+                  style={
+                    Object {
+                      "marginLeft": false,
+                      "marginRight": "4px",
+                    }
+                  }
                 >
                   Logo Subtext
                 </span>
@@ -996,33 +2929,52 @@ exports[`Storyshots NavBar With subtext 1`] = `
             </div>
           </a>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 cDPANM"
-            style="flex-grow:1;margin:0 0 0 24px"
+            className="c7"
+            style={
+              Object {
+                "flexGrow": "1",
+                "margin": "0 0 0 24px",
+              }
+            }
           >
             <nav
               aria-label="Primary navigation"
-              class="DesktopMenu__Nav-e4dzdq-3 bWwdcq DesktopMenu-e4dzdq-4 irbObu"
-              style="padding-right:24px"
+              className="c8 c9"
+              style={
+                Object {
+                  "paddingRight": "24px",
+                }
+              }
             >
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c10"
                   color="#ffffff"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Dashboard
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    aria-hidden={true}
+                    className="c11"
                     color="#ffffff"
                     fill="#ffffff"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -1034,7 +2986,7 @@ exports[`Storyshots NavBar With subtext 1`] = `
               </div>
               <div>
                 <a
-                  class="DesktopMenu__MenuLink-e4dzdq-1 kgAySz"
+                  className="c12"
                   color="#ffffff"
                   href="/"
                 >
@@ -1042,7 +2994,7 @@ exports[`Storyshots NavBar With subtext 1`] = `
                 </a>
               </div>
               <div
-                class="DesktopMenu__ApplyMenuLinkStyles-e4dzdq-0 cMjXYC"
+                className="c13"
                 color="#ffffff"
               >
                 <a
@@ -1053,37 +3005,43 @@ exports[`Storyshots NavBar With subtext 1`] = `
               </div>
             </nav>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
-              style="float:right"
+              className="c14"
+              style={
+                Object {
+                  "float": "right",
+                }
+              }
             >
               <div
-                class="Box-sc-1qu1edy-0 iByNwK"
+                className="c15"
               >
                 <form
-                  class="NavBarSearch-sc-1aq0npd-0 lfszCe"
+                  className="c16"
+                  onSubmit={[Function]}
                 >
                   <div
-                    class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+                    className="c14"
                     role="search"
                   >
                     <div
-                      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+                      className="c17"
                     >
                       <div
-                        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+                        className="c18"
                       >
                         <div
-                          class="Box-sc-1qu1edy-0 hxUhcg"
+                          className="c19"
                           display="flex"
                         >
                           <input
-                            aria-invalid="false"
+                            aria-invalid={false}
                             aria-labelledby="global-search"
-                            aria-required="true"
-                            class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                            aria-required={true}
+                            className="c20"
+                            disabled={false}
                             id="navbar-search"
                             placeholder="Search Nulogy..."
-                            required=""
+                            required={true}
                             type="search"
                           />
                         </div>
@@ -1094,13 +3052,15 @@ exports[`Storyshots NavBar With subtext 1`] = `
                       id="global-search"
                     >
                       <svg
-                        aria-hidden="true"
-                        class="Icon-fc7twp-0 dkBAgY"
+                        aria-hidden={true}
+                        className="c21"
                         color="currentColor"
                         fill="currentColor"
-                        focusable="false"
+                        focusable={false}
                         height="24px"
                         icon="search"
+                        size="24px"
+                        title={null}
                         viewBox="0 0 24 24"
                         width="24px"
                       >
@@ -1122,35 +3082,247 @@ exports[`Storyshots NavBar With subtext 1`] = `
 `;
 
 exports[`Storyshots NavBar With text in the menu 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-content: flex-end;
+  -ms-flex-line-pack: end;
+  align-content: flex-end;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c9 {
+  padding: 2px;
+  color: #ffffff;
+  min-width: 20px;
+}
+
+.c3 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
+.c4 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding: 2px 0;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  color: #ffffff;
+  border: none;
+  background-color: transparent;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  line-height: 1.5;
+  -webkit-transition: background-color .2s;
+  transition: background-color .2s;
+  font-size: 16px;
+  padding: 8px 28px 8px 16px;
+  border-radius: 4px;
+}
+
+.c8:hover,
+.c8:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c8:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c8:disabled {
+  opacity: .5;
+}
+
+.c10 {
+  display: block;
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: none;
+  background-color: transparent;
+  vertical-align: middle;
+  line-height: 1.5;
+  font-size: 16px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c10:hover,
+.c10:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c10:disabled {
+  opacity: .5;
+}
+
+.c10:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c11 {
+  display: block;
+  color: #c0c8d1;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: none;
+  background-color: transparent;
+  vertical-align: middle;
+  line-height: 1.5;
+  font-size: 16px;
+  padding: 8px 16px;
+  border-radius: 4px;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c7 div:not(:last-of-type) {
+  margin-right: 8px;
+}
+
+.c2 {
+  background-color: #122b47;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: #122b47;
+  padding: 16px 24px;
+}
+
+.c1 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="NavBarstory__ResetStorybookView-hsfjc-0 jahzXr"
+      className="c1"
     >
       <header
-        class="NavBar-iayrjp-3 bwrKUV"
+        className=""
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 NavBar__NavBarBackground-iayrjp-0 btupnB"
+          className="Box-sc-1qu1edy-0 c2"
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 clvBNI"
+            className="c3"
             color="blue"
-            font-size="medium"
+            fontSize="medium"
             href="/"
-            style="display:block;height:40px"
+            style={
+              Object {
+                "display": "block",
+                "height": "40px",
+              }
+            }
           >
             <div
-              class="Branding__BrandingWrap-ranqri-0 gACiZG Branding-ranqri-2 kQRWHN"
+              className="c4 "
+              size="medium"
             >
               <svg
                 height="32px"
-                style="display:block;margin:2px 0"
+                style={
+                  Object {
+                    "display": "block",
+                    "margin": "2px 0",
+                  }
+                }
                 viewBox="0 0 133 32"
                 width="133px"
               >
@@ -1186,33 +3358,52 @@ exports[`Storyshots NavBar With text in the menu 1`] = `
             </div>
           </a>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 cDPANM"
-            style="flex-grow:1;margin:0 0 0 24px"
+            className="Box-sc-1qu1edy-0 c5"
+            style={
+              Object {
+                "flexGrow": "1",
+                "margin": "0 0 0 24px",
+              }
+            }
           >
             <nav
               aria-label="Primary navigation"
-              class="DesktopMenu__Nav-e4dzdq-3 bWwdcq DesktopMenu-e4dzdq-4 irbObu"
-              style="padding-right:24px"
+              className="c6 c7"
+              style={
+                Object {
+                  "paddingRight": "24px",
+                }
+              }
             >
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c8"
                   color="#ffffff"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Dashboard
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    aria-hidden={true}
+                    className="c9"
                     color="#ffffff"
                     fill="#ffffff"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -1224,7 +3415,7 @@ exports[`Storyshots NavBar With text in the menu 1`] = `
               </div>
               <div>
                 <a
-                  class="DesktopMenu__MenuLink-e4dzdq-1 kgAySz"
+                  className="c10"
                   color="#ffffff"
                   href="/"
                 >
@@ -1232,15 +3423,19 @@ exports[`Storyshots NavBar With text in the menu 1`] = `
                 </a>
               </div>
               <div
-                class="DesktopMenu__MenuText-e4dzdq-2 jYyOMA"
+                className="c11"
                 color="#ffffff"
               >
                 Just Text
               </div>
             </nav>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
-              style="float:right"
+              className="Box-sc-1qu1edy-0 c12"
+              style={
+                Object {
+                  "float": "right",
+                }
+              }
             />
           </div>
         </div>
@@ -1251,35 +3446,233 @@ exports[`Storyshots NavBar With text in the menu 1`] = `
 `;
 
 exports[`Storyshots NavBar Without search 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-content: flex-end;
+  -ms-flex-line-pack: end;
+  align-content: flex-end;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c9 {
+  padding: 2px;
+  color: #ffffff;
+  min-width: 20px;
+}
+
+.c3 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
+.c4 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding: 2px 0;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  color: #ffffff;
+  border: none;
+  background-color: transparent;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  line-height: 1.5;
+  -webkit-transition: background-color .2s;
+  transition: background-color .2s;
+  font-size: 16px;
+  padding: 8px 28px 8px 16px;
+  border-radius: 4px;
+}
+
+.c8:hover,
+.c8:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c8:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c8:disabled {
+  opacity: .5;
+}
+
+.c10 {
+  display: block;
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: none;
+  background-color: transparent;
+  vertical-align: middle;
+  line-height: 1.5;
+  font-size: 16px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c10:hover,
+.c10:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c10:disabled {
+  opacity: .5;
+}
+
+.c10:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c7 div:not(:last-of-type) {
+  margin-right: 8px;
+}
+
+.c2 {
+  background-color: #122b47;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: #122b47;
+  padding: 16px 24px;
+}
+
+.c1 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="NavBarstory__ResetStorybookView-hsfjc-0 jahzXr"
+      className="c1"
     >
       <header
-        class="NavBar-iayrjp-3 bwrKUV"
+        className=""
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 NavBar__NavBarBackground-iayrjp-0 btupnB"
+          className="Box-sc-1qu1edy-0 c2"
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 clvBNI"
+            className="c3"
             color="blue"
-            font-size="medium"
+            fontSize="medium"
             href="/"
-            style="display:block;height:40px"
+            style={
+              Object {
+                "display": "block",
+                "height": "40px",
+              }
+            }
           >
             <div
-              class="Branding__BrandingWrap-ranqri-0 gACiZG Branding-ranqri-2 kQRWHN"
+              className="c4 "
+              size="medium"
             >
               <svg
                 height="32px"
-                style="display:block;margin:2px 0"
+                style={
+                  Object {
+                    "display": "block",
+                    "margin": "2px 0",
+                  }
+                }
                 viewBox="0 0 133 32"
                 width="133px"
               >
@@ -1315,33 +3708,52 @@ exports[`Storyshots NavBar Without search 1`] = `
             </div>
           </a>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 cDPANM"
-            style="flex-grow:1;margin:0 0 0 24px"
+            className="Box-sc-1qu1edy-0 c5"
+            style={
+              Object {
+                "flexGrow": "1",
+                "margin": "0 0 0 24px",
+              }
+            }
           >
             <nav
               aria-label="Primary navigation"
-              class="DesktopMenu__Nav-e4dzdq-3 bWwdcq DesktopMenu-e4dzdq-4 irbObu"
-              style="padding-right:24px"
+              className="c6 c7"
+              style={
+                Object {
+                  "paddingRight": "24px",
+                }
+              }
             >
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c8"
                   color="#ffffff"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Dashboard
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    aria-hidden={true}
+                    className="c9"
                     color="#ffffff"
                     fill="#ffffff"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -1353,23 +3765,33 @@ exports[`Storyshots NavBar Without search 1`] = `
               </div>
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c8"
                   color="#ffffff"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Inspector
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    aria-hidden={true}
+                    className="c9"
                     color="#ffffff"
                     fill="#ffffff"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -1381,23 +3803,33 @@ exports[`Storyshots NavBar Without search 1`] = `
               </div>
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c8"
                   color="#ffffff"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Operations
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    aria-hidden={true}
+                    className="c9"
                     color="#ffffff"
                     fill="#ffffff"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -1409,7 +3841,7 @@ exports[`Storyshots NavBar Without search 1`] = `
               </div>
               <div>
                 <a
-                  class="DesktopMenu__MenuLink-e4dzdq-1 kgAySz"
+                  className="c10"
                   color="#ffffff"
                   href="/"
                 >
@@ -1418,32 +3850,46 @@ exports[`Storyshots NavBar Without search 1`] = `
               </div>
             </nav>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
-              style="float:right"
+              className="Box-sc-1qu1edy-0 c11"
+              style={
+                Object {
+                  "float": "right",
+                }
+              }
             >
               <nav
                 aria-label="Secondary navigation"
-                class="DesktopMenu__Nav-e4dzdq-3 bWwdcq DesktopMenu-e4dzdq-4 irbObu"
+                className="c6 c7"
               >
                 <div>
                   <button
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="c8"
                     color="#ffffff"
+                    onBlur={[Function]}
+                    onClick={[Function]}
                     type="button"
                   >
                     User@Nulogy.com
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 hIxIEB"
+                      aria-hidden={true}
+                      className="c9"
                       color="#ffffff"
                       fill="#ffffff"
-                      focusable="false"
+                      focusable={false}
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px;right:8px"
+                      size="20px"
+                      style={
+                        Object {
+                          "position": "absolute",
+                          "right": "8px",
+                          "top": "11px",
+                        }
+                      }
+                      title={null}
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -1455,23 +3901,33 @@ exports[`Storyshots NavBar Without search 1`] = `
                 </div>
                 <div>
                   <button
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="c8"
                     color="#ffffff"
+                    onBlur={[Function]}
+                    onClick={[Function]}
                     type="button"
                   >
                     Settings
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 hIxIEB"
+                      aria-hidden={true}
+                      className="c9"
                       color="#ffffff"
                       fill="#ffffff"
-                      focusable="false"
+                      focusable={false}
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px;right:8px"
+                      size="20px"
+                      style={
+                        Object {
+                          "position": "absolute",
+                          "right": "8px",
+                          "top": "11px",
+                        }
+                      }
+                      title={null}
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -1492,35 +3948,201 @@ exports[`Storyshots NavBar Without search 1`] = `
 `;
 
 exports[`Storyshots NavBar Without search and primary menu 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-content: flex-end;
+  -ms-flex-line-pack: end;
+  align-content: flex-end;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c10 {
+  padding: 2px;
+  color: #ffffff;
+  min-width: 20px;
+}
+
+.c3 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
+.c4 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding: 2px 0;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  color: #ffffff;
+  border: none;
+  background-color: transparent;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  line-height: 1.5;
+  -webkit-transition: background-color .2s;
+  transition: background-color .2s;
+  font-size: 16px;
+  padding: 8px 28px 8px 16px;
+  border-radius: 4px;
+}
+
+.c9:hover,
+.c9:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c9:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c9:disabled {
+  opacity: .5;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c8 div:not(:last-of-type) {
+  margin-right: 8px;
+}
+
+.c2 {
+  background-color: #122b47;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: #122b47;
+  padding: 16px 24px;
+}
+
+.c1 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="NavBarstory__ResetStorybookView-hsfjc-0 jahzXr"
+      className="c1"
     >
       <header
-        class="NavBar-iayrjp-3 bwrKUV"
+        className=""
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 NavBar__NavBarBackground-iayrjp-0 btupnB"
+          className="Box-sc-1qu1edy-0 c2"
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 clvBNI"
+            className="c3"
             color="blue"
-            font-size="medium"
+            fontSize="medium"
             href="/"
-            style="display:block;height:40px"
+            style={
+              Object {
+                "display": "block",
+                "height": "40px",
+              }
+            }
           >
             <div
-              class="Branding__BrandingWrap-ranqri-0 gACiZG Branding-ranqri-2 kQRWHN"
+              className="c4 "
+              size="medium"
             >
               <svg
                 height="32px"
-                style="display:block;margin:2px 0"
+                style={
+                  Object {
+                    "display": "block",
+                    "margin": "2px 0",
+                  }
+                }
                 viewBox="0 0 133 32"
                 width="133px"
               >
@@ -1556,36 +4178,55 @@ exports[`Storyshots NavBar Without search and primary menu 1`] = `
             </div>
           </a>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 cDPANM"
-            style="flex-grow:1;margin:0 0 0 24px"
+            className="Box-sc-1qu1edy-0 c5"
+            style={
+              Object {
+                "flexGrow": "1",
+                "margin": "0 0 0 24px",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
-              style="float:right"
+              className="Box-sc-1qu1edy-0 c6"
+              style={
+                Object {
+                  "float": "right",
+                }
+              }
             >
               <nav
                 aria-label="Secondary navigation"
-                class="DesktopMenu__Nav-e4dzdq-3 bWwdcq DesktopMenu-e4dzdq-4 irbObu"
+                className="c7 c8"
               >
                 <div>
                   <button
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="c9"
                     color="#ffffff"
+                    onBlur={[Function]}
+                    onClick={[Function]}
                     type="button"
                   >
                     User@Nulogy.com
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 hIxIEB"
+                      aria-hidden={true}
+                      className="c10"
                       color="#ffffff"
                       fill="#ffffff"
-                      focusable="false"
+                      focusable={false}
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px;right:8px"
+                      size="20px"
+                      style={
+                        Object {
+                          "position": "absolute",
+                          "right": "8px",
+                          "top": "11px",
+                        }
+                      }
+                      title={null}
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -1597,23 +4238,33 @@ exports[`Storyshots NavBar Without search and primary menu 1`] = `
                 </div>
                 <div>
                   <button
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="c9"
                     color="#ffffff"
+                    onBlur={[Function]}
+                    onClick={[Function]}
                     type="button"
                   >
                     Settings
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 hIxIEB"
+                      aria-hidden={true}
+                      className="c10"
                       color="#ffffff"
                       fill="#ffffff"
-                      focusable="false"
+                      focusable={false}
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px;right:8px"
+                      size="20px"
+                      style={
+                        Object {
+                          "position": "absolute",
+                          "right": "8px",
+                          "top": "11px",
+                        }
+                      }
+                      title={null}
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -1634,35 +4285,233 @@ exports[`Storyshots NavBar Without search and primary menu 1`] = `
 `;
 
 exports[`Storyshots NavBar Without search and secondary menu 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-content: flex-end;
+  -ms-flex-line-pack: end;
+  align-content: flex-end;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c9 {
+  padding: 2px;
+  color: #ffffff;
+  min-width: 20px;
+}
+
+.c3 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
+.c4 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding: 2px 0;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  color: #ffffff;
+  border: none;
+  background-color: transparent;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  line-height: 1.5;
+  -webkit-transition: background-color .2s;
+  transition: background-color .2s;
+  font-size: 16px;
+  padding: 8px 28px 8px 16px;
+  border-radius: 4px;
+}
+
+.c8:hover,
+.c8:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c8:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c8:disabled {
+  opacity: .5;
+}
+
+.c10 {
+  display: block;
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: none;
+  background-color: transparent;
+  vertical-align: middle;
+  line-height: 1.5;
+  font-size: 16px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c10:hover,
+.c10:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c10:disabled {
+  opacity: .5;
+}
+
+.c10:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c7 div:not(:last-of-type) {
+  margin-right: 8px;
+}
+
+.c2 {
+  background-color: #122b47;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: #122b47;
+  padding: 16px 24px;
+}
+
+.c1 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="NavBarstory__ResetStorybookView-hsfjc-0 jahzXr"
+      className="c1"
     >
       <header
-        class="NavBar-iayrjp-3 bwrKUV"
+        className=""
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 NavBar__NavBarBackground-iayrjp-0 btupnB"
+          className="Box-sc-1qu1edy-0 c2"
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 clvBNI"
+            className="c3"
             color="blue"
-            font-size="medium"
+            fontSize="medium"
             href="/"
-            style="display:block;height:40px"
+            style={
+              Object {
+                "display": "block",
+                "height": "40px",
+              }
+            }
           >
             <div
-              class="Branding__BrandingWrap-ranqri-0 gACiZG Branding-ranqri-2 kQRWHN"
+              className="c4 "
+              size="medium"
             >
               <svg
                 height="32px"
-                style="display:block;margin:2px 0"
+                style={
+                  Object {
+                    "display": "block",
+                    "margin": "2px 0",
+                  }
+                }
                 viewBox="0 0 133 32"
                 width="133px"
               >
@@ -1698,33 +4547,52 @@ exports[`Storyshots NavBar Without search and secondary menu 1`] = `
             </div>
           </a>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 cDPANM"
-            style="flex-grow:1;margin:0 0 0 24px"
+            className="Box-sc-1qu1edy-0 c5"
+            style={
+              Object {
+                "flexGrow": "1",
+                "margin": "0 0 0 24px",
+              }
+            }
           >
             <nav
               aria-label="Primary navigation"
-              class="DesktopMenu__Nav-e4dzdq-3 bWwdcq DesktopMenu-e4dzdq-4 irbObu"
-              style="padding-right:24px"
+              className="c6 c7"
+              style={
+                Object {
+                  "paddingRight": "24px",
+                }
+              }
             >
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c8"
                   color="#ffffff"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Dashboard
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    aria-hidden={true}
+                    className="c9"
                     color="#ffffff"
                     fill="#ffffff"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -1736,23 +4604,33 @@ exports[`Storyshots NavBar Without search and secondary menu 1`] = `
               </div>
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c8"
                   color="#ffffff"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Inspector
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    aria-hidden={true}
+                    className="c9"
                     color="#ffffff"
                     fill="#ffffff"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -1764,23 +4642,33 @@ exports[`Storyshots NavBar Without search and secondary menu 1`] = `
               </div>
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c8"
                   color="#ffffff"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Operations
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    aria-hidden={true}
+                    className="c9"
                     color="#ffffff"
                     fill="#ffffff"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -1792,7 +4680,7 @@ exports[`Storyshots NavBar Without search and secondary menu 1`] = `
               </div>
               <div>
                 <a
-                  class="DesktopMenu__MenuLink-e4dzdq-1 kgAySz"
+                  className="c10"
                   color="#ffffff"
                   href="/"
                 >
@@ -1801,8 +4689,12 @@ exports[`Storyshots NavBar Without search and secondary menu 1`] = `
               </div>
             </nav>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
-              style="float:right"
+              className="Box-sc-1qu1edy-0 c11"
+              style={
+                Object {
+                  "float": "right",
+                }
+              }
             />
           </div>
         </div>
@@ -1813,35 +4705,381 @@ exports[`Storyshots NavBar Without search and secondary menu 1`] = `
 `;
 
 exports[`Storyshots NavBar Without secondary menu 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c12 {
+  margin-right: 0px;
+  max-width: 18em;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-content: flex-end;
+  -ms-flex-line-pack: end;
+  align-content: flex-end;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c9 {
+  padding: 2px;
+  color: #ffffff;
+  min-width: 20px;
+}
+
+.c18 {
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c3 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
+.c4 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding: 2px 0;
+}
+
+.c14 {
+  width: 100%;
+}
+
+.c17 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c17:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c17:focus ~ svg {
+  fill: #00438f;
+}
+
+.c17::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c17::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c17:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c17::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c13 {
+  background: #e1ebfa;
+  border-radius: 4px;
+  height: 40px;
+  min-width: 7em;
+  width: 100%;
+}
+
+.c13 button {
+  padding: 7px;
+  color: #122b47;
+  background: transparent;
+  border: solid 1px transparent;
+  border-radius: 4px;
+  min-width: 40px;
+}
+
+.c13 button:focus {
+  color: #ffffff;
+  background: #1254c7;
+  border: solid 1px #e1ebfa;
+  outline: none;
+  box-shadow: none;
+}
+
+.c13 button svg {
+  display: block;
+}
+
+.c13 Input {
+  color: #122b47;
+  background: transparent;
+  border: solid 1px transparent;
+  border-radius: 4px;
+}
+
+.c13 Input:focus {
+  background: #ffffff;
+  border: solid 1px transparent;
+  box-shadow: none;
+}
+
+.c13 Input::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c13 Input::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c13 Input:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c13 Input::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c13 Input[type='search'] {
+  -webkit-appearance: textfield;
+}
+
+.c13 Input[type='search']::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  color: #ffffff;
+  border: none;
+  background-color: transparent;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  line-height: 1.5;
+  -webkit-transition: background-color .2s;
+  transition: background-color .2s;
+  font-size: 16px;
+  padding: 8px 28px 8px 16px;
+  border-radius: 4px;
+}
+
+.c8:hover,
+.c8:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c8:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c8:disabled {
+  opacity: .5;
+}
+
+.c10 {
+  display: block;
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: none;
+  background-color: transparent;
+  vertical-align: middle;
+  line-height: 1.5;
+  font-size: 16px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c10:hover,
+.c10:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c10:disabled {
+  opacity: .5;
+}
+
+.c10:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c7 div:not(:last-of-type) {
+  margin-right: 8px;
+}
+
+.c2 {
+  background-color: #122b47;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: #122b47;
+  padding: 16px 24px;
+}
+
+.c1 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="NavBarstory__ResetStorybookView-hsfjc-0 jahzXr"
+      className="c1"
     >
       <header
-        class="NavBar-iayrjp-3 bwrKUV"
+        className=""
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 NavBar__NavBarBackground-iayrjp-0 btupnB"
+          className="c2"
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 clvBNI"
+            className="c3"
             color="blue"
-            font-size="medium"
+            fontSize="medium"
             href="/"
-            style="display:block;height:40px"
+            style={
+              Object {
+                "display": "block",
+                "height": "40px",
+              }
+            }
           >
             <div
-              class="Branding__BrandingWrap-ranqri-0 gACiZG Branding-ranqri-2 kQRWHN"
+              className="c4 "
+              size="medium"
             >
               <svg
                 height="32px"
-                style="display:block;margin:2px 0"
+                style={
+                  Object {
+                    "display": "block",
+                    "margin": "2px 0",
+                  }
+                }
                 viewBox="0 0 133 32"
                 width="133px"
               >
@@ -1877,33 +5115,52 @@ exports[`Storyshots NavBar Without secondary menu 1`] = `
             </div>
           </a>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 cDPANM"
-            style="flex-grow:1;margin:0 0 0 24px"
+            className="c5"
+            style={
+              Object {
+                "flexGrow": "1",
+                "margin": "0 0 0 24px",
+              }
+            }
           >
             <nav
               aria-label="Primary navigation"
-              class="DesktopMenu__Nav-e4dzdq-3 bWwdcq DesktopMenu-e4dzdq-4 irbObu"
-              style="padding-right:24px"
+              className="c6 c7"
+              style={
+                Object {
+                  "paddingRight": "24px",
+                }
+              }
             >
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c8"
                   color="#ffffff"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Dashboard
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    aria-hidden={true}
+                    className="c9"
                     color="#ffffff"
                     fill="#ffffff"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -1915,23 +5172,33 @@ exports[`Storyshots NavBar Without secondary menu 1`] = `
               </div>
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c8"
                   color="#ffffff"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Inspector
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    aria-hidden={true}
+                    className="c9"
                     color="#ffffff"
                     fill="#ffffff"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -1943,23 +5210,33 @@ exports[`Storyshots NavBar Without secondary menu 1`] = `
               </div>
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c8"
                   color="#ffffff"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Operations
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    aria-hidden={true}
+                    className="c9"
                     color="#ffffff"
                     fill="#ffffff"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -1971,7 +5248,7 @@ exports[`Storyshots NavBar Without secondary menu 1`] = `
               </div>
               <div>
                 <a
-                  class="DesktopMenu__MenuLink-e4dzdq-1 kgAySz"
+                  className="c10"
                   color="#ffffff"
                   href="/"
                 >
@@ -1980,37 +5257,43 @@ exports[`Storyshots NavBar Without secondary menu 1`] = `
               </div>
             </nav>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
-              style="float:right"
+              className="c11"
+              style={
+                Object {
+                  "float": "right",
+                }
+              }
             >
               <div
-                class="Box-sc-1qu1edy-0 iByNwK"
+                className="c12"
               >
                 <form
-                  class="NavBarSearch-sc-1aq0npd-0 lfszCe"
+                  className="c13"
+                  onSubmit={[Function]}
                 >
                   <div
-                    class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+                    className="c11"
                     role="search"
                   >
                     <div
-                      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+                      className="c14"
                     >
                       <div
-                        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+                        className="c15"
                       >
                         <div
-                          class="Box-sc-1qu1edy-0 hxUhcg"
+                          className="c16"
                           display="flex"
                         >
                           <input
-                            aria-invalid="false"
+                            aria-invalid={false}
                             aria-labelledby="global-search"
-                            aria-required="true"
-                            class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                            aria-required={true}
+                            className="c17"
+                            disabled={false}
                             id="navbar-search"
                             placeholder="Search Nulogy..."
-                            required=""
+                            required={true}
                             type="search"
                           />
                         </div>
@@ -2021,13 +5304,15 @@ exports[`Storyshots NavBar Without secondary menu 1`] = `
                       id="global-search"
                     >
                       <svg
-                        aria-hidden="true"
-                        class="Icon-fc7twp-0 dkBAgY"
+                        aria-hidden={true}
+                        className="c18"
                         color="currentColor"
                         fill="currentColor"
-                        focusable="false"
+                        focusable={false}
                         height="24px"
                         icon="search"
+                        size="24px"
+                        title={null}
                         viewBox="0 0 24 24"
                         width="24px"
                       >

--- a/components/src/Overlay/__snapshots__/Overlay.story.storyshot
+++ b/components/src/Overlay/__snapshots__/Overlay.story.storyshot
@@ -1,29 +1,98 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Overlay Dark 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c3 {
+  background-color: #f0f2f5;
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-left: 16px;
+  padding-right: 16px;
+  border-radius: 4px;
+  box-shadow: 0px 0px 3px 0px rgba(1,30,56,0.2);
+  position: relative;
+}
+
+.c2 {
+  position: fixed;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1000;
+  background-color: rgba(18,43,71,0.5);
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <p
-      class="Text-sc-1wu7vpu-0 RbfMK"
+      className="c1"
       color="currentColor"
-      font-size="medium"
+      disabled={false}
+      fontSize="medium"
     >
       Background content
     </p>
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 Overlay-spdky8-0 eOYFJr"
+      className="Box-sc-1qu1edy-0 Flex-hrfu3s-0 c2"
     >
       <div
-        class="Box-sc-1qu1edy-0 Card-sc-1vyc3zz-0 lfpbjM"
+        className="Box-sc-1qu1edy-0 c3"
       >
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c1"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           Overlay content
         </p>
@@ -34,21 +103,78 @@ exports[`Storyshots Overlay Dark 1`] = `
 `;
 
 exports[`Storyshots Overlay Light (default) 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c2 {
+  position: fixed;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1000;
+  background-color: rgba(255,255,255,0.95);
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <p
-      class="Text-sc-1wu7vpu-0 RbfMK"
+      className="c1"
       color="currentColor"
-      font-size="medium"
+      disabled={false}
+      fontSize="medium"
     >
       Background content
     </p>
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 Overlay-spdky8-0 jYvdrA"
+      className="Box-sc-1qu1edy-0 Flex-hrfu3s-0 c2"
     >
       Overlay content
     </div>

--- a/components/src/PMPagination/__snapshots__/PMPagination.story.storyshot
+++ b/components/src/PMPagination/__snapshots__/PMPagination.story.storyshot
@@ -1,30 +1,209 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots PM/PMPagination default 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c4 {
+  margin-left: -8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c8 {
+  margin-right: -8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c3 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #e4e7eb;
+  color: #c0c8d1;
+  cursor: default;
+}
+
+.c3:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c3:hover {
+  background: inital;
+}
+
+.c7 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #e4e7eb;
+  color: #011e38;
+  cursor: pointer;
+}
+
+.c7:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c7:hover {
+  background: #e4e7eb;
+}
+
+.c5 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #00438f;
+  color: #c0c8d1;
+  cursor: default;
+  background: #00438f;
+  color: #f0f2f5;
+}
+
+.c5:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c5:hover {
+  background: #00438f;
+}
+
+.c6 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #e4e7eb;
+  color: #011e38;
+  cursor: pointer;
+  background: transparent;
+  color: #011e38;
+}
+
+.c6:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c6:hover {
+  background: #e4e7eb;
+}
+
+.c2 {
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c2 button {
+  font-size: 12px;
+  padding: 0 4px;
+  min-width: 22px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  border-radius: 3px;
+}
+
+.c2 button:not([disabled]) {
+  color: #3593d8;
+}
+
+.c2 button:not(:last-child) {
+  margin-right: 6px;
+}
+
+.c2 button[aria-current=true] {
+  background-color: #2E5C87;
+  font-weight: bold;
+}
+
+.c2 button svg {
+  display: none;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <nav
       aria-label="Pagination navigation"
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd PMPagination___StyledPagination-h94owo-0 hSgwGX"
+      className="Box-sc-1qu1edy-0 c1 c2"
     >
       <button
         aria-label="Go to previous results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 kZsQns"
-        disabled=""
+        className="c3"
+        disabled={true}
+        onClick={null}
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 bLUmHQ"
+          aria-hidden={true}
+          className="c4"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="leftArrow"
           ml="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -32,50 +211,64 @@ exports[`Storyshots PM/PMPagination default 1`] = `
             d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-         ← Previous
+         
+        ← Previous
       </button>
       <button
-        aria-current="true"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 khkrHJ"
-        disabled=""
+        aria-current={true}
+        aria-label={null}
+        className="c5"
+        disabled={true}
+        onClick={[Function]}
       >
         1
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c6"
+        disabled={false}
+        onClick={[Function]}
       >
         2
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c6"
+        disabled={false}
+        onClick={[Function]}
       >
         3
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c6"
+        disabled={false}
+        onClick={[Function]}
       >
         4
       </button>
       <button
         aria-label="Go to next results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 iFOkT"
+        className="c7"
+        disabled={false}
+        onClick={null}
       >
-        Next → 
+        Next →
+         
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 dEtgXr"
+          aria-hidden={true}
+          className="c8"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="rightArrow"
           mr="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >

--- a/components/src/PMTable/__snapshots__/PMTable.story.storyshot
+++ b/components/src/PMTable/__snapshots__/PMTable.story.storyshot
@@ -1,96 +1,509 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots PM/PMTable default 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c15 {
+  padding-top: 16px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c18 {
+  margin-left: -8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c22 {
+  margin-right: -8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c6 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c13 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c13:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
+.c9 {
+  min-width: 16px;
+  height: 16px;
+  border-radius: 2px;
+  border: solid 1px;
+  position: relative;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c9:before {
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  width: 3px;
+  height: 9px;
+  border: solid #ffffff;
+  border-radius: 1px;
+  border-width: 0 3px 3px 0;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.c7 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c7:focus + .c8 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:checked + .c8 {
+  border-color: #00438f;
+  background-color: #00438f;
+}
+
+.c7:checked + .c8:before {
+  display: block;
+}
+
+.c7:not(:checked) + .c8 {
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+}
+
+.c5 {
+  padding: 4px 0;
+}
+
+.c5 .Text-sc-1wu7vpu-0 {
+  margin-left: 8px;
+}
+
+.c4 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: 30px;
+}
+
+.c4:first-child {
+  padding-left: 16px;
+}
+
+.c10 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: auto;
+}
+
+.c10:first-child {
+  padding-left: 16px;
+}
+
+.c3 {
+  color: #434d59;
+  border-bottom: 1px solid #e4e7eb;
+}
+
+.c11 {
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-right: 16px;
+}
+
+.c11:first-child {
+  padding-left: 16px;
+}
+
+.c23 {
+  padding: 24px 0;
+  font-size: 14px;
+  color: #434d59;
+}
+
+.c14:first-of-type {
+  border-top: 1px solid #e4e7eb;
+}
+
+.c1 {
+  border-collapse: collapse;
+  width: 100%;
+  background: white;
+}
+
+.c17 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #e4e7eb;
+  color: #c0c8d1;
+  cursor: default;
+}
+
+.c17:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c17:hover {
+  background: inital;
+}
+
+.c21 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #e4e7eb;
+  color: #011e38;
+  cursor: pointer;
+}
+
+.c21:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c21:hover {
+  background: #e4e7eb;
+}
+
+.c19 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #00438f;
+  color: #c0c8d1;
+  cursor: default;
+  background: #00438f;
+  color: #f0f2f5;
+}
+
+.c19:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c19:hover {
+  background: #00438f;
+}
+
+.c20 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #e4e7eb;
+  color: #011e38;
+  cursor: pointer;
+  background: transparent;
+  color: #011e38;
+}
+
+.c20:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c20:hover {
+  background: #e4e7eb;
+}
+
+.c16 {
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c16 button {
+  font-size: 12px;
+  padding: 0 4px;
+  min-width: 22px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  border-radius: 3px;
+}
+
+.c16 button:not([disabled]) {
+  color: #3593d8;
+}
+
+.c16 button:not(:last-child) {
+  margin-right: 6px;
+}
+
+.c16 button[aria-current=true] {
+  background-color: #2E5C87;
+  font-weight: bold;
+}
+
+.c16 button svg {
+  display: none;
+}
+
+.c2 {
+  font-size: 12px;
+}
+
+.c2 .nds-table__no-rows-content {
+  padding: 0;
+  font-size: 12px;
+}
+
+.c2 thead tr {
+  border-bottom: none;
+}
+
+.c2 thead th,
+.c2 tfoot th,
+.c2 tfoot td {
+  font-weight: bold;
+  color: #222;
+  height: 34px;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.c2 thead th:first-child,
+.c2 tfoot th:first-child,
+.c2 tbody td:first-child {
+  padding-left: 8px;
+}
+
+.c2 .table-row--odd {
+  background-color: #f0f0f0;
+}
+
+.c2 .table-row--odd + [data-testid='expanded-table-row'] {
+  background-color: #f0f0f0;
+}
+
+.c2 tbody td,
+.c2 tfoot td {
+  padding: 0;
+  height: 34px;
+  color: #444;
+}
+
+.c2 tr[data-testid='expanded-table-row'] > td:first-child {
+  padding-left: 0;
+}
+
+.c2 nav {
+  background-color: #660099;
+}
+
+.c2 .c12 {
+  font-size: 12px;
+  color: #3593d8;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2 .c12:visited {
+  color: #660099;
+}
+
+.c2 .c12:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c2 button[class*='ControlIcon'] {
+  -webkit-transform: scale(0.7);
+  -ms-transform: scale(0.7);
+  transform: scale(0.7);
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub PMTable___StyledTable-sc-1bray0a-0 hVNzGP"
+      className="c1 c2"
     >
       <thead>
         <tr
-          class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
+          className="c3"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 kfgNsH"
+            className="c4"
             data-testid="table-head"
             scope="col"
             width="30px"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c5"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c6"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="select all"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c7 c5"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c8 c9"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c10"
             data-testid="table-head"
             scope="col"
           >
             ID
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c10"
             data-testid="table-head"
             scope="col"
           >
             Expected Ship
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c10"
             data-testid="table-head"
             scope="col"
           >
             Customer
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c10"
             data-testid="table-head"
             scope="col"
           >
             Ship To
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c10"
             data-testid="table-head"
             scope="col"
           >
             Shipped
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c10"
             data-testid="table-head"
             scope="col"
           >
             Expected Quantity
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c10"
             data-testid="table-head"
             scope="col"
           >
             Actual Quantity
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c10"
             data-testid="table-head"
             scope="col"
           >
@@ -102,147 +515,167 @@ exports[`Storyshots PM/PMTable default 1`] = `
         data-testid="table-body"
       >
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--odd"
+          className="table-row--odd"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c5"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c6"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c7 c5"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c8 c9"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
-          <td>
+          <td
+            colSpan={null}
+          >
             <a
-              class="Link-sc-1lpx3d0-0 gxbSxg"
+              className="c12 c13"
               color="blue"
-              font-size="medium"
+              fontSize="medium"
               href="/"
             >
               1234454
             </a>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2019-10-01
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             National Widgets
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             99 Reactor Blvd., Springfield, SI
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             No
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2,025 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             1,800 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             --
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--even"
+          className="table-row--even"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c5"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c6"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c7 c5"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c8 c9"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
-          <td>
+          <td
+            colSpan={null}
+          >
             <a
-              class="Link-sc-1lpx3d0-0 gxbSxg"
+              className="c12 c13"
               color="blue"
-              font-size="medium"
+              fontSize="medium"
               href="/"
             >
               1234455
             </a>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2019-10-02
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             National Widgets
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             7 New St., New York, NY
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             Yes
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2,250 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             --
           </td>
@@ -250,95 +683,120 @@ exports[`Storyshots PM/PMTable default 1`] = `
       </tbody>
       <tfoot>
         <tr
-          class="TableFoot__StyledFooterRow-sc-1q56pdo-0 gVNRxT"
+          className="c14"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
-            colspan="2"
+            className="c10"
+            colSpan={2}
             scope="row"
           >
             Total
           </th>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c11"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c11"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c11"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c11"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             18,000 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             7,725 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c11"
+          >
+            
+          </td>
         </tr>
         <tr
-          class="TableFoot__StyledFooterRow-sc-1q56pdo-0 gVNRxT"
+          className="c14"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
-            colspan="2"
+            className="c10"
+            colSpan={2}
             scope="row"
           >
             Attainment
           </th>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c11"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c11"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c11"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c11"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c11"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             41.5%
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c11"
+          >
+            
+          </td>
         </tr>
       </tfoot>
     </table>
     <nav
       aria-label="Pagination navigation"
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iCmkqG StatefulTable___StyledPagination-sc-196ra2t-0 hJdjBx"
+      className="c15 c16"
     >
       <button
         aria-label="Go to previous results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 kZsQns"
-        disabled=""
+        className="c17"
+        disabled={true}
+        onClick={[Function]}
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 bLUmHQ"
+          aria-hidden={true}
+          className="c18"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="leftArrow"
           ml="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -346,50 +804,64 @@ exports[`Storyshots PM/PMTable default 1`] = `
             d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-         ← Previous
+         
+        ← Previous
       </button>
       <button
-        aria-current="true"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 khkrHJ"
-        disabled=""
+        aria-current={true}
+        aria-label={null}
+        className="c19"
+        disabled={true}
+        onClick={[Function]}
       >
         1
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c20"
+        disabled={false}
+        onClick={[Function]}
       >
         2
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c20"
+        disabled={false}
+        onClick={[Function]}
       >
         3
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c20"
+        disabled={false}
+        onClick={[Function]}
       >
         4
       </button>
       <button
         aria-label="Go to next results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 iFOkT"
+        className="c21"
+        disabled={false}
+        onClick={[Function]}
       >
-        Next → 
+        Next →
+         
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 dEtgXr"
+          aria-hidden={true}
+          className="c22"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="rightArrow"
           mr="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -400,63 +872,63 @@ exports[`Storyshots PM/PMTable default 1`] = `
       </button>
     </nav>
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub PMTable___StyledTable-sc-1bray0a-0 hVNzGP"
+      className="c1 c2"
     >
       <thead>
         <tr
-          class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
+          className="c3"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c10"
             data-testid="table-head"
             scope="col"
           >
             ID
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c10"
             data-testid="table-head"
             scope="col"
           >
             Expected Ship
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c10"
             data-testid="table-head"
             scope="col"
           >
             Customer
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c10"
             data-testid="table-head"
             scope="col"
           >
             Ship To
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c10"
             data-testid="table-head"
             scope="col"
           >
             Shipped
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c10"
             data-testid="table-head"
             scope="col"
           >
             Expected Quantity
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c10"
             data-testid="table-head"
             scope="col"
           >
             Actual Quantity
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c10"
             data-testid="table-head"
             scope="col"
           >
@@ -468,401 +940,417 @@ exports[`Storyshots PM/PMTable default 1`] = `
         data-testid="table-body"
       >
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--odd"
+          className="table-row--odd"
           data-testid="table-row"
         >
-          <td>
+          <td
+            colSpan={null}
+          >
             <a
-              class="Link-sc-1lpx3d0-0 gxbSxg"
+              className="c12 c13"
               color="blue"
-              font-size="medium"
+              fontSize="medium"
               href="/"
             >
               1234454
             </a>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2019-10-01
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             National Widgets
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             99 Reactor Blvd., Springfield, SI
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             No
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2,025 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             1,800 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             --
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--even"
+          className="table-row--even"
           data-testid="table-row"
         >
-          <td>
+          <td
+            colSpan={null}
+          >
             <a
-              class="Link-sc-1lpx3d0-0 gxbSxg"
+              className="c12 c13"
               color="blue"
-              font-size="medium"
+              fontSize="medium"
               href="/"
             >
               1234455
             </a>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2019-10-02
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             National Widgets
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             7 New St., New York, NY
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             Yes
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2,250 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             --
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--odd"
+          className="table-row--odd"
           data-testid="table-row"
         >
-          <td>
+          <td
+            colSpan={null}
+          >
             <a
-              class="Link-sc-1lpx3d0-0 gxbSxg"
+              className="c12 c13"
               color="blue"
-              font-size="medium"
+              fontSize="medium"
               href="/"
             >
               1234461
             </a>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2019-10-03
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             LTS Corp
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             11 Peter St., Toronto, ON
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             No
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             1,425 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             --
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--even"
+          className="table-row--even"
           data-testid="table-row"
         >
-          <td>
+          <td
+            colSpan={null}
+          >
             <a
-              class="Link-sc-1lpx3d0-0 gxbSxg"
+              className="c12 c13"
               color="blue"
-              font-size="medium"
+              fontSize="medium"
               href="/"
             >
               1234424
             </a>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2019-10-04
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             Neutron
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             5555 Hwy 6., Toronto, ON
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             No
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             675 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             --
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--odd"
+          className="table-row--odd"
           data-testid="table-row"
         >
-          <td>
+          <td
+            colSpan={null}
+          >
             <a
-              class="Link-sc-1lpx3d0-0 gxbSxg"
+              className="c12 c13"
               color="blue"
-              font-size="medium"
+              fontSize="medium"
               href="/"
             >
               1234453
             </a>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2019-10-07
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             Scopewise
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             7 New St., New York, NY
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             No
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             1,575 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             --
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--even"
+          className="table-row--even"
           data-testid="table-row"
         >
-          <td>
+          <td
+            colSpan={null}
+          >
             <a
-              class="Link-sc-1lpx3d0-0 gxbSxg"
+              className="c12 c13"
               color="blue"
-              font-size="medium"
+              fontSize="medium"
               href="/"
             >
               1232221
             </a>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2019-10-22
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             Scopewise
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             871 Husky St., Toronto, ON
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             No
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             1,725 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             --
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             --
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--odd"
+          className="table-row--odd"
           data-testid="table-row"
         >
-          <td>
+          <td
+            colSpan={null}
+          >
             <a
-              class="Link-sc-1lpx3d0-0 gxbSxg"
+              className="c12 c13"
               color="blue"
-              font-size="medium"
+              fontSize="medium"
               href="/"
             >
               1444453
             </a>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2019-10-23
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             Fresh Farm
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             7 New St., New York, NY
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             Yes
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             --
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             --
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--even"
+          className="table-row--even"
           data-testid="table-row"
         >
-          <td>
+          <td
+            colSpan={null}
+          >
             <a
-              class="Link-sc-1lpx3d0-0 gxbSxg"
+              className="c12 c13"
               color="blue"
-              font-size="medium"
+              fontSize="medium"
               href="/"
             >
               1224478
             </a>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2019-10-24
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             LTS Corp
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             12345 Rodeo Ave., Los Angeles, CA
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             No
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             --
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             --
           </td>
@@ -870,135 +1358,157 @@ exports[`Storyshots PM/PMTable default 1`] = `
       </tbody>
       <tfoot>
         <tr
-          class="TableFoot__StyledFooterRow-sc-1q56pdo-0 gVNRxT"
+          className="c14"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
-            colspan="1"
+            className="c10"
+            colSpan={1}
             scope="row"
           >
             Total
           </th>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c11"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c11"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c11"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c11"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             18,000 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             7,725 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c11"
+          >
+            
+          </td>
         </tr>
         <tr
-          class="TableFoot__StyledFooterRow-sc-1q56pdo-0 gVNRxT"
+          className="c14"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
-            colspan="1"
+            className="c10"
+            colSpan={1}
             scope="row"
           >
             Attainment
           </th>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c11"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c11"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c11"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c11"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c11"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             41.5%
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c11"
+          >
+            
+          </td>
         </tr>
       </tfoot>
     </table>
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub PMTable___StyledTable-sc-1bray0a-0 hVNzGP"
+      className="c1 c2"
     >
       <thead>
         <tr
-          class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
+          className="c3"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c10"
             data-testid="table-head"
             scope="col"
           >
             ID
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c10"
             data-testid="table-head"
             scope="col"
           >
             Expected Ship
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c10"
             data-testid="table-head"
             scope="col"
           >
             Customer
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c10"
             data-testid="table-head"
             scope="col"
           >
             Ship To
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c10"
             data-testid="table-head"
             scope="col"
           >
             Shipped
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c10"
             data-testid="table-head"
             scope="col"
           >
             Expected Quantity
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c10"
             data-testid="table-head"
             scope="col"
           >
             Actual Quantity
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c10"
             data-testid="table-head"
             scope="col"
           >
@@ -1013,10 +1523,10 @@ exports[`Storyshots PM/PMTable default 1`] = `
           data-testid="table-message-container"
         >
           <td
-            colspan="8"
+            colSpan={8}
           >
             <div
-              class="Box-sc-1qu1edy-0 TableBody__StyledMessageContainer-sc-1amzhx8-0 fEzznw nds-table__no-rows-content"
+              className="c23 nds-table__no-rows-content"
             >
               No records have been created for this table.
             </div>
@@ -1030,76 +1540,428 @@ exports[`Storyshots PM/PMTable default 1`] = `
 `;
 
 exports[`Storyshots PM/PMTable with expandable rows 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c12 {
+  padding-top: 16px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c15 {
+  margin-left: -8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c19 {
+  margin-right: -8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c7 {
+  background: transparent;
+  border: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px;
+  border-radius: 50%;
+  color: #434d59;
+}
+
+.c7:focus {
+  outline: none;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:hover:enabled {
+  cursor: pointer;
+  color: #122b47;
+  background-color: #e4e7eb;
+}
+
+.c10 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c10:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
+.c4 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: 30px;
+}
+
+.c4:first-child {
+  padding-left: 16px;
+}
+
+.c5 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: auto;
+}
+
+.c5:first-child {
+  padding-left: 16px;
+}
+
+.c3 {
+  color: #434d59;
+  border-bottom: 1px solid #e4e7eb;
+}
+
+.c6 {
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-right: 16px;
+}
+
+.c6:first-child {
+  padding-left: 16px;
+}
+
+.c11:first-of-type {
+  border-top: 1px solid #e4e7eb;
+}
+
+.c1 {
+  border-collapse: collapse;
+  width: 100%;
+  background: white;
+}
+
+.c14 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #e4e7eb;
+  color: #c0c8d1;
+  cursor: default;
+}
+
+.c14:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c14:hover {
+  background: inital;
+}
+
+.c18 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #e4e7eb;
+  color: #011e38;
+  cursor: pointer;
+}
+
+.c18:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c18:hover {
+  background: #e4e7eb;
+}
+
+.c16 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #00438f;
+  color: #c0c8d1;
+  cursor: default;
+  background: #00438f;
+  color: #f0f2f5;
+}
+
+.c16:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c16:hover {
+  background: #00438f;
+}
+
+.c17 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #e4e7eb;
+  color: #011e38;
+  cursor: pointer;
+  background: transparent;
+  color: #011e38;
+}
+
+.c17:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c17:hover {
+  background: #e4e7eb;
+}
+
+.c13 {
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c13 button {
+  font-size: 12px;
+  padding: 0 4px;
+  min-width: 22px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  border-radius: 3px;
+}
+
+.c13 button:not([disabled]) {
+  color: #3593d8;
+}
+
+.c13 button:not(:last-child) {
+  margin-right: 6px;
+}
+
+.c13 button[aria-current=true] {
+  background-color: #2E5C87;
+  font-weight: bold;
+}
+
+.c13 button svg {
+  display: none;
+}
+
+.c2 {
+  font-size: 12px;
+}
+
+.c2 .nds-table__no-rows-content {
+  padding: 0;
+  font-size: 12px;
+}
+
+.c2 thead tr {
+  border-bottom: none;
+}
+
+.c2 thead th,
+.c2 tfoot th,
+.c2 tfoot td {
+  font-weight: bold;
+  color: #222;
+  height: 34px;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.c2 thead th:first-child,
+.c2 tfoot th:first-child,
+.c2 tbody td:first-child {
+  padding-left: 8px;
+}
+
+.c2 .table-row--odd {
+  background-color: #f0f0f0;
+}
+
+.c2 .table-row--odd + [data-testid='expanded-table-row'] {
+  background-color: #f0f0f0;
+}
+
+.c2 tbody td,
+.c2 tfoot td {
+  padding: 0;
+  height: 34px;
+  color: #444;
+}
+
+.c2 tr[data-testid='expanded-table-row'] > td:first-child {
+  padding-left: 0;
+}
+
+.c2 nav {
+  background-color: #660099;
+}
+
+.c2 .c9 {
+  font-size: 12px;
+  color: #3593d8;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c2 .c9:visited {
+  color: #660099;
+}
+
+.c2 .c9:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c2 button[class*='ControlIcon'] {
+  -webkit-transform: scale(0.7);
+  -ms-transform: scale(0.7);
+  transform: scale(0.7);
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub PMTable___StyledTable-sc-1bray0a-0 hVNzGP"
+      className="c1 c2"
     >
       <thead>
         <tr
-          class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
+          className="c3"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 kfgNsH"
+            className="c4"
             data-testid="table-head"
             scope="col"
             width="30px"
           />
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c5"
             data-testid="table-head"
             scope="col"
           >
             ID
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c5"
             data-testid="table-head"
             scope="col"
           >
             Expected Ship
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c5"
             data-testid="table-head"
             scope="col"
           >
             Customer
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c5"
             data-testid="table-head"
             scope="col"
           >
             Ship To
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c5"
             data-testid="table-head"
             scope="col"
           >
             Shipped
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c5"
             data-testid="table-head"
             scope="col"
           >
             Expected Quantity
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c5"
             data-testid="table-head"
             scope="col"
           >
             Actual Quantity
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c5"
             data-testid="table-head"
             scope="col"
           >
@@ -1111,25 +1973,29 @@ exports[`Storyshots PM/PMTable with expandable rows 1`] = `
         data-testid="table-body"
       >
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--odd"
+          className="table-row--odd"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             <button
               aria-label="Expand row"
-              class="ControlIcon__StyledButton-sc-1h83lvi-0 cCdEvo"
+              className="c7"
+              disabled={false}
+              onClick={[Function]}
               type="button"
             >
               <svg
-                aria-hidden="true"
-                class="Icon-fc7twp-0 efirdb"
+                aria-hidden={true}
+                className="c8"
                 color="currentColor"
                 fill="currentColor"
-                focusable="false"
+                focusable={false}
                 height="32px"
                 icon="downArrow"
+                size="32px"
+                title={null}
                 viewBox="0 0 24 24"
                 width="32px"
               >
@@ -1139,72 +2005,78 @@ exports[`Storyshots PM/PMTable with expandable rows 1`] = `
               </svg>
             </button>
           </td>
-          <td>
+          <td
+            colSpan={null}
+          >
             <a
-              class="Link-sc-1lpx3d0-0 gxbSxg"
+              className="c9 c10"
               color="blue"
-              font-size="medium"
+              fontSize="medium"
               href="/"
             >
               1234454
             </a>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-01
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             National Widgets
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             99 Reactor Blvd., Springfield, SI
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             No
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,025 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             1,800 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             --
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--even"
+          className="table-row--even"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             <button
               aria-label="Expand row"
-              class="ControlIcon__StyledButton-sc-1h83lvi-0 cCdEvo"
+              className="c7"
+              disabled={false}
+              onClick={[Function]}
               type="button"
             >
               <svg
-                aria-hidden="true"
-                class="Icon-fc7twp-0 efirdb"
+                aria-hidden={true}
+                className="c8"
                 color="currentColor"
                 fill="currentColor"
-                focusable="false"
+                focusable={false}
                 height="32px"
                 icon="downArrow"
+                size="32px"
+                title={null}
                 viewBox="0 0 24 24"
                 width="32px"
               >
@@ -1214,72 +2086,78 @@ exports[`Storyshots PM/PMTable with expandable rows 1`] = `
               </svg>
             </button>
           </td>
-          <td>
+          <td
+            colSpan={null}
+          >
             <a
-              class="Link-sc-1lpx3d0-0 gxbSxg"
+              className="c9 c10"
               color="blue"
-              font-size="medium"
+              fontSize="medium"
               href="/"
             >
               1234455
             </a>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-02
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             National Widgets
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             7 New St., New York, NY
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             Yes
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,250 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             --
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 guzDVv table-row--odd"
+          className="table-row--odd"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             <button
               aria-label="Expand row"
-              class="ControlIcon__StyledButton-sc-1h83lvi-0 cCdEvo"
+              className="c7"
+              disabled={false}
+              onClick={[Function]}
               type="button"
             >
               <svg
-                aria-hidden="true"
-                class="Icon-fc7twp-0 efirdb"
+                aria-hidden={true}
+                className="c8"
                 color="currentColor"
                 fill="currentColor"
-                focusable="false"
+                focusable={false}
                 height="32px"
                 icon="downArrow"
+                size="32px"
+                title={null}
                 viewBox="0 0 24 24"
                 width="32px"
               >
@@ -1289,48 +2167,50 @@ exports[`Storyshots PM/PMTable with expandable rows 1`] = `
               </svg>
             </button>
           </td>
-          <td>
+          <td
+            colSpan={null}
+          >
             <a
-              class="Link-sc-1lpx3d0-0 gxbSxg"
+              className="c9 c10"
               color="blue"
-              font-size="medium"
+              fontSize="medium"
               href="/"
             >
               1234461
             </a>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-03
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             LTS Corp
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             11 Peter St., Toronto, ON
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             No
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             1,425 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             --
           </td>
@@ -1338,95 +2218,120 @@ exports[`Storyshots PM/PMTable with expandable rows 1`] = `
       </tbody>
       <tfoot>
         <tr
-          class="TableFoot__StyledFooterRow-sc-1q56pdo-0 gVNRxT"
+          className="c11"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
-            colspan="2"
+            className="c5"
+            colSpan={2}
             scope="row"
           >
             Total
           </th>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c6"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c6"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c6"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c6"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             18,000 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             7,725 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c6"
+          >
+            
+          </td>
         </tr>
         <tr
-          class="TableFoot__StyledFooterRow-sc-1q56pdo-0 gVNRxT"
+          className="c11"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
-            colspan="2"
+            className="c5"
+            colSpan={2}
             scope="row"
           >
             Attainment
           </th>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c6"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c6"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c6"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c6"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c6"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             41.5%
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c6"
+          >
+            
+          </td>
         </tr>
       </tfoot>
     </table>
     <nav
       aria-label="Pagination navigation"
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iCmkqG StatefulTable___StyledPagination-sc-196ra2t-0 hJdjBx"
+      className="Box-sc-1qu1edy-0 c12 c13"
     >
       <button
         aria-label="Go to previous results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 kZsQns"
-        disabled=""
+        className="c14"
+        disabled={true}
+        onClick={[Function]}
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 bLUmHQ"
+          aria-hidden={true}
+          className="c15"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="leftArrow"
           ml="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -1434,43 +2339,55 @@ exports[`Storyshots PM/PMTable with expandable rows 1`] = `
             d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-         ← Previous
+         
+        ← Previous
       </button>
       <button
-        aria-current="true"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 khkrHJ"
-        disabled=""
+        aria-current={true}
+        aria-label={null}
+        className="c16"
+        disabled={true}
+        onClick={[Function]}
       >
         1
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c17"
+        disabled={false}
+        onClick={[Function]}
       >
         2
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c17"
+        disabled={false}
+        onClick={[Function]}
       >
         3
       </button>
       <button
         aria-label="Go to next results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 iFOkT"
+        className="c18"
+        disabled={false}
+        onClick={[Function]}
       >
-        Next → 
+        Next →
+         
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 dEtgXr"
+          aria-hidden={true}
+          className="c19"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="rightArrow"
           mr="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >

--- a/components/src/Pagination/__snapshots__/Pagination.story.storyshot
+++ b/components/src/Pagination/__snapshots__/Pagination.story.storyshot
@@ -1,30 +1,181 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Pagination Pagination 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  margin-left: -8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c8 {
+  margin-right: -8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c6 {
+  padding-top: 8px;
+  padding-bottom: 8px;
+  margin-right: 16px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 14px;
+  line-height: 1.71428571;
+  color: currentColor;
+}
+
+.c2 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #e4e7eb;
+  color: #c0c8d1;
+  cursor: default;
+}
+
+.c2:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c2:hover {
+  background: inital;
+}
+
+.c7 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #e4e7eb;
+  color: #011e38;
+  cursor: pointer;
+}
+
+.c7:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c7:hover {
+  background: #e4e7eb;
+}
+
+.c4 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #00438f;
+  color: #c0c8d1;
+  cursor: default;
+  background: #00438f;
+  color: #f0f2f5;
+}
+
+.c4:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c4:hover {
+  background: #00438f;
+}
+
+.c5 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #e4e7eb;
+  color: #011e38;
+  cursor: pointer;
+  background: transparent;
+  color: #011e38;
+}
+
+.c5:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c5:hover {
+  background: #e4e7eb;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <nav
       aria-label="Pagination navigation"
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+      className="Box-sc-1qu1edy-0 c1"
     >
       <button
         aria-label="Go to previous results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 kZsQns"
-        disabled=""
+        className="c2"
+        disabled={true}
+        onClick={[Function]}
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 bLUmHQ"
+          aria-hidden={true}
+          className="c3"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="leftArrow"
           ml="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -32,71 +183,90 @@ exports[`Storyshots Pagination Pagination 1`] = `
             d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-         Previous
+         
+        Previous
       </button>
       <button
-        aria-current="true"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 khkrHJ"
-        disabled=""
+        aria-current={true}
+        aria-label={null}
+        className="c4"
+        disabled={true}
+        onClick={[Function]}
       >
         1
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         2
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         3
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         4
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         5
       </button>
       <p
-        class="Text-sc-1wu7vpu-0 dqAYor"
+        className="c6"
         color="currentColor"
-        font-size="small"
+        disabled={false}
+        fontSize="small"
       >
         ...
       </p>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         7
       </button>
       <button
         aria-label="Go to next results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 iFOkT"
+        className="c7"
+        disabled={false}
+        onClick={[Function]}
       >
-        Next 
+        Next
+         
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 dEtgXr"
+          aria-hidden={true}
+          className="c8"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="rightArrow"
           mr="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -108,21 +278,25 @@ exports[`Storyshots Pagination Pagination 1`] = `
     </nav>
     <nav
       aria-label="Pagination navigation"
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+      className="Box-sc-1qu1edy-0 c1"
     >
       <button
         aria-label="Go to previous results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 iFOkT"
+        className="c7"
+        disabled={false}
+        onClick={null}
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 bLUmHQ"
+          aria-hidden={true}
+          className="c3"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="leftArrow"
           ml="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -130,71 +304,90 @@ exports[`Storyshots Pagination Pagination 1`] = `
             d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-         Previous
+         
+        Previous
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         1
       </button>
       <button
-        aria-current="true"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 khkrHJ"
-        disabled=""
+        aria-current={true}
+        aria-label={null}
+        className="c4"
+        disabled={true}
+        onClick={[Function]}
       >
         2
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         3
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         4
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         5
       </button>
       <p
-        class="Text-sc-1wu7vpu-0 dqAYor"
+        className="c6"
         color="currentColor"
-        font-size="small"
+        disabled={false}
+        fontSize="small"
       >
         ...
       </p>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         7
       </button>
       <button
         aria-label="Go to next results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 iFOkT"
+        className="c7"
+        disabled={false}
+        onClick={null}
       >
-        Next 
+        Next
+         
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 dEtgXr"
+          aria-hidden={true}
+          className="c8"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="rightArrow"
           mr="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -206,21 +399,25 @@ exports[`Storyshots Pagination Pagination 1`] = `
     </nav>
     <nav
       aria-label="Pagination navigation"
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+      className="Box-sc-1qu1edy-0 c1"
     >
       <button
         aria-label="Go to previous results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 iFOkT"
+        className="c7"
+        disabled={false}
+        onClick={null}
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 bLUmHQ"
+          aria-hidden={true}
+          className="c3"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="leftArrow"
           ml="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -228,71 +425,90 @@ exports[`Storyshots Pagination Pagination 1`] = `
             d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-         Previous
+         
+        Previous
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         1
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         2
       </button>
       <button
-        aria-current="true"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 khkrHJ"
-        disabled=""
+        aria-current={true}
+        aria-label={null}
+        className="c4"
+        disabled={true}
+        onClick={[Function]}
       >
         3
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         4
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         5
       </button>
       <p
-        class="Text-sc-1wu7vpu-0 dqAYor"
+        className="c6"
         color="currentColor"
-        font-size="small"
+        disabled={false}
+        fontSize="small"
       >
         ...
       </p>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         7
       </button>
       <button
         aria-label="Go to next results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 iFOkT"
+        className="c7"
+        disabled={false}
+        onClick={null}
       >
-        Next 
+        Next
+         
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 dEtgXr"
+          aria-hidden={true}
+          className="c8"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="rightArrow"
           mr="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -304,21 +520,25 @@ exports[`Storyshots Pagination Pagination 1`] = `
     </nav>
     <nav
       aria-label="Pagination navigation"
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+      className="Box-sc-1qu1edy-0 c1"
     >
       <button
         aria-label="Go to previous results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 iFOkT"
+        className="c7"
+        disabled={false}
+        onClick={null}
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 bLUmHQ"
+          aria-hidden={true}
+          className="c3"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="leftArrow"
           ml="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -326,71 +546,90 @@ exports[`Storyshots Pagination Pagination 1`] = `
             d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-         Previous
+         
+        Previous
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         1
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         2
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         3
       </button>
       <button
-        aria-current="true"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 khkrHJ"
-        disabled=""
+        aria-current={true}
+        aria-label={null}
+        className="c4"
+        disabled={true}
+        onClick={[Function]}
       >
         4
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         5
       </button>
       <p
-        class="Text-sc-1wu7vpu-0 dqAYor"
+        className="c6"
         color="currentColor"
-        font-size="small"
+        disabled={false}
+        fontSize="small"
       >
         ...
       </p>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         7
       </button>
       <button
         aria-label="Go to next results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 iFOkT"
+        className="c7"
+        disabled={false}
+        onClick={null}
       >
-        Next 
+        Next
+         
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 dEtgXr"
+          aria-hidden={true}
+          className="c8"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="rightArrow"
           mr="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -402,21 +641,25 @@ exports[`Storyshots Pagination Pagination 1`] = `
     </nav>
     <nav
       aria-label="Pagination navigation"
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+      className="Box-sc-1qu1edy-0 c1"
     >
       <button
         aria-label="Go to previous results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 iFOkT"
+        className="c7"
+        disabled={false}
+        onClick={null}
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 bLUmHQ"
+          aria-hidden={true}
+          className="c3"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="leftArrow"
           ml="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -424,71 +667,90 @@ exports[`Storyshots Pagination Pagination 1`] = `
             d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-         Previous
+         
+        Previous
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         1
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         2
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         3
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         4
       </button>
       <button
-        aria-current="true"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 khkrHJ"
-        disabled=""
+        aria-current={true}
+        aria-label={null}
+        className="c4"
+        disabled={true}
+        onClick={[Function]}
       >
         5
       </button>
       <p
-        class="Text-sc-1wu7vpu-0 dqAYor"
+        className="c6"
         color="currentColor"
-        font-size="small"
+        disabled={false}
+        fontSize="small"
       >
         ...
       </p>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         7
       </button>
       <button
         aria-label="Go to next results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 iFOkT"
+        className="c7"
+        disabled={false}
+        onClick={null}
       >
-        Next 
+        Next
+         
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 dEtgXr"
+          aria-hidden={true}
+          className="c8"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="rightArrow"
           mr="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -500,21 +762,25 @@ exports[`Storyshots Pagination Pagination 1`] = `
     </nav>
     <nav
       aria-label="Pagination navigation"
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+      className="Box-sc-1qu1edy-0 c1"
     >
       <button
         aria-label="Go to previous results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 iFOkT"
+        className="c7"
+        disabled={false}
+        onClick={null}
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 bLUmHQ"
+          aria-hidden={true}
+          className="c3"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="leftArrow"
           ml="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -522,71 +788,90 @@ exports[`Storyshots Pagination Pagination 1`] = `
             d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-         Previous
+         
+        Previous
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         1
       </button>
       <p
-        class="Text-sc-1wu7vpu-0 dqAYor"
+        className="c6"
         color="currentColor"
-        font-size="small"
+        disabled={false}
+        fontSize="small"
       >
         ...
       </p>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         3
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         4
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         5
       </button>
       <button
-        aria-current="true"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 khkrHJ"
-        disabled=""
+        aria-current={true}
+        aria-label={null}
+        className="c4"
+        disabled={true}
+        onClick={[Function]}
       >
         6
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         7
       </button>
       <button
         aria-label="Go to next results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 iFOkT"
+        className="c7"
+        disabled={false}
+        onClick={null}
       >
-        Next 
+        Next
+         
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 dEtgXr"
+          aria-hidden={true}
+          className="c8"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="rightArrow"
           mr="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -598,21 +883,25 @@ exports[`Storyshots Pagination Pagination 1`] = `
     </nav>
     <nav
       aria-label="Pagination navigation"
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+      className="Box-sc-1qu1edy-0 c1"
     >
       <button
         aria-label="Go to previous results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 iFOkT"
+        className="c7"
+        disabled={false}
+        onClick={null}
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 bLUmHQ"
+          aria-hidden={true}
+          className="c3"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="leftArrow"
           ml="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -620,72 +909,90 @@ exports[`Storyshots Pagination Pagination 1`] = `
             d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-         Previous
+         
+        Previous
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         1
       </button>
       <p
-        class="Text-sc-1wu7vpu-0 dqAYor"
+        className="c6"
         color="currentColor"
-        font-size="small"
+        disabled={false}
+        fontSize="small"
       >
         ...
       </p>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         3
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         4
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         5
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         6
       </button>
       <button
-        aria-current="true"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 khkrHJ"
-        disabled=""
+        aria-current={true}
+        aria-label={null}
+        className="c4"
+        disabled={true}
+        onClick={[Function]}
       >
         7
       </button>
       <button
         aria-label="Go to next results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 kZsQns"
-        disabled=""
+        className="c2"
+        disabled={true}
+        onClick={null}
       >
-        Next 
+        Next
+         
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 dEtgXr"
+          aria-hidden={true}
+          className="c8"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="rightArrow"
           mr="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -700,30 +1007,181 @@ exports[`Storyshots Pagination Pagination 1`] = `
 `;
 
 exports[`Storyshots Pagination on the first page 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  margin-left: -8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c8 {
+  margin-right: -8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c6 {
+  padding-top: 8px;
+  padding-bottom: 8px;
+  margin-right: 16px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 14px;
+  line-height: 1.71428571;
+  color: currentColor;
+}
+
+.c2 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #e4e7eb;
+  color: #c0c8d1;
+  cursor: default;
+}
+
+.c2:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c2:hover {
+  background: inital;
+}
+
+.c7 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #e4e7eb;
+  color: #011e38;
+  cursor: pointer;
+}
+
+.c7:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c7:hover {
+  background: #e4e7eb;
+}
+
+.c4 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #00438f;
+  color: #c0c8d1;
+  cursor: default;
+  background: #00438f;
+  color: #f0f2f5;
+}
+
+.c4:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c4:hover {
+  background: #00438f;
+}
+
+.c5 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #e4e7eb;
+  color: #011e38;
+  cursor: pointer;
+  background: transparent;
+  color: #011e38;
+}
+
+.c5:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c5:hover {
+  background: #e4e7eb;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <nav
       aria-label="Pagination navigation"
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+      className="Box-sc-1qu1edy-0 c1"
     >
       <button
         aria-label="Go to previous results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 kZsQns"
-        disabled=""
+        className="c2"
+        disabled={true}
+        onClick={null}
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 bLUmHQ"
+          aria-hidden={true}
+          className="c3"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="leftArrow"
           ml="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -731,71 +1189,90 @@ exports[`Storyshots Pagination on the first page 1`] = `
             d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-         Previous
+         
+        Previous
       </button>
       <button
-        aria-current="true"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 khkrHJ"
-        disabled=""
+        aria-current={true}
+        aria-label={null}
+        className="c4"
+        disabled={true}
+        onClick={[Function]}
       >
         1
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         2
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         3
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         4
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         5
       </button>
       <p
-        class="Text-sc-1wu7vpu-0 dqAYor"
+        className="c6"
         color="currentColor"
-        font-size="small"
+        disabled={false}
+        fontSize="small"
       >
         ...
       </p>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c5"
+        disabled={false}
+        onClick={[Function]}
       >
         10
       </button>
       <button
         aria-label="Go to next results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 iFOkT"
+        className="c7"
+        disabled={false}
+        onClick={null}
       >
-        Next 
+        Next
+         
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 dEtgXr"
+          aria-hidden={true}
+          className="c8"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="rightArrow"
           mr="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -810,29 +1287,181 @@ exports[`Storyshots Pagination on the first page 1`] = `
 `;
 
 exports[`Storyshots Pagination on the last page 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  margin-left: -8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c8 {
+  margin-right: -8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c5 {
+  padding-top: 8px;
+  padding-bottom: 8px;
+  margin-right: 16px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 14px;
+  line-height: 1.71428571;
+  color: currentColor;
+}
+
+.c2 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #e4e7eb;
+  color: #011e38;
+  cursor: pointer;
+}
+
+.c2:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c2:hover {
+  background: #e4e7eb;
+}
+
+.c7 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #e4e7eb;
+  color: #c0c8d1;
+  cursor: default;
+}
+
+.c7:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c7:hover {
+  background: inital;
+}
+
+.c4 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #e4e7eb;
+  color: #011e38;
+  cursor: pointer;
+  background: transparent;
+  color: #011e38;
+}
+
+.c4:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c4:hover {
+  background: #e4e7eb;
+}
+
+.c6 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #00438f;
+  color: #c0c8d1;
+  cursor: default;
+  background: #00438f;
+  color: #f0f2f5;
+}
+
+.c6:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c6:hover {
+  background: #00438f;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <nav
       aria-label="Pagination navigation"
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+      className="Box-sc-1qu1edy-0 c1"
     >
       <button
         aria-label="Go to previous results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 iFOkT"
+        className="c2"
+        disabled={false}
+        onClick={null}
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 bLUmHQ"
+          aria-hidden={true}
+          className="c3"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="leftArrow"
           ml="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -840,72 +1469,90 @@ exports[`Storyshots Pagination on the last page 1`] = `
             d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-         Previous
+         
+        Previous
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c4"
+        disabled={false}
+        onClick={[Function]}
       >
         1
       </button>
       <p
-        class="Text-sc-1wu7vpu-0 dqAYor"
+        className="c5"
         color="currentColor"
-        font-size="small"
+        disabled={false}
+        fontSize="small"
       >
         ...
       </p>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c4"
+        disabled={false}
+        onClick={[Function]}
       >
         6
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c4"
+        disabled={false}
+        onClick={[Function]}
       >
         7
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c4"
+        disabled={false}
+        onClick={[Function]}
       >
         8
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c4"
+        disabled={false}
+        onClick={[Function]}
       >
         9
       </button>
       <button
-        aria-current="true"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 khkrHJ"
-        disabled=""
+        aria-current={true}
+        aria-label={null}
+        className="c6"
+        disabled={true}
+        onClick={[Function]}
       >
         10
       </button>
       <button
         aria-label="Go to next results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 kZsQns"
-        disabled=""
+        className="c7"
+        disabled={true}
+        onClick={null}
       >
-        Next 
+        Next
+         
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 dEtgXr"
+          aria-hidden={true}
+          className="c8"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="rightArrow"
           mr="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -920,29 +1567,148 @@ exports[`Storyshots Pagination on the last page 1`] = `
 `;
 
 exports[`Storyshots Pagination with less than 5 pages 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3 {
+  margin-left: -8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c6 {
+  margin-right: -8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c2 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #e4e7eb;
+  color: #011e38;
+  cursor: pointer;
+}
+
+.c2:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c2:hover {
+  background: #e4e7eb;
+}
+
+.c4 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #e4e7eb;
+  color: #011e38;
+  cursor: pointer;
+  background: transparent;
+  color: #011e38;
+}
+
+.c4:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c4:hover {
+  background: #e4e7eb;
+}
+
+.c5 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #00438f;
+  color: #c0c8d1;
+  cursor: default;
+  background: #00438f;
+  color: #f0f2f5;
+}
+
+.c5:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c5:hover {
+  background: #00438f;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <nav
       aria-label="Pagination navigation"
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+      className="Box-sc-1qu1edy-0 c1"
     >
       <button
         aria-label="Go to previous results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 iFOkT"
+        className="c2"
+        disabled={false}
+        onClick={null}
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 bLUmHQ"
+          aria-hidden={true}
+          className="c3"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="leftArrow"
           ml="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -950,50 +1716,64 @@ exports[`Storyshots Pagination with less than 5 pages 1`] = `
             d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-         Previous
+         
+        Previous
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c4"
+        disabled={false}
+        onClick={[Function]}
       >
         1
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c4"
+        disabled={false}
+        onClick={[Function]}
       >
         2
       </button>
       <button
-        aria-current="true"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 khkrHJ"
-        disabled=""
+        aria-current={true}
+        aria-label={null}
+        className="c5"
+        disabled={true}
+        onClick={[Function]}
       >
         3
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c4"
+        disabled={false}
+        onClick={[Function]}
       >
         4
       </button>
       <button
         aria-label="Go to next results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 iFOkT"
+        className="c2"
+        disabled={false}
+        onClick={null}
       >
-        Next 
+        Next
+         
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 dEtgXr"
+          aria-hidden={true}
+          className="c6"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="rightArrow"
           mr="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >

--- a/components/src/Radio/__snapshots__/Radio.story.storyshot
+++ b/components/src/Radio/__snapshots__/Radio.story.storyshot
@@ -1,63 +1,188 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Radio Controlled 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c6 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c2 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c5 {
+  min-width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  border-radius: 50%;
+  border: solid 1px;
+  position: relative;
+  top: 4px;
+}
+
+.c5:before {
+  cursor: pointer;
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  top: 4px;
+  width: 2px;
+  height: 2px;
+  background: #ffffff;
+  border: 2px solid #ffffff;
+  border-radius: 50%;
+}
+
+.c3 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c3:focus + .c4 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c3:checked + .c4 {
+  border-color: #00438f;
+  background-color: #00438f;
+}
+
+.c3:checked + .c4:before {
+  display: block;
+}
+
+.c3:not(:checked) + .c4 {
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+}
+
+.c1 {
+  padding: 4px 0;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+      className="c1"
     >
       <label
-        class="ClickInputLabel-j2axnv-0 kemUmZ"
+        className="c2"
+        disabled={false}
       >
         <input
-          aria-checked="true"
-          aria-invalid="false"
-          aria-required="false"
-          checked=""
-          class="Radio__RadioInput-sc-82dpxx-1 lnYmAf Radio-sc-82dpxx-2 jeIhWi"
+          aria-checked={true}
+          aria-invalid={false}
+          aria-required={false}
+          checked={true}
+          className="c3 c1"
+          disabled={false}
           id="radio-1"
+          onChange={[Function]}
+          required={false}
           type="radio"
         />
         <div
-          checked=""
-          class="Radio__VisualRadio-sc-82dpxx-0 cMunLd"
+          checked={true}
+          className="c4 c5"
+          disabled={false}
         />
         <span
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c6"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
-           I am controlled and checked 
+           
+          I am controlled and checked
+           
         </span>
       </label>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+      className="c1"
     >
       <label
-        class="ClickInputLabel-j2axnv-0 kemUmZ"
+        className="c2"
+        disabled={false}
       >
         <input
-          aria-checked="false"
-          aria-invalid="false"
-          aria-required="false"
-          class="Radio__RadioInput-sc-82dpxx-1 lnYmAf Radio-sc-82dpxx-2 jeIhWi"
+          aria-checked={false}
+          aria-invalid={false}
+          aria-required={false}
+          checked={false}
+          className="c3 c1"
+          disabled={false}
           id="radio-2"
+          onChange={[Function]}
+          required={false}
           type="radio"
         />
         <div
-          class="Radio__VisualRadio-sc-82dpxx-0 cMunLd"
+          checked={false}
+          className="c4 c5"
+          disabled={false}
         />
         <span
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c6"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
-           I am controlled and unchecked 
+           
+          I am controlled and unchecked
+           
         </span>
       </label>
     </div>
@@ -66,34 +191,148 @@ exports[`Storyshots Radio Controlled 1`] = `
 `;
 
 exports[`Storyshots Radio Radio 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c6 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c2 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c5 {
+  min-width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  border-radius: 50%;
+  border: solid 1px;
+  position: relative;
+  top: 4px;
+}
+
+.c5:before {
+  cursor: pointer;
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  top: 4px;
+  width: 2px;
+  height: 2px;
+  background: #ffffff;
+  border: 2px solid #ffffff;
+  border-radius: 50%;
+}
+
+.c3 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c3:focus + .c4 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c3:checked + .c4 {
+  border-color: #00438f;
+  background-color: #00438f;
+}
+
+.c3:checked + .c4:before {
+  display: block;
+}
+
+.c3:not(:checked) + .c4 {
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+}
+
+.c1 {
+  padding: 4px 0;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+      className="c1"
     >
       <label
-        class="ClickInputLabel-j2axnv-0 kemUmZ"
+        className="c2"
+        disabled={false}
       >
         <input
-          aria-invalid="false"
-          aria-required="false"
-          class="Radio__RadioInput-sc-82dpxx-1 lnYmAf Radio-sc-82dpxx-2 jeIhWi"
+          aria-invalid={false}
+          aria-required={false}
+          className="c3 c1"
+          disabled={false}
           id="radio"
+          required={false}
           type="radio"
         />
         <div
-          class="Radio__VisualRadio-sc-82dpxx-0 cMunLd"
+          className="c4 c5"
+          disabled={false}
         />
         <span
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c6"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
-           I am a radio button 
+           
+          I am a radio button
+           
         </span>
       </label>
     </div>
@@ -102,35 +341,149 @@ exports[`Storyshots Radio Radio 1`] = `
 `;
 
 exports[`Storyshots Radio Set to defaultChecked 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c6 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c2 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c5 {
+  min-width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  border-radius: 50%;
+  border: solid 1px;
+  position: relative;
+  top: 4px;
+}
+
+.c5:before {
+  cursor: pointer;
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  top: 4px;
+  width: 2px;
+  height: 2px;
+  background: #ffffff;
+  border: 2px solid #ffffff;
+  border-radius: 50%;
+}
+
+.c3 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c3:focus + .c4 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c3:checked + .c4 {
+  border-color: #00438f;
+  background-color: #00438f;
+}
+
+.c3:checked + .c4:before {
+  display: block;
+}
+
+.c3:not(:checked) + .c4 {
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+}
+
+.c1 {
+  padding: 4px 0;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+      className="c1"
     >
       <label
-        class="ClickInputLabel-j2axnv-0 kemUmZ"
+        className="c2"
+        disabled={false}
       >
         <input
-          aria-invalid="false"
-          aria-required="false"
-          checked=""
-          class="Radio__RadioInput-sc-82dpxx-1 lnYmAf Radio-sc-82dpxx-2 jeIhWi"
+          aria-invalid={false}
+          aria-required={false}
+          className="c3 c1"
+          defaultChecked={true}
+          disabled={false}
           id="radio"
+          required={false}
           type="radio"
         />
         <div
-          class="Radio__VisualRadio-sc-82dpxx-0 cMunLd"
+          className="c4 c5"
+          disabled={false}
         />
         <span
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c6"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
-           I am checked by default 
+           
+          I am checked by default
+           
         </span>
       </label>
     </div>
@@ -139,70 +492,182 @@ exports[`Storyshots Radio Set to defaultChecked 1`] = `
 `;
 
 exports[`Storyshots Radio Set to disabled 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c6 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+  opacity: 0.3333;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c5 {
+  min-width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  border-radius: 50%;
+  border: solid 1px;
+  position: relative;
+  top: 4px;
+}
+
+.c5:before {
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  top: 4px;
+  width: 2px;
+  height: 2px;
+  background: #ffffff;
+  border: 2px solid #ffffff;
+  border-radius: 50%;
+}
+
+.c3 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c3:focus + .c4 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c3:checked + .c4 {
+  border-color: #e4e7eb;
+  background-color: #e4e7eb;
+}
+
+.c3:checked + .c4:before {
+  display: block;
+}
+
+.c3:not(:checked) + .c4 {
+  border-color: #e4e7eb;
+  background-color: #f0f2f5;
+}
+
+.c1 {
+  padding: 4px 0;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+      className="c1"
     >
       <label
-        class="ClickInputLabel-j2axnv-0 kjxgat"
-        disabled=""
+        className="c2"
+        disabled={true}
       >
         <input
-          aria-invalid="false"
-          aria-required="false"
-          class="Radio__RadioInput-sc-82dpxx-1 hBtCEn Radio-sc-82dpxx-2 jeIhWi"
-          disabled=""
+          aria-invalid={false}
+          aria-required={false}
+          className="c3 c1"
+          disabled={true}
           id="radio-1"
+          required={false}
           type="radio"
         />
         <div
-          class="Radio__VisualRadio-sc-82dpxx-0 bCyppR"
-          disabled=""
+          className="c4 c5"
+          disabled={true}
         />
         <span
-          class="Text-sc-1wu7vpu-0 hdrQgs"
+          className="c6"
           color="currentColor"
-          disabled=""
-          font-size="medium"
+          disabled={true}
+          fontSize="medium"
         >
-           I am disabled 
+           
+          I am disabled
+           
         </span>
       </label>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+      className="c1"
     >
       <label
-        class="ClickInputLabel-j2axnv-0 kjxgat"
-        disabled=""
+        className="c2"
+        disabled={true}
       >
         <input
-          aria-checked="true"
-          aria-invalid="false"
-          aria-required="false"
-          checked=""
-          class="Radio__RadioInput-sc-82dpxx-1 hBtCEn Radio-sc-82dpxx-2 jeIhWi"
-          disabled=""
+          aria-checked={true}
+          aria-invalid={false}
+          aria-required={false}
+          checked={true}
+          className="c3 c1"
+          disabled={true}
           id="radio-2"
+          required={false}
           type="radio"
         />
         <div
-          checked=""
-          class="Radio__VisualRadio-sc-82dpxx-0 bCyppR"
-          disabled=""
+          checked={true}
+          className="c4 c5"
+          disabled={true}
         />
         <span
-          class="Text-sc-1wu7vpu-0 hdrQgs"
+          className="c6"
           color="currentColor"
-          disabled=""
-          font-size="medium"
+          disabled={true}
+          fontSize="medium"
         >
-           I am disabled 
+           
+          I am disabled
+           
         </span>
       </label>
     </div>
@@ -211,60 +676,181 @@ exports[`Storyshots Radio Set to disabled 1`] = `
 `;
 
 exports[`Storyshots Radio Set to error 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c6 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c2 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c5 {
+  min-width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  border-radius: 50%;
+  border: solid 1px;
+  position: relative;
+  top: 4px;
+}
+
+.c5:before {
+  cursor: pointer;
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  top: 4px;
+  width: 2px;
+  height: 2px;
+  background: #ffffff;
+  border: 2px solid #ffffff;
+  border-radius: 50%;
+}
+
+.c3 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c3:focus + .c4 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c3:checked + .c4 {
+  border-color: #cc1439;
+  background-color: #cc1439;
+}
+
+.c3:checked + .c4:before {
+  display: block;
+}
+
+.c3:not(:checked) + .c4 {
+  border-color: #cc1439;
+  background-color: #ffffff;
+}
+
+.c1 {
+  padding: 4px 0;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+      className="c1"
     >
       <label
-        class="ClickInputLabel-j2axnv-0 kemUmZ"
+        className="c2"
+        disabled={false}
       >
         <input
-          aria-invalid="true"
-          aria-required="false"
-          class="Radio__RadioInput-sc-82dpxx-1 iSoGgh Radio-sc-82dpxx-2 jeIhWi"
+          aria-invalid={true}
+          aria-required={false}
+          className="c3 c1"
+          disabled={false}
           id="radio"
+          required={false}
           type="radio"
         />
         <div
-          class="Radio__VisualRadio-sc-82dpxx-0 cMunLd"
+          className="c4 c5"
+          disabled={false}
         />
         <span
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c6"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
-           I am error 
+           
+          I am error
+           
         </span>
       </label>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+      className="c1"
     >
       <label
-        class="ClickInputLabel-j2axnv-0 kemUmZ"
+        className="c2"
+        disabled={false}
       >
         <input
-          aria-invalid="true"
-          aria-required="false"
-          checked=""
-          class="Radio__RadioInput-sc-82dpxx-1 iSoGgh Radio-sc-82dpxx-2 jeIhWi"
+          aria-invalid={true}
+          aria-required={false}
+          className="c3 c1"
+          defaultChecked={true}
+          disabled={false}
           id="radio"
+          required={false}
           type="radio"
         />
         <div
-          class="Radio__VisualRadio-sc-82dpxx-0 cMunLd"
+          className="c4 c5"
+          disabled={false}
         />
         <span
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c6"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
-           I am error 
+           
+          I am error
+           
         </span>
       </label>
     </div>
@@ -273,35 +859,148 @@ exports[`Storyshots Radio Set to error 1`] = `
 `;
 
 exports[`Storyshots Radio Set to required 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c6 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c2 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c5 {
+  min-width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  border-radius: 50%;
+  border: solid 1px;
+  position: relative;
+  top: 4px;
+}
+
+.c5:before {
+  cursor: pointer;
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  top: 4px;
+  width: 2px;
+  height: 2px;
+  background: #ffffff;
+  border: 2px solid #ffffff;
+  border-radius: 50%;
+}
+
+.c3 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c3:focus + .c4 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c3:checked + .c4 {
+  border-color: #00438f;
+  background-color: #00438f;
+}
+
+.c3:checked + .c4:before {
+  display: block;
+}
+
+.c3:not(:checked) + .c4 {
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+}
+
+.c1 {
+  padding: 4px 0;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+      className="c1"
     >
       <label
-        class="ClickInputLabel-j2axnv-0 kemUmZ"
+        className="c2"
+        disabled={false}
       >
         <input
-          aria-invalid="false"
-          aria-required="true"
-          class="Radio__RadioInput-sc-82dpxx-1 lnYmAf Radio-sc-82dpxx-2 jeIhWi"
+          aria-invalid={false}
+          aria-required={true}
+          className="c3 c1"
+          disabled={false}
           id="radio"
-          required=""
+          required={true}
           type="radio"
         />
         <div
-          class="Radio__VisualRadio-sc-82dpxx-0 cMunLd"
+          className="c4 c5"
+          disabled={false}
         />
         <span
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c6"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
-           I am a radio button 
+           
+          I am a radio button
+           
         </span>
       </label>
     </div>

--- a/components/src/Radio/__snapshots__/RadioGroup.story.storyshot
+++ b/components/src/Radio/__snapshots__/RadioGroup.story.storyshot
@@ -1,104 +1,263 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots RadioGroup Controlled 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c7 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c3 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c1 {
+  padding: 0;
+  border: 0;
+  margin: 0;
+  width: 100%;
+}
+
+.c1 legend {
+  padding: 0;
+}
+
+.c6 {
+  min-width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  border-radius: 50%;
+  border: solid 1px;
+  position: relative;
+  top: 4px;
+}
+
+.c6:before {
+  cursor: pointer;
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  top: 4px;
+  width: 2px;
+  height: 2px;
+  background: #ffffff;
+  border: 2px solid #ffffff;
+  border-radius: 50%;
+}
+
+.c4 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c4:focus + .c5 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c4:checked + .c5 {
+  border-color: #00438f;
+  background-color: #00438f;
+}
+
+.c4:checked + .c5:before {
+  display: block;
+}
+
+.c4:not(:checked) + .c5 {
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+}
+
+.c2 {
+  padding: 4px 0;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <fieldset
-      class="Fieldset-sc-9aoml1-0 eiFgjk RadioGroup-pgv2w1-0 hFKzrk"
+      className="c1 "
     >
       <legend
-        style="margin-bottom:8px"
+        style={
+          Object {
+            "marginBottom": "8px",
+          }
+        }
       >
         <span
-          style="font-size:14px;font-weight:600;line-height:1.71428571"
+          style={
+            Object {
+              "fontSize": "14px",
+              "fontWeight": "600",
+              "lineHeight": "1.71428571",
+            }
+          }
         >
           Setting Selection
         </span>
       </legend>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+        className="c2"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c3"
+          disabled={false}
         >
           <input
-            aria-checked="true"
-            aria-invalid="false"
-            aria-required="false"
-            checked=""
-            class="Radio__RadioInput-sc-82dpxx-1 lnYmAf Radio-sc-82dpxx-2 jeIhWi"
+            aria-checked={true}
+            aria-invalid={false}
+            aria-required={false}
+            checked={true}
+            className="c4 c2"
+            disabled={false}
+            id={null}
             name="settingSelection"
+            onChange={[Function]}
+            required={false}
             type="radio"
             value="a"
           />
           <div
-            checked=""
-            class="Radio__VisualRadio-sc-82dpxx-0 cMunLd"
+            checked={true}
+            className="c5 c6"
+            disabled={false}
           />
           <span
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c7"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
-             Option A 
+             
+            Option A
+             
           </span>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+        className="c2"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c3"
+          disabled={false}
         >
           <input
-            aria-checked="false"
-            aria-invalid="false"
-            aria-required="false"
-            class="Radio__RadioInput-sc-82dpxx-1 lnYmAf Radio-sc-82dpxx-2 jeIhWi"
+            aria-checked={false}
+            aria-invalid={false}
+            aria-required={false}
+            checked={false}
+            className="c4 c2"
+            disabled={false}
+            id={null}
             name="settingSelection"
+            onChange={[Function]}
+            required={false}
             type="radio"
             value="b"
           />
           <div
-            class="Radio__VisualRadio-sc-82dpxx-0 cMunLd"
+            checked={false}
+            className="c5 c6"
+            disabled={false}
           />
           <span
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c7"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
-             Option B 
+             
+            Option B
+             
           </span>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+        className="c2"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c3"
+          disabled={false}
         >
           <input
-            aria-checked="false"
-            aria-invalid="false"
-            aria-required="false"
-            class="Radio__RadioInput-sc-82dpxx-1 lnYmAf Radio-sc-82dpxx-2 jeIhWi"
+            aria-checked={false}
+            aria-invalid={false}
+            aria-required={false}
+            checked={false}
+            className="c4 c2"
+            disabled={false}
+            id={null}
             name="settingSelection"
+            onChange={[Function]}
+            required={false}
             type="radio"
             value="c"
           />
           <div
-            class="Radio__VisualRadio-sc-82dpxx-0 cMunLd"
+            checked={false}
+            className="c5 c6"
+            disabled={false}
           />
           <span
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c7"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
-             Option C 
+             
+            Option C
+             
           </span>
         </label>
       </div>
@@ -108,99 +267,251 @@ exports[`Storyshots RadioGroup Controlled 1`] = `
 `;
 
 exports[`Storyshots RadioGroup RadioGroup 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c7 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c3 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c1 {
+  padding: 0;
+  border: 0;
+  margin: 0;
+  width: 100%;
+}
+
+.c1 legend {
+  padding: 0;
+}
+
+.c6 {
+  min-width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  border-radius: 50%;
+  border: solid 1px;
+  position: relative;
+  top: 4px;
+}
+
+.c6:before {
+  cursor: pointer;
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  top: 4px;
+  width: 2px;
+  height: 2px;
+  background: #ffffff;
+  border: 2px solid #ffffff;
+  border-radius: 50%;
+}
+
+.c4 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c4:focus + .c5 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c4:checked + .c5 {
+  border-color: #00438f;
+  background-color: #00438f;
+}
+
+.c4:checked + .c5:before {
+  display: block;
+}
+
+.c4:not(:checked) + .c5 {
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+}
+
+.c2 {
+  padding: 4px 0;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <fieldset
-      class="Fieldset-sc-9aoml1-0 eiFgjk RadioGroup-pgv2w1-0 hFKzrk"
+      className="c1 "
     >
       <legend
-        style="margin-bottom:8px"
+        style={
+          Object {
+            "marginBottom": "8px",
+          }
+        }
       >
         <span
-          style="font-size:14px;font-weight:600;line-height:1.71428571"
+          style={
+            Object {
+              "fontSize": "14px",
+              "fontWeight": "600",
+              "lineHeight": "1.71428571",
+            }
+          }
         >
           Setting Selection
         </span>
       </legend>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+        className="c2"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c3"
+          disabled={false}
         >
           <input
-            aria-invalid="false"
-            aria-required="false"
-            class="Radio__RadioInput-sc-82dpxx-1 lnYmAf Radio-sc-82dpxx-2 jeIhWi"
+            aria-invalid={false}
+            aria-required={false}
+            className="c4 c2"
+            disabled={false}
+            id={null}
             name="settingSelection"
+            required={false}
             type="radio"
             value="a"
           />
           <div
-            class="Radio__VisualRadio-sc-82dpxx-0 cMunLd"
+            className="c5 c6"
+            disabled={false}
           />
           <span
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c7"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
-             Option A 
+             
+            Option A
+             
           </span>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+        className="c2"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c3"
+          disabled={false}
         >
           <input
-            aria-invalid="false"
-            aria-required="false"
-            class="Radio__RadioInput-sc-82dpxx-1 lnYmAf Radio-sc-82dpxx-2 jeIhWi"
+            aria-invalid={false}
+            aria-required={false}
+            className="c4 c2"
+            disabled={false}
+            id={null}
             name="settingSelection"
+            required={false}
             type="radio"
             value="b"
           />
           <div
-            class="Radio__VisualRadio-sc-82dpxx-0 cMunLd"
+            className="c5 c6"
+            disabled={false}
           />
           <span
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c7"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
-             Option B 
+             
+            Option B
+             
           </span>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+        className="c2"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c3"
+          disabled={false}
         >
           <input
-            aria-invalid="false"
-            aria-required="false"
-            class="Radio__RadioInput-sc-82dpxx-1 lnYmAf Radio-sc-82dpxx-2 jeIhWi"
+            aria-invalid={false}
+            aria-required={false}
+            className="c4 c2"
+            disabled={false}
+            id={null}
             name="settingSelection"
+            required={false}
             type="radio"
             value="c"
           />
           <div
-            class="Radio__VisualRadio-sc-82dpxx-0 cMunLd"
+            className="c5 c6"
+            disabled={false}
           />
           <span
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c7"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
-             Option C 
+             
+            Option C
+             
           </span>
         </label>
       </div>
@@ -210,117 +521,291 @@ exports[`Storyshots RadioGroup RadioGroup 1`] = `
 `;
 
 exports[`Storyshots RadioGroup RadioGroup with all props 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c2 {
+  margin-left: 8px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #434d59;
+}
+
+.c9 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c5 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c3 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+  font-size: 14px;
+  line-height: 1.71428571;
+}
+
+.c3 .Link-sc-1lpx3d0-0 {
+  font-size: 14px;
+}
+
+.c1 {
+  padding: 0;
+  border: 0;
+  margin: 0;
+  width: 100%;
+}
+
+.c1 legend {
+  padding: 0;
+}
+
+.c8 {
+  min-width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  border-radius: 50%;
+  border: solid 1px;
+  position: relative;
+  top: 4px;
+}
+
+.c8:before {
+  cursor: pointer;
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  top: 4px;
+  width: 2px;
+  height: 2px;
+  background: #ffffff;
+  border: 2px solid #ffffff;
+  border-radius: 50%;
+}
+
+.c6 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c6:focus + .c7 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c6:checked + .c7 {
+  border-color: #00438f;
+  background-color: #00438f;
+}
+
+.c6:checked + .c7:before {
+  display: block;
+}
+
+.c6:not(:checked) + .c7 {
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+}
+
+.c4 {
+  padding: 4px 0;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <fieldset
-      class="Fieldset-sc-9aoml1-0 eiFgjk RadioGroup-pgv2w1-0 hFKzrk"
+      className="c1 "
     >
       <legend
-        style="margin-bottom:8px"
+        style={
+          Object {
+            "marginBottom": "8px",
+          }
+        }
       >
         <span
-          style="font-size:14px;font-weight:600;line-height:1.71428571"
+          style={
+            Object {
+              "fontSize": "14px",
+              "fontWeight": "600",
+              "lineHeight": "1.71428571",
+            }
+          }
         >
           Setting Selection
         </span>
         <span
-          class="Text-sc-1wu7vpu-0 bphWXP"
+          className="c2"
           color="darkGrey"
-          font-size="12px"
+          disabled={false}
+          fontSize="12px"
         >
           (Required)
         </span>
       </legend>
       <p
-        class="Text-sc-1wu7vpu-0 HelpText__HelpTextContent-sc-1jzmq2g-0 feAJVX"
+        className="c3"
         color="currentColor"
-        font-size="medium"
+        disabled={false}
+        fontSize="medium"
       >
         Select a setting from the menu below:
       </p>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+        className="c4"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c5"
+          disabled={false}
         >
           <input
-            aria-invalid="false"
-            aria-required="true"
-            checked=""
-            class="Radio__RadioInput-sc-82dpxx-1 lnYmAf Radio-sc-82dpxx-2 jeIhWi"
+            aria-invalid={false}
+            aria-required={true}
+            className="c6 c4"
+            defaultChecked={true}
+            disabled={false}
+            id={null}
             name="settingSelection"
-            required=""
+            required={true}
             type="radio"
             value="a"
           />
           <div
-            class="Radio__VisualRadio-sc-82dpxx-0 cMunLd"
+            className="c7 c8"
+            disabled={false}
           />
           <span
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c9"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
-             Option A 
+             
+            Option A
+             
           </span>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+        className="c4"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c5"
+          disabled={false}
         >
           <input
-            aria-invalid="false"
-            aria-required="true"
-            class="Radio__RadioInput-sc-82dpxx-1 lnYmAf Radio-sc-82dpxx-2 jeIhWi"
+            aria-invalid={false}
+            aria-required={true}
+            className="c6 c4"
+            disabled={false}
+            id={null}
             name="settingSelection"
-            required=""
+            required={true}
             type="radio"
             value="b"
           />
           <div
-            class="Radio__VisualRadio-sc-82dpxx-0 cMunLd"
+            className="c7 c8"
+            disabled={false}
           />
           <span
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c9"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
-             Option B 
+             
+            Option B
+             
           </span>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+        className="c4"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c5"
+          disabled={false}
         >
           <input
-            aria-invalid="false"
-            aria-required="true"
-            class="Radio__RadioInput-sc-82dpxx-1 lnYmAf Radio-sc-82dpxx-2 jeIhWi"
+            aria-invalid={false}
+            aria-required={true}
+            className="c6 c4"
+            disabled={false}
+            id={null}
             name="settingSelection"
-            required=""
+            required={true}
             type="radio"
             value="c"
           />
           <div
-            class="Radio__VisualRadio-sc-82dpxx-0 cMunLd"
+            className="c7 c8"
+            disabled={false}
           />
           <span
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c9"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
-             Option C 
+             
+            Option C
+             
           </span>
         </label>
       </div>
@@ -330,112 +815,251 @@ exports[`Storyshots RadioGroup RadioGroup with all props 1`] = `
 `;
 
 exports[`Storyshots RadioGroup Set to disabled 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c7 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+  opacity: 0.3333;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c1 {
+  padding: 0;
+  border: 0;
+  margin: 0;
+  width: 100%;
+}
+
+.c1 legend {
+  padding: 0;
+}
+
+.c6 {
+  min-width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  border-radius: 50%;
+  border: solid 1px;
+  position: relative;
+  top: 4px;
+}
+
+.c6:before {
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  top: 4px;
+  width: 2px;
+  height: 2px;
+  background: #ffffff;
+  border: 2px solid #ffffff;
+  border-radius: 50%;
+}
+
+.c4 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c4:focus + .c5 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c4:checked + .c5 {
+  border-color: #e4e7eb;
+  background-color: #e4e7eb;
+}
+
+.c4:checked + .c5:before {
+  display: block;
+}
+
+.c4:not(:checked) + .c5 {
+  border-color: #e4e7eb;
+  background-color: #f0f2f5;
+}
+
+.c2 {
+  padding: 4px 0;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <fieldset
-      class="Fieldset-sc-9aoml1-0 eiFgjk RadioGroup-pgv2w1-0 hFKzrk"
+      className="c1 "
     >
       <legend
-        style="margin-bottom:8px"
+        style={
+          Object {
+            "marginBottom": "8px",
+          }
+        }
       >
         <span
-          style="font-size:14px;font-weight:600;line-height:1.71428571"
+          style={
+            Object {
+              "fontSize": "14px",
+              "fontWeight": "600",
+              "lineHeight": "1.71428571",
+            }
+          }
         >
           Setting Selection
         </span>
       </legend>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+        className="c2"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kjxgat"
-          disabled=""
+          className="c3"
+          disabled={true}
         >
           <input
-            aria-invalid="false"
-            aria-required="false"
-            checked=""
-            class="Radio__RadioInput-sc-82dpxx-1 hBtCEn Radio-sc-82dpxx-2 jeIhWi"
-            disabled=""
+            aria-invalid={false}
+            aria-required={false}
+            className="c4 c2"
+            defaultChecked={true}
+            disabled={true}
+            id={null}
             name="settingSelection"
+            required={false}
             type="radio"
             value="a"
           />
           <div
-            class="Radio__VisualRadio-sc-82dpxx-0 bCyppR"
-            disabled=""
+            className="c5 c6"
+            disabled={true}
           />
           <span
-            class="Text-sc-1wu7vpu-0 hdrQgs"
+            className="c7"
             color="currentColor"
-            disabled=""
-            font-size="medium"
+            disabled={true}
+            fontSize="medium"
           >
-             Option A 
+             
+            Option A
+             
           </span>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+        className="c2"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kjxgat"
-          disabled=""
+          className="c3"
+          disabled={true}
         >
           <input
-            aria-invalid="false"
-            aria-required="false"
-            class="Radio__RadioInput-sc-82dpxx-1 hBtCEn Radio-sc-82dpxx-2 jeIhWi"
-            disabled=""
+            aria-invalid={false}
+            aria-required={false}
+            className="c4 c2"
+            disabled={true}
+            id={null}
             name="settingSelection"
+            required={false}
             type="radio"
             value="b"
           />
           <div
-            class="Radio__VisualRadio-sc-82dpxx-0 bCyppR"
-            disabled=""
+            className="c5 c6"
+            disabled={true}
           />
           <span
-            class="Text-sc-1wu7vpu-0 hdrQgs"
+            className="c7"
             color="currentColor"
-            disabled=""
-            font-size="medium"
+            disabled={true}
+            fontSize="medium"
           >
-             Option B 
+             
+            Option B
+             
           </span>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+        className="c2"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kjxgat"
-          disabled=""
+          className="c3"
+          disabled={true}
         >
           <input
-            aria-invalid="false"
-            aria-required="false"
-            class="Radio__RadioInput-sc-82dpxx-1 hBtCEn Radio-sc-82dpxx-2 jeIhWi"
-            disabled=""
+            aria-invalid={false}
+            aria-required={false}
+            className="c4 c2"
+            disabled={true}
+            id={null}
             name="settingSelection"
+            required={false}
             type="radio"
             value="c"
           />
           <div
-            class="Radio__VisualRadio-sc-82dpxx-0 bCyppR"
-            disabled=""
+            className="c5 c6"
+            disabled={true}
           />
           <span
-            class="Text-sc-1wu7vpu-0 hdrQgs"
+            className="c7"
             color="currentColor"
-            disabled=""
-            font-size="medium"
+            disabled={true}
+            fontSize="medium"
           >
-             Option C 
+             
+            Option C
+             
           </span>
         </label>
       </div>
@@ -445,116 +1069,312 @@ exports[`Storyshots RadioGroup Set to disabled 1`] = `
 `;
 
 exports[`Storyshots RadioGroup with error list 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c9 {
+  color: #cc1439;
+  margin-top: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c10 {
+  margin-right: 8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c8 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c3 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c14 {
+  margin-bottom: 8px;
+  color: currentColor;
+}
+
+.c14:last-child {
+  margin-bottom: 0;
+}
+
+.c12 {
+  color: currentColor;
+  margin: 0;
+  padding-left: 18px;
+}
+
+.c12 .c13 {
+  margin-bottom: 0;
+}
+
+.c11 .c7 {
+  margin-bottom: 8px;
+}
+
+.c11 > *:last-child {
+  margin-bottom: 0;
+}
+
+.c1 {
+  padding: 0;
+  border: 0;
+  margin: 0;
+  width: 100%;
+}
+
+.c1 legend {
+  padding: 0;
+}
+
+.c6 {
+  min-width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  border-radius: 50%;
+  border: solid 1px;
+  position: relative;
+  top: 4px;
+}
+
+.c6:before {
+  cursor: pointer;
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  top: 4px;
+  width: 2px;
+  height: 2px;
+  background: #ffffff;
+  border: 2px solid #ffffff;
+  border-radius: 50%;
+}
+
+.c4 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c4:focus + .c5 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c4:checked + .c5 {
+  border-color: #cc1439;
+  background-color: #cc1439;
+}
+
+.c4:checked + .c5:before {
+  display: block;
+}
+
+.c4:not(:checked) + .c5 {
+  border-color: #cc1439;
+  background-color: #ffffff;
+}
+
+.c2 {
+  padding: 4px 0;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <fieldset
-      class="Fieldset-sc-9aoml1-0 eiFgjk RadioGroup-pgv2w1-0 hFKzrk"
+      className="c1 "
     >
       <legend
-        style="margin-bottom:8px"
+        style={
+          Object {
+            "marginBottom": "8px",
+          }
+        }
       >
         <span
-          style="font-size:14px;font-weight:600;line-height:1.71428571"
+          style={
+            Object {
+              "fontSize": "14px",
+              "fontWeight": "600",
+              "lineHeight": "1.71428571",
+            }
+          }
         >
           Setting Selection
         </span>
       </legend>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+        className="c2"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c3"
+          disabled={false}
         >
           <input
-            aria-invalid="true"
-            aria-required="false"
-            checked=""
-            class="Radio__RadioInput-sc-82dpxx-1 iSoGgh Radio-sc-82dpxx-2 jeIhWi"
+            aria-invalid={true}
+            aria-required={false}
+            className="c4 c2"
+            defaultChecked={true}
+            disabled={false}
+            id={null}
             name="settingSelection"
+            required={false}
             type="radio"
             value="a"
           />
           <div
-            class="Radio__VisualRadio-sc-82dpxx-0 cMunLd"
+            className="c5 c6"
+            disabled={false}
           />
           <span
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c7 c8"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
-             Option A 
+             
+            Option A
+             
           </span>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+        className="c2"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c3"
+          disabled={false}
         >
           <input
-            aria-invalid="true"
-            aria-required="false"
-            class="Radio__RadioInput-sc-82dpxx-1 iSoGgh Radio-sc-82dpxx-2 jeIhWi"
+            aria-invalid={true}
+            aria-required={false}
+            className="c4 c2"
+            disabled={false}
+            id={null}
             name="settingSelection"
+            required={false}
             type="radio"
             value="b"
           />
           <div
-            class="Radio__VisualRadio-sc-82dpxx-0 cMunLd"
+            className="c5 c6"
+            disabled={false}
           />
           <span
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c7 c8"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
-             Option B 
+             
+            Option B
+             
           </span>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+        className="c2"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c3"
+          disabled={false}
         >
           <input
-            aria-invalid="true"
-            aria-required="false"
-            class="Radio__RadioInput-sc-82dpxx-1 iSoGgh Radio-sc-82dpxx-2 jeIhWi"
+            aria-invalid={true}
+            aria-required={false}
+            className="c4 c2"
+            disabled={false}
+            id={null}
             name="settingSelection"
+            required={false}
             type="radio"
             value="c"
           />
           <div
-            class="Radio__VisualRadio-sc-82dpxx-0 cMunLd"
+            className="c5 c6"
+            disabled={false}
           />
           <span
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c7 c8"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
-             Option C 
+             
+            Option C
+             
           </span>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 ycNbA"
+        className="c9"
         color="red"
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 QuoIa"
+          aria-hidden={true}
+          className="c10"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="error"
           mr="x1"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -563,27 +1383,28 @@ exports[`Storyshots RadioGroup with error list 1`] = `
           />
         </svg>
         <div
-          class="InlineValidation__Wrapper-sc-1jic7dw-0 kqhCKM"
+          className="c11"
         >
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c7 c8"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Please select an option
           </p>
           <ul
-            class="List-sc-1cqkmnl-0 diqcEx"
+            className="c12"
             color="currentColor"
           >
             <li
-              class="ListItem-qqenhw-0 gzsWDK"
+              className="c13 c14"
               color="currentColor"
             >
               Error message 1
             </li>
             <li
-              class="ListItem-qqenhw-0 gzsWDK"
+              className="c13 c14"
               color="currentColor"
             >
               Error message 2
@@ -597,116 +1418,293 @@ exports[`Storyshots RadioGroup with error list 1`] = `
 `;
 
 exports[`Storyshots RadioGroup with error message 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c9 {
+  color: #cc1439;
+  margin-top: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c10 {
+  margin-right: 8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c8 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c3 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c11 .c7 {
+  margin-bottom: 8px;
+}
+
+.c11 > *:last-child {
+  margin-bottom: 0;
+}
+
+.c1 {
+  padding: 0;
+  border: 0;
+  margin: 0;
+  width: 100%;
+}
+
+.c1 legend {
+  padding: 0;
+}
+
+.c6 {
+  min-width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  border-radius: 50%;
+  border: solid 1px;
+  position: relative;
+  top: 4px;
+}
+
+.c6:before {
+  cursor: pointer;
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  top: 4px;
+  width: 2px;
+  height: 2px;
+  background: #ffffff;
+  border: 2px solid #ffffff;
+  border-radius: 50%;
+}
+
+.c4 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c4:focus + .c5 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c4:checked + .c5 {
+  border-color: #cc1439;
+  background-color: #cc1439;
+}
+
+.c4:checked + .c5:before {
+  display: block;
+}
+
+.c4:not(:checked) + .c5 {
+  border-color: #cc1439;
+  background-color: #ffffff;
+}
+
+.c2 {
+  padding: 4px 0;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <fieldset
-      class="Fieldset-sc-9aoml1-0 eiFgjk RadioGroup-pgv2w1-0 hFKzrk"
+      className="c1 "
     >
       <legend
-        style="margin-bottom:8px"
+        style={
+          Object {
+            "marginBottom": "8px",
+          }
+        }
       >
         <span
-          style="font-size:14px;font-weight:600;line-height:1.71428571"
+          style={
+            Object {
+              "fontSize": "14px",
+              "fontWeight": "600",
+              "lineHeight": "1.71428571",
+            }
+          }
         >
           Setting Selection
         </span>
       </legend>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+        className="c2"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c3"
+          disabled={false}
         >
           <input
-            aria-invalid="true"
-            aria-required="false"
-            checked=""
-            class="Radio__RadioInput-sc-82dpxx-1 iSoGgh Radio-sc-82dpxx-2 jeIhWi"
+            aria-invalid={true}
+            aria-required={false}
+            className="c4 c2"
+            defaultChecked={true}
+            disabled={false}
+            id={null}
             name="settingSelection"
+            required={false}
             type="radio"
             value="a"
           />
           <div
-            class="Radio__VisualRadio-sc-82dpxx-0 cMunLd"
+            className="c5 c6"
+            disabled={false}
           />
           <span
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c7 c8"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
-             Option A 
+             
+            Option A
+             
           </span>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+        className="c2"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c3"
+          disabled={false}
         >
           <input
-            aria-invalid="true"
-            aria-required="false"
-            class="Radio__RadioInput-sc-82dpxx-1 iSoGgh Radio-sc-82dpxx-2 jeIhWi"
+            aria-invalid={true}
+            aria-required={false}
+            className="c4 c2"
+            disabled={false}
+            id={null}
             name="settingSelection"
+            required={false}
             type="radio"
             value="b"
           />
           <div
-            class="Radio__VisualRadio-sc-82dpxx-0 cMunLd"
+            className="c5 c6"
+            disabled={false}
           />
           <span
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c7 c8"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
-             Option B 
+             
+            Option B
+             
           </span>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+        className="c2"
       >
         <label
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c3"
+          disabled={false}
         >
           <input
-            aria-invalid="true"
-            aria-required="false"
-            class="Radio__RadioInput-sc-82dpxx-1 iSoGgh Radio-sc-82dpxx-2 jeIhWi"
+            aria-invalid={true}
+            aria-required={false}
+            className="c4 c2"
+            disabled={false}
+            id={null}
             name="settingSelection"
+            required={false}
             type="radio"
             value="c"
           />
           <div
-            class="Radio__VisualRadio-sc-82dpxx-0 cMunLd"
+            className="c5 c6"
+            disabled={false}
           />
           <span
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c7 c8"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
-             Option C 
+             
+            Option C
+             
           </span>
         </label>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 ycNbA"
+        className="c9"
         color="red"
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 QuoIa"
+          aria-hidden={true}
+          className="c10"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="error"
           mr="x1"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -715,12 +1713,13 @@ exports[`Storyshots RadioGroup with error message 1`] = `
           />
         </svg>
         <div
-          class="InlineValidation__Wrapper-sc-1jic7dw-0 kqhCKM"
+          className="c11"
         >
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c7 c8"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Please select an option
           </p>

--- a/components/src/RangeContainer/__snapshots__/RangeContainer.story.storyshot
+++ b/components/src/RangeContainer/__snapshots__/RangeContainer.story.storyshot
@@ -1,23 +1,99 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots RangeContainer RangeContainer 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c2 {
+  margin-bottom: 8px;
+}
+
+.c4 {
+  margin-top: 8px;
+  margin-bottom: 24px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c5 {
+  padding-left: 4px;
+  padding-right: 4px;
+  max-height: 38px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c6 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c1 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c3 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      className="c1 "
       color="black"
-      style="display:block"
+      style={
+        Object {
+          "display": "block",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 ilQgHG"
+        className="c2"
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          className="c3"
         >
           Range
         </span>
@@ -25,16 +101,17 @@ exports[`Storyshots RangeContainer RangeContainer 1`] = `
       Example
     </label>
     <div
-      class="Box-sc-1qu1edy-0 iTGQcd"
+      className="c4"
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hYUuLW"
+        className="c5"
       >
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c6"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           -
         </p>

--- a/components/src/Select/__snapshots__/Select.story.storyshot
+++ b/components/src/Select/__snapshots__/Select.story.storyshot
@@ -1,26 +1,75 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Select Select 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Inventory status
           </span>
@@ -29,19 +78,22 @@ exports[`Storyshots Select Select 1`] = `
           data-testid="select-container"
         >
           <div
-            class="Select css-2b097c-container"
+            className="Select css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class="SelectTest__control css-1liu8yu-Control"
+                className="SelectTest__control css-1liu8yu-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class="SelectTest__value-container css-7zc8my"
+                  className="SelectTest__value-container css-7zc8my"
                 >
                   <div
-                    class="SelectTest__placeholder css-1yhx6vz-Placeholder"
+                    className="SelectTest__placeholder css-1yhx6vz-Placeholder"
                   >
                     Please select inventory status
                   </div>
@@ -49,48 +101,83 @@ exports[`Storyshots Select Select 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class="SelectTest__input"
-                        style="display:inline-block"
+                        className="SelectTest__input"
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          id="react-select-9-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
+                          id="react-select-11-input"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class="SelectTest__indicators css-173cxbq-IndicatorsContainer"
+                  className="SelectTest__indicators css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class="SelectTest__indicator-separator css-4z5mi-indicatorSeparator"
+                    className="SelectTest__indicator-separator css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class="SelectTest__indicator SelectTest__dropdown-indicator css-19phze7-indicatorContainer"
+                    className="SelectTest__indicator SelectTest__dropdown-indicator css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
                       aria-hidden="true"
-                      class="css-6q0nyr-Svg"
+                      className="css-6q0nyr-Svg"
                       focusable="false"
-                      height="20"
+                      height={20}
                       viewBox="0 0 20 20"
-                      width="20"
+                      width={20}
                     >
                       <path
                         d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
@@ -109,26 +196,95 @@ exports[`Storyshots Select Select 1`] = `
 `;
 
 exports[`Storyshots Select With wrapping text 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c5:last-child {
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+.c5 div {
+  padding: 7px;
+  font-weight: 400;
+  min-height: 32px;
+  min-width: -webkit-max-content;
+  min-width: -moz-max-content;
+  min-width: max-content;
+  white-space: nowrap;
+}
+
+.c5 div:hover {
+  background: #e1ebfa;
+  cursor: pointer;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Inventory status
           </span>
@@ -137,19 +293,22 @@ exports[`Storyshots Select With wrapping text 1`] = `
           data-testid="select-container"
         >
           <div
-            class=" css-2b097c-container"
+            className=" css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-w42fll-Control"
+                className=" css-w42fll-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    className=" css-1yhx6vz-Placeholder"
                   >
                     Please select inventory status
                   </div>
@@ -157,48 +316,83 @@ exports[`Storyshots Select With wrapping text 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          id="react-select-24-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
+                          id="react-select-26-input"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
                       aria-hidden="true"
-                      class="css-6q0nyr-Svg"
+                      className="css-6q0nyr-Svg"
                       focusable="false"
-                      height="20"
+                      height={20}
                       viewBox="0 0 20 20"
-                      width="20"
+                      width={20}
                     >
                       <path
                         d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
@@ -212,39 +406,59 @@ exports[`Storyshots Select With wrapping text 1`] = `
               data-testid="select-dropdown"
             >
               <div
-                class=" css-1l502d3-Menu"
+                className=" css-1l502d3-Menu"
+                onMouseDown={[Function]}
+                onMouseMove={[Function]}
               >
                 <div
-                  class=" css-famnlw-MenuList"
+                  className=" css-famnlw-MenuList"
                 >
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
-                    data="[object Object]"
+                    className="c5"
+                    cx={null}
+                    data={
+                      Object {
+                        "label": "Onelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstring",
+                        "value": "onestring",
+                      }
+                    }
                     data-testid="select-option"
                     label="Onelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstring"
                     type="option"
                     value="onestring"
                   >
                     <div
-                      class=" css-5aymxm-Option"
-                      id="react-select-24-option-0"
-                      tabindex="-1"
+                      className=" css-5aymxm-Option"
+                      id="react-select-26-option-0"
+                      onClick={[Function]}
+                      onMouseMove={[Function]}
+                      onMouseOver={[Function]}
+                      tabIndex={-1}
                     >
                       Onelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstring
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
-                    data="[object Object]"
+                    className="c5"
+                    cx={null}
+                    data={
+                      Object {
+                        "label": "Many words many words many words many words many words many words many words many words many words many words many words many words many words",
+                        "value": "manywords",
+                      }
+                    }
                     data-testid="select-option"
                     label="Many words many words many words many words many words many words many words many words many words many words many words many words many words"
                     type="option"
                     value="manywords"
                   >
                     <div
-                      class=" css-5aymxm-Option"
-                      id="react-select-24-option-1"
-                      tabindex="-1"
+                      className=" css-5aymxm-Option"
+                      id="react-select-26-option-1"
+                      onClick={[Function]}
+                      onMouseMove={[Function]}
+                      onMouseOver={[Function]}
+                      tabIndex={-1}
                     >
                       Many words many words many words many words many words many words many words many words many words many words many words many words many words
                     </div>
@@ -261,26 +475,75 @@ exports[`Storyshots Select With wrapping text 1`] = `
 `;
 
 exports[`Storyshots Select set to disabled 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Inventory status
           </span>
@@ -289,19 +552,22 @@ exports[`Storyshots Select set to disabled 1`] = `
           data-testid="select-container"
         >
           <div
-            class=" css-14jk2my-container"
+            className=" css-14jk2my-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1aojeu-Control"
+                className=" css-1aojeu-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-b1k6bm-Placeholder"
+                    className=" css-b1k6bm-Placeholder"
                   >
                     Please select inventory status
                   </div>
@@ -309,49 +575,83 @@ exports[`Storyshots Select set to disabled 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          disabled=""
-                          id="react-select-15-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={true}
+                          id="react-select-17-input"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
                       aria-hidden="true"
-                      class="css-6q0nyr-Svg"
+                      className="css-6q0nyr-Svg"
                       focusable="false"
-                      height="20"
+                      height={20}
                       viewBox="0 0 20 20"
-                      width="20"
+                      width={20}
                     >
                       <path
                         d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
@@ -370,53 +670,262 @@ exports[`Storyshots Select set to disabled 1`] = `
 `;
 
 exports[`Storyshots Select set to required 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c6 {
+  margin-bottom: 8px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c8 {
+  margin-left: 8px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #434d59;
+}
+
+.c9 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+  margin-top: 8px;
+}
+
+.c9:hover {
+  background-color: #e1ebfa;
+}
+
+.c9:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c9:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c9:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c9:disabled {
+  opacity: .5;
+}
+
+.c10 {
+  color: #ffffff;
+  border-color: #216beb;
+  background-color: #216beb;
+}
+
+.c10:hover {
+  background-color: #1254c7;
+  border-color: #1254c7;
+}
+
+.c10:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #216beb;
+}
+
+.c10:focus:hover {
+  background-color: #1254c7;
+}
+
+.c5 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c7 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c4 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c4:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c4:focus ~ svg {
+  fill: #00438f;
+}
+
+.c4::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c4::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c4:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c4::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <form>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+        className="c1"
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+          className="c2"
         >
           <div
-            class="Box-sc-1qu1edy-0 hxUhcg"
+            className="c3"
             display="flex"
           >
             <input
-              aria-invalid="false"
-              aria-required="false"
-              class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+              aria-invalid={false}
+              aria-required={false}
+              className="c4"
+              disabled={false}
               placeholder="Please select inventory status"
+              required={false}
             />
           </div>
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+        className="c1"
       >
         <label
-          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+          className="c5 "
           color="black"
-          style="display:block"
+          style={
+            Object {
+              "display": "block",
+            }
+          }
         >
           <div
-            class="Box-sc-1qu1edy-0 ilQgHG"
+            className="c6"
             data-testid="field-label"
           >
             <span
-              class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+              className="c7"
             >
               Inventory status
             </span>
             <span
-              class="Text-sc-1wu7vpu-0 bphWXP"
+              className="c8"
               color="darkGrey"
-              font-size="12px"
+              disabled={false}
+              fontSize="12px"
             >
               (Required)
             </span>
@@ -425,19 +934,22 @@ exports[`Storyshots Select set to required 1`] = `
             data-testid="select-container"
           >
             <div
-              class=" css-2b097c-container"
+              className=" css-2b097c-container"
+              onKeyDown={[Function]}
             >
               <div
                 data-testid="select-control"
               >
                 <div
-                  class=" css-1liu8yu-Control"
+                  className=" css-1liu8yu-Control"
+                  onMouseDown={[Function]}
+                  onTouchEnd={[Function]}
                 >
                   <div
-                    class=" css-7zc8my"
+                    className=" css-7zc8my"
                   >
                     <div
-                      class=" css-1yhx6vz-Placeholder"
+                      className=" css-1yhx6vz-Placeholder"
                     >
                       Please select inventory status
                     </div>
@@ -445,48 +957,83 @@ exports[`Storyshots Select set to required 1`] = `
                       data-testid="select-input"
                     >
                       <div
-                        class="css-17yls17-Input"
+                        className="css-17yls17-Input"
                       >
                         <div
-                          class=""
-                          style="display:inline-block"
+                          className=""
+                          style={
+                            Object {
+                              "display": "inline-block",
+                            }
+                          }
                         >
                           <input
                             aria-autocomplete="list"
-                            autocapitalize="none"
-                            autocomplete="off"
-                            autocorrect="off"
-                            id="react-select-20-input"
-                            spellcheck="false"
-                            style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                            tabindex="0"
+                            autoCapitalize="none"
+                            autoComplete="off"
+                            autoCorrect="off"
+                            disabled={null}
+                            id="react-select-22-input"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            spellCheck="false"
+                            style={
+                              Object {
+                                "background": 0,
+                                "border": 0,
+                                "boxSizing": "content-box",
+                                "color": "inherit",
+                                "fontSize": "inherit",
+                                "label": "input",
+                                "opacity": 1,
+                                "outline": 0,
+                                "padding": 0,
+                                "width": "1px",
+                              }
+                            }
+                            tabIndex="0"
                             type="text"
                             value=""
                           />
                           <div
-                            style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                          />
+                            style={
+                              Object {
+                                "height": 0,
+                                "left": 0,
+                                "overflow": "scroll",
+                                "position": "absolute",
+                                "top": 0,
+                                "visibility": "hidden",
+                                "whiteSpace": "pre",
+                              }
+                            }
+                          >
+                            
+                          </div>
                         </div>
                       </div>
                     </div>
                   </div>
                   <div
-                    class=" css-173cxbq-IndicatorsContainer"
+                    className=" css-173cxbq-IndicatorsContainer"
                   >
                     <span
-                      class=" css-4z5mi-indicatorSeparator"
+                      className=" css-4z5mi-indicatorSeparator"
                     />
                     <div
                       aria-hidden="true"
-                      class=" css-19phze7-indicatorContainer"
+                      className=" css-19phze7-indicatorContainer"
+                      onMouseDown={[Function]}
+                      onTouchEnd={[Function]}
                     >
                       <svg
                         aria-hidden="true"
-                        class="css-6q0nyr-Svg"
+                        className="css-6q0nyr-Svg"
                         focusable="false"
-                        height="20"
+                        height={20}
                         viewBox="0 0 20 20"
-                        width="20"
+                        width={20}
                       >
                         <path
                           d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
@@ -501,7 +1048,9 @@ exports[`Storyshots Select set to required 1`] = `
         </label>
       </div>
       <button
-        class="Button__WrapperButton-sc-1omxup2-0 foHPrS PrimaryButton-qz78sb-0 cGyyDq"
+        className="c9 c10"
+        disabled={false}
+        size="medium"
         type="submit"
       >
         Submit
@@ -512,26 +1061,83 @@ exports[`Storyshots Select set to required 1`] = `
 `;
 
 exports[`Storyshots Select test multiselect overflow 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c5 {
+  width: 300px;
+}
+
+.c6 {
+  width: 400px;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Inventory status
           </span>
@@ -540,38 +1146,44 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
           data-testid="select-container"
         >
           <div
-            class=" css-2b097c-container"
+            className=" css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1liu8yu-Control"
+                className=" css-1liu8yu-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
                     data-testid="select-multivalue"
                   >
                     <div
-                      class="css-gxde6l-multiValue"
+                      className="css-gxde6l-multiValue"
                     >
                       <div
-                        class="css-1ekzmfk"
+                        className="css-1ekzmfk"
                       >
                         Accepted
                       </div>
                       <div
-                        class="css-kurm45"
+                        className="css-kurm45"
+                        onClick={[Function]}
+                        onMouseDown={[Function]}
+                        onTouchEnd={[Function]}
                       >
                         <svg
                           aria-hidden="true"
-                          class="css-6q0nyr-Svg"
+                          className="css-6q0nyr-Svg"
                           focusable="false"
-                          height="14"
+                          height={14}
                           viewBox="0 0 20 20"
-                          width="14"
+                          width={14}
                         >
                           <path
                             d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
@@ -584,23 +1196,26 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
                     data-testid="select-multivalue"
                   >
                     <div
-                      class="css-gxde6l-multiValue"
+                      className="css-gxde6l-multiValue"
                     >
                       <div
-                        class="css-1ekzmfk"
+                        className="css-1ekzmfk"
                       >
                         Assigned to a line
                       </div>
                       <div
-                        class="css-kurm45"
+                        className="css-kurm45"
+                        onClick={[Function]}
+                        onMouseDown={[Function]}
+                        onTouchEnd={[Function]}
                       >
                         <svg
                           aria-hidden="true"
-                          class="css-6q0nyr-Svg"
+                          className="css-6q0nyr-Svg"
                           focusable="false"
-                          height="14"
+                          height={14}
                           viewBox="0 0 20 20"
-                          width="14"
+                          width={14}
                         >
                           <path
                             d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
@@ -613,48 +1228,83 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          id="react-select-26-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
+                          id="react-select-28-input"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <div
                     data-testid="select-clear"
                   >
                     <div
                       aria-hidden="true"
-                      class=" css-kaqmzc-indicatorContainer"
+                      className=" css-kaqmzc-indicatorContainer"
+                      onMouseDown={[Function]}
+                      onTouchEnd={[Function]}
                     >
                       <svg
                         aria-hidden="true"
-                        class="css-6q0nyr-Svg"
+                        className="css-6q0nyr-Svg"
                         focusable="false"
-                        height="20"
+                        height={20}
                         viewBox="0 0 20 20"
-                        width="20"
+                        width={20}
                       >
                         <path
                           d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
@@ -663,19 +1313,21 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
                     </div>
                   </div>
                   <span
-                    class=" css-uv1fd5-indicatorSeparator"
+                    className=" css-uv1fd5-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
                       aria-hidden="true"
-                      class="css-6q0nyr-Svg"
+                      className="css-6q0nyr-Svg"
                       focusable="false"
-                      height="20"
+                      height={20}
                       viewBox="0 0 20 20"
-                      width="20"
+                      width={20}
                     >
                       <path
                         d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
@@ -690,23 +1342,27 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
       </label>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 kxBKkD"
+      className="c5"
       width="300px"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+        className="c1"
       >
         <label
-          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+          className="c2 "
           color="black"
-          style="display:block"
+          style={
+            Object {
+              "display": "block",
+            }
+          }
         >
           <div
-            class="Box-sc-1qu1edy-0 ilQgHG"
+            className="c3"
             data-testid="field-label"
           >
             <span
-              class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+              className="c4"
             >
               PCN
             </span>
@@ -715,38 +1371,44 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
             data-testid="select-container"
           >
             <div
-              class=" css-2b097c-container"
+              className=" css-2b097c-container"
+              onKeyDown={[Function]}
             >
               <div
                 data-testid="select-control"
               >
                 <div
-                  class=" css-1liu8yu-Control"
+                  className=" css-1liu8yu-Control"
+                  onMouseDown={[Function]}
+                  onTouchEnd={[Function]}
                 >
                   <div
-                    class=" css-7zc8my"
+                    className=" css-7zc8my"
                   >
                     <div
                       data-testid="select-multivalue"
                     >
                       <div
-                        class="css-gxde6l-multiValue"
+                        className="css-gxde6l-multiValue"
                       >
                         <div
-                          class="css-1ekzmfk"
+                          className="css-1ekzmfk"
                         >
                           PCN2 12387387484895884957848576867587685780
                         </div>
                         <div
-                          class="css-kurm45"
+                          className="css-kurm45"
+                          onClick={[Function]}
+                          onMouseDown={[Function]}
+                          onTouchEnd={[Function]}
                         >
                           <svg
                             aria-hidden="true"
-                            class="css-6q0nyr-Svg"
+                            className="css-6q0nyr-Svg"
                             focusable="false"
-                            height="14"
+                            height={14}
                             viewBox="0 0 20 20"
-                            width="14"
+                            width={14}
                           >
                             <path
                               d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
@@ -759,23 +1421,26 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
                       data-testid="select-multivalue"
                     >
                       <div
-                        class="css-gxde6l-multiValue"
+                        className="css-gxde6l-multiValue"
                       >
                         <div
-                          class="css-1ekzmfk"
+                          className="css-1ekzmfk"
                         >
                           PCN4 12387387484895884957848576867587685780
                         </div>
                         <div
-                          class="css-kurm45"
+                          className="css-kurm45"
+                          onClick={[Function]}
+                          onMouseDown={[Function]}
+                          onTouchEnd={[Function]}
                         >
                           <svg
                             aria-hidden="true"
-                            class="css-6q0nyr-Svg"
+                            className="css-6q0nyr-Svg"
                             focusable="false"
-                            height="14"
+                            height={14}
                             viewBox="0 0 20 20"
-                            width="14"
+                            width={14}
                           >
                             <path
                               d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
@@ -788,23 +1453,26 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
                       data-testid="select-multivalue"
                     >
                       <div
-                        class="css-gxde6l-multiValue"
+                        className="css-gxde6l-multiValue"
                       >
                         <div
-                          class="css-1ekzmfk"
+                          className="css-1ekzmfk"
                         >
                           PCN1 12387387484895884957848576867587685780
                         </div>
                         <div
-                          class="css-kurm45"
+                          className="css-kurm45"
+                          onClick={[Function]}
+                          onMouseDown={[Function]}
+                          onTouchEnd={[Function]}
                         >
                           <svg
                             aria-hidden="true"
-                            class="css-6q0nyr-Svg"
+                            className="css-6q0nyr-Svg"
                             focusable="false"
-                            height="14"
+                            height={14}
                             viewBox="0 0 20 20"
-                            width="14"
+                            width={14}
                           >
                             <path
                               d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
@@ -817,23 +1485,26 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
                       data-testid="select-multivalue"
                     >
                       <div
-                        class="css-gxde6l-multiValue"
+                        className="css-gxde6l-multiValue"
                       >
                         <div
-                          class="css-1ekzmfk"
+                          className="css-1ekzmfk"
                         >
                           PCN9 12387387484895884957848576867587685780
                         </div>
                         <div
-                          class="css-kurm45"
+                          className="css-kurm45"
+                          onClick={[Function]}
+                          onMouseDown={[Function]}
+                          onTouchEnd={[Function]}
                         >
                           <svg
                             aria-hidden="true"
-                            class="css-6q0nyr-Svg"
+                            className="css-6q0nyr-Svg"
                             focusable="false"
-                            height="14"
+                            height={14}
                             viewBox="0 0 20 20"
-                            width="14"
+                            width={14}
                           >
                             <path
                               d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
@@ -846,23 +1517,26 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
                       data-testid="select-multivalue"
                     >
                       <div
-                        class="css-gxde6l-multiValue"
+                        className="css-gxde6l-multiValue"
                       >
                         <div
-                          class="css-1ekzmfk"
+                          className="css-1ekzmfk"
                         >
                           PCN7 12387387484895884957848576867587685780
                         </div>
                         <div
-                          class="css-kurm45"
+                          className="css-kurm45"
+                          onClick={[Function]}
+                          onMouseDown={[Function]}
+                          onTouchEnd={[Function]}
                         >
                           <svg
                             aria-hidden="true"
-                            class="css-6q0nyr-Svg"
+                            className="css-6q0nyr-Svg"
                             focusable="false"
-                            height="14"
+                            height={14}
                             viewBox="0 0 20 20"
-                            width="14"
+                            width={14}
                           >
                             <path
                               d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
@@ -875,23 +1549,26 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
                       data-testid="select-multivalue"
                     >
                       <div
-                        class="css-gxde6l-multiValue"
+                        className="css-gxde6l-multiValue"
                       >
                         <div
-                          class="css-1ekzmfk"
+                          className="css-1ekzmfk"
                         >
                           PCN6 12387387484895884957848576867587685780
                         </div>
                         <div
-                          class="css-kurm45"
+                          className="css-kurm45"
+                          onClick={[Function]}
+                          onMouseDown={[Function]}
+                          onTouchEnd={[Function]}
                         >
                           <svg
                             aria-hidden="true"
-                            class="css-6q0nyr-Svg"
+                            className="css-6q0nyr-Svg"
                             focusable="false"
-                            height="14"
+                            height={14}
                             viewBox="0 0 20 20"
-                            width="14"
+                            width={14}
                           >
                             <path
                               d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
@@ -904,23 +1581,26 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
                       data-testid="select-multivalue"
                     >
                       <div
-                        class="css-gxde6l-multiValue"
+                        className="css-gxde6l-multiValue"
                       >
                         <div
-                          class="css-1ekzmfk"
+                          className="css-1ekzmfk"
                         >
                           PCN3 12387387484895884957848576867587685780e
                         </div>
                         <div
-                          class="css-kurm45"
+                          className="css-kurm45"
+                          onClick={[Function]}
+                          onMouseDown={[Function]}
+                          onTouchEnd={[Function]}
                         >
                           <svg
                             aria-hidden="true"
-                            class="css-6q0nyr-Svg"
+                            className="css-6q0nyr-Svg"
                             focusable="false"
-                            height="14"
+                            height={14}
                             viewBox="0 0 20 20"
-                            width="14"
+                            width={14}
                           >
                             <path
                               d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
@@ -933,48 +1613,83 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
                       data-testid="select-input"
                     >
                       <div
-                        class="css-17yls17-Input"
+                        className="css-17yls17-Input"
                       >
                         <div
-                          class=""
-                          style="display:inline-block"
+                          className=""
+                          style={
+                            Object {
+                              "display": "inline-block",
+                            }
+                          }
                         >
                           <input
                             aria-autocomplete="list"
-                            autocapitalize="none"
-                            autocomplete="off"
-                            autocorrect="off"
-                            id="react-select-27-input"
-                            spellcheck="false"
-                            style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                            tabindex="0"
+                            autoCapitalize="none"
+                            autoComplete="off"
+                            autoCorrect="off"
+                            disabled={null}
+                            id="react-select-29-input"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            spellCheck="false"
+                            style={
+                              Object {
+                                "background": 0,
+                                "border": 0,
+                                "boxSizing": "content-box",
+                                "color": "inherit",
+                                "fontSize": "inherit",
+                                "label": "input",
+                                "opacity": 1,
+                                "outline": 0,
+                                "padding": 0,
+                                "width": "1px",
+                              }
+                            }
+                            tabIndex="0"
                             type="text"
                             value=""
                           />
                           <div
-                            style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                          />
+                            style={
+                              Object {
+                                "height": 0,
+                                "left": 0,
+                                "overflow": "scroll",
+                                "position": "absolute",
+                                "top": 0,
+                                "visibility": "hidden",
+                                "whiteSpace": "pre",
+                              }
+                            }
+                          >
+                            
+                          </div>
                         </div>
                       </div>
                     </div>
                   </div>
                   <div
-                    class=" css-173cxbq-IndicatorsContainer"
+                    className=" css-173cxbq-IndicatorsContainer"
                   >
                     <div
                       data-testid="select-clear"
                     >
                       <div
                         aria-hidden="true"
-                        class=" css-kaqmzc-indicatorContainer"
+                        className=" css-kaqmzc-indicatorContainer"
+                        onMouseDown={[Function]}
+                        onTouchEnd={[Function]}
                       >
                         <svg
                           aria-hidden="true"
-                          class="css-6q0nyr-Svg"
+                          className="css-6q0nyr-Svg"
                           focusable="false"
-                          height="20"
+                          height={20}
                           viewBox="0 0 20 20"
-                          width="20"
+                          width={20}
                         >
                           <path
                             d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
@@ -983,19 +1698,21 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
                       </div>
                     </div>
                     <span
-                      class=" css-uv1fd5-indicatorSeparator"
+                      className=" css-uv1fd5-indicatorSeparator"
                     />
                     <div
                       aria-hidden="true"
-                      class=" css-19phze7-indicatorContainer"
+                      className=" css-19phze7-indicatorContainer"
+                      onMouseDown={[Function]}
+                      onTouchEnd={[Function]}
                     >
                       <svg
                         aria-hidden="true"
-                        class="css-6q0nyr-Svg"
+                        className="css-6q0nyr-Svg"
                         focusable="false"
-                        height="20"
+                        height={20}
                         viewBox="0 0 20 20"
-                        width="20"
+                        width={20}
                       >
                         <path
                           d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
@@ -1011,23 +1728,27 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
       </div>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 gzPQPo"
+      className="c6"
       width="400px"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+        className="c1"
       >
         <label
-          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+          className="c2 "
           color="black"
-          style="display:block"
+          style={
+            Object {
+              "display": "block",
+            }
+          }
         >
           <div
-            class="Box-sc-1qu1edy-0 ilQgHG"
+            className="c3"
             data-testid="field-label"
           >
             <span
-              class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+              className="c4"
             >
               Inventory status
             </span>
@@ -1036,38 +1757,44 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
             data-testid="select-container"
           >
             <div
-              class=" css-2b097c-container"
+              className=" css-2b097c-container"
+              onKeyDown={[Function]}
             >
               <div
                 data-testid="select-control"
               >
                 <div
-                  class=" css-1liu8yu-Control"
+                  className=" css-1liu8yu-Control"
+                  onMouseDown={[Function]}
+                  onTouchEnd={[Function]}
                 >
                   <div
-                    class=" css-7zc8my"
+                    className=" css-7zc8my"
                   >
                     <div
                       data-testid="select-multivalue"
                     >
                       <div
-                        class="css-gxde6l-multiValue"
+                        className="css-gxde6l-multiValue"
                       >
                         <div
-                          class="css-1ekzmfk"
+                          className="css-1ekzmfk"
                         >
                           Accepted
                         </div>
                         <div
-                          class="css-kurm45"
+                          className="css-kurm45"
+                          onClick={[Function]}
+                          onMouseDown={[Function]}
+                          onTouchEnd={[Function]}
                         >
                           <svg
                             aria-hidden="true"
-                            class="css-6q0nyr-Svg"
+                            className="css-6q0nyr-Svg"
                             focusable="false"
-                            height="14"
+                            height={14}
                             viewBox="0 0 20 20"
-                            width="14"
+                            width={14}
                           >
                             <path
                               d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
@@ -1080,23 +1807,26 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
                       data-testid="select-multivalue"
                     >
                       <div
-                        class="css-gxde6l-multiValue"
+                        className="css-gxde6l-multiValue"
                       >
                         <div
-                          class="css-1ekzmfk"
+                          className="css-1ekzmfk"
                         >
                           Assigned to a line
                         </div>
                         <div
-                          class="css-kurm45"
+                          className="css-kurm45"
+                          onClick={[Function]}
+                          onMouseDown={[Function]}
+                          onTouchEnd={[Function]}
                         >
                           <svg
                             aria-hidden="true"
-                            class="css-6q0nyr-Svg"
+                            className="css-6q0nyr-Svg"
                             focusable="false"
-                            height="14"
+                            height={14}
                             viewBox="0 0 20 20"
-                            width="14"
+                            width={14}
                           >
                             <path
                               d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
@@ -1109,23 +1839,26 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
                       data-testid="select-multivalue"
                     >
                       <div
-                        class="css-gxde6l-multiValue"
+                        className="css-gxde6l-multiValue"
                       >
                         <div
-                          class="css-1ekzmfk"
+                          className="css-1ekzmfk"
                         >
                           On hold
                         </div>
                         <div
-                          class="css-kurm45"
+                          className="css-kurm45"
+                          onClick={[Function]}
+                          onMouseDown={[Function]}
+                          onTouchEnd={[Function]}
                         >
                           <svg
                             aria-hidden="true"
-                            class="css-6q0nyr-Svg"
+                            className="css-6q0nyr-Svg"
                             focusable="false"
-                            height="14"
+                            height={14}
                             viewBox="0 0 20 20"
-                            width="14"
+                            width={14}
                           >
                             <path
                               d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
@@ -1138,23 +1871,26 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
                       data-testid="select-multivalue"
                     >
                       <div
-                        class="css-gxde6l-multiValue"
+                        className="css-gxde6l-multiValue"
                       >
                         <div
-                          class="css-1ekzmfk"
+                          className="css-1ekzmfk"
                         >
                           Rejected
                         </div>
                         <div
-                          class="css-kurm45"
+                          className="css-kurm45"
+                          onClick={[Function]}
+                          onMouseDown={[Function]}
+                          onTouchEnd={[Function]}
                         >
                           <svg
                             aria-hidden="true"
-                            class="css-6q0nyr-Svg"
+                            className="css-6q0nyr-Svg"
                             focusable="false"
-                            height="14"
+                            height={14}
                             viewBox="0 0 20 20"
-                            width="14"
+                            width={14}
                           >
                             <path
                               d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
@@ -1167,23 +1903,26 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
                       data-testid="select-multivalue"
                     >
                       <div
-                        class="css-gxde6l-multiValue"
+                        className="css-gxde6l-multiValue"
                       >
                         <div
-                          class="css-1ekzmfk"
+                          className="css-1ekzmfk"
                         >
                           Open
                         </div>
                         <div
-                          class="css-kurm45"
+                          className="css-kurm45"
+                          onClick={[Function]}
+                          onMouseDown={[Function]}
+                          onTouchEnd={[Function]}
                         >
                           <svg
                             aria-hidden="true"
-                            class="css-6q0nyr-Svg"
+                            className="css-6q0nyr-Svg"
                             focusable="false"
-                            height="14"
+                            height={14}
                             viewBox="0 0 20 20"
-                            width="14"
+                            width={14}
                           >
                             <path
                               d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
@@ -1196,23 +1935,26 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
                       data-testid="select-multivalue"
                     >
                       <div
-                        class="css-gxde6l-multiValue"
+                        className="css-gxde6l-multiValue"
                       >
                         <div
-                          class="css-1ekzmfk"
+                          className="css-1ekzmfk"
                         >
                           In progress
                         </div>
                         <div
-                          class="css-kurm45"
+                          className="css-kurm45"
+                          onClick={[Function]}
+                          onMouseDown={[Function]}
+                          onTouchEnd={[Function]}
                         >
                           <svg
                             aria-hidden="true"
-                            class="css-6q0nyr-Svg"
+                            className="css-6q0nyr-Svg"
                             focusable="false"
-                            height="14"
+                            height={14}
                             viewBox="0 0 20 20"
-                            width="14"
+                            width={14}
                           >
                             <path
                               d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
@@ -1225,23 +1967,26 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
                       data-testid="select-multivalue"
                     >
                       <div
-                        class="css-gxde6l-multiValue"
+                        className="css-gxde6l-multiValue"
                       >
                         <div
-                          class="css-1ekzmfk"
+                          className="css-1ekzmfk"
                         >
                           In quarantine
                         </div>
                         <div
-                          class="css-kurm45"
+                          className="css-kurm45"
+                          onClick={[Function]}
+                          onMouseDown={[Function]}
+                          onTouchEnd={[Function]}
                         >
                           <svg
                             aria-hidden="true"
-                            class="css-6q0nyr-Svg"
+                            className="css-6q0nyr-Svg"
                             focusable="false"
-                            height="14"
+                            height={14}
                             viewBox="0 0 20 20"
-                            width="14"
+                            width={14}
                           >
                             <path
                               d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
@@ -1254,48 +1999,83 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
                       data-testid="select-input"
                     >
                       <div
-                        class="css-17yls17-Input"
+                        className="css-17yls17-Input"
                       >
                         <div
-                          class=""
-                          style="display:inline-block"
+                          className=""
+                          style={
+                            Object {
+                              "display": "inline-block",
+                            }
+                          }
                         >
                           <input
                             aria-autocomplete="list"
-                            autocapitalize="none"
-                            autocomplete="off"
-                            autocorrect="off"
-                            id="react-select-28-input"
-                            spellcheck="false"
-                            style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                            tabindex="0"
+                            autoCapitalize="none"
+                            autoComplete="off"
+                            autoCorrect="off"
+                            disabled={null}
+                            id="react-select-30-input"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            spellCheck="false"
+                            style={
+                              Object {
+                                "background": 0,
+                                "border": 0,
+                                "boxSizing": "content-box",
+                                "color": "inherit",
+                                "fontSize": "inherit",
+                                "label": "input",
+                                "opacity": 1,
+                                "outline": 0,
+                                "padding": 0,
+                                "width": "1px",
+                              }
+                            }
+                            tabIndex="0"
                             type="text"
                             value=""
                           />
                           <div
-                            style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                          />
+                            style={
+                              Object {
+                                "height": 0,
+                                "left": 0,
+                                "overflow": "scroll",
+                                "position": "absolute",
+                                "top": 0,
+                                "visibility": "hidden",
+                                "whiteSpace": "pre",
+                              }
+                            }
+                          >
+                            
+                          </div>
                         </div>
                       </div>
                     </div>
                   </div>
                   <div
-                    class=" css-173cxbq-IndicatorsContainer"
+                    className=" css-173cxbq-IndicatorsContainer"
                   >
                     <div
                       data-testid="select-clear"
                     >
                       <div
                         aria-hidden="true"
-                        class=" css-kaqmzc-indicatorContainer"
+                        className=" css-kaqmzc-indicatorContainer"
+                        onMouseDown={[Function]}
+                        onTouchEnd={[Function]}
                       >
                         <svg
                           aria-hidden="true"
-                          class="css-6q0nyr-Svg"
+                          className="css-6q0nyr-Svg"
                           focusable="false"
-                          height="20"
+                          height={20}
                           viewBox="0 0 20 20"
-                          width="20"
+                          width={20}
                         >
                           <path
                             d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
@@ -1304,19 +2084,21 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
                       </div>
                     </div>
                     <span
-                      class=" css-uv1fd5-indicatorSeparator"
+                      className=" css-uv1fd5-indicatorSeparator"
                     />
                     <div
                       aria-hidden="true"
-                      class=" css-19phze7-indicatorContainer"
+                      className=" css-19phze7-indicatorContainer"
+                      onMouseDown={[Function]}
+                      onTouchEnd={[Function]}
                     >
                       <svg
                         aria-hidden="true"
-                        class="css-6q0nyr-Svg"
+                        className="css-6q0nyr-Svg"
                         focusable="false"
-                        height="20"
+                        height={20}
                         viewBox="0 0 20 20"
-                        width="20"
+                        width={20}
                       >
                         <path
                           d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
@@ -1336,26 +2118,75 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
 `;
 
 exports[`Storyshots Select with a blank value 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Inventory status
           </span>
@@ -1364,19 +2195,22 @@ exports[`Storyshots Select with a blank value 1`] = `
           data-testid="select-container"
         >
           <div
-            class=" css-2b097c-container"
+            className=" css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1liu8yu-Control"
+                className=" css-1liu8yu-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    className=" css-1yhx6vz-Placeholder"
                   >
                     Please select inventory status
                   </div>
@@ -1384,48 +2218,83 @@ exports[`Storyshots Select with a blank value 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          id="react-select-11-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
+                          id="react-select-13-input"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
                       aria-hidden="true"
-                      class="css-6q0nyr-Svg"
+                      className="css-6q0nyr-Svg"
                       focusable="false"
-                      height="20"
+                      height={20}
                       viewBox="0 0 20 20"
-                      width="20"
+                      width={20}
                     >
                       <path
                         d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
@@ -1444,26 +2313,75 @@ exports[`Storyshots Select with a blank value 1`] = `
 `;
 
 exports[`Storyshots Select with a defaultValue 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Inventory status
           </span>
@@ -1472,19 +2390,22 @@ exports[`Storyshots Select with a defaultValue 1`] = `
           data-testid="select-container"
         >
           <div
-            class=" css-2b097c-container"
+            className=" css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1liu8yu-Control"
+                className=" css-1liu8yu-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-r447wv-singleValue"
+                    className=" css-r447wv-singleValue"
                   >
                     Accepted
                   </div>
@@ -1492,48 +2413,83 @@ exports[`Storyshots Select with a defaultValue 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          id="react-select-10-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
+                          id="react-select-12-input"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
                       aria-hidden="true"
-                      class="css-6q0nyr-Svg"
+                      className="css-6q0nyr-Svg"
                       focusable="false"
-                      height="20"
+                      height={20}
                       viewBox="0 0 20 20"
-                      width="20"
+                      width={20}
                     >
                       <path
                         d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
@@ -1552,26 +2508,114 @@ exports[`Storyshots Select with a defaultValue 1`] = `
 `;
 
 exports[`Storyshots Select with an option selected 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c5:last-child {
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+.c5 div {
+  padding: 7px;
+  font-weight: 500;
+  min-height: 32px;
+  min-width: -webkit-max-content;
+  min-width: -moz-max-content;
+  min-width: max-content;
+  white-space: nowrap;
+}
+
+.c5 div:hover {
+  cursor: pointer;
+}
+
+.c6:last-child {
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+.c6 div {
+  padding: 7px;
+  font-weight: 400;
+  min-height: 32px;
+  min-width: -webkit-max-content;
+  min-width: -moz-max-content;
+  min-width: max-content;
+  white-space: nowrap;
+}
+
+.c6 div:hover {
+  background: #e1ebfa;
+  cursor: pointer;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Inventory status
           </span>
@@ -1580,19 +2624,22 @@ exports[`Storyshots Select with an option selected 1`] = `
           data-testid="select-container"
         >
           <div
-            class=" css-2b097c-container"
+            className=" css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1liu8yu-Control"
+                className=" css-1liu8yu-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-r447wv-singleValue"
+                    className=" css-r447wv-singleValue"
                   >
                     Accepted
                   </div>
@@ -1600,48 +2647,83 @@ exports[`Storyshots Select with an option selected 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          id="react-select-12-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
+                          id="react-select-14-input"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
                       aria-hidden="true"
-                      class="css-6q0nyr-Svg"
+                      className="css-6q0nyr-Svg"
                       focusable="false"
-                      height="20"
+                      height={20}
                       viewBox="0 0 20 20"
-                      width="20"
+                      width={20}
                     >
                       <path
                         d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
@@ -1657,19 +2739,23 @@ exports[`Storyshots Select with an option selected 1`] = `
     </div>
     <br />
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Inventory status
           </span>
@@ -1678,19 +2764,22 @@ exports[`Storyshots Select with an option selected 1`] = `
           data-testid="select-container"
         >
           <div
-            class=" css-2b097c-container"
+            className=" css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-w42fll-Control"
+                className=" css-w42fll-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-r447wv-singleValue"
+                    className=" css-r447wv-singleValue"
                   >
                     Accepted
                   </div>
@@ -1698,48 +2787,83 @@ exports[`Storyshots Select with an option selected 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          id="react-select-13-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
+                          id="react-select-15-input"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
                       aria-hidden="true"
-                      class="css-6q0nyr-Svg"
+                      className="css-6q0nyr-Svg"
                       focusable="false"
-                      height="20"
+                      height={20}
                       viewBox="0 0 20 20"
-                      width="20"
+                      width={20}
                     >
                       <path
                         d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
@@ -1753,119 +2877,184 @@ exports[`Storyshots Select with an option selected 1`] = `
               data-testid="select-dropdown"
             >
               <div
-                class=" css-1l502d3-Menu"
+                className=" css-1l502d3-Menu"
+                onMouseDown={[Function]}
+                onMouseMove={[Function]}
               >
                 <div
-                  class=" css-famnlw-MenuList"
+                  className=" css-famnlw-MenuList"
                 >
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 blgViL"
-                    data="[object Object]"
+                    className="c5"
+                    cx={null}
+                    data={
+                      Object {
+                        "label": "Accepted",
+                        "value": "accepted",
+                      }
+                    }
                     data-testid="select-option"
                     label="Accepted"
                     type="option"
                     value="accepted"
                   >
                     <div
-                      class=" css-5aymxm-Option"
-                      id="react-select-13-option-0"
-                      tabindex="-1"
+                      className=" css-5aymxm-Option"
+                      id="react-select-15-option-0"
+                      onClick={[Function]}
+                      onMouseMove={[Function]}
+                      onMouseOver={[Function]}
+                      tabIndex={-1}
                     >
                       Accepted
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
-                    data="[object Object]"
+                    className="c6"
+                    cx={null}
+                    data={
+                      Object {
+                        "label": "Assigned to a line",
+                        "value": "assigned",
+                      }
+                    }
                     data-testid="select-option"
                     label="Assigned to a line"
                     type="option"
                     value="assigned"
                   >
                     <div
-                      class=" css-5aymxm-Option"
-                      id="react-select-13-option-1"
-                      tabindex="-1"
+                      className=" css-5aymxm-Option"
+                      id="react-select-15-option-1"
+                      onClick={[Function]}
+                      onMouseMove={[Function]}
+                      onMouseOver={[Function]}
+                      tabIndex={-1}
                     >
                       Assigned to a line
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
-                    data="[object Object]"
+                    className="c6"
+                    cx={null}
+                    data={
+                      Object {
+                        "label": "On hold",
+                        "value": "hold",
+                      }
+                    }
                     data-testid="select-option"
                     label="On hold"
                     type="option"
                     value="hold"
                   >
                     <div
-                      class=" css-5aymxm-Option"
-                      id="react-select-13-option-2"
-                      tabindex="-1"
+                      className=" css-5aymxm-Option"
+                      id="react-select-15-option-2"
+                      onClick={[Function]}
+                      onMouseMove={[Function]}
+                      onMouseOver={[Function]}
+                      tabIndex={-1}
                     >
                       On hold
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
-                    data="[object Object]"
+                    className="c6"
+                    cx={null}
+                    data={
+                      Object {
+                        "label": "Rejected",
+                        "value": "rejected",
+                      }
+                    }
                     data-testid="select-option"
                     label="Rejected"
                     type="option"
                     value="rejected"
                   >
                     <div
-                      class=" css-5aymxm-Option"
-                      id="react-select-13-option-3"
-                      tabindex="-1"
+                      className=" css-5aymxm-Option"
+                      id="react-select-15-option-3"
+                      onClick={[Function]}
+                      onMouseMove={[Function]}
+                      onMouseOver={[Function]}
+                      tabIndex={-1}
                     >
                       Rejected
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
-                    data="[object Object]"
+                    className="c6"
+                    cx={null}
+                    data={
+                      Object {
+                        "label": "Open",
+                        "value": "open",
+                      }
+                    }
                     data-testid="select-option"
                     label="Open"
                     type="option"
                     value="open"
                   >
                     <div
-                      class=" css-5aymxm-Option"
-                      id="react-select-13-option-4"
-                      tabindex="-1"
+                      className=" css-5aymxm-Option"
+                      id="react-select-15-option-4"
+                      onClick={[Function]}
+                      onMouseMove={[Function]}
+                      onMouseOver={[Function]}
+                      tabIndex={-1}
                     >
                       Open
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
-                    data="[object Object]"
+                    className="c6"
+                    cx={null}
+                    data={
+                      Object {
+                        "label": "In progress",
+                        "value": "progress",
+                      }
+                    }
                     data-testid="select-option"
                     label="In progress"
                     type="option"
                     value="progress"
                   >
                     <div
-                      class=" css-5aymxm-Option"
-                      id="react-select-13-option-5"
-                      tabindex="-1"
+                      className=" css-5aymxm-Option"
+                      id="react-select-15-option-5"
+                      onClick={[Function]}
+                      onMouseMove={[Function]}
+                      onMouseOver={[Function]}
+                      tabIndex={-1}
                     >
                       In progress
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
-                    data="[object Object]"
+                    className="c6"
+                    cx={null}
+                    data={
+                      Object {
+                        "label": "In quarantine",
+                        "value": "quarantine",
+                      }
+                    }
                     data-testid="select-option"
                     label="In quarantine"
                     type="option"
                     value="quarantine"
                   >
                     <div
-                      class=" css-5aymxm-Option"
-                      id="react-select-13-option-6"
-                      tabindex="-1"
+                      className=" css-5aymxm-Option"
+                      id="react-select-15-option-6"
+                      onClick={[Function]}
+                      onMouseMove={[Function]}
+                      onMouseOver={[Function]}
+                      tabIndex={-1}
                     >
                       In quarantine
                     </div>
@@ -1882,33 +3071,97 @@ exports[`Storyshots Select with an option selected 1`] = `
 `;
 
 exports[`Storyshots Select with custom id 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c5 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+  font-size: 14px;
+  line-height: 1.71428571;
+}
+
+.c5 .Link-sc-1lpx3d0-0 {
+  font-size: 14px;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Inventory status
           </span>
           <p
-            class="Text-sc-1wu7vpu-0 HelpText__HelpTextContent-sc-1jzmq2g-0 feAJVX"
+            className="Text-sc-1wu7vpu-0 c5"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Additional information about input
           </p>
@@ -1917,19 +3170,22 @@ exports[`Storyshots Select with custom id 1`] = `
           data-testid="select-container"
         >
           <div
-            class=" css-2b097c-container"
+            className=" css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1liu8yu-Control"
+                className=" css-1liu8yu-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    className=" css-1yhx6vz-Placeholder"
                   >
                     Please select inventory status
                   </div>
@@ -1937,48 +3193,83 @@ exports[`Storyshots Select with custom id 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
                           id="my-custom-id"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
                       aria-hidden="true"
-                      class="css-6q0nyr-Svg"
+                      className="css-6q0nyr-Svg"
                       focusable="false"
-                      height="20"
+                      height={20}
                       viewBox="0 0 20 20"
-                      width="20"
+                      width={20}
                     >
                       <path
                         d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
@@ -1997,26 +3288,145 @@ exports[`Storyshots Select with custom id 1`] = `
 `;
 
 exports[`Storyshots Select with error list 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c5 {
+  color: #cc1439;
+  margin-top: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c6 {
+  margin-right: 8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c9 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c12 {
+  margin-bottom: 8px;
+  color: currentColor;
+}
+
+.c12:last-child {
+  margin-bottom: 0;
+}
+
+.c10 {
+  color: currentColor;
+  margin: 0;
+  padding-left: 18px;
+}
+
+.c10 .c11 {
+  margin-bottom: 0;
+}
+
+.c7 .c8 {
+  margin-bottom: 8px;
+}
+
+.c7 > *:last-child {
+  margin-bottom: 0;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c13:last-child {
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+.c13 div {
+  padding: 7px;
+  font-weight: 400;
+  min-height: 32px;
+  min-width: -webkit-max-content;
+  min-width: -moz-max-content;
+  min-width: max-content;
+  white-space: nowrap;
+}
+
+.c13 div:hover {
+  background: #e1ebfa;
+  cursor: pointer;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Inventory status
           </span>
@@ -2025,19 +3435,22 @@ exports[`Storyshots Select with error list 1`] = `
           data-testid="select-container"
         >
           <div
-            class=" css-2b097c-container"
+            className=" css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1j4q2ea-Control"
+                className=" css-1j4q2ea-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    className=" css-1yhx6vz-Placeholder"
                   >
                     Please select inventory status
                   </div>
@@ -2045,48 +3458,83 @@ exports[`Storyshots Select with error list 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          id="react-select-18-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
+                          id="react-select-20-input"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
                       aria-hidden="true"
-                      class="css-6q0nyr-Svg"
+                      className="css-6q0nyr-Svg"
                       focusable="false"
-                      height="20"
+                      height={20}
                       viewBox="0 0 20 20"
-                      width="20"
+                      width={20}
                     >
                       <path
                         d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
@@ -2099,18 +3547,20 @@ exports[`Storyshots Select with error list 1`] = `
           </div>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 ycNbA"
+          className="c5"
           color="red"
         >
           <svg
-            aria-hidden="true"
-            class="Icon-fc7twp-0 QuoIa"
+            aria-hidden={true}
+            className="c6"
             color="currentColor"
             fill="currentColor"
-            focusable="false"
+            focusable={false}
             height="24px"
             icon="error"
             mr="x1"
+            size="24px"
+            title={null}
             viewBox="0 0 24 24"
             width="24px"
           >
@@ -2119,27 +3569,28 @@ exports[`Storyshots Select with error list 1`] = `
             />
           </svg>
           <div
-            class="InlineValidation__Wrapper-sc-1jic7dw-0 kqhCKM"
+            className="c7"
           >
             <p
-              class="Text-sc-1wu7vpu-0 RbfMK"
+              className="c8 c9"
               color="currentColor"
-              font-size="medium"
+              disabled={false}
+              fontSize="medium"
             >
               Please select an inventory status
             </p>
             <ul
-              class="List-sc-1cqkmnl-0 diqcEx"
+              className="c10"
               color="currentColor"
             >
               <li
-                class="ListItem-qqenhw-0 gzsWDK"
+                className="c11 c12"
                 color="currentColor"
               >
                 Error message 1
               </li>
               <li
-                class="ListItem-qqenhw-0 gzsWDK"
+                className="c11 c12"
                 color="currentColor"
               >
                 Error message 2
@@ -2151,25 +3602,28 @@ exports[`Storyshots Select with error list 1`] = `
     </div>
     <br />
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <div
         data-testid="select-container"
       >
         <div
-          class=" css-2b097c-container"
+          className=" css-2b097c-container"
+          onKeyDown={[Function]}
         >
           <div
             data-testid="select-control"
           >
             <div
-              class=" css-1odmq7e-Control"
+              className=" css-1odmq7e-Control"
+              onMouseDown={[Function]}
+              onTouchEnd={[Function]}
             >
               <div
-                class=" css-7zc8my"
+                className=" css-7zc8my"
               >
                 <div
-                  class=" css-1yhx6vz-Placeholder"
+                  className=" css-1yhx6vz-Placeholder"
                 >
                   Please select inventory status
                 </div>
@@ -2177,48 +3631,83 @@ exports[`Storyshots Select with error list 1`] = `
                   data-testid="select-input"
                 >
                   <div
-                    class="css-17yls17-Input"
+                    className="css-17yls17-Input"
                   >
                     <div
-                      class=""
-                      style="display:inline-block"
+                      className=""
+                      style={
+                        Object {
+                          "display": "inline-block",
+                        }
+                      }
                     >
                       <input
                         aria-autocomplete="list"
-                        autocapitalize="none"
-                        autocomplete="off"
-                        autocorrect="off"
-                        id="react-select-19-input"
-                        spellcheck="false"
-                        style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                        tabindex="0"
+                        autoCapitalize="none"
+                        autoComplete="off"
+                        autoCorrect="off"
+                        disabled={null}
+                        id="react-select-21-input"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        spellCheck="false"
+                        style={
+                          Object {
+                            "background": 0,
+                            "border": 0,
+                            "boxSizing": "content-box",
+                            "color": "inherit",
+                            "fontSize": "inherit",
+                            "label": "input",
+                            "opacity": 1,
+                            "outline": 0,
+                            "padding": 0,
+                            "width": "1px",
+                          }
+                        }
+                        tabIndex="0"
                         type="text"
                         value=""
                       />
                       <div
-                        style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                      />
+                        style={
+                          Object {
+                            "height": 0,
+                            "left": 0,
+                            "overflow": "scroll",
+                            "position": "absolute",
+                            "top": 0,
+                            "visibility": "hidden",
+                            "whiteSpace": "pre",
+                          }
+                        }
+                      >
+                        
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
               <div
-                class=" css-173cxbq-IndicatorsContainer"
+                className=" css-173cxbq-IndicatorsContainer"
               >
                 <span
-                  class=" css-4z5mi-indicatorSeparator"
+                  className=" css-4z5mi-indicatorSeparator"
                 />
                 <div
                   aria-hidden="true"
-                  class=" css-19phze7-indicatorContainer"
+                  className=" css-19phze7-indicatorContainer"
+                  onMouseDown={[Function]}
+                  onTouchEnd={[Function]}
                 >
                   <svg
                     aria-hidden="true"
-                    class="css-6q0nyr-Svg"
+                    className="css-6q0nyr-Svg"
                     focusable="false"
-                    height="20"
+                    height={20}
                     viewBox="0 0 20 20"
-                    width="20"
+                    width={20}
                   >
                     <path
                       d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
@@ -2232,119 +3721,184 @@ exports[`Storyshots Select with error list 1`] = `
             data-testid="select-dropdown"
           >
             <div
-              class=" css-6mfljk-Menu"
+              className=" css-6mfljk-Menu"
+              onMouseDown={[Function]}
+              onMouseMove={[Function]}
             >
               <div
-                class=" css-famnlw-MenuList"
+                className=" css-famnlw-MenuList"
               >
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
-                  data="[object Object]"
+                  className="c13"
+                  cx={null}
+                  data={
+                    Object {
+                      "label": "Accepted",
+                      "value": "accepted",
+                    }
+                  }
                   data-testid="select-option"
                   label="Accepted"
                   type="option"
                   value="accepted"
                 >
                   <div
-                    class=" css-5aymxm-Option"
-                    id="react-select-19-option-0"
-                    tabindex="-1"
+                    className=" css-5aymxm-Option"
+                    id="react-select-21-option-0"
+                    onClick={[Function]}
+                    onMouseMove={[Function]}
+                    onMouseOver={[Function]}
+                    tabIndex={-1}
                   >
                     Accepted
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
-                  data="[object Object]"
+                  className="c13"
+                  cx={null}
+                  data={
+                    Object {
+                      "label": "Assigned to a line",
+                      "value": "assigned",
+                    }
+                  }
                   data-testid="select-option"
                   label="Assigned to a line"
                   type="option"
                   value="assigned"
                 >
                   <div
-                    class=" css-5aymxm-Option"
-                    id="react-select-19-option-1"
-                    tabindex="-1"
+                    className=" css-5aymxm-Option"
+                    id="react-select-21-option-1"
+                    onClick={[Function]}
+                    onMouseMove={[Function]}
+                    onMouseOver={[Function]}
+                    tabIndex={-1}
                   >
                     Assigned to a line
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
-                  data="[object Object]"
+                  className="c13"
+                  cx={null}
+                  data={
+                    Object {
+                      "label": "On hold",
+                      "value": "hold",
+                    }
+                  }
                   data-testid="select-option"
                   label="On hold"
                   type="option"
                   value="hold"
                 >
                   <div
-                    class=" css-5aymxm-Option"
-                    id="react-select-19-option-2"
-                    tabindex="-1"
+                    className=" css-5aymxm-Option"
+                    id="react-select-21-option-2"
+                    onClick={[Function]}
+                    onMouseMove={[Function]}
+                    onMouseOver={[Function]}
+                    tabIndex={-1}
                   >
                     On hold
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
-                  data="[object Object]"
+                  className="c13"
+                  cx={null}
+                  data={
+                    Object {
+                      "label": "Rejected",
+                      "value": "rejected",
+                    }
+                  }
                   data-testid="select-option"
                   label="Rejected"
                   type="option"
                   value="rejected"
                 >
                   <div
-                    class=" css-5aymxm-Option"
-                    id="react-select-19-option-3"
-                    tabindex="-1"
+                    className=" css-5aymxm-Option"
+                    id="react-select-21-option-3"
+                    onClick={[Function]}
+                    onMouseMove={[Function]}
+                    onMouseOver={[Function]}
+                    tabIndex={-1}
                   >
                     Rejected
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
-                  data="[object Object]"
+                  className="c13"
+                  cx={null}
+                  data={
+                    Object {
+                      "label": "Open",
+                      "value": "open",
+                    }
+                  }
                   data-testid="select-option"
                   label="Open"
                   type="option"
                   value="open"
                 >
                   <div
-                    class=" css-5aymxm-Option"
-                    id="react-select-19-option-4"
-                    tabindex="-1"
+                    className=" css-5aymxm-Option"
+                    id="react-select-21-option-4"
+                    onClick={[Function]}
+                    onMouseMove={[Function]}
+                    onMouseOver={[Function]}
+                    tabIndex={-1}
                   >
                     Open
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
-                  data="[object Object]"
+                  className="c13"
+                  cx={null}
+                  data={
+                    Object {
+                      "label": "In progress",
+                      "value": "progress",
+                    }
+                  }
                   data-testid="select-option"
                   label="In progress"
                   type="option"
                   value="progress"
                 >
                   <div
-                    class=" css-5aymxm-Option"
-                    id="react-select-19-option-5"
-                    tabindex="-1"
+                    className=" css-5aymxm-Option"
+                    id="react-select-21-option-5"
+                    onClick={[Function]}
+                    onMouseMove={[Function]}
+                    onMouseOver={[Function]}
+                    tabIndex={-1}
                   >
                     In progress
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
-                  data="[object Object]"
+                  className="c13"
+                  cx={null}
+                  data={
+                    Object {
+                      "label": "In quarantine",
+                      "value": "quarantine",
+                    }
+                  }
                   data-testid="select-option"
                   label="In quarantine"
                   type="option"
                   value="quarantine"
                 >
                   <div
-                    class=" css-5aymxm-Option"
-                    id="react-select-19-option-6"
-                    tabindex="-1"
+                    className=" css-5aymxm-Option"
+                    id="react-select-21-option-6"
+                    onClick={[Function]}
+                    onMouseMove={[Function]}
+                    onMouseOver={[Function]}
+                    tabIndex={-1}
                   >
                     In quarantine
                   </div>
@@ -2355,18 +3909,20 @@ exports[`Storyshots Select with error list 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 ycNbA"
+        className="c5"
         color="red"
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 QuoIa"
+          aria-hidden={true}
+          className="c6"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="error"
           mr="x1"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -2375,27 +3931,28 @@ exports[`Storyshots Select with error list 1`] = `
           />
         </svg>
         <div
-          class="InlineValidation__Wrapper-sc-1jic7dw-0 kqhCKM"
+          className="c7"
         >
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c8 c9"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Please select an inventory status
           </p>
           <ul
-            class="List-sc-1cqkmnl-0 diqcEx"
+            className="c10"
             color="currentColor"
           >
             <li
-              class="ListItem-qqenhw-0 gzsWDK"
+              className="c11 c12"
               color="currentColor"
             >
               Error message 1
             </li>
             <li
-              class="ListItem-qqenhw-0 gzsWDK"
+              className="c11 c12"
               color="currentColor"
             >
               Error message 2
@@ -2409,26 +3966,126 @@ exports[`Storyshots Select with error list 1`] = `
 `;
 
 exports[`Storyshots Select with error message 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c5 {
+  color: #cc1439;
+  margin-top: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c6 {
+  margin-right: 8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c9 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c7 .c8 {
+  margin-bottom: 8px;
+}
+
+.c7 > *:last-child {
+  margin-bottom: 0;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c10:last-child {
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+.c10 div {
+  padding: 7px;
+  font-weight: 400;
+  min-height: 32px;
+  min-width: -webkit-max-content;
+  min-width: -moz-max-content;
+  min-width: max-content;
+  white-space: nowrap;
+}
+
+.c10 div:hover {
+  background: #e1ebfa;
+  cursor: pointer;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Inventory status
           </span>
@@ -2437,19 +4094,22 @@ exports[`Storyshots Select with error message 1`] = `
           data-testid="select-container"
         >
           <div
-            class=" css-2b097c-container"
+            className=" css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1j4q2ea-Control"
+                className=" css-1j4q2ea-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    className=" css-1yhx6vz-Placeholder"
                   >
                     Please select inventory status
                   </div>
@@ -2457,48 +4117,83 @@ exports[`Storyshots Select with error message 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          id="react-select-16-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
+                          id="react-select-18-input"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
                       aria-hidden="true"
-                      class="css-6q0nyr-Svg"
+                      className="css-6q0nyr-Svg"
                       focusable="false"
-                      height="20"
+                      height={20}
                       viewBox="0 0 20 20"
-                      width="20"
+                      width={20}
                     >
                       <path
                         d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
@@ -2511,18 +4206,20 @@ exports[`Storyshots Select with error message 1`] = `
           </div>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 ycNbA"
+          className="c5"
           color="red"
         >
           <svg
-            aria-hidden="true"
-            class="Icon-fc7twp-0 QuoIa"
+            aria-hidden={true}
+            className="c6"
             color="currentColor"
             fill="currentColor"
-            focusable="false"
+            focusable={false}
             height="24px"
             icon="error"
             mr="x1"
+            size="24px"
+            title={null}
             viewBox="0 0 24 24"
             width="24px"
           >
@@ -2531,12 +4228,13 @@ exports[`Storyshots Select with error message 1`] = `
             />
           </svg>
           <div
-            class="InlineValidation__Wrapper-sc-1jic7dw-0 kqhCKM"
+            className="c7"
           >
             <p
-              class="Text-sc-1wu7vpu-0 RbfMK"
+              className="c8 c9"
               color="currentColor"
-              font-size="medium"
+              disabled={false}
+              fontSize="medium"
             >
               Please select an inventory status
             </p>
@@ -2546,25 +4244,28 @@ exports[`Storyshots Select with error message 1`] = `
     </div>
     <br />
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <div
         data-testid="select-container"
       >
         <div
-          class=" css-2b097c-container"
+          className=" css-2b097c-container"
+          onKeyDown={[Function]}
         >
           <div
             data-testid="select-control"
           >
             <div
-              class=" css-1odmq7e-Control"
+              className=" css-1odmq7e-Control"
+              onMouseDown={[Function]}
+              onTouchEnd={[Function]}
             >
               <div
-                class=" css-7zc8my"
+                className=" css-7zc8my"
               >
                 <div
-                  class=" css-1yhx6vz-Placeholder"
+                  className=" css-1yhx6vz-Placeholder"
                 >
                   Please select inventory status
                 </div>
@@ -2572,48 +4273,83 @@ exports[`Storyshots Select with error message 1`] = `
                   data-testid="select-input"
                 >
                   <div
-                    class="css-17yls17-Input"
+                    className="css-17yls17-Input"
                   >
                     <div
-                      class=""
-                      style="display:inline-block"
+                      className=""
+                      style={
+                        Object {
+                          "display": "inline-block",
+                        }
+                      }
                     >
                       <input
                         aria-autocomplete="list"
-                        autocapitalize="none"
-                        autocomplete="off"
-                        autocorrect="off"
-                        id="react-select-17-input"
-                        spellcheck="false"
-                        style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                        tabindex="0"
+                        autoCapitalize="none"
+                        autoComplete="off"
+                        autoCorrect="off"
+                        disabled={null}
+                        id="react-select-19-input"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        spellCheck="false"
+                        style={
+                          Object {
+                            "background": 0,
+                            "border": 0,
+                            "boxSizing": "content-box",
+                            "color": "inherit",
+                            "fontSize": "inherit",
+                            "label": "input",
+                            "opacity": 1,
+                            "outline": 0,
+                            "padding": 0,
+                            "width": "1px",
+                          }
+                        }
+                        tabIndex="0"
                         type="text"
                         value=""
                       />
                       <div
-                        style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                      />
+                        style={
+                          Object {
+                            "height": 0,
+                            "left": 0,
+                            "overflow": "scroll",
+                            "position": "absolute",
+                            "top": 0,
+                            "visibility": "hidden",
+                            "whiteSpace": "pre",
+                          }
+                        }
+                      >
+                        
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
               <div
-                class=" css-173cxbq-IndicatorsContainer"
+                className=" css-173cxbq-IndicatorsContainer"
               >
                 <span
-                  class=" css-4z5mi-indicatorSeparator"
+                  className=" css-4z5mi-indicatorSeparator"
                 />
                 <div
                   aria-hidden="true"
-                  class=" css-19phze7-indicatorContainer"
+                  className=" css-19phze7-indicatorContainer"
+                  onMouseDown={[Function]}
+                  onTouchEnd={[Function]}
                 >
                   <svg
                     aria-hidden="true"
-                    class="css-6q0nyr-Svg"
+                    className="css-6q0nyr-Svg"
                     focusable="false"
-                    height="20"
+                    height={20}
                     viewBox="0 0 20 20"
-                    width="20"
+                    width={20}
                   >
                     <path
                       d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
@@ -2627,119 +4363,184 @@ exports[`Storyshots Select with error message 1`] = `
             data-testid="select-dropdown"
           >
             <div
-              class=" css-6mfljk-Menu"
+              className=" css-6mfljk-Menu"
+              onMouseDown={[Function]}
+              onMouseMove={[Function]}
             >
               <div
-                class=" css-famnlw-MenuList"
+                className=" css-famnlw-MenuList"
               >
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
-                  data="[object Object]"
+                  className="c10"
+                  cx={null}
+                  data={
+                    Object {
+                      "label": "Accepted",
+                      "value": "accepted",
+                    }
+                  }
                   data-testid="select-option"
                   label="Accepted"
                   type="option"
                   value="accepted"
                 >
                   <div
-                    class=" css-5aymxm-Option"
-                    id="react-select-17-option-0"
-                    tabindex="-1"
+                    className=" css-5aymxm-Option"
+                    id="react-select-19-option-0"
+                    onClick={[Function]}
+                    onMouseMove={[Function]}
+                    onMouseOver={[Function]}
+                    tabIndex={-1}
                   >
                     Accepted
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
-                  data="[object Object]"
+                  className="c10"
+                  cx={null}
+                  data={
+                    Object {
+                      "label": "Assigned to a line",
+                      "value": "assigned",
+                    }
+                  }
                   data-testid="select-option"
                   label="Assigned to a line"
                   type="option"
                   value="assigned"
                 >
                   <div
-                    class=" css-5aymxm-Option"
-                    id="react-select-17-option-1"
-                    tabindex="-1"
+                    className=" css-5aymxm-Option"
+                    id="react-select-19-option-1"
+                    onClick={[Function]}
+                    onMouseMove={[Function]}
+                    onMouseOver={[Function]}
+                    tabIndex={-1}
                   >
                     Assigned to a line
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
-                  data="[object Object]"
+                  className="c10"
+                  cx={null}
+                  data={
+                    Object {
+                      "label": "On hold",
+                      "value": "hold",
+                    }
+                  }
                   data-testid="select-option"
                   label="On hold"
                   type="option"
                   value="hold"
                 >
                   <div
-                    class=" css-5aymxm-Option"
-                    id="react-select-17-option-2"
-                    tabindex="-1"
+                    className=" css-5aymxm-Option"
+                    id="react-select-19-option-2"
+                    onClick={[Function]}
+                    onMouseMove={[Function]}
+                    onMouseOver={[Function]}
+                    tabIndex={-1}
                   >
                     On hold
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
-                  data="[object Object]"
+                  className="c10"
+                  cx={null}
+                  data={
+                    Object {
+                      "label": "Rejected",
+                      "value": "rejected",
+                    }
+                  }
                   data-testid="select-option"
                   label="Rejected"
                   type="option"
                   value="rejected"
                 >
                   <div
-                    class=" css-5aymxm-Option"
-                    id="react-select-17-option-3"
-                    tabindex="-1"
+                    className=" css-5aymxm-Option"
+                    id="react-select-19-option-3"
+                    onClick={[Function]}
+                    onMouseMove={[Function]}
+                    onMouseOver={[Function]}
+                    tabIndex={-1}
                   >
                     Rejected
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
-                  data="[object Object]"
+                  className="c10"
+                  cx={null}
+                  data={
+                    Object {
+                      "label": "Open",
+                      "value": "open",
+                    }
+                  }
                   data-testid="select-option"
                   label="Open"
                   type="option"
                   value="open"
                 >
                   <div
-                    class=" css-5aymxm-Option"
-                    id="react-select-17-option-4"
-                    tabindex="-1"
+                    className=" css-5aymxm-Option"
+                    id="react-select-19-option-4"
+                    onClick={[Function]}
+                    onMouseMove={[Function]}
+                    onMouseOver={[Function]}
+                    tabIndex={-1}
                   >
                     Open
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
-                  data="[object Object]"
+                  className="c10"
+                  cx={null}
+                  data={
+                    Object {
+                      "label": "In progress",
+                      "value": "progress",
+                    }
+                  }
                   data-testid="select-option"
                   label="In progress"
                   type="option"
                   value="progress"
                 >
                   <div
-                    class=" css-5aymxm-Option"
-                    id="react-select-17-option-5"
-                    tabindex="-1"
+                    className=" css-5aymxm-Option"
+                    id="react-select-19-option-5"
+                    onClick={[Function]}
+                    onMouseMove={[Function]}
+                    onMouseOver={[Function]}
+                    tabIndex={-1}
                   >
                     In progress
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
-                  data="[object Object]"
+                  className="c10"
+                  cx={null}
+                  data={
+                    Object {
+                      "label": "In quarantine",
+                      "value": "quarantine",
+                    }
+                  }
                   data-testid="select-option"
                   label="In quarantine"
                   type="option"
                   value="quarantine"
                 >
                   <div
-                    class=" css-5aymxm-Option"
-                    id="react-select-17-option-6"
-                    tabindex="-1"
+                    className=" css-5aymxm-Option"
+                    id="react-select-19-option-6"
+                    onClick={[Function]}
+                    onMouseMove={[Function]}
+                    onMouseOver={[Function]}
+                    tabIndex={-1}
                   >
                     In quarantine
                   </div>
@@ -2750,18 +4551,20 @@ exports[`Storyshots Select with error message 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 ycNbA"
+        className="c5"
         color="red"
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 QuoIa"
+          aria-hidden={true}
+          className="c6"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="error"
           mr="x1"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -2770,12 +4573,13 @@ exports[`Storyshots Select with error message 1`] = `
           />
         </svg>
         <div
-          class="InlineValidation__Wrapper-sc-1jic7dw-0 kqhCKM"
+          className="c7"
         >
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c8 c9"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Please select an inventory status
           </p>
@@ -2787,30 +4591,86 @@ exports[`Storyshots Select with error message 1`] = `
 `;
 
 exports[`Storyshots Select with fixed positioning 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 jlPsmj"
-      style="position:relative;overflow:hidden;width:300px;height:100px"
+      className=""
+      style={
+        Object {
+          "height": "100px",
+          "overflow": "hidden",
+          "position": "relative",
+          "width": "300px",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+        className="c1"
       >
         <label
-          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+          className="c2 "
           color="black"
-          style="display:block"
+          style={
+            Object {
+              "display": "block",
+            }
+          }
         >
           <div
-            class="Box-sc-1qu1edy-0 ilQgHG"
+            className="c3"
             data-testid="field-label"
           >
             <span
-              class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+              className="c4"
             >
               Inventory status
             </span>
@@ -2819,19 +4679,22 @@ exports[`Storyshots Select with fixed positioning 1`] = `
             data-testid="select-container"
           >
             <div
-              class=" css-2b097c-container"
+              className=" css-2b097c-container"
+              onKeyDown={[Function]}
             >
               <div
                 data-testid="select-control"
               >
                 <div
-                  class=" css-1liu8yu-Control"
+                  className=" css-1liu8yu-Control"
+                  onMouseDown={[Function]}
+                  onTouchEnd={[Function]}
                 >
                   <div
-                    class=" css-7zc8my"
+                    className=" css-7zc8my"
                   >
                     <div
-                      class=" css-r447wv-singleValue"
+                      className=" css-r447wv-singleValue"
                     >
                       Accepted
                     </div>
@@ -2839,48 +4702,83 @@ exports[`Storyshots Select with fixed positioning 1`] = `
                       data-testid="select-input"
                     >
                       <div
-                        class="css-17yls17-Input"
+                        className="css-17yls17-Input"
                       >
                         <div
-                          class=""
-                          style="display:inline-block"
+                          className=""
+                          style={
+                            Object {
+                              "display": "inline-block",
+                            }
+                          }
                         >
                           <input
                             aria-autocomplete="list"
-                            autocapitalize="none"
-                            autocomplete="off"
-                            autocorrect="off"
-                            id="react-select-29-input"
-                            spellcheck="false"
-                            style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                            tabindex="0"
+                            autoCapitalize="none"
+                            autoComplete="off"
+                            autoCorrect="off"
+                            disabled={null}
+                            id="react-select-31-input"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            spellCheck="false"
+                            style={
+                              Object {
+                                "background": 0,
+                                "border": 0,
+                                "boxSizing": "content-box",
+                                "color": "inherit",
+                                "fontSize": "inherit",
+                                "label": "input",
+                                "opacity": 1,
+                                "outline": 0,
+                                "padding": 0,
+                                "width": "1px",
+                              }
+                            }
+                            tabIndex="0"
                             type="text"
                             value=""
                           />
                           <div
-                            style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                          />
+                            style={
+                              Object {
+                                "height": 0,
+                                "left": 0,
+                                "overflow": "scroll",
+                                "position": "absolute",
+                                "top": 0,
+                                "visibility": "hidden",
+                                "whiteSpace": "pre",
+                              }
+                            }
+                          >
+                            
+                          </div>
                         </div>
                       </div>
                     </div>
                   </div>
                   <div
-                    class=" css-173cxbq-IndicatorsContainer"
+                    className=" css-173cxbq-IndicatorsContainer"
                   >
                     <span
-                      class=" css-4z5mi-indicatorSeparator"
+                      className=" css-4z5mi-indicatorSeparator"
                     />
                     <div
                       aria-hidden="true"
-                      class=" css-19phze7-indicatorContainer"
+                      className=" css-19phze7-indicatorContainer"
+                      onMouseDown={[Function]}
+                      onTouchEnd={[Function]}
                     >
                       <svg
                         aria-hidden="true"
-                        class="css-6q0nyr-Svg"
+                        className="css-6q0nyr-Svg"
                         focusable="false"
-                        height="20"
+                        height={20}
                         viewBox="0 0 20 20"
-                        width="20"
+                        width={20}
                       >
                         <path
                           d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
@@ -2900,33 +4798,97 @@ exports[`Storyshots Select with fixed positioning 1`] = `
 `;
 
 exports[`Storyshots Select with helpText 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c5 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+  font-size: 14px;
+  line-height: 1.71428571;
+}
+
+.c5 .Link-sc-1lpx3d0-0 {
+  font-size: 14px;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Inventory status
           </span>
           <p
-            class="Text-sc-1wu7vpu-0 HelpText__HelpTextContent-sc-1jzmq2g-0 feAJVX"
+            className="Text-sc-1wu7vpu-0 c5"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Additional information about input
           </p>
@@ -2935,19 +4897,22 @@ exports[`Storyshots Select with helpText 1`] = `
           data-testid="select-container"
         >
           <div
-            class=" css-2b097c-container"
+            className=" css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1liu8yu-Control"
+                className=" css-1liu8yu-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    className=" css-1yhx6vz-Placeholder"
                   >
                     Please select inventory status
                   </div>
@@ -2955,48 +4920,83 @@ exports[`Storyshots Select with helpText 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          id="react-select-21-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
+                          id="react-select-23-input"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
                       aria-hidden="true"
-                      class="css-6q0nyr-Svg"
+                      className="css-6q0nyr-Svg"
                       focusable="false"
-                      height="20"
+                      height={20}
                       viewBox="0 0 20 20"
-                      width="20"
+                      width={20}
                     >
                       <path
                         d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
@@ -3015,26 +5015,75 @@ exports[`Storyshots Select with helpText 1`] = `
 `;
 
 exports[`Storyshots Select with multiselect 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Select PCN
           </span>
@@ -3043,38 +5092,44 @@ exports[`Storyshots Select with multiselect 1`] = `
           data-testid="select-container"
         >
           <div
-            class="Select css-2b097c-container"
+            className="Select css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1liu8yu-Control"
+                className=" css-1liu8yu-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
                     data-testid="select-multivalue"
                   >
                     <div
-                      class="css-gxde6l-multiValue"
+                      className="css-gxde6l-multiValue"
                     >
                       <div
-                        class="css-1ekzmfk"
+                        className="css-1ekzmfk"
                       >
                         PCN2
                       </div>
                       <div
-                        class="css-kurm45"
+                        className="css-kurm45"
+                        onClick={[Function]}
+                        onMouseDown={[Function]}
+                        onTouchEnd={[Function]}
                       >
                         <svg
                           aria-hidden="true"
-                          class="css-6q0nyr-Svg"
+                          className="css-6q0nyr-Svg"
                           focusable="false"
-                          height="14"
+                          height={14}
                           viewBox="0 0 20 20"
-                          width="14"
+                          width={14}
                         >
                           <path
                             d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
@@ -3087,23 +5142,26 @@ exports[`Storyshots Select with multiselect 1`] = `
                     data-testid="select-multivalue"
                   >
                     <div
-                      class="css-gxde6l-multiValue"
+                      className="css-gxde6l-multiValue"
                     >
                       <div
-                        class="css-1ekzmfk"
+                        className="css-1ekzmfk"
                       >
                         PCN1
                       </div>
                       <div
-                        class="css-kurm45"
+                        className="css-kurm45"
+                        onClick={[Function]}
+                        onMouseDown={[Function]}
+                        onTouchEnd={[Function]}
                       >
                         <svg
                           aria-hidden="true"
-                          class="css-6q0nyr-Svg"
+                          className="css-6q0nyr-Svg"
                           focusable="false"
-                          height="14"
+                          height={14}
                           viewBox="0 0 20 20"
-                          width="14"
+                          width={14}
                         >
                           <path
                             d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
@@ -3116,48 +5174,83 @@ exports[`Storyshots Select with multiselect 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          id="react-select-25-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
+                          id="react-select-27-input"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <div
                     data-testid="select-clear"
                   >
                     <div
                       aria-hidden="true"
-                      class=" css-kaqmzc-indicatorContainer"
+                      className=" css-kaqmzc-indicatorContainer"
+                      onMouseDown={[Function]}
+                      onTouchEnd={[Function]}
                     >
                       <svg
                         aria-hidden="true"
-                        class="css-6q0nyr-Svg"
+                        className="css-6q0nyr-Svg"
                         focusable="false"
-                        height="20"
+                        height={20}
                         viewBox="0 0 20 20"
-                        width="20"
+                        width={20}
                       >
                         <path
                           d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
@@ -3166,19 +5259,21 @@ exports[`Storyshots Select with multiselect 1`] = `
                     </div>
                   </div>
                   <span
-                    class=" css-uv1fd5-indicatorSeparator"
+                    className=" css-uv1fd5-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
                       aria-hidden="true"
-                      class="css-6q0nyr-Svg"
+                      className="css-6q0nyr-Svg"
                       focusable="false"
-                      height="20"
+                      height={20}
                       viewBox="0 0 20 20"
-                      width="20"
+                      width={20}
                     >
                       <path
                         d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
@@ -3197,26 +5292,114 @@ exports[`Storyshots Select with multiselect 1`] = `
 `;
 
 exports[`Storyshots Select with smaller maxHeight 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c5:last-child {
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+.c5 div {
+  padding: 7px;
+  font-weight: 500;
+  min-height: 32px;
+  min-width: -webkit-max-content;
+  min-width: -moz-max-content;
+  min-width: max-content;
+  white-space: nowrap;
+}
+
+.c5 div:hover {
+  cursor: pointer;
+}
+
+.c6:last-child {
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+.c6 div {
+  padding: 7px;
+  font-weight: 400;
+  min-height: 32px;
+  min-width: -webkit-max-content;
+  min-width: -moz-max-content;
+  min-width: max-content;
+  white-space: nowrap;
+}
+
+.c6 div:hover {
+  background: #e1ebfa;
+  cursor: pointer;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Inventory status
           </span>
@@ -3225,19 +5408,22 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
           data-testid="select-container"
         >
           <div
-            class=" css-2b097c-container"
+            className=" css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-w42fll-Control"
+                className=" css-w42fll-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-r447wv-singleValue"
+                    className=" css-r447wv-singleValue"
                   >
                     Accepted
                   </div>
@@ -3245,48 +5431,83 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          id="react-select-23-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
+                          id="react-select-25-input"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
                       aria-hidden="true"
-                      class="css-6q0nyr-Svg"
+                      className="css-6q0nyr-Svg"
                       focusable="false"
-                      height="20"
+                      height={20}
                       viewBox="0 0 20 20"
-                      width="20"
+                      width={20}
                     >
                       <path
                         d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
@@ -3300,119 +5521,184 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
               data-testid="select-dropdown"
             >
               <div
-                class=" css-1l502d3-Menu"
+                className=" css-1l502d3-Menu"
+                onMouseDown={[Function]}
+                onMouseMove={[Function]}
               >
                 <div
-                  class=" css-1hz449x-MenuList"
+                  className=" css-1hz449x-MenuList"
                 >
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 blgViL"
-                    data="[object Object]"
+                    className="c5"
+                    cx={null}
+                    data={
+                      Object {
+                        "label": "Accepted",
+                        "value": "accepted",
+                      }
+                    }
                     data-testid="select-option"
                     label="Accepted"
                     type="option"
                     value="accepted"
                   >
                     <div
-                      class=" css-5aymxm-Option"
-                      id="react-select-23-option-0"
-                      tabindex="-1"
+                      className=" css-5aymxm-Option"
+                      id="react-select-25-option-0"
+                      onClick={[Function]}
+                      onMouseMove={[Function]}
+                      onMouseOver={[Function]}
+                      tabIndex={-1}
                     >
                       Accepted
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
-                    data="[object Object]"
+                    className="c6"
+                    cx={null}
+                    data={
+                      Object {
+                        "label": "Assigned to a line",
+                        "value": "assigned",
+                      }
+                    }
                     data-testid="select-option"
                     label="Assigned to a line"
                     type="option"
                     value="assigned"
                   >
                     <div
-                      class=" css-5aymxm-Option"
-                      id="react-select-23-option-1"
-                      tabindex="-1"
+                      className=" css-5aymxm-Option"
+                      id="react-select-25-option-1"
+                      onClick={[Function]}
+                      onMouseMove={[Function]}
+                      onMouseOver={[Function]}
+                      tabIndex={-1}
                     >
                       Assigned to a line
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
-                    data="[object Object]"
+                    className="c6"
+                    cx={null}
+                    data={
+                      Object {
+                        "label": "On hold",
+                        "value": "hold",
+                      }
+                    }
                     data-testid="select-option"
                     label="On hold"
                     type="option"
                     value="hold"
                   >
                     <div
-                      class=" css-5aymxm-Option"
-                      id="react-select-23-option-2"
-                      tabindex="-1"
+                      className=" css-5aymxm-Option"
+                      id="react-select-25-option-2"
+                      onClick={[Function]}
+                      onMouseMove={[Function]}
+                      onMouseOver={[Function]}
+                      tabIndex={-1}
                     >
                       On hold
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
-                    data="[object Object]"
+                    className="c6"
+                    cx={null}
+                    data={
+                      Object {
+                        "label": "Rejected",
+                        "value": "rejected",
+                      }
+                    }
                     data-testid="select-option"
                     label="Rejected"
                     type="option"
                     value="rejected"
                   >
                     <div
-                      class=" css-5aymxm-Option"
-                      id="react-select-23-option-3"
-                      tabindex="-1"
+                      className=" css-5aymxm-Option"
+                      id="react-select-25-option-3"
+                      onClick={[Function]}
+                      onMouseMove={[Function]}
+                      onMouseOver={[Function]}
+                      tabIndex={-1}
                     >
                       Rejected
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
-                    data="[object Object]"
+                    className="c6"
+                    cx={null}
+                    data={
+                      Object {
+                        "label": "Open",
+                        "value": "open",
+                      }
+                    }
                     data-testid="select-option"
                     label="Open"
                     type="option"
                     value="open"
                   >
                     <div
-                      class=" css-5aymxm-Option"
-                      id="react-select-23-option-4"
-                      tabindex="-1"
+                      className=" css-5aymxm-Option"
+                      id="react-select-25-option-4"
+                      onClick={[Function]}
+                      onMouseMove={[Function]}
+                      onMouseOver={[Function]}
+                      tabIndex={-1}
                     >
                       Open
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
-                    data="[object Object]"
+                    className="c6"
+                    cx={null}
+                    data={
+                      Object {
+                        "label": "In progress",
+                        "value": "progress",
+                      }
+                    }
                     data-testid="select-option"
                     label="In progress"
                     type="option"
                     value="progress"
                   >
                     <div
-                      class=" css-5aymxm-Option"
-                      id="react-select-23-option-5"
-                      tabindex="-1"
+                      className=" css-5aymxm-Option"
+                      id="react-select-25-option-5"
+                      onClick={[Function]}
+                      onMouseMove={[Function]}
+                      onMouseOver={[Function]}
+                      tabIndex={-1}
                     >
                       In progress
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
-                    data="[object Object]"
+                    className="c6"
+                    cx={null}
+                    data={
+                      Object {
+                        "label": "In quarantine",
+                        "value": "quarantine",
+                      }
+                    }
                     data-testid="select-option"
                     label="In quarantine"
                     type="option"
                     value="quarantine"
                   >
                     <div
-                      class=" css-5aymxm-Option"
-                      id="react-select-23-option-6"
-                      tabindex="-1"
+                      className=" css-5aymxm-Option"
+                      id="react-select-25-option-6"
+                      onClick={[Function]}
+                      onMouseMove={[Function]}
+                      onMouseOver={[Function]}
+                      tabIndex={-1}
                     >
                       In quarantine
                     </div>
@@ -3429,26 +5715,132 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
 `;
 
 exports[`Storyshots Select with state 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c5 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c5:hover {
+  background-color: #e1ebfa;
+}
+
+.c5:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c5:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c5:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c5:disabled {
+  opacity: .5;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Inventory status
           </span>
@@ -3457,19 +5849,22 @@ exports[`Storyshots Select with state 1`] = `
           data-testid="select-container"
         >
           <div
-            class="Select css-2b097c-container"
+            className="Select css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class="SelectTest__control css-1liu8yu-Control"
+                className="SelectTest__control css-1liu8yu-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class="SelectTest__value-container css-7zc8my"
+                  className="SelectTest__value-container css-7zc8my"
                 >
                   <div
-                    class="SelectTest__placeholder css-1yhx6vz-Placeholder"
+                    className="SelectTest__placeholder css-1yhx6vz-Placeholder"
                   >
                     Please select inventory status
                   </div>
@@ -3477,48 +5872,83 @@ exports[`Storyshots Select with state 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class="SelectTest__input"
-                        style="display:inline-block"
+                        className="SelectTest__input"
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          id="react-select-14-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
+                          id="react-select-16-input"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class="SelectTest__indicators css-173cxbq-IndicatorsContainer"
+                  className="SelectTest__indicators css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class="SelectTest__indicator-separator css-4z5mi-indicatorSeparator"
+                    className="SelectTest__indicator-separator css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class="SelectTest__indicator SelectTest__dropdown-indicator css-19phze7-indicatorContainer"
+                    className="SelectTest__indicator SelectTest__dropdown-indicator css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
                       aria-hidden="true"
-                      class="css-6q0nyr-Svg"
+                      className="css-6q0nyr-Svg"
                       focusable="false"
-                      height="20"
+                      height={20}
                       viewBox="0 0 20 20"
-                      width="20"
+                      width={20}
                     >
                       <path
                         d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
@@ -3533,7 +5963,10 @@ exports[`Storyshots Select with state 1`] = `
       </label>
     </div>
     <button
-      class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+      className="c5"
+      disabled={false}
+      onClick={[Function]}
+      size="medium"
     >
       Clear selection
     </button>

--- a/components/src/StatusIndicator/__snapshots__/StatusIndicator.story.storyshot
+++ b/components/src/StatusIndicator/__snapshots__/StatusIndicator.story.storyshot
@@ -1,50 +1,238 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots StatusIndicator All 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: inline-block;
+  font-weight: 600;
+  text-transform: uppercase;
+  -webkit-letter-spacing: .05em;
+  -moz-letter-spacing: .05em;
+  -ms-letter-spacing: .05em;
+  letter-spacing: .05em;
+  border-radius: 8px;
+  margin-right: 4px;
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-left: 0;
+  padding-top: 0;
+  padding-right: 8px;
+  padding-bottom: 0;
+  padding-left: 8px;
+  font-size: 12px;
+  line-height: 1.33333333;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  border-color: #e4e7eb;
+  background-color: #e4e7eb;
+  color: #434d59;
+}
+
+.c2 {
+  display: inline-block;
+  font-weight: 600;
+  text-transform: uppercase;
+  -webkit-letter-spacing: .05em;
+  -moz-letter-spacing: .05em;
+  -ms-letter-spacing: .05em;
+  letter-spacing: .05em;
+  border-radius: 8px;
+  margin-right: 4px;
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-left: 0;
+  padding-top: 0;
+  padding-right: 8px;
+  padding-bottom: 0;
+  padding-left: 8px;
+  font-size: 12px;
+  line-height: 1.33333333;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  border-color: #ffffff;
+  background-color: #ffffff;
+  color: #434d59;
+}
+
+.c3 {
+  display: inline-block;
+  font-weight: 600;
+  text-transform: uppercase;
+  -webkit-letter-spacing: .05em;
+  -moz-letter-spacing: .05em;
+  -ms-letter-spacing: .05em;
+  letter-spacing: .05em;
+  border-radius: 8px;
+  margin-right: 4px;
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-left: 0;
+  padding-top: 0;
+  padding-right: 8px;
+  padding-bottom: 0;
+  padding-left: 8px;
+  font-size: 12px;
+  line-height: 1.33333333;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  border-color: #216beb;
+  background-color: #216beb;
+  color: #ffffff;
+}
+
+.c4 {
+  display: inline-block;
+  font-weight: 600;
+  text-transform: uppercase;
+  -webkit-letter-spacing: .05em;
+  -moz-letter-spacing: .05em;
+  -ms-letter-spacing: .05em;
+  letter-spacing: .05em;
+  border-radius: 8px;
+  margin-right: 4px;
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-left: 0;
+  padding-top: 0;
+  padding-right: 8px;
+  padding-bottom: 0;
+  padding-left: 8px;
+  font-size: 12px;
+  line-height: 1.33333333;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  border-color: #008059;
+  background-color: #008059;
+  color: #ffffff;
+}
+
+.c5 {
+  display: inline-block;
+  font-weight: 600;
+  text-transform: uppercase;
+  -webkit-letter-spacing: .05em;
+  -moz-letter-spacing: .05em;
+  -ms-letter-spacing: .05em;
+  letter-spacing: .05em;
+  border-radius: 8px;
+  margin-right: 4px;
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-left: 0;
+  padding-top: 0;
+  padding-right: 8px;
+  padding-bottom: 0;
+  padding-left: 8px;
+  font-size: 12px;
+  line-height: 1.33333333;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  border-color: #ffbb00;
+  background-color: #ffbb00;
+  color: #434d59;
+}
+
+.c6 {
+  display: inline-block;
+  font-weight: 600;
+  text-transform: uppercase;
+  -webkit-letter-spacing: .05em;
+  -moz-letter-spacing: .05em;
+  -ms-letter-spacing: .05em;
+  letter-spacing: .05em;
+  border-radius: 8px;
+  margin-right: 4px;
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-left: 0;
+  padding-top: 0;
+  padding-right: 8px;
+  padding-bottom: 0;
+  padding-left: 8px;
+  font-size: 12px;
+  line-height: 1.33333333;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  border-color: #cc1439;
+  background-color: #cc1439;
+  color: #ffffff;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <p
-      class="StatusIndicator-t1vtrp-0 RKBBg"
-      font-size="smaller"
+      className="c1"
+      fontSize="smaller"
       type="neutral"
     >
       Neutral
     </p>
     <p
-      class="StatusIndicator-t1vtrp-0 bRgec"
-      font-size="smaller"
+      className="c2"
+      fontSize="smaller"
       type="quiet"
     >
       Quiet
     </p>
     <p
-      class="StatusIndicator-t1vtrp-0 kcwFtD"
-      font-size="smaller"
+      className="c3"
+      fontSize="smaller"
       type="informative"
     >
       Informative
     </p>
     <p
-      class="StatusIndicator-t1vtrp-0 bgEnVn"
-      font-size="smaller"
+      className="c4"
+      fontSize="smaller"
       type="success"
     >
       Success
     </p>
     <p
-      class="StatusIndicator-t1vtrp-0 kskdzU"
-      font-size="smaller"
+      className="c5"
+      fontSize="smaller"
       type="warning"
     >
       Warning
     </p>
     <p
-      class="StatusIndicator-t1vtrp-0 cpshFT"
-      font-size="smaller"
+      className="c6"
+      fontSize="smaller"
       type="danger"
     >
       Danger
@@ -54,15 +242,68 @@ exports[`Storyshots StatusIndicator All 1`] = `
 `;
 
 exports[`Storyshots StatusIndicator Danger 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: inline-block;
+  font-weight: 600;
+  text-transform: uppercase;
+  -webkit-letter-spacing: .05em;
+  -moz-letter-spacing: .05em;
+  -ms-letter-spacing: .05em;
+  letter-spacing: .05em;
+  border-radius: 8px;
+  margin-top: 0;
+  margin-right: 0;
+  margin-bottom: 0;
+  margin-left: 0;
+  padding-top: 0;
+  padding-right: 8px;
+  padding-bottom: 0;
+  padding-left: 8px;
+  font-size: 12px;
+  line-height: 1.33333333;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  border-color: #cc1439;
+  background-color: #cc1439;
+  color: #ffffff;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <p
-      class="StatusIndicator-t1vtrp-0 cXXUWf"
-      font-size="smaller"
+      className="c1"
+      fontSize="smaller"
       type="danger"
     >
       Danger
@@ -72,115 +313,221 @@ exports[`Storyshots StatusIndicator Danger 1`] = `
 `;
 
 exports[`Storyshots StatusIndicator Following text 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  margin-bottom: 24px;
+}
+
+.c5 {
+  margin-right: 8px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c6 {
+  margin-right: 8px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 14px;
+  line-height: 1.71428571;
+  color: currentColor;
+}
+
+.c7 {
+  margin-right: 8px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 12px;
+  line-height: 1.33333333;
+  color: currentColor;
+}
+
+.c2 {
+  margin-right: 8px;
+  margin-top: 0;
+  margin-bottom: 16px;
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.23076923;
+}
+
+.c4 {
+  margin-right: 8px;
+  margin-top: 0;
+  margin-bottom: 8px;
+  font-weight: 500;
+  font-size: 20px;
+  line-height: 1.2;
+}
+
+.c3 {
+  display: inline-block;
+  font-weight: 600;
+  text-transform: uppercase;
+  -webkit-letter-spacing: .05em;
+  -moz-letter-spacing: .05em;
+  -ms-letter-spacing: .05em;
+  letter-spacing: .05em;
+  border-radius: 8px;
+  margin-top: 0;
+  margin-right: 0;
+  margin-bottom: 0;
+  margin-left: 0;
+  padding-top: 0;
+  padding-right: 8px;
+  padding-bottom: 0;
+  padding-left: 8px;
+  font-size: 12px;
+  line-height: 1.33333333;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  border-color: #e4e7eb;
+  background-color: #e4e7eb;
+  color: #434d59;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 dgqwRo"
+      className="c1"
     >
       <span
-        class="Text-sc-1wu7vpu-0-h2 brpaKQ"
-        font-size="larger"
-        font-weight="medium"
+        className="c2"
+        fontSize="larger"
+        fontWeight="medium"
       >
         Label
       </span>
       <p
-        class="StatusIndicator-t1vtrp-0 buWDcg"
-        font-size="smaller"
+        className="c3"
+        fontSize="smaller"
         type="neutral"
       >
         Status
       </p>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 dgqwRo"
+      className="c1"
     >
       <span
-        class="Text-sc-1wu7vpu-0-h3 Headings__SubsectionTitle-igpciy-0 MApIk"
-        font-size="large"
-        font-weight="medium"
+        className="-h3 c4"
+        fontSize="large"
+        fontWeight="medium"
       >
         Label
       </span>
       <p
-        class="StatusIndicator-t1vtrp-0 buWDcg"
-        font-size="smaller"
+        className="c3"
+        fontSize="smaller"
         type="neutral"
       >
         Status
       </p>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 dgqwRo"
+      className="c1"
     >
       <span
-        class="Text-sc-1wu7vpu-0 ipzFTA"
+        className="c5"
         color="currentColor"
-        font-size="medium"
+        disabled={false}
+        fontSize="medium"
       >
         Label
       </span>
       <p
-        class="StatusIndicator-t1vtrp-0 buWDcg"
-        font-size="smaller"
+        className="c3"
+        fontSize="smaller"
         type="neutral"
       >
         Status
       </p>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 dgqwRo"
+      className="c1"
     >
       <span
-        class="Text-sc-1wu7vpu-0 gtpyno"
+        className="c6"
         color="currentColor"
-        font-size="small"
+        disabled={false}
+        fontSize="small"
       >
         Label
       </span>
       <p
-        class="StatusIndicator-t1vtrp-0 buWDcg"
-        font-size="smaller"
+        className="c3"
+        fontSize="smaller"
         type="neutral"
       >
         Status
       </p>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 dgqwRo"
+      className="c1"
     >
       <span
-        class="Text-sc-1wu7vpu-0 emQXPB"
+        className="c7"
         color="currentColor"
-        font-size="smaller"
+        disabled={false}
+        fontSize="smaller"
       >
         Label
       </span>
       <p
-        class="StatusIndicator-t1vtrp-0 buWDcg"
-        font-size="smaller"
+        className="c3"
+        fontSize="smaller"
         type="neutral"
       >
         Status
       </p>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 dgqwRo"
+      className="c1"
     >
       <span
-        class="Text-sc-1wu7vpu-0 ipzFTA"
+        className="c5"
         color="currentColor"
-        font-size="medium"
+        disabled={false}
+        fontSize="medium"
       >
         Long label Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus in eleifend metus, in tempus sapien. Morbi eget felis est. Nunc facilisis vel nisi nec ornare. Ut blandit ullamcorper enim sed fringilla. Quisque malesuada pharetra tincidunt. Mauris mauris tortor, maximus vitae tempor ac, tincidunt pharetra augue. In eget suscipit est. Suspendisse feugiat risus urna
       </span>
       <p
-        class="StatusIndicator-t1vtrp-0 buWDcg"
-        font-size="smaller"
+        className="c3"
+        fontSize="smaller"
         type="neutral"
       >
         Status
@@ -191,15 +538,68 @@ exports[`Storyshots StatusIndicator Following text 1`] = `
 `;
 
 exports[`Storyshots StatusIndicator Informative 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: inline-block;
+  font-weight: 600;
+  text-transform: uppercase;
+  -webkit-letter-spacing: .05em;
+  -moz-letter-spacing: .05em;
+  -ms-letter-spacing: .05em;
+  letter-spacing: .05em;
+  border-radius: 8px;
+  margin-top: 0;
+  margin-right: 0;
+  margin-bottom: 0;
+  margin-left: 0;
+  padding-top: 0;
+  padding-right: 8px;
+  padding-bottom: 0;
+  padding-left: 8px;
+  font-size: 12px;
+  line-height: 1.33333333;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  border-color: #216beb;
+  background-color: #216beb;
+  color: #ffffff;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <p
-      class="StatusIndicator-t1vtrp-0 fhSGRP"
-      font-size="smaller"
+      className="c1"
+      fontSize="smaller"
       type="informative"
     >
       Informative
@@ -209,97 +609,206 @@ exports[`Storyshots StatusIndicator Informative 1`] = `
 `;
 
 exports[`Storyshots StatusIndicator Inside flex 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  margin-bottom: 24px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c5 {
+  margin-right: 8px;
+  margin-bottom: 0;
+  margin-top: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c6 {
+  margin-right: 8px;
+  margin-bottom: 0;
+  margin-top: 0;
+  font-size: 14px;
+  line-height: 1.71428571;
+  color: currentColor;
+}
+
+.c7 {
+  margin-right: 8px;
+  margin-bottom: 0;
+  margin-top: 0;
+  font-size: 12px;
+  line-height: 1.33333333;
+  color: currentColor;
+}
+
+.c2 {
+  margin-right: 8px;
+  margin-bottom: 0;
+  margin-top: 0;
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.23076923;
+}
+
+.c4 {
+  margin-right: 8px;
+  margin-bottom: 0;
+  margin-top: 0;
+  font-weight: 500;
+  font-size: 20px;
+  line-height: 1.2;
+}
+
+.c3 {
+  display: inline-block;
+  font-weight: 600;
+  text-transform: uppercase;
+  -webkit-letter-spacing: .05em;
+  -moz-letter-spacing: .05em;
+  -ms-letter-spacing: .05em;
+  letter-spacing: .05em;
+  border-radius: 8px;
+  margin-top: 0;
+  margin-right: 0;
+  margin-bottom: 0;
+  margin-left: 0;
+  padding-top: 0;
+  padding-right: 8px;
+  padding-bottom: 0;
+  padding-left: 8px;
+  font-size: 12px;
+  line-height: 1.33333333;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  border-color: #e4e7eb;
+  background-color: #e4e7eb;
+  color: #434d59;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fjbNzW"
+      className="Box-sc-1qu1edy-0 c1"
     >
       <span
-        class="Text-sc-1wu7vpu-0-h2 beQSnH"
-        font-size="larger"
-        font-weight="medium"
+        className="c2"
+        fontSize="larger"
+        fontWeight="medium"
       >
         Label
       </span>
       <p
-        class="StatusIndicator-t1vtrp-0 buWDcg"
-        font-size="smaller"
+        className="c3"
+        fontSize="smaller"
         type="neutral"
       >
         Status
       </p>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fjbNzW"
+      className="Box-sc-1qu1edy-0 c1"
     >
       <span
-        class="Text-sc-1wu7vpu-0-h3 Headings__SubsectionTitle-igpciy-0 kekrzE"
-        font-size="large"
-        font-weight="medium"
+        className="-h3 c4"
+        fontSize="large"
+        fontWeight="medium"
       >
         Label
       </span>
       <p
-        class="StatusIndicator-t1vtrp-0 buWDcg"
-        font-size="smaller"
+        className="c3"
+        fontSize="smaller"
         type="neutral"
       >
         Status
       </p>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fjbNzW"
+      className="Box-sc-1qu1edy-0 c1"
     >
       <span
-        class="Text-sc-1wu7vpu-0 kmQoAM"
+        className="c5"
         color="currentColor"
-        font-size="medium"
+        disabled={false}
+        fontSize="medium"
       >
         Label
       </span>
       <p
-        class="StatusIndicator-t1vtrp-0 buWDcg"
-        font-size="smaller"
+        className="c3"
+        fontSize="smaller"
         type="neutral"
       >
         Status
       </p>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fjbNzW"
+      className="Box-sc-1qu1edy-0 c1"
     >
       <span
-        class="Text-sc-1wu7vpu-0 icwHeY"
+        className="c6"
         color="currentColor"
-        font-size="small"
+        disabled={false}
+        fontSize="small"
       >
         Label
       </span>
       <p
-        class="StatusIndicator-t1vtrp-0 buWDcg"
-        font-size="smaller"
+        className="c3"
+        fontSize="smaller"
         type="neutral"
       >
         Status
       </p>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fjbNzW"
+      className="Box-sc-1qu1edy-0 c1"
     >
       <span
-        class="Text-sc-1wu7vpu-0 gQrkYx"
+        className="c7"
         color="currentColor"
-        font-size="smaller"
+        disabled={false}
+        fontSize="smaller"
       >
         Label
       </span>
       <p
-        class="StatusIndicator-t1vtrp-0 buWDcg"
-        font-size="smaller"
+        className="c3"
+        fontSize="smaller"
         type="neutral"
       >
         Status
@@ -310,15 +819,68 @@ exports[`Storyshots StatusIndicator Inside flex 1`] = `
 `;
 
 exports[`Storyshots StatusIndicator Neutral 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: inline-block;
+  font-weight: 600;
+  text-transform: uppercase;
+  -webkit-letter-spacing: .05em;
+  -moz-letter-spacing: .05em;
+  -ms-letter-spacing: .05em;
+  letter-spacing: .05em;
+  border-radius: 8px;
+  margin-top: 0;
+  margin-right: 0;
+  margin-bottom: 0;
+  margin-left: 0;
+  padding-top: 0;
+  padding-right: 8px;
+  padding-bottom: 0;
+  padding-left: 8px;
+  font-size: 12px;
+  line-height: 1.33333333;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  border-color: #e4e7eb;
+  background-color: #e4e7eb;
+  color: #434d59;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <p
-      class="StatusIndicator-t1vtrp-0 buWDcg"
-      font-size="smaller"
+      className="c1"
+      fontSize="smaller"
       type="neutral"
     >
       Neutral
@@ -328,15 +890,68 @@ exports[`Storyshots StatusIndicator Neutral 1`] = `
 `;
 
 exports[`Storyshots StatusIndicator Quiet 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: inline-block;
+  font-weight: 600;
+  text-transform: uppercase;
+  -webkit-letter-spacing: .05em;
+  -moz-letter-spacing: .05em;
+  -ms-letter-spacing: .05em;
+  letter-spacing: .05em;
+  border-radius: 8px;
+  margin-top: 0;
+  margin-right: 0;
+  margin-bottom: 0;
+  margin-left: 0;
+  padding-top: 0;
+  padding-right: 8px;
+  padding-bottom: 0;
+  padding-left: 8px;
+  font-size: 12px;
+  line-height: 1.33333333;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  border-color: #ffffff;
+  background-color: #ffffff;
+  color: #434d59;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <p
-      class="StatusIndicator-t1vtrp-0 kMMSHk"
-      font-size="smaller"
+      className="c1"
+      fontSize="smaller"
       type="quiet"
     >
       Quiet
@@ -346,15 +961,68 @@ exports[`Storyshots StatusIndicator Quiet 1`] = `
 `;
 
 exports[`Storyshots StatusIndicator Success 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: inline-block;
+  font-weight: 600;
+  text-transform: uppercase;
+  -webkit-letter-spacing: .05em;
+  -moz-letter-spacing: .05em;
+  -ms-letter-spacing: .05em;
+  letter-spacing: .05em;
+  border-radius: 8px;
+  margin-top: 0;
+  margin-right: 0;
+  margin-bottom: 0;
+  margin-left: 0;
+  padding-top: 0;
+  padding-right: 8px;
+  padding-bottom: 0;
+  padding-left: 8px;
+  font-size: 12px;
+  line-height: 1.33333333;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  border-color: #008059;
+  background-color: #008059;
+  color: #ffffff;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <p
-      class="StatusIndicator-t1vtrp-0 gyZmjr"
-      font-size="smaller"
+      className="c1"
+      fontSize="smaller"
       type="success"
     >
       Success
@@ -364,15 +1032,68 @@ exports[`Storyshots StatusIndicator Success 1`] = `
 `;
 
 exports[`Storyshots StatusIndicator Warning 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: inline-block;
+  font-weight: 600;
+  text-transform: uppercase;
+  -webkit-letter-spacing: .05em;
+  -moz-letter-spacing: .05em;
+  -ms-letter-spacing: .05em;
+  letter-spacing: .05em;
+  border-radius: 8px;
+  margin-top: 0;
+  margin-right: 0;
+  margin-bottom: 0;
+  margin-left: 0;
+  padding-top: 0;
+  padding-right: 8px;
+  padding-bottom: 0;
+  padding-left: 8px;
+  font-size: 12px;
+  line-height: 1.33333333;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  border-color: #ffbb00;
+  background-color: #ffbb00;
+  color: #434d59;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <p
-      class="StatusIndicator-t1vtrp-0 jRRKcw"
-      font-size="smaller"
+      className="c1"
+      fontSize="smaller"
       type="warning"
     >
       Warning

--- a/components/src/Table/__snapshots__/BaseTable.story.storyshot
+++ b/components/src/Table/__snapshots__/BaseTable.story.storyshot
@@ -1,35 +1,99 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Table  with data 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: auto;
+}
+
+.c3:first-child {
+  padding-left: 16px;
+}
+
+.c2 {
+  color: #434d59;
+  border-bottom: 1px solid #e4e7eb;
+}
+
+.c5 {
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-right: 16px;
+}
+
+.c5:first-child {
+  padding-left: 16px;
+}
+
+.c4:hover {
+  background-color: #f0f2f5;
+}
+
+.c1 {
+  border-collapse: collapse;
+  width: 100%;
+  background: white;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub Table"
+      className="c1 Table"
     >
       <thead>
         <tr
-          class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
+          className="c2"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
             Date
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
             Expected Quantity
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
@@ -41,161 +105,161 @@ exports[`Storyshots Table  with data 1`] = `
         data-testid="table-body"
       >
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-01
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,025 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             1,800 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-02
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,250 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-03
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             1,425 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-04
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             675 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-07
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             1,575 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-22
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             1,725 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             -
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-23
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             -
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-24
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             -
           </td>
@@ -208,35 +272,99 @@ exports[`Storyshots Table  with data 1`] = `
 `;
 
 exports[`Storyshots Table with a cell formatter 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: auto;
+}
+
+.c3:first-child {
+  padding-left: 16px;
+}
+
+.c2 {
+  color: #434d59;
+  border-bottom: 1px solid #e4e7eb;
+}
+
+.c5 {
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-right: 16px;
+}
+
+.c5:first-child {
+  padding-left: 16px;
+}
+
+.c4:hover {
+  background-color: #f0f2f5;
+}
+
+.c1 {
+  border-collapse: collapse;
+  width: 100%;
+  background: white;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+      className="c1"
     >
       <thead>
         <tr
-          class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
+          className="c2"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
             Date
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
             Expected Quantity
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
@@ -248,161 +376,161 @@ exports[`Storyshots Table with a cell formatter 1`] = `
         data-testid="table-body"
       >
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             Tue, 01 Oct 2019
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,025 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             1,800 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             Wed, 02 Oct 2019
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,250 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             Thu, 03 Oct 2019
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             1,425 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             Fri, 04 Oct 2019
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             675 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             Mon, 07 Oct 2019
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             1,575 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             Tue, 22 Oct 2019
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             1,725 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             -
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             Wed, 23 Oct 2019
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             -
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             Thu, 24 Oct 2019
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             -
           </td>
@@ -415,77 +543,236 @@ exports[`Storyshots Table with a cell formatter 1`] = `
 `;
 
 exports[`Storyshots Table with a custom cell component 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c6 {
+  padding-right: 24px;
+  text-align: right;
+}
+
+.c9 {
+  padding: 4px;
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c7 {
+  background: transparent;
+  border: none;
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px 0px;
+  color: #00438f;
+  cursor: pointer;
+}
+
+.c7 .c8 {
+  border-radius: 50%;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c7 .Text-sc-1wu7vpu-0 {
+  display: block;
+  font-weight: 500;
+  text-align: left;
+}
+
+.c7 .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 0;
+}
+
+.c7:hover .c8 {
+  background-color: #e1ebfa;
+}
+
+.c7:hover .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c7:active .c8 {
+  -webkit-transform: scale(0.875);
+  -ms-transform: scale(0.875);
+  transform: scale(0.875);
+  -webkit-transition: .2s ease-in;
+  transition: .2s ease-in;
+}
+
+.c7:disabled {
+  opacity: .5;
+}
+
+.c7:disabled:hover .c8,
+.c7:disabled:active .c8 {
+  background: none;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.c7:focus {
+  outline: none;
+}
+
+.c7:focus .c8 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:focus .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c3 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: auto;
+}
+
+.c3:first-child {
+  padding-left: 16px;
+}
+
+.c2 {
+  color: #434d59;
+  border-bottom: 1px solid #e4e7eb;
+}
+
+.c5 {
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-right: 16px;
+}
+
+.c5:first-child {
+  padding-left: 16px;
+}
+
+.c4:hover {
+  background-color: #f0f2f5;
+}
+
+.c1 {
+  border-collapse: collapse;
+  width: 100%;
+  background: white;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+      className="c1"
     >
       <thead>
         <tr
-          class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
+          className="c2"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
             Date
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
             Expected Quantity
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
-          />
+          >
+            
+          </th>
         </tr>
       </thead>
       <tbody
         data-testid="table-body"
       >
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-01
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,025 eaches
           </td>
-          <td>
+          <td
+            colSpan={null}
+          >
             <div
-              class="Box-sc-1qu1edy-0 gqpebI"
+              className="c6"
             >
               <button
-                aria-expanded="false"
-                aria-haspopup="true"
+                aria-describedby={null}
+                aria-expanded={false}
+                aria-haspopup={true}
                 aria-label="Open"
-                class="IconicButton__WrapperButton-sc-1u3dojp-1 UMPof IconicButton-sc-1u3dojp-2 gZASNp"
+                className="c7 "
+                disabled={null}
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseDown={[Function]}
                 type="button"
               >
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 cwKdbD"
+                  aria-hidden={true}
+                  className="c8 c9"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="32px"
                   icon="more"
                   p="half"
+                  size="32px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="32px"
                 >
@@ -498,39 +785,48 @@ exports[`Storyshots Table with a custom cell component 1`] = `
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-02
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
-          <td>
+          <td
+            colSpan={null}
+          >
             <div
-              class="Box-sc-1qu1edy-0 gqpebI"
+              className="c6"
             >
               <button
-                aria-expanded="false"
-                aria-haspopup="true"
+                aria-describedby={null}
+                aria-expanded={false}
+                aria-haspopup={true}
                 aria-label="Open"
-                class="IconicButton__WrapperButton-sc-1u3dojp-1 UMPof IconicButton-sc-1u3dojp-2 gZASNp"
+                className="c7 "
+                disabled={null}
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseDown={[Function]}
                 type="button"
               >
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 cwKdbD"
+                  aria-hidden={true}
+                  className="c8 c9"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="32px"
                   icon="more"
                   p="half"
+                  size="32px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="32px"
                 >
@@ -543,39 +839,48 @@ exports[`Storyshots Table with a custom cell component 1`] = `
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-03
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
-          <td>
+          <td
+            colSpan={null}
+          >
             <div
-              class="Box-sc-1qu1edy-0 gqpebI"
+              className="c6"
             >
               <button
-                aria-expanded="false"
-                aria-haspopup="true"
+                aria-describedby={null}
+                aria-expanded={false}
+                aria-haspopup={true}
                 aria-label="Open"
-                class="IconicButton__WrapperButton-sc-1u3dojp-1 UMPof IconicButton-sc-1u3dojp-2 gZASNp"
+                className="c7 "
+                disabled={null}
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseDown={[Function]}
                 type="button"
               >
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 cwKdbD"
+                  aria-hidden={true}
+                  className="c8 c9"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="32px"
                   icon="more"
                   p="half"
+                  size="32px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="32px"
                 >
@@ -588,39 +893,48 @@ exports[`Storyshots Table with a custom cell component 1`] = `
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-04
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
-          <td>
+          <td
+            colSpan={null}
+          >
             <div
-              class="Box-sc-1qu1edy-0 gqpebI"
+              className="c6"
             >
               <button
-                aria-expanded="false"
-                aria-haspopup="true"
+                aria-describedby={null}
+                aria-expanded={false}
+                aria-haspopup={true}
                 aria-label="Open"
-                class="IconicButton__WrapperButton-sc-1u3dojp-1 UMPof IconicButton-sc-1u3dojp-2 gZASNp"
+                className="c7 "
+                disabled={null}
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseDown={[Function]}
                 type="button"
               >
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 cwKdbD"
+                  aria-hidden={true}
+                  className="c8 c9"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="32px"
                   icon="more"
                   p="half"
+                  size="32px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="32px"
                 >
@@ -633,39 +947,48 @@ exports[`Storyshots Table with a custom cell component 1`] = `
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-07
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
-          <td>
+          <td
+            colSpan={null}
+          >
             <div
-              class="Box-sc-1qu1edy-0 gqpebI"
+              className="c6"
             >
               <button
-                aria-expanded="false"
-                aria-haspopup="true"
+                aria-describedby={null}
+                aria-expanded={false}
+                aria-haspopup={true}
                 aria-label="Open"
-                class="IconicButton__WrapperButton-sc-1u3dojp-1 UMPof IconicButton-sc-1u3dojp-2 gZASNp"
+                className="c7 "
+                disabled={null}
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseDown={[Function]}
                 type="button"
               >
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 cwKdbD"
+                  aria-hidden={true}
+                  className="c8 c9"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="32px"
                   icon="more"
                   p="half"
+                  size="32px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="32px"
                 >
@@ -678,39 +1001,48 @@ exports[`Storyshots Table with a custom cell component 1`] = `
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-22
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             1,725 eaches
           </td>
-          <td>
+          <td
+            colSpan={null}
+          >
             <div
-              class="Box-sc-1qu1edy-0 gqpebI"
+              className="c6"
             >
               <button
-                aria-expanded="false"
-                aria-haspopup="true"
+                aria-describedby={null}
+                aria-expanded={false}
+                aria-haspopup={true}
                 aria-label="Open"
-                class="IconicButton__WrapperButton-sc-1u3dojp-1 UMPof IconicButton-sc-1u3dojp-2 gZASNp"
+                className="c7 "
+                disabled={null}
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseDown={[Function]}
                 type="button"
               >
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 cwKdbD"
+                  aria-hidden={true}
+                  className="c8 c9"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="32px"
                   icon="more"
                   p="half"
+                  size="32px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="32px"
                 >
@@ -723,39 +1055,48 @@ exports[`Storyshots Table with a custom cell component 1`] = `
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-23
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
-          <td>
+          <td
+            colSpan={null}
+          >
             <div
-              class="Box-sc-1qu1edy-0 gqpebI"
+              className="c6"
             >
               <button
-                aria-expanded="false"
-                aria-haspopup="true"
+                aria-describedby={null}
+                aria-expanded={false}
+                aria-haspopup={true}
                 aria-label="Open"
-                class="IconicButton__WrapperButton-sc-1u3dojp-1 UMPof IconicButton-sc-1u3dojp-2 gZASNp"
+                className="c7 "
+                disabled={null}
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseDown={[Function]}
                 type="button"
               >
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 cwKdbD"
+                  aria-hidden={true}
+                  className="c8 c9"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="32px"
                   icon="more"
                   p="half"
+                  size="32px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="32px"
                 >
@@ -768,39 +1109,48 @@ exports[`Storyshots Table with a custom cell component 1`] = `
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-24
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
-          <td>
+          <td
+            colSpan={null}
+          >
             <div
-              class="Box-sc-1qu1edy-0 gqpebI"
+              className="c6"
             >
               <button
-                aria-expanded="false"
-                aria-haspopup="true"
+                aria-describedby={null}
+                aria-expanded={false}
+                aria-haspopup={true}
                 aria-label="Open"
-                class="IconicButton__WrapperButton-sc-1u3dojp-1 UMPof IconicButton-sc-1u3dojp-2 gZASNp"
+                className="c7 "
+                disabled={null}
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseDown={[Function]}
                 type="button"
               >
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 cwKdbD"
+                  aria-hidden={true}
+                  className="c8 c9"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="32px"
                   icon="more"
                   p="half"
+                  size="32px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="32px"
                 >
@@ -820,47 +1170,171 @@ exports[`Storyshots Table with a custom cell component 1`] = `
 `;
 
 exports[`Storyshots Table with a custom column label component 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c4 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c4:hover {
+  background-color: #e1ebfa;
+}
+
+.c4:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c4:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c4:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c4:disabled {
+  opacity: .5;
+}
+
+.c3 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: auto;
+}
+
+.c3:first-child {
+  padding-left: 16px;
+}
+
+.c2 {
+  color: #434d59;
+  border-bottom: 1px solid #e4e7eb;
+}
+
+.c6 {
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-right: 16px;
+}
+
+.c6:first-child {
+  padding-left: 16px;
+}
+
+.c5:hover {
+  background-color: #f0f2f5;
+}
+
+.c1 {
+  border-collapse: collapse;
+  width: 100%;
+  background: white;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+      className="c1"
     >
       <thead>
         <tr
-          class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
+          className="c2"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
             Date
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
             Expected Quantity
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
             Actual Quantity
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
             <button
-              class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+              className="c4"
+              disabled={false}
+              onClick={[Function]}
+              size="medium"
             >
               Add record
             </button>
@@ -871,188 +1345,204 @@ exports[`Storyshots Table with a custom column label component 1`] = `
         data-testid="table-body"
       >
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-01
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,025 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             1,800 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c6"
+          >
+            
+          </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-02
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,250 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c6"
+          >
+            
+          </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-03
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             1,425 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c6"
+          >
+            
+          </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-04
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             675 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c6"
+          >
+            
+          </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-07
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             1,575 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c6"
+          >
+            
+          </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-22
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             1,725 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             -
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c6"
+          >
+            
+          </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-23
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             -
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c6"
+          >
+            
+          </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-24
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             -
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c6"
+          >
+            
+          </td>
         </tr>
       </tbody>
       <tfoot />
@@ -1062,35 +1552,103 @@ exports[`Storyshots Table with a custom column label component 1`] = `
 `;
 
 exports[`Storyshots Table with a footer 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: auto;
+}
+
+.c3:first-child {
+  padding-left: 16px;
+}
+
+.c2 {
+  color: #434d59;
+  border-bottom: 1px solid #e4e7eb;
+}
+
+.c5 {
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-right: 16px;
+}
+
+.c5:first-child {
+  padding-left: 16px;
+}
+
+.c4:hover {
+  background-color: #f0f2f5;
+}
+
+.c6:first-of-type {
+  border-top: 1px solid #e4e7eb;
+}
+
+.c1 {
+  border-collapse: collapse;
+  width: 100%;
+  background: white;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+      className="c1"
     >
       <thead>
         <tr
-          class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
+          className="c2"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
             Date
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
             Expected Quantity
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
@@ -1102,161 +1660,161 @@ exports[`Storyshots Table with a footer 1`] = `
         data-testid="table-body"
       >
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-01
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,025 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             1,800 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-02
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,250 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-03
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             1,425 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-04
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             675 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-07
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             1,575 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-22
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             1,725 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             -
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-23
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             -
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-24
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             -
           </td>
@@ -1264,41 +1822,43 @@ exports[`Storyshots Table with a footer 1`] = `
       </tbody>
       <tfoot>
         <tr
-          class="TableFoot__StyledFooterRow-sc-1q56pdo-0 gVNRxT"
+          className="c6"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
-            colspan="1"
+            className="c3"
+            colSpan={1}
             scope="row"
           >
             Total
           </th>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             18,000 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             7,725 eaches
           </td>
         </tr>
         <tr
-          class="TableFoot__StyledFooterRow-sc-1q56pdo-0 gVNRxT"
+          className="c6"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
-            colspan="1"
+            className="c3"
+            colSpan={1}
             scope="row"
           >
             Attainment
           </th>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c5"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             41.5%
           </td>
@@ -1310,35 +1870,110 @@ exports[`Storyshots Table with a footer 1`] = `
 `;
 
 exports[`Storyshots Table with cell alignment 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: auto;
+}
+
+.c3:first-child {
+  padding-left: 16px;
+}
+
+.c2 {
+  color: #434d59;
+  border-bottom: 1px solid #e4e7eb;
+}
+
+.c5 {
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-right: 16px;
+}
+
+.c5:first-child {
+  padding-left: 16px;
+}
+
+.c6 {
+  padding-top: 16px;
+  padding-bottom: 16px;
+  text-align: right;
+  padding-right: 16px;
+}
+
+.c6:first-child {
+  padding-left: 16px;
+}
+
+.c4:hover {
+  background-color: #f0f2f5;
+}
+
+.c1 {
+  border-collapse: collapse;
+  width: 100%;
+  background: white;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+      className="c1"
     >
       <thead>
         <tr
-          class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
+          className="c2"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
             Date
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
             Expected Eaches
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
@@ -1350,161 +1985,161 @@ exports[`Storyshots Table with cell alignment 1`] = `
         data-testid="table-body"
       >
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-01
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,025 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 ddNAAS"
+            className="c6"
           >
             1,800 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-02
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 ddNAAS"
+            className="c6"
           >
             2,250 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-03
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 ddNAAS"
+            className="c6"
           >
             1,425 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-04
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 ddNAAS"
+            className="c6"
           >
             675 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-07
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 ddNAAS"
+            className="c6"
           >
             1,575 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-22
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             1,725 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 ddNAAS"
+            className="c6"
           >
             -
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-23
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 ddNAAS"
+            className="c6"
           >
             -
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-24
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 ddNAAS"
+            className="c6"
           >
             -
           </td>
@@ -1517,42 +2152,119 @@ exports[`Storyshots Table with cell alignment 1`] = `
 `;
 
 exports[`Storyshots Table with custom column widths 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: auto;
+}
+
+.c3:first-child {
+  padding-left: 16px;
+}
+
+.c4 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: 50%;
+}
+
+.c4:first-child {
+  padding-left: 16px;
+}
+
+.c2 {
+  color: #434d59;
+  border-bottom: 1px solid #e4e7eb;
+}
+
+.c6 {
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-right: 16px;
+}
+
+.c6:first-child {
+  padding-left: 16px;
+}
+
+.c5:hover {
+  background-color: #f0f2f5;
+}
+
+.c1 {
+  border-collapse: collapse;
+  width: 100%;
+  background: white;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+      className="c1"
     >
       <thead>
         <tr
-          class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
+          className="c2"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
             Date
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
             Expected Quantity
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
             Actual Quantity
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 kJomuc"
+            className="c4"
             data-testid="table-head"
             scope="col"
             width="50%"
@@ -1565,190 +2277,204 @@ exports[`Storyshots Table with custom column widths 1`] = `
         data-testid="table-body"
       >
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-01
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,025 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             1,800 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c6"
+          >
+            
+          </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-02
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,250 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c6"
+          >
+            
+          </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-03
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             1,425 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c6"
+          >
+            
+          </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-04
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             675 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             1c Other Plant-related issue, equipment issues
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-07
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             1,575 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c6"
+          >
+            
+          </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-22
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             1,725 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             -
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c6"
+          >
+            
+          </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-23
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             -
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c6"
+          >
+            
+          </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-24
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             -
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c6"
+          >
+            
+          </td>
         </tr>
       </tbody>
       <tfoot />
@@ -1758,35 +2484,116 @@ exports[`Storyshots Table with custom column widths 1`] = `
 `;
 
 exports[`Storyshots Table with full width section 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c6 {
+  background-color: #e1ebfa;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+.c7 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 1.5;
+  color: #122b47;
+}
+
+.c3 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: auto;
+}
+
+.c3:first-child {
+  padding-left: 16px;
+}
+
+.c2 {
+  color: #434d59;
+  border-bottom: 1px solid #e4e7eb;
+}
+
+.c5 {
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-right: 16px;
+}
+
+.c5:first-child {
+  padding-left: 16px;
+}
+
+.c4:hover {
+  background-color: #f0f2f5;
+}
+
+.c1 {
+  border-collapse: collapse;
+  width: 100%;
+  background: white;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+      className="c1"
     >
       <thead>
         <tr
-          class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
+          className="c2"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
             Date
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
             Expected Quantity
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
@@ -1798,100 +2605,101 @@ exports[`Storyshots Table with full width section 1`] = `
         data-testid="table-body"
       >
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-01
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,025 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             1,800 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-02
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,250 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-03
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             1,425 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-04
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             675 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            colspan="3"
+            colSpan={3}
           >
             <div
-              class="Box-sc-1qu1edy-0 kOlJoM"
+              className="c6"
             >
               <p
-                class="Text-sc-1wu7vpu-0 iHOIzo"
+                className="c7"
                 color="blackBlue"
-                font-size="medium"
-                font-weight="bold"
+                disabled={false}
+                fontSize="medium"
+                fontWeight="bold"
               >
                 ABC & XYZ Company
               </p>
@@ -1899,61 +2707,61 @@ exports[`Storyshots Table with full width section 1`] = `
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-22
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             1,725 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             -
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-23
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             -
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-24
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             -
           </td>
@@ -1966,187 +2774,351 @@ exports[`Storyshots Table with full width section 1`] = `
 `;
 
 exports[`Storyshots Table with lots of rows and columns 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c5 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c8 {
+  min-width: 16px;
+  height: 16px;
+  border-radius: 2px;
+  border: solid 1px;
+  position: relative;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c8:before {
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  width: 3px;
+  height: 9px;
+  border: solid #ffffff;
+  border-radius: 1px;
+  border-width: 0 3px 3px 0;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.c6 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c6:focus + .c7 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c6:checked + .c7 {
+  border-color: #00438f;
+  background-color: #00438f;
+}
+
+.c6:checked + .c7:before {
+  display: block;
+}
+
+.c6:not(:checked) + .c7 {
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+}
+
+.c4 {
+  padding: 4px 0;
+}
+
+.c4 .Text-sc-1wu7vpu-0 {
+  margin-left: 8px;
+}
+
+.c3 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: 30px;
+}
+
+.c3:first-child {
+  padding-left: 16px;
+}
+
+.c9 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: auto;
+}
+
+.c9:first-child {
+  padding-left: 16px;
+}
+
+.c2 {
+  color: #434d59;
+  border-bottom: 1px solid #e4e7eb;
+}
+
+.c11 {
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-right: 16px;
+}
+
+.c11:first-child {
+  padding-left: 16px;
+}
+
+.c10:hover {
+  background-color: #f0f2f5;
+}
+
+.c1 {
+  border-collapse: collapse;
+  width: 100%;
+  background: white;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+      className="c1"
     >
       <thead>
         <tr
-          class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
+          className="c2"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 kfgNsH"
+            className="c3"
             data-testid="table-head"
             scope="col"
             width="30px"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="select all"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c9"
             data-testid="table-head"
             scope="col"
           >
             Column 1
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c9"
             data-testid="table-head"
             scope="col"
           >
             Column 2
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c9"
             data-testid="table-head"
             scope="col"
           >
             Column 3
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c9"
             data-testid="table-head"
             scope="col"
           >
             Column 4
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c9"
             data-testid="table-head"
             scope="col"
           >
             Column 5
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c9"
             data-testid="table-head"
             scope="col"
           >
             Column 6
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c9"
             data-testid="table-head"
             scope="col"
           >
             Column 7
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c9"
             data-testid="table-head"
             scope="col"
           >
             Column 8
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c9"
             data-testid="table-head"
             scope="col"
           >
             Column 9
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c9"
             data-testid="table-head"
             scope="col"
           >
             Column 10
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c9"
             data-testid="table-head"
             scope="col"
           >
             Column 11
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c9"
             data-testid="table-head"
             scope="col"
           >
             Column 12
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c9"
             data-testid="table-head"
             scope="col"
           >
             Column 13
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c9"
             data-testid="table-head"
             scope="col"
           >
             Column 14
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c9"
             data-testid="table-head"
             scope="col"
           >
             Column 15
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c9"
             data-testid="table-head"
             scope="col"
           >
             Column 16
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c9"
             data-testid="table-head"
             scope="col"
           >
             Column 17
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c9"
             data-testid="table-head"
             scope="col"
           >
             Column 18
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c9"
             data-testid="table-head"
             scope="col"
           >
             Column 19
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c9"
             data-testid="table-head"
             scope="col"
           >
             Column 20
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c9"
             data-testid="table-head"
             scope="col"
           >
@@ -2158,6651 +3130,7051 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
         data-testid="table-body"
       >
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 0
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 1
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 2
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 3
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 4
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 5
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 6
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 7
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 8
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 9
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 10
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 11
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 12
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 13
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 14
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 15
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 16
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 17
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 18
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 19
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 20
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 21
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 22
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 23
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 24
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 25
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 26
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 27
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 28
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 29
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 30
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 31
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 32
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 33
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 34
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 35
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 36
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 37
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 38
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 39
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 40
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 41
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 42
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 43
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 44
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 45
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 46
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 47
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 48
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data 49
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             some data
           </td>
@@ -8815,35 +10187,91 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
 `;
 
 exports[`Storyshots Table with no data 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: auto;
+}
+
+.c3:first-child {
+  padding-left: 16px;
+}
+
+.c2 {
+  color: #434d59;
+  border-bottom: 1px solid #e4e7eb;
+}
+
+.c4 {
+  padding: 24px 0;
+  font-size: 14px;
+  color: #434d59;
+}
+
+.c1 {
+  border-collapse: collapse;
+  width: 100%;
+  background: white;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+      className="c1"
     >
       <thead>
         <tr
-          class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
+          className="c2"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
             Date
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
             Expected Quantity
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
@@ -8858,10 +10286,10 @@ exports[`Storyshots Table with no data 1`] = `
           data-testid="table-message-container"
         >
           <td
-            colspan="3"
+            colSpan={3}
           >
             <div
-              class="Box-sc-1qu1edy-0 TableBody__StyledMessageContainer-sc-1amzhx8-0 fEzznw nds-table__no-rows-content"
+              className="Box-sc-1qu1edy-0 c4 nds-table__no-rows-content"
             >
               No records have been created for this table.
             </div>

--- a/components/src/Table/__snapshots__/SortingColumnHeader.story.storyshot
+++ b/components/src/Table/__snapshots__/SortingColumnHeader.story.storyshot
@@ -1,35 +1,118 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Table.Headers Sorting Header 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c4 {
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c2 {
+  margin-right: 8px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c3 {
+  background: transparent;
+  border: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px;
+  border-radius: 50%;
+  color: #434d59;
+}
+
+.c3:focus {
+  outline: none;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c3:hover:enabled {
+  cursor: pointer;
+  color: #122b47;
+  background-color: #e4e7eb;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 geyRYt"
+      className="Box-sc-1qu1edy-0 c1"
     >
       <p
-        class="Text-sc-1wu7vpu-0 ipzFTA"
+        className="c2"
         color="currentColor"
-        font-size="medium"
+        disabled={false}
+        fontSize="medium"
       >
         Header Label
       </p>
       <button
         aria-label="Sort ascending"
-        class="ControlIcon__StyledButton-sc-1h83lvi-0 cCdEvo"
+        className="c3"
+        disabled={false}
+        onClick={[Function]}
         type="button"
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 dkBAgY"
+          aria-hidden={true}
+          className="c4"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="sortUp"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >

--- a/components/src/Table/__snapshots__/Table.story.storyshot
+++ b/components/src/Table/__snapshots__/Table.story.storyshot
@@ -1,53 +1,522 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Table with everything 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c14 {
+  background-color: #e1ebfa;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+.c21 {
+  padding-right: 24px;
+  text-align: right;
+}
+
+.c26 {
+  padding-top: 16px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c20 {
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c23 {
+  padding: 4px;
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c28 {
+  margin-left: -8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c32 {
+  margin-right: -8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c16 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 1.5;
+  color: #122b47;
+}
+
+.c5 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c22 {
+  background: transparent;
+  border: none;
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px 0px;
+  color: #00438f;
+  cursor: pointer;
+}
+
+.c22 .c19 {
+  border-radius: 50%;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c22 .c15 {
+  display: block;
+  font-weight: 500;
+  text-align: left;
+}
+
+.c22 .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 0;
+}
+
+.c22:hover .c19 {
+  background-color: #e1ebfa;
+}
+
+.c22:hover .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c22:active .c19 {
+  -webkit-transform: scale(0.875);
+  -ms-transform: scale(0.875);
+  transform: scale(0.875);
+  -webkit-transition: .2s ease-in;
+  transition: .2s ease-in;
+}
+
+.c22:disabled {
+  opacity: .5;
+}
+
+.c22:disabled:hover .c19,
+.c22:disabled:active .c19 {
+  background: none;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.c22:focus {
+  outline: none;
+}
+
+.c22:focus .c19 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c22:focus .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c18 {
+  background: transparent;
+  border: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px;
+  border-radius: 50%;
+  color: #434d59;
+}
+
+.c18:focus {
+  outline: none;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c18:hover:enabled {
+  cursor: pointer;
+  color: #122b47;
+  background-color: #e4e7eb;
+}
+
+.c8 {
+  min-width: 16px;
+  height: 16px;
+  border-radius: 2px;
+  border: solid 1px;
+  position: relative;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c8:before {
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  width: 3px;
+  height: 9px;
+  border: solid #ffffff;
+  border-radius: 1px;
+  border-width: 0 3px 3px 0;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.c6 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c6:focus + .c7 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c6:checked + .c7 {
+  border-color: #00438f;
+  background-color: #00438f;
+}
+
+.c6:checked + .c7:before {
+  display: block;
+}
+
+.c6:not(:checked) + .c7 {
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+}
+
+.c4 {
+  padding: 4px 0;
+}
+
+.c4 .c15 {
+  margin-left: 8px;
+}
+
+.c3 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: 30px;
+}
+
+.c3:first-child {
+  padding-left: 16px;
+}
+
+.c9 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: 15%;
+}
+
+.c9:first-child {
+  padding-left: 16px;
+}
+
+.c10 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: 20%;
+}
+
+.c10:first-child {
+  padding-left: 16px;
+}
+
+.c11 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: 45%;
+}
+
+.c11:first-child {
+  padding-left: 16px;
+}
+
+.c12 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: 5%;
+}
+
+.c12:first-child {
+  padding-left: 16px;
+}
+
+.c25 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: auto;
+}
+
+.c25:first-child {
+  padding-left: 16px;
+}
+
+.c2 {
+  color: #434d59;
+  border-bottom: 1px solid #e4e7eb;
+}
+
+.c17 {
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-right: 16px;
+}
+
+.c17:first-child {
+  padding-left: 16px;
+}
+
+.c13:hover {
+  background-color: #f0f2f5;
+}
+
+.c24:first-of-type {
+  border-top: 1px solid #e4e7eb;
+}
+
+.c1 {
+  border-collapse: collapse;
+  width: 100%;
+  background: white;
+}
+
+.c27 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #e4e7eb;
+  color: #c0c8d1;
+  cursor: default;
+}
+
+.c27:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c27:hover {
+  background: inital;
+}
+
+.c31 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #e4e7eb;
+  color: #011e38;
+  cursor: pointer;
+}
+
+.c31:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c31:hover {
+  background: #e4e7eb;
+}
+
+.c29 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #00438f;
+  color: #c0c8d1;
+  cursor: default;
+  background: #00438f;
+  color: #f0f2f5;
+}
+
+.c29:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c29:hover {
+  background: #00438f;
+}
+
+.c30 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #e4e7eb;
+  color: #011e38;
+  cursor: pointer;
+  background: transparent;
+  color: #011e38;
+}
+
+.c30:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c30:hover {
+  background: #e4e7eb;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub Table"
+      className="c1 Table"
     >
       <thead>
         <tr
-          class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
+          className="c2"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 kfgNsH"
+            className="c3"
             data-testid="table-head"
             scope="col"
             width="30px"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="select all"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 kfgNsH"
+            className="c3"
             data-testid="table-head"
             scope="col"
             width="30px"
           />
           <th
-            class="StyledTh-sc-10nzyk9-0 bocKtx"
+            className="c9"
             data-testid="table-head"
             scope="col"
             width="15%"
@@ -55,7 +524,7 @@ exports[`Storyshots Table with everything 1`] = `
             Date
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 iPIuAn"
+            className="c10"
             data-testid="table-head"
             scope="col"
             width="20%"
@@ -63,7 +532,7 @@ exports[`Storyshots Table with everything 1`] = `
             Expected Quantity
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 iPIuAn"
+            className="c10"
             data-testid="table-head"
             scope="col"
             width="20%"
@@ -71,7 +540,7 @@ exports[`Storyshots Table with everything 1`] = `
             Actual Quantity
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 esKZsE"
+            className="c11"
             data-testid="table-head"
             scope="col"
             width="45%"
@@ -79,31 +548,34 @@ exports[`Storyshots Table with everything 1`] = `
             Note
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 djOqlg"
+            className="c12"
             data-testid="table-head"
             scope="col"
             width="5%"
-          />
+          >
+            
+          </th>
         </tr>
       </thead>
       <tbody
         data-testid="table-body"
       >
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c13"
           data-testid="table-row"
         >
           <td
-            colspan="7"
+            colSpan={7}
           >
             <div
-              class="Box-sc-1qu1edy-0 kOlJoM"
+              className="c14"
             >
               <p
-                class="Text-sc-1wu7vpu-0 iHOIzo"
+                className="c15 c16"
                 color="blackBlue"
-                font-size="medium"
-                font-weight="bold"
+                disabled={false}
+                fontSize="medium"
+                fontWeight="bold"
               >
                 ABC & XYZ Company
               </p>
@@ -111,48 +583,60 @@ exports[`Storyshots Table with everything 1`] = `
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c13"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c17"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="deselect item 12"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c17"
           >
             <button
               aria-label="Expand row"
-              class="ControlIcon__StyledButton-sc-1h83lvi-0 cCdEvo"
+              className="c18"
+              disabled={false}
+              onClick={[Function]}
               type="button"
             >
               <svg
-                aria-hidden="true"
-                class="Icon-fc7twp-0 efirdb"
+                aria-hidden={true}
+                className="c19 c20"
                 color="currentColor"
                 fill="currentColor"
-                focusable="false"
+                focusable={false}
                 height="32px"
                 icon="downArrow"
+                size="32px"
+                title={null}
                 viewBox="0 0 24 24"
                 width="32px"
               >
@@ -163,43 +647,54 @@ exports[`Storyshots Table with everything 1`] = `
             </button>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c17"
           >
             Tue, 01 Oct 2019
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c17"
           >
             2,025 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c17"
           >
             1,800 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
-          <td>
+            className="c17"
+          >
+            
+          </td>
+          <td
+            colSpan={null}
+          >
             <div
-              class="Box-sc-1qu1edy-0 gqpebI"
+              className="c21"
             >
               <button
-                aria-expanded="false"
-                aria-haspopup="true"
+                aria-describedby={null}
+                aria-expanded={false}
+                aria-haspopup={true}
                 aria-label="Open"
-                class="IconicButton__WrapperButton-sc-1u3dojp-1 UMPof IconicButton-sc-1u3dojp-2 gZASNp"
+                className="c22 "
+                disabled={null}
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseDown={[Function]}
                 type="button"
               >
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 cwKdbD"
+                  aria-hidden={true}
+                  className="c19 c23"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="32px"
                   icon="more"
                   p="half"
+                  size="32px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="32px"
                 >
@@ -212,73 +707,92 @@ exports[`Storyshots Table with everything 1`] = `
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c13"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c17"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c17"
           />
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c17"
           >
             Wed, 02 Oct 2019
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c17"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c17"
           >
             2,250 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
-          <td>
+            className="c17"
+          >
+            
+          </td>
+          <td
+            colSpan={null}
+          >
             <div
-              class="Box-sc-1qu1edy-0 gqpebI"
+              className="c21"
             >
               <button
-                aria-expanded="false"
-                aria-haspopup="true"
+                aria-describedby={null}
+                aria-expanded={false}
+                aria-haspopup={true}
                 aria-label="Open"
-                class="IconicButton__WrapperButton-sc-1u3dojp-1 UMPof IconicButton-sc-1u3dojp-2 gZASNp"
+                className="c22 "
+                disabled={null}
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseDown={[Function]}
                 type="button"
               >
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 cwKdbD"
+                  aria-hidden={true}
+                  className="c19 c23"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="32px"
                   icon="more"
                   p="half"
+                  size="32px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="32px"
                 >
@@ -291,73 +805,92 @@ exports[`Storyshots Table with everything 1`] = `
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c13"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c17"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c17"
           />
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c17"
           >
             Thu, 03 Oct 2019
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c17"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c17"
           >
             1,425 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
-          <td>
+            className="c17"
+          >
+            
+          </td>
+          <td
+            colSpan={null}
+          >
             <div
-              class="Box-sc-1qu1edy-0 gqpebI"
+              className="c21"
             >
               <button
-                aria-expanded="false"
-                aria-haspopup="true"
+                aria-describedby={null}
+                aria-expanded={false}
+                aria-haspopup={true}
                 aria-label="Open"
-                class="IconicButton__WrapperButton-sc-1u3dojp-1 UMPof IconicButton-sc-1u3dojp-2 gZASNp"
+                className="c22 "
+                disabled={null}
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseDown={[Function]}
                 type="button"
               >
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 cwKdbD"
+                  aria-hidden={true}
+                  className="c19 c23"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="32px"
                   icon="more"
                   p="half"
+                  size="32px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="32px"
                 >
@@ -370,75 +903,92 @@ exports[`Storyshots Table with everything 1`] = `
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c13"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c17"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c17"
           />
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c17"
           >
             Fri, 04 Oct 2019
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c17"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c17"
           >
             675 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c17"
           >
             1c Other Plant-related issue, equipment issues
           </td>
-          <td>
+          <td
+            colSpan={null}
+          >
             <div
-              class="Box-sc-1qu1edy-0 gqpebI"
+              className="c21"
             >
               <button
-                aria-expanded="false"
-                aria-haspopup="true"
+                aria-describedby={null}
+                aria-expanded={false}
+                aria-haspopup={true}
                 aria-label="Open"
-                class="IconicButton__WrapperButton-sc-1u3dojp-1 UMPof IconicButton-sc-1u3dojp-2 gZASNp"
+                className="c22 "
+                disabled={null}
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseDown={[Function]}
                 type="button"
               >
                 <svg
-                  aria-hidden="true"
-                  class="Icon-fc7twp-0 cwKdbD"
+                  aria-hidden={true}
+                  className="c19 c23"
                   color="currentColor"
                   fill="currentColor"
-                  focusable="false"
+                  focusable={false}
                   height="32px"
                   icon="more"
                   p="half"
+                  size="32px"
+                  title={null}
                   viewBox="0 0 24 24"
                   width="32px"
                 >
@@ -453,77 +1003,90 @@ exports[`Storyshots Table with everything 1`] = `
       </tbody>
       <tfoot>
         <tr
-          class="TableFoot__StyledFooterRow-sc-1q56pdo-0 gVNRxT"
+          className="c24"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
-            colspan="3"
+            className="c25"
+            colSpan={3}
             scope="row"
           >
             Total
           </th>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c17"
           >
             18,000 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c17"
           >
             7,725 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c17"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c17"
+          >
+            
+          </td>
         </tr>
         <tr
-          class="TableFoot__StyledFooterRow-sc-1q56pdo-0 gVNRxT"
+          className="c24"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
-            colspan="3"
+            className="c25"
+            colSpan={3}
             scope="row"
           >
             Attainment
           </th>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c17"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c17"
           >
             41.5%
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c17"
+          >
+            
+          </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          />
+            className="c17"
+          >
+            
+          </td>
         </tr>
       </tfoot>
     </table>
     <nav
       aria-label="Pagination navigation"
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iCmkqG StatefulTable___StyledPagination-sc-196ra2t-0 dSyvuL"
+      className="c26 "
     >
       <button
         aria-label="Go to previous results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 kZsQns"
-        disabled=""
+        className="c27"
+        disabled={true}
+        onClick={[Function]}
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 bLUmHQ"
+          aria-hidden={true}
+          className="c19 c28"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="leftArrow"
           ml="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -531,43 +1094,55 @@ exports[`Storyshots Table with everything 1`] = `
             d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-         Previous
+         
+        Previous
       </button>
       <button
-        aria-current="true"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 khkrHJ"
-        disabled=""
+        aria-current={true}
+        aria-label={null}
+        className="c29"
+        disabled={true}
+        onClick={[Function]}
       >
         1
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c30"
+        disabled={false}
+        onClick={[Function]}
       >
         2
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c30"
+        disabled={false}
+        onClick={[Function]}
       >
         3
       </button>
       <button
         aria-label="Go to next results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 iFOkT"
+        className="c31"
+        disabled={false}
+        onClick={[Function]}
       >
-        Next 
+        Next
+         
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 dEtgXr"
+          aria-hidden={true}
+          className="c19 c32"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="rightArrow"
           mr="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -582,35 +1157,226 @@ exports[`Storyshots Table with everything 1`] = `
 `;
 
 exports[`Storyshots Table with pagination 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c6 {
+  padding-top: 16px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c8 {
+  margin-left: -8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c13 {
+  margin-right: -8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c11 {
+  padding-top: 8px;
+  padding-bottom: 8px;
+  margin-right: 16px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 14px;
+  line-height: 1.71428571;
+  color: currentColor;
+}
+
+.c3 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: auto;
+}
+
+.c3:first-child {
+  padding-left: 16px;
+}
+
+.c2 {
+  color: #434d59;
+  border-bottom: 1px solid #e4e7eb;
+}
+
+.c5 {
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-right: 16px;
+}
+
+.c5:first-child {
+  padding-left: 16px;
+}
+
+.c4:hover {
+  background-color: #f0f2f5;
+}
+
+.c1 {
+  border-collapse: collapse;
+  width: 100%;
+  background: white;
+}
+
+.c7 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #e4e7eb;
+  color: #c0c8d1;
+  cursor: default;
+}
+
+.c7:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c7:hover {
+  background: inital;
+}
+
+.c12 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #e4e7eb;
+  color: #011e38;
+  cursor: pointer;
+}
+
+.c12:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c12:hover {
+  background: #e4e7eb;
+}
+
+.c9 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #00438f;
+  color: #c0c8d1;
+  cursor: default;
+  background: #00438f;
+  color: #f0f2f5;
+}
+
+.c9:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c9:hover {
+  background: #00438f;
+}
+
+.c10 {
+  font-size: 14px;
+  padding: 8px 16px;
+  line-height: 1.71428571;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  border-radius: 4px;
+  border: 1px solid #e4e7eb;
+  color: #011e38;
+  cursor: pointer;
+  background: transparent;
+  color: #011e38;
+}
+
+.c10:not(:last-child) {
+  margin-right: 16px;
+}
+
+.c10:hover {
+  background: #e4e7eb;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub Table"
+      className="c1 Table"
     >
       <thead>
         <tr
-          class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
+          className="c2"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
             Date
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
             Expected Quantity
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c3"
             data-testid="table-head"
             scope="col"
           >
@@ -622,21 +1388,21 @@ exports[`Storyshots Table with pagination 1`] = `
         data-testid="table-body"
       >
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c4"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2019-10-01
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             2,025 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c5"
           >
             1,800 eaches
           </td>
@@ -646,22 +1412,25 @@ exports[`Storyshots Table with pagination 1`] = `
     </table>
     <nav
       aria-label="Pagination navigation"
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iCmkqG StatefulTable___StyledPagination-sc-196ra2t-0 dSyvuL"
+      className="Box-sc-1qu1edy-0 c6 "
     >
       <button
         aria-label="Go to previous results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 kZsQns"
-        disabled=""
+        className="c7"
+        disabled={true}
+        onClick={[Function]}
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 bLUmHQ"
+          aria-hidden={true}
+          className="c8"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="leftArrow"
           ml="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -669,71 +1438,90 @@ exports[`Storyshots Table with pagination 1`] = `
             d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"
           />
         </svg>
-         Previous
+         
+        Previous
       </button>
       <button
-        aria-current="true"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 khkrHJ"
-        disabled=""
+        aria-current={true}
+        aria-label={null}
+        className="c9"
+        disabled={true}
+        onClick={[Function]}
       >
         1
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c10"
+        disabled={false}
+        onClick={[Function]}
       >
         2
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c10"
+        disabled={false}
+        onClick={[Function]}
       >
         3
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c10"
+        disabled={false}
+        onClick={[Function]}
       >
         4
       </button>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c10"
+        disabled={false}
+        onClick={[Function]}
       >
         5
       </button>
       <p
-        class="Text-sc-1wu7vpu-0 dqAYor"
+        className="c11"
         color="currentColor"
-        font-size="small"
+        disabled={false}
+        fontSize="small"
       >
         ...
       </p>
       <button
-        aria-current="false"
+        aria-current={false}
         aria-label="Go to page {{count}}"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 Pagination__PageNumber-sc-1fsx1pp-1 bpxFKh"
+        className="c10"
+        disabled={false}
+        onClick={[Function]}
       >
         8
       </button>
       <button
         aria-label="Go to next results"
-        class="Pagination__PaginationButton-sc-1fsx1pp-0 iFOkT"
+        className="c12"
+        disabled={false}
+        onClick={[Function]}
       >
-        Next 
+        Next
+         
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 dEtgXr"
+          aria-hidden={true}
+          className="c13"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="rightArrow"
           mr="-8px"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >

--- a/components/src/Table/__snapshots__/TableWithExpandableRows.story.storyshot
+++ b/components/src/Table/__snapshots__/TableWithExpandableRows.story.storyshot
@@ -1,41 +1,150 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Table/with expandable rows with expandable rows 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c7 {
+  background: transparent;
+  border: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px;
+  border-radius: 50%;
+  color: #434d59;
+}
+
+.c7:focus {
+  outline: none;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:hover:enabled {
+  cursor: pointer;
+  color: #122b47;
+  background-color: #e4e7eb;
+}
+
+.c3 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: 30px;
+}
+
+.c3:first-child {
+  padding-left: 16px;
+}
+
+.c4 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: auto;
+}
+
+.c4:first-child {
+  padding-left: 16px;
+}
+
+.c2 {
+  color: #434d59;
+  border-bottom: 1px solid #e4e7eb;
+}
+
+.c6 {
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-right: 16px;
+}
+
+.c6:first-child {
+  padding-left: 16px;
+}
+
+.c5:hover {
+  background-color: #f0f2f5;
+}
+
+.c1 {
+  border-collapse: collapse;
+  width: 100%;
+  background: white;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+      className="c1"
     >
       <thead>
         <tr
-          class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
+          className="c2"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 kfgNsH"
+            className="c3"
             data-testid="table-head"
             scope="col"
             width="30px"
           />
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c4"
             data-testid="table-head"
             scope="col"
           >
             Date
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c4"
             data-testid="table-head"
             scope="col"
           >
             Expected Quantity
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c4"
             data-testid="table-head"
             scope="col"
           >
@@ -47,48 +156,52 @@ exports[`Storyshots Table/with expandable rows with expandable rows 1`] = `
         data-testid="table-body"
       >
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           />
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-01
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,025 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             1,800 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             <button
               aria-label="Expand row"
-              class="ControlIcon__StyledButton-sc-1h83lvi-0 cCdEvo"
+              className="c7"
+              disabled={false}
+              onClick={[Function]}
               type="button"
             >
               <svg
-                aria-hidden="true"
-                class="Icon-fc7twp-0 efirdb"
+                aria-hidden={true}
+                className="c8"
                 color="currentColor"
                 fill="currentColor"
-                focusable="false"
+                focusable={false}
                 height="32px"
                 icon="downArrow"
+                size="32px"
+                title={null}
                 viewBox="0 0 24 24"
                 width="32px"
               >
@@ -99,64 +212,68 @@ exports[`Storyshots Table/with expandable rows with expandable rows 1`] = `
             </button>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-02
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,250 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           />
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-03
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             1,425 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             <button
               aria-label="Expand row"
-              class="ControlIcon__StyledButton-sc-1h83lvi-0 cCdEvo"
+              className="c7"
+              disabled={false}
+              onClick={[Function]}
               type="button"
             >
               <svg
-                aria-hidden="true"
-                class="Icon-fc7twp-0 efirdb"
+                aria-hidden={true}
+                className="c8"
                 color="currentColor"
                 fill="currentColor"
-                focusable="false"
+                focusable={false}
                 height="32px"
                 icon="downArrow"
+                size="32px"
+                title={null}
                 viewBox="0 0 24 24"
                 width="32px"
               >
@@ -167,64 +284,68 @@ exports[`Storyshots Table/with expandable rows with expandable rows 1`] = `
             </button>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-04
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             675 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           />
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-07
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             1,575 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             <button
               aria-label="Expand row"
-              class="ControlIcon__StyledButton-sc-1h83lvi-0 cCdEvo"
+              className="c7"
+              disabled={false}
+              onClick={[Function]}
               type="button"
             >
               <svg
-                aria-hidden="true"
-                class="Icon-fc7twp-0 efirdb"
+                aria-hidden={true}
+                className="c8"
                 color="currentColor"
                 fill="currentColor"
-                focusable="false"
+                focusable={false}
                 height="32px"
                 icon="downArrow"
+                size="32px"
+                title={null}
                 viewBox="0 0 24 24"
                 width="32px"
               >
@@ -235,63 +356,63 @@ exports[`Storyshots Table/with expandable rows with expandable rows 1`] = `
             </button>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-22
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             1,725 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             -
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           />
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-23
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             -
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           />
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-24
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             -
           </td>
@@ -304,41 +425,167 @@ exports[`Storyshots Table/with expandable rows with expandable rows 1`] = `
 `;
 
 exports[`Storyshots Table/with expandable rows with rows expanded by default 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c9 {
+  background-color: #e1ebfa;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c10 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 1.5;
+  color: #122b47;
+}
+
+.c7 {
+  background: transparent;
+  border: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px;
+  border-radius: 50%;
+  color: #434d59;
+}
+
+.c7:focus {
+  outline: none;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7:hover:enabled {
+  cursor: pointer;
+  color: #122b47;
+  background-color: #e4e7eb;
+}
+
+.c3 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: 30px;
+}
+
+.c3:first-child {
+  padding-left: 16px;
+}
+
+.c4 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: auto;
+}
+
+.c4:first-child {
+  padding-left: 16px;
+}
+
+.c2 {
+  color: #434d59;
+  border-bottom: 1px solid #e4e7eb;
+}
+
+.c6 {
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-right: 16px;
+}
+
+.c6:first-child {
+  padding-left: 16px;
+}
+
+.c5:hover {
+  background-color: #f0f2f5;
+}
+
+.c1 {
+  border-collapse: collapse;
+  width: 100%;
+  background: white;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+      className="c1"
     >
       <thead>
         <tr
-          class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
+          className="c2"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 kfgNsH"
+            className="c3"
             data-testid="table-head"
             scope="col"
             width="30px"
           />
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c4"
             data-testid="table-head"
             scope="col"
           >
             Date
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c4"
             data-testid="table-head"
             scope="col"
           >
             Expected Quantity
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c4"
             data-testid="table-head"
             scope="col"
           >
@@ -350,48 +597,52 @@ exports[`Storyshots Table/with expandable rows with rows expanded by default 1`]
         data-testid="table-body"
       >
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           />
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-01
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,025 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             1,800 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             <button
               aria-label="Expand row"
-              class="ControlIcon__StyledButton-sc-1h83lvi-0 cCdEvo"
+              className="c7"
+              disabled={false}
+              onClick={[Function]}
               type="button"
             >
               <svg
-                aria-hidden="true"
-                class="Icon-fc7twp-0 efirdb"
+                aria-hidden={true}
+                className="c8"
                 color="currentColor"
                 fill="currentColor"
-                focusable="false"
+                focusable={false}
                 height="32px"
                 icon="downArrow"
+                size="32px"
+                title={null}
                 viewBox="0 0 24 24"
                 width="32px"
               >
@@ -402,64 +653,68 @@ exports[`Storyshots Table/with expandable rows with rows expanded by default 1`]
             </button>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-02
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,250 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           />
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-03
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             1,425 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             <button
               aria-label="Collapse row"
-              class="ControlIcon__StyledButton-sc-1h83lvi-0 cCdEvo"
+              className="c7"
+              disabled={false}
+              onClick={[Function]}
               type="button"
             >
               <svg
-                aria-hidden="true"
-                class="Icon-fc7twp-0 efirdb"
+                aria-hidden={true}
+                className="c8"
                 color="currentColor"
                 fill="currentColor"
-                focusable="false"
+                focusable={false}
                 height="32px"
                 icon="upArrow"
+                size="32px"
+                title={null}
                 viewBox="0 0 24 24"
                 width="32px"
               >
@@ -470,17 +725,17 @@ exports[`Storyshots Table/with expandable rows with rows expanded by default 1`]
             </button>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-04
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             675 eaches
           </td>
@@ -489,16 +744,17 @@ exports[`Storyshots Table/with expandable rows with rows expanded by default 1`]
           data-testid="expanded-table-row"
         >
           <td
-            colspan="4"
+            colSpan={4}
           >
             <div
-              class="Box-sc-1qu1edy-0 kOlJoM"
+              className="c9"
             >
               <p
-                class="Text-sc-1wu7vpu-0 iHOIzo"
+                className="c10"
                 color="blackBlue"
-                font-size="medium"
-                font-weight="bold"
+                disabled={false}
+                fontSize="medium"
+                fontWeight="bold"
               >
                 Expands!
               </p>
@@ -506,48 +762,52 @@ exports[`Storyshots Table/with expandable rows with rows expanded by default 1`]
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           />
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-07
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             1,575 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             <button
               aria-label="Collapse row"
-              class="ControlIcon__StyledButton-sc-1h83lvi-0 cCdEvo"
+              className="c7"
+              disabled={false}
+              onClick={[Function]}
               type="button"
             >
               <svg
-                aria-hidden="true"
-                class="Icon-fc7twp-0 efirdb"
+                aria-hidden={true}
+                className="c8"
                 color="currentColor"
                 fill="currentColor"
-                focusable="false"
+                focusable={false}
                 height="32px"
                 icon="upArrow"
+                size="32px"
+                title={null}
                 viewBox="0 0 24 24"
                 width="32px"
               >
@@ -558,17 +818,17 @@ exports[`Storyshots Table/with expandable rows with rows expanded by default 1`]
             </button>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-22
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             1,725 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             -
           </td>
@@ -577,16 +837,17 @@ exports[`Storyshots Table/with expandable rows with rows expanded by default 1`]
           data-testid="expanded-table-row"
         >
           <td
-            colspan="4"
+            colSpan={4}
           >
             <div
-              class="Box-sc-1qu1edy-0 kOlJoM"
+              className="c9"
             >
               <p
-                class="Text-sc-1wu7vpu-0 iHOIzo"
+                className="c10"
                 color="blackBlue"
-                font-size="medium"
-                font-weight="bold"
+                disabled={false}
+                fontSize="medium"
+                fontWeight="bold"
               >
                 Expands!
               </p>
@@ -594,47 +855,47 @@ exports[`Storyshots Table/with expandable rows with rows expanded by default 1`]
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           />
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-23
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             -
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c5"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           />
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2019-10-24
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c6"
           >
             -
           </td>

--- a/components/src/Table/__snapshots__/TableWithSelectableRows.story.storyshot
+++ b/components/src/Table/__snapshots__/TableWithSelectableRows.story.storyshot
@@ -1,61 +1,225 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c5 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c8 {
+  min-width: 16px;
+  height: 16px;
+  border-radius: 2px;
+  border: solid 1px;
+  position: relative;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c8:before {
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  width: 3px;
+  height: 9px;
+  border: solid #ffffff;
+  border-radius: 1px;
+  border-width: 0 3px 3px 0;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.c6 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c6:focus + .c7 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c6:checked + .c7 {
+  border-color: #00438f;
+  background-color: #00438f;
+}
+
+.c6:checked + .c7:before {
+  display: block;
+}
+
+.c6:not(:checked) + .c7 {
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+}
+
+.c4 {
+  padding: 4px 0;
+}
+
+.c4 .Text-sc-1wu7vpu-0 {
+  margin-left: 8px;
+}
+
+.c3 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: 30px;
+}
+
+.c3:first-child {
+  padding-left: 16px;
+}
+
+.c9 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: auto;
+}
+
+.c9:first-child {
+  padding-left: 16px;
+}
+
+.c2 {
+  color: #434d59;
+  border-bottom: 1px solid #e4e7eb;
+}
+
+.c11 {
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-right: 16px;
+}
+
+.c11:first-child {
+  padding-left: 16px;
+}
+
+.c10:hover {
+  background-color: #f0f2f5;
+}
+
+.c1 {
+  border-collapse: collapse;
+  width: 100%;
+  background: white;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+      className="c1"
     >
       <thead>
         <tr
-          class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
+          className="c2"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 kfgNsH"
+            className="c3"
             data-testid="table-head"
             scope="col"
             width="30px"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="select all"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c9"
             data-testid="table-head"
             scope="col"
           >
             Date
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c9"
             data-testid="table-head"
             scope="col"
           >
             Expected Quantity
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c9"
             data-testid="table-head"
             scope="col"
           >
@@ -67,347 +231,409 @@ exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
         data-testid="table-body"
       >
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  checked=""
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={true}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  checked=""
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={true}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2019-10-01
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2,025 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             1,800 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2019-10-02
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2,250 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2019-10-03
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             1,425 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2019-10-04
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             675 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2019-10-07
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             1,575 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2019-10-22
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             1,725 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             -
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2019-10-23
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             -
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2019-10-24
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             -
           </td>
@@ -420,61 +646,225 @@ exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
 `;
 
 exports[`Storyshots Table/with selectable rows with selectable rows 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c5 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c8 {
+  min-width: 16px;
+  height: 16px;
+  border-radius: 2px;
+  border: solid 1px;
+  position: relative;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c8:before {
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  width: 3px;
+  height: 9px;
+  border: solid #ffffff;
+  border-radius: 1px;
+  border-width: 0 3px 3px 0;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.c6 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c6:focus + .c7 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c6:checked + .c7 {
+  border-color: #00438f;
+  background-color: #00438f;
+}
+
+.c6:checked + .c7:before {
+  display: block;
+}
+
+.c6:not(:checked) + .c7 {
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+}
+
+.c4 {
+  padding: 4px 0;
+}
+
+.c4 .Text-sc-1wu7vpu-0 {
+  margin-left: 8px;
+}
+
+.c3 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: 30px;
+}
+
+.c3:first-child {
+  padding-left: 16px;
+}
+
+.c9 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: auto;
+}
+
+.c9:first-child {
+  padding-left: 16px;
+}
+
+.c2 {
+  color: #434d59;
+  border-bottom: 1px solid #e4e7eb;
+}
+
+.c11 {
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-right: 16px;
+}
+
+.c11:first-child {
+  padding-left: 16px;
+}
+
+.c10:hover {
+  background-color: #f0f2f5;
+}
+
+.c1 {
+  border-collapse: collapse;
+  width: 100%;
+  background: white;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+      className="c1"
     >
       <thead>
         <tr
-          class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
+          className="c2"
         >
           <th
-            class="StyledTh-sc-10nzyk9-0 kfgNsH"
+            className="c3"
             data-testid="table-head"
             scope="col"
             width="30px"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="select all"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c9"
             data-testid="table-head"
             scope="col"
           >
             Date
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c9"
             data-testid="table-head"
             scope="col"
           >
             Expected Quantity
           </th>
           <th
-            class="StyledTh-sc-10nzyk9-0 sBlyT"
+            className="c9"
             data-testid="table-head"
             scope="col"
           >
@@ -486,345 +876,409 @@ exports[`Storyshots Table/with selectable rows with selectable rows 1`] = `
         data-testid="table-body"
       >
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2019-10-01
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2,025 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             1,800 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2019-10-02
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2,250 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2019-10-03
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             1,425 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2019-10-04
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             675 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2019-10-07
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             1,575 eaches
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2019-10-22
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             1,725 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             -
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2019-10-23
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             -
           </td>
         </tr>
         <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          className="c10"
           data-testid="table-row"
         >
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+              className="c4"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c5"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
+                  aria-invalid={false}
                   aria-label="Select row"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                  aria-required={false}
+                  checked={false}
+                  className="c6 c4"
+                  disabled={false}
+                  id={null}
+                  onChange={[Function]}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  checked={false}
+                  className="c7 c8"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
               </label>
             </div>
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2019-10-24
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             2,475 eaches
           </td>
           <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            className="c11"
           >
             -
           </td>

--- a/components/src/Tabs/__snapshots__/Tabs.story.storyshot
+++ b/components/src/Tabs/__snapshots__/Tabs.story.storyshot
@@ -1,75 +1,203 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Tabs Tabs 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 16px;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #00438f;
+  background-color: transparent;
+  border: none;
+  margin: 0px;
+  padding: 8px 24px;
+  position: relative;
+}
+
+.c3:focus {
+  outline: none;
+  background-color: #e1ebfa;
+}
+
+.c3:disabled {
+  opacity: .5;
+}
+
+.c3:before {
+  content: '';
+  background-color: #c0c8d1;
+  height: 1px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 210;
+}
+
+.c3:hover:before {
+  content: '';
+  background-color: #e1ebfa;
+  height: 3px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  border-radius: 2px 2px 0 0;
+}
+
+.c1 {
+  position: absolute;
+  width: 0;
+  height: 40px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  white-space: nowrap;
+  overflow-x: scroll;
+  overflow-y: hidden;
+  margin-bottom: 8px;
+  position: relative;
+}
+
+.c2::-webkit-scrollbar {
+  display: none;
+}
+
+.c2:before {
+  content: '';
+  background-color: #c0c8d1;
+  height: 1px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="TabScrollIndicators__TabScrollIndicatorContainer-sc-1cljxwo-0 gsIAKI"
-      width="0"
+      className="c1"
+      width={0}
     />
     <div
-      class="Tabs__TabContainer-o5d5cd-0 giufLG"
+      className="c2"
+      onScroll={[Function]}
       role="tablist"
     >
       <div />
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 gcfVpD Tab1"
+        aria-selected={false}
+        className="c3 Tab1"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="0"
+        selected={false}
+        tabIndex={0}
       >
         Tab 1
       </button>
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 gcfVpD Tab2"
+        aria-selected={false}
+        className="c3 Tab2"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="-1"
+        selected={false}
+        tabIndex={-1}
       >
         Tab 2
       </button>
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 gcfVpD Tab3"
+        aria-selected={false}
+        className="c3 Tab3"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="-1"
+        selected={false}
+        tabIndex={-1}
       >
         Tab 3
       </button>
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 gcfVpD Tab4"
+        aria-selected={false}
+        className="c3 Tab4"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="-1"
+        selected={false}
+        tabIndex={-1}
       >
         Tab 4
       </button>
     </div>
     <div
-      aria-hidden="true"
-      hidden=""
+      aria-hidden={true}
+      hidden={true}
+      selected={false}
     >
       Tab 1 Content
     </div>
     <div
-      aria-hidden="true"
-      hidden=""
+      aria-hidden={true}
+      hidden={true}
+      selected={false}
     >
       Tab 2 Content
     </div>
     <div
-      aria-hidden="true"
-      hidden=""
+      aria-hidden={true}
+      hidden={true}
+      selected={false}
     >
       Tab 3 Content
     </div>
     <div
-      aria-hidden="true"
-      hidden=""
+      aria-hidden={true}
+      hidden={true}
+      selected={false}
     >
       Tab 4 Content
     </div>
@@ -78,157 +206,415 @@ exports[`Storyshots Tabs Tabs 1`] = `
 `;
 
 exports[`Storyshots Tabs controlled 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 16px;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #00438f;
+  background-color: transparent;
+  border: none;
+  margin: 0px;
+  padding: 8px 24px;
+  position: relative;
+}
+
+.c3:focus {
+  outline: none;
+  background-color: #e1ebfa;
+}
+
+.c3:disabled {
+  opacity: .5;
+}
+
+.c3:before {
+  content: '';
+  background-color: #c0c8d1;
+  height: 1px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 210;
+}
+
+.c3:hover:before {
+  content: '';
+  background-color: #e1ebfa;
+  height: 3px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  border-radius: 2px 2px 0 0;
+}
+
+.c1 {
+  position: absolute;
+  width: 0;
+  height: 40px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  white-space: nowrap;
+  overflow-x: scroll;
+  overflow-y: hidden;
+  margin-bottom: 8px;
+  position: relative;
+}
+
+.c2::-webkit-scrollbar {
+  display: none;
+}
+
+.c2:before {
+  content: '';
+  background-color: #c0c8d1;
+  height: 1px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="TabScrollIndicators__TabScrollIndicatorContainer-sc-1cljxwo-0 gsIAKI"
-      width="0"
+      className="c1"
+      width={0}
     />
     <div
-      class="Tabs__TabContainer-o5d5cd-0 giufLG"
+      className="c2"
+      onScroll={[Function]}
       role="tablist"
     >
       <div />
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 gcfVpD Tab1"
+        aria-selected={false}
+        className="c3 Tab1"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="0"
+        selected={false}
+        tabIndex={0}
       >
         Tab 1
       </button>
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 gcfVpD Tab2"
+        aria-selected={false}
+        className="c3 Tab2"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="-1"
+        selected={false}
+        tabIndex={-1}
       >
         Tab 2
       </button>
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 gcfVpD Tab3"
+        aria-selected={false}
+        className="c3 Tab3"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="-1"
+        selected={false}
+        tabIndex={-1}
       >
         Tab 3
       </button>
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 gcfVpD Tab4"
+        aria-selected={false}
+        className="c3 Tab4"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="-1"
+        selected={false}
+        tabIndex={-1}
       >
         Tab 4
       </button>
     </div>
     <div
-      aria-hidden="true"
-      hidden=""
+      aria-hidden={true}
+      hidden={true}
+      selected={false}
     >
       Uncontrolled Content: Tab 1
     </div>
     <div
-      aria-hidden="true"
-      hidden=""
+      aria-hidden={true}
+      hidden={true}
+      selected={false}
     >
       Uncontrolled Content: Tab 2
     </div>
     <div
-      aria-hidden="true"
-      hidden=""
+      aria-hidden={true}
+      hidden={true}
+      selected={false}
     >
       Uncontrolled Content: Tab 3
     </div>
     <div
-      aria-hidden="true"
-      hidden=""
+      aria-hidden={true}
+      hidden={true}
+      selected={false}
     >
       Uncontrolled Content: Tab 4
     </div>
     <div
-      class="ControlledTabContent"
+      className="ControlledTabContent"
     >
-      Controlled Content: Tab 1
+      Controlled Content: Tab 
+      1
     </div>
   </div>
 </div>
 `;
 
 exports[`Storyshots Tabs set to fitted 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  width: 100%;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 16px;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #00438f;
+  background-color: transparent;
+  border: none;
+  margin: 0px;
+  padding: 8px 24px;
+  position: relative;
+}
+
+.c3:focus {
+  outline: none;
+  background-color: #e1ebfa;
+}
+
+.c3:disabled {
+  opacity: .5;
+}
+
+.c3:before {
+  content: '';
+  background-color: #c0c8d1;
+  height: 1px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 210;
+}
+
+.c3:hover:before {
+  content: '';
+  background-color: #e1ebfa;
+  height: 3px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  border-radius: 2px 2px 0 0;
+}
+
+.c1 {
+  position: absolute;
+  width: 0;
+  height: 40px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  white-space: nowrap;
+  overflow-x: scroll;
+  overflow-y: hidden;
+  margin-bottom: 8px;
+  position: relative;
+}
+
+.c2::-webkit-scrollbar {
+  display: none;
+}
+
+.c2:before {
+  content: '';
+  background-color: #c0c8d1;
+  height: 1px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="TabScrollIndicators__TabScrollIndicatorContainer-sc-1cljxwo-0 gsIAKI"
-      width="0"
+      className="c1"
+      width={0}
     />
     <div
-      class="Tabs__TabContainer-o5d5cd-0 giufLG"
+      className="c2"
+      onScroll={[Function]}
       role="tablist"
     >
       <div />
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 bJxQOQ"
+        aria-selected={false}
+        className="c3"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="0"
+        selected={false}
+        tabIndex={0}
       >
         Tab 1
       </button>
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 bJxQOQ"
+        aria-selected={false}
+        className="c3"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="-1"
+        selected={false}
+        tabIndex={-1}
       >
         Tab 2
       </button>
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 bJxQOQ"
+        aria-selected={false}
+        className="c3"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="-1"
+        selected={false}
+        tabIndex={-1}
       >
         Tab 3
       </button>
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 bJxQOQ"
+        aria-selected={false}
+        className="c3"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="-1"
+        selected={false}
+        tabIndex={-1}
       >
         Tab 4
       </button>
     </div>
     <div
-      aria-hidden="true"
-      hidden=""
+      aria-hidden={true}
+      hidden={true}
+      selected={false}
     >
       Tab 1 Content
     </div>
     <div
-      aria-hidden="true"
-      hidden=""
+      aria-hidden={true}
+      hidden={true}
+      selected={false}
     >
       Tab 2 Content
     </div>
     <div
-      aria-hidden="true"
-      hidden=""
+      aria-hidden={true}
+      hidden={true}
+      selected={false}
     >
       Tab 3 Content
     </div>
     <div
-      aria-hidden="true"
-      hidden=""
+      aria-hidden={true}
+      hidden={true}
+      selected={false}
     >
       Tab 4 Content
     </div>
@@ -237,76 +623,239 @@ exports[`Storyshots Tabs set to fitted 1`] = `
 `;
 
 exports[`Storyshots Tabs with a defaultSelectedIndex 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 16px;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #00438f;
+  background-color: transparent;
+  border: none;
+  margin: 0px;
+  padding: 8px 24px;
+  position: relative;
+}
+
+.c3:focus {
+  outline: none;
+  background-color: #e1ebfa;
+}
+
+.c3:disabled {
+  opacity: .5;
+}
+
+.c3:before {
+  content: '';
+  background-color: #00438f;
+  height: 3px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  border-radius: 2px 2px 0 0;
+}
+
+.c4 {
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 16px;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #00438f;
+  background-color: transparent;
+  border: none;
+  margin: 0px;
+  padding: 8px 24px;
+  position: relative;
+}
+
+.c4:focus {
+  outline: none;
+  background-color: #e1ebfa;
+}
+
+.c4:disabled {
+  opacity: .5;
+}
+
+.c4:before {
+  content: '';
+  background-color: #c0c8d1;
+  height: 1px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 210;
+}
+
+.c4:hover:before {
+  content: '';
+  background-color: #e1ebfa;
+  height: 3px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  border-radius: 2px 2px 0 0;
+}
+
+.c1 {
+  position: absolute;
+  width: 0;
+  height: 40px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  white-space: nowrap;
+  overflow-x: scroll;
+  overflow-y: hidden;
+  margin-bottom: 8px;
+  position: relative;
+}
+
+.c2::-webkit-scrollbar {
+  display: none;
+}
+
+.c2:before {
+  content: '';
+  background-color: #c0c8d1;
+  height: 1px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="TabScrollIndicators__TabScrollIndicatorContainer-sc-1cljxwo-0 gsIAKI"
-      width="0"
+      className="c1"
+      width={0}
     />
     <div
-      class="Tabs__TabContainer-o5d5cd-0 giufLG"
+      className="c2"
+      onScroll={[Function]}
       role="tablist"
     >
       <div />
       <button
-        aria-selected="true"
-        class="Tab__TabButton-sc-69abpu-0 kfQsHL"
+        aria-selected={true}
+        className="c3"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        selected=""
-        tabindex="0"
+        selected={true}
+        tabIndex={0}
       >
         Tab 1
       </button>
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 gcfVpD"
+        aria-selected={false}
+        className="c4"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="-1"
+        selected={false}
+        tabIndex={-1}
       >
         Tab 2
       </button>
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 gcfVpD"
+        aria-selected={false}
+        className="c4"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="-1"
+        selected={false}
+        tabIndex={-1}
       >
         Tab 3
       </button>
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 gcfVpD"
+        aria-selected={false}
+        className="c4"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="-1"
+        selected={false}
+        tabIndex={-1}
       >
         Tab 4
       </button>
     </div>
     <div
-      aria-hidden="false"
-      selected=""
+      aria-hidden={false}
+      hidden={false}
+      selected={true}
     >
       Tab 1 Content
     </div>
     <div
-      aria-hidden="true"
-      hidden=""
+      aria-hidden={true}
+      hidden={true}
+      selected={false}
     >
       Tab 2 Content
     </div>
     <div
-      aria-hidden="true"
-      hidden=""
+      aria-hidden={true}
+      hidden={true}
+      selected={false}
     >
       Tab 3 Content
     </div>
     <div
-      aria-hidden="true"
-      hidden=""
+      aria-hidden={true}
+      hidden={true}
+      selected={false}
     >
       Tab 4 Content
     </div>
@@ -315,38 +864,220 @@ exports[`Storyshots Tabs with a defaultSelectedIndex 1`] = `
 `;
 
 exports[`Storyshots Tabs with all tab states 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 16px;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #00438f;
+  background-color: transparent;
+  border: none;
+  margin: 0px;
+  padding: 8px 24px;
+  position: relative;
+}
+
+.c1:focus {
+  outline: none;
+  background-color: #e1ebfa;
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
+.c1:before {
+  content: '';
+  background-color: #c0c8d1;
+  height: 1px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 210;
+}
+
+.c1:hover:before {
+  content: '';
+  background-color: #e1ebfa;
+  height: 3px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  border-radius: 2px 2px 0 0;
+}
+
+.c2 {
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 16px;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #00438f;
+  background-color: transparent;
+  border: none;
+  margin: 0px;
+  padding: 8px 24px;
+  position: relative;
+}
+
+.c2:focus {
+  outline: none;
+  background-color: #e1ebfa;
+}
+
+.c2:disabled {
+  opacity: .5;
+}
+
+.c2:before {
+  content: '';
+  background-color: #00438f;
+  height: 3px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  border-radius: 2px 2px 0 0;
+}
+
+.c3 {
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 16px;
+  line-height: 1.5;
+  cursor: default;
+  color: #00438f;
+  background-color: transparent;
+  border: none;
+  margin: 0px;
+  padding: 8px 24px;
+  position: relative;
+}
+
+.c3:focus {
+  outline: none;
+  background-color: #e1ebfa;
+}
+
+.c3:disabled {
+  opacity: .5;
+}
+
+.c3:before {
+  content: '';
+  background-color: #c0c8d1;
+  height: 1px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 210;
+}
+
+.c4 {
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 16px;
+  line-height: 1.5;
+  cursor: default;
+  color: #00438f;
+  background-color: transparent;
+  border: none;
+  margin: 0px;
+  padding: 8px 24px;
+  position: relative;
+}
+
+.c4:focus {
+  outline: none;
+  background-color: #e1ebfa;
+}
+
+.c4:disabled {
+  opacity: .5;
+}
+
+.c4:before {
+  content: '';
+  background-color: #00438f;
+  height: 3px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  border-radius: 2px 2px 0 0;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div>
       <button
-        class="Tab__TabButton-sc-69abpu-0 gcfVpD"
+        className="c1"
         role="tab"
       >
         Tab
       </button>
       <button
-        class="Tab__TabButton-sc-69abpu-0 kfQsHL"
+        className="c2"
         role="tab"
-        selected=""
+        selected={true}
       >
         Tab
       </button>
       <button
-        class="Tab__TabButton-sc-69abpu-0 iQOraC"
-        disabled=""
+        className="c3"
+        disabled={true}
         role="tab"
       >
         Tab
       </button>
       <button
-        class="Tab__TabButton-sc-69abpu-0 kEPjFn"
-        disabled=""
+        className="c4"
+        disabled={true}
         role="tab"
-        selected=""
+        selected={true}
       >
         Tab
       </button>
@@ -356,34 +1087,150 @@ exports[`Storyshots Tabs with all tab states 1`] = `
 `;
 
 exports[`Storyshots Tabs with content loaded on selection 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 16px;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #00438f;
+  background-color: transparent;
+  border: none;
+  margin: 0px;
+  padding: 8px 24px;
+  position: relative;
+}
+
+.c3:focus {
+  outline: none;
+  background-color: #e1ebfa;
+}
+
+.c3:disabled {
+  opacity: .5;
+}
+
+.c3:before {
+  content: '';
+  background-color: #c0c8d1;
+  height: 1px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 210;
+}
+
+.c3:hover:before {
+  content: '';
+  background-color: #e1ebfa;
+  height: 3px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  border-radius: 2px 2px 0 0;
+}
+
+.c1 {
+  position: absolute;
+  width: 0;
+  height: 40px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  white-space: nowrap;
+  overflow-x: scroll;
+  overflow-y: hidden;
+  margin-bottom: 8px;
+  position: relative;
+}
+
+.c2::-webkit-scrollbar {
+  display: none;
+}
+
+.c2:before {
+  content: '';
+  background-color: #c0c8d1;
+  height: 1px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="TabScrollIndicators__TabScrollIndicatorContainer-sc-1cljxwo-0 gsIAKI"
-      width="0"
+      className="c1"
+      width={0}
     />
     <div
-      class="Tabs__TabContainer-o5d5cd-0 giufLG"
+      className="c2"
+      onScroll={[Function]}
       role="tablist"
     >
       <div />
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 gcfVpD Tab1"
+        aria-selected={false}
+        className="c3 Tab1"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="0"
+        selected={false}
+        tabIndex={0}
       >
         Tab 1
       </button>
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 gcfVpD Tab2"
+        aria-selected={false}
+        className="c3 Tab2"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="-1"
+        selected={false}
+        tabIndex={-1}
       >
         Tab 2
       </button>
@@ -393,52 +1240,170 @@ exports[`Storyshots Tabs with content loaded on selection 1`] = `
 `;
 
 exports[`Storyshots Tabs with inputs 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 16px;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #00438f;
+  background-color: transparent;
+  border: none;
+  margin: 0px;
+  padding: 8px 24px;
+  position: relative;
+}
+
+.c3:focus {
+  outline: none;
+  background-color: #e1ebfa;
+}
+
+.c3:disabled {
+  opacity: .5;
+}
+
+.c3:before {
+  content: '';
+  background-color: #c0c8d1;
+  height: 1px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 210;
+}
+
+.c3:hover:before {
+  content: '';
+  background-color: #e1ebfa;
+  height: 3px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  border-radius: 2px 2px 0 0;
+}
+
+.c1 {
+  position: absolute;
+  width: 0;
+  height: 40px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  white-space: nowrap;
+  overflow-x: scroll;
+  overflow-y: hidden;
+  margin-bottom: 8px;
+  position: relative;
+}
+
+.c2::-webkit-scrollbar {
+  display: none;
+}
+
+.c2:before {
+  content: '';
+  background-color: #c0c8d1;
+  height: 1px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="TabScrollIndicators__TabScrollIndicatorContainer-sc-1cljxwo-0 gsIAKI"
-      width="0"
+      className="c1"
+      width={0}
     />
     <div
-      class="Tabs__TabContainer-o5d5cd-0 giufLG"
+      className="c2"
+      onScroll={[Function]}
       role="tablist"
     >
       <div />
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 gcfVpD Tab1"
+        aria-selected={false}
+        className="c3 Tab1"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="0"
+        selected={false}
+        tabIndex={0}
       >
         Tab 1
       </button>
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 gcfVpD Tab2"
+        aria-selected={false}
+        className="c3 Tab2"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="-1"
+        selected={false}
+        tabIndex={-1}
       >
         Tab 2
       </button>
     </div>
     <div
-      aria-hidden="true"
-      hidden=""
+      aria-hidden={true}
+      hidden={true}
+      selected={false}
     >
       <input
-        class="Input1"
+        className="Input1"
       />
     </div>
     <div
-      aria-hidden="true"
-      hidden=""
+      aria-hidden={true}
+      hidden={true}
+      selected={false}
     >
       <input
-        class="Input2"
+        className="Input2"
       />
     </div>
   </div>
@@ -446,187 +1411,355 @@ exports[`Storyshots Tabs with inputs 1`] = `
 `;
 
 exports[`Storyshots Tabs with scrolling tabs 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 16px;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #00438f;
+  background-color: transparent;
+  border: none;
+  margin: 0px;
+  padding: 8px 24px;
+  position: relative;
+}
+
+.c3:focus {
+  outline: none;
+  background-color: #e1ebfa;
+}
+
+.c3:disabled {
+  opacity: .5;
+}
+
+.c3:before {
+  content: '';
+  background-color: #c0c8d1;
+  height: 1px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 210;
+}
+
+.c3:hover:before {
+  content: '';
+  background-color: #e1ebfa;
+  height: 3px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  border-radius: 2px 2px 0 0;
+}
+
+.c1 {
+  position: absolute;
+  width: 0;
+  height: 40px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  white-space: nowrap;
+  overflow-x: scroll;
+  overflow-y: hidden;
+  margin-bottom: 8px;
+  position: relative;
+}
+
+.c2::-webkit-scrollbar {
+  display: none;
+}
+
+.c2:before {
+  content: '';
+  background-color: #c0c8d1;
+  height: 1px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="TabScrollIndicators__TabScrollIndicatorContainer-sc-1cljxwo-0 gsIAKI"
-      width="0"
+      className="c1"
+      width={0}
     />
     <div
-      class="Tabs__TabContainer-o5d5cd-0 giufLG tab-container"
+      className="c2 tab-container"
+      onScroll={[Function]}
       role="tablist"
     >
       <div />
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 gcfVpD"
+        aria-selected={false}
+        className="c3"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="0"
+        selected={false}
+        tabIndex={0}
       >
         Tab 1
       </button>
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 gcfVpD"
+        aria-selected={false}
+        className="c3"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="-1"
+        selected={false}
+        tabIndex={-1}
       >
         Tab 2
       </button>
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 gcfVpD"
+        aria-selected={false}
+        className="c3"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="-1"
+        selected={false}
+        tabIndex={-1}
       >
         Tab 3
       </button>
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 gcfVpD"
+        aria-selected={false}
+        className="c3"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="-1"
+        selected={false}
+        tabIndex={-1}
       >
         Tab 4
       </button>
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 gcfVpD"
+        aria-selected={false}
+        className="c3"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="-1"
+        selected={false}
+        tabIndex={-1}
       >
         Tab 5
       </button>
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 gcfVpD"
+        aria-selected={false}
+        className="c3"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="-1"
+        selected={false}
+        tabIndex={-1}
       >
         Tab 6
       </button>
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 gcfVpD"
+        aria-selected={false}
+        className="c3"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="-1"
+        selected={false}
+        tabIndex={-1}
       >
         Tab 7
       </button>
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 gcfVpD"
+        aria-selected={false}
+        className="c3"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="-1"
+        selected={false}
+        tabIndex={-1}
       >
         Tab 8
       </button>
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 gcfVpD"
+        aria-selected={false}
+        className="c3"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="-1"
+        selected={false}
+        tabIndex={-1}
       >
         Tab 9
       </button>
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 gcfVpD"
+        aria-selected={false}
+        className="c3"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="-1"
+        selected={false}
+        tabIndex={-1}
       >
         Tab 10
       </button>
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 gcfVpD"
+        aria-selected={false}
+        className="c3"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="-1"
+        selected={false}
+        tabIndex={-1}
       >
         Tab 11
       </button>
       <button
-        aria-selected="false"
-        class="Tab__TabButton-sc-69abpu-0 gcfVpD"
+        aria-selected={false}
+        className="c3"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
         role="tab"
-        tabindex="-1"
+        selected={false}
+        tabIndex={-1}
       >
         Tab 12
       </button>
     </div>
     <div
-      aria-hidden="true"
-      hidden=""
+      aria-hidden={true}
+      hidden={true}
+      selected={false}
     >
       Tab 1 Content
     </div>
     <div
-      aria-hidden="true"
-      hidden=""
+      aria-hidden={true}
+      hidden={true}
+      selected={false}
     >
       Tab 2 Content
     </div>
     <div
-      aria-hidden="true"
-      hidden=""
+      aria-hidden={true}
+      hidden={true}
+      selected={false}
     >
       Tab 3 Content
     </div>
     <div
-      aria-hidden="true"
-      hidden=""
+      aria-hidden={true}
+      hidden={true}
+      selected={false}
     >
       Tab 4 Content
     </div>
     <div
-      aria-hidden="true"
-      hidden=""
+      aria-hidden={true}
+      hidden={true}
+      selected={false}
     >
       Tab 5 Content
     </div>
     <div
-      aria-hidden="true"
-      hidden=""
+      aria-hidden={true}
+      hidden={true}
+      selected={false}
     >
       Tab 6 Content
     </div>
     <div
-      aria-hidden="true"
-      hidden=""
+      aria-hidden={true}
+      hidden={true}
+      selected={false}
     >
       Tab 7 Content
     </div>
     <div
-      aria-hidden="true"
-      hidden=""
+      aria-hidden={true}
+      hidden={true}
+      selected={false}
     >
       Tab 8 Content
     </div>
     <div
-      aria-hidden="true"
-      hidden=""
+      aria-hidden={true}
+      hidden={true}
+      selected={false}
     >
       Tab 9 Content
     </div>
     <div
-      aria-hidden="true"
-      hidden=""
+      aria-hidden={true}
+      hidden={true}
+      selected={false}
     >
       Tab 10 Content
     </div>
     <div
-      aria-hidden="true"
-      hidden=""
+      aria-hidden={true}
+      hidden={true}
+      selected={false}
     >
       Tab 11 Content
     </div>
     <div
-      aria-hidden="true"
-      hidden=""
+      aria-hidden={true}
+      hidden={true}
+      selected={false}
     >
       Tab 12 Content
     </div>

--- a/components/src/Textarea/__snapshots__/Textarea.story.storyshot
+++ b/components/src/Textarea/__snapshots__/Textarea.story.storyshot
@@ -1,36 +1,126 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Textarea Set to disabled 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c5 {
+  display: block;
+  width: 100%;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  min-height: 40px;
+  min-width: 20em;
+  color: rgba(1,30,56,0.3333);
+  border-color: #e4e7eb;
+  background-color: #f0f2f5;
+}
+
+.c5:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c5::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c5::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c5:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c5::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Label
           </span>
         </div>
         <textarea
-          aria-invalid="false"
-          aria-required="false"
-          class="Textarea__StyledTextarea-sc-1tyrhr0-0 khvyNi"
-          disabled=""
-          rows="3"
+          aria-invalid={false}
+          aria-required={false}
+          className="c5"
+          disabled={true}
+          id={null}
+          required={false}
+          rows={3}
         />
       </label>
     </div>
@@ -39,35 +129,127 @@ exports[`Storyshots Textarea Set to disabled 1`] = `
 `;
 
 exports[`Storyshots Textarea Textarea 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c5 {
+  display: block;
+  width: 100%;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  min-height: 40px;
+  min-width: 20em;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c5:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c5::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c5::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c5:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c5::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Label
           </span>
         </div>
         <textarea
-          aria-invalid="false"
-          aria-required="false"
-          class="Textarea__StyledTextarea-sc-1tyrhr0-0 JjIln"
-          rows="3"
+          aria-invalid={false}
+          aria-required={false}
+          className="c5"
+          disabled={false}
+          id={null}
+          onBlur={[Function]}
+          onChange={[Function]}
+          required={false}
+          rows={3}
         />
       </label>
     </div>
@@ -76,51 +258,167 @@ exports[`Storyshots Textarea Textarea 1`] = `
 `;
 
 exports[`Storyshots Textarea Textarea with all props 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c5 {
+  margin-left: 8px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #434d59;
+}
+
+.c6 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+  font-size: 14px;
+  line-height: 1.71428571;
+}
+
+.c6 .Link-sc-1lpx3d0-0 {
+  font-size: 14px;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c7 {
+  display: block;
+  width: 100%;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  min-height: 40px;
+  min-width: 20em;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c7:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c7::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Label
           </span>
           <span
-            class="Text-sc-1wu7vpu-0 bphWXP"
+            className="c5"
             color="darkGrey"
-            font-size="12px"
+            disabled={false}
+            fontSize="12px"
           >
             (Required)
           </span>
           <p
-            class="Text-sc-1wu7vpu-0 HelpText__HelpTextContent-sc-1jzmq2g-0 feAJVX"
+            className="c6"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             here's some help...
           </p>
         </div>
         <textarea
-          aria-invalid="false"
-          aria-required="true"
-          class="Textarea__StyledTextarea-sc-1tyrhr0-0 JjIln"
+          aria-invalid={false}
+          aria-required={true}
+          className="c7"
+          disabled={false}
+          id={null}
+          onBlur={[Function]}
+          onChange={[Function]}
           placeholder="Placeholder"
-          required=""
-          rows="3"
+          required={true}
+          rows={3}
         />
       </label>
     </div>
@@ -129,36 +427,127 @@ exports[`Storyshots Textarea Textarea with all props 1`] = `
 `;
 
 exports[`Storyshots Textarea With custom id 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c5 {
+  display: block;
+  width: 100%;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  min-height: 40px;
+  min-width: 20em;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c5:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c5::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c5::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c5:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c5::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Label
           </span>
         </div>
         <textarea
-          aria-invalid="false"
-          aria-required="false"
-          class="Textarea__StyledTextarea-sc-1tyrhr0-0 JjIln"
+          aria-invalid={false}
+          aria-required={false}
+          className="c5"
+          disabled={false}
           id="my-custom-id"
-          rows="3"
+          onBlur={[Function]}
+          onChange={[Function]}
+          required={false}
+          rows={3}
         />
       </label>
     </div>
@@ -167,35 +556,127 @@ exports[`Storyshots Textarea With custom id 1`] = `
 `;
 
 exports[`Storyshots Textarea With custom number of rows 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c5 {
+  display: block;
+  width: 100%;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  min-height: 40px;
+  min-width: 20em;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c5:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c5::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c5::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c5:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c5::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Label
           </span>
         </div>
         <textarea
-          aria-invalid="false"
-          aria-required="false"
-          class="Textarea__StyledTextarea-sc-1tyrhr0-0 JjIln"
-          rows="7"
+          aria-invalid={false}
+          aria-required={false}
+          className="c5"
+          disabled={false}
+          id={null}
+          onBlur={[Function]}
+          onChange={[Function]}
+          required={false}
+          rows={7}
         />
       </label>
     </div>
@@ -204,51 +685,261 @@ exports[`Storyshots Textarea With custom number of rows 1`] = `
 `;
 
 exports[`Storyshots Textarea set to required 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c7 {
+  margin-bottom: 8px;
+}
+
+.c3 {
+  margin-top: 0;
+  margin-bottom: 16px;
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.23076923;
+}
+
+.c10 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c10:hover {
+  background-color: #e1ebfa;
+}
+
+.c10:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c10:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c10:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c10:disabled {
+  opacity: .5;
+}
+
+.c11 {
+  color: #ffffff;
+  border-color: #216beb;
+  background-color: #216beb;
+}
+
+.c11:hover {
+  background-color: #1254c7;
+  border-color: #1254c7;
+}
+
+.c11:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #216beb;
+}
+
+.c11:focus:hover {
+  background-color: #1254c7;
+}
+
+.c6 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c8 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c5 {
+  width: 100%;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c1 .c2 {
+  margin-bottom: 48px;
+}
+
+.c1 .Alert-u8lbe-0 {
+  margin-bottom: 48px;
+}
+
+.c1 .c4,
+.c1 .Fieldset-sc-9aoml1-0 {
+  margin-bottom: 24px;
+}
+
+.c1 .c4:last-child,
+.c1 .Fieldset-sc-9aoml1-0:last-child {
+  margin-bottom: 0;
+}
+
+.c1 .FormSection-sc-5yud6c-1 {
+  margin-bottom: 48px;
+}
+
+.c1 .FormSection-sc-5yud6c-1:last-child {
+  margin-bottom: 0;
+}
+
+.c9 {
+  display: block;
+  width: 100%;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  min-height: 40px;
+  min-width: 20em;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c9:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c9::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c9::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c9:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c9::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <form
-      class="Form-n70q8u-0 laLzBn"
+      className="c1"
     >
       <h2
-        class="Text-sc-1wu7vpu-0-h2 heWDlS"
-        font-size="larger"
-        font-weight="medium"
+        className="c2 c3"
+        fontSize="larger"
+        fontWeight="medium"
       >
         Required field example
       </h2>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+        className="c4 c5"
       >
         <label
-          class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+          className="c6 "
           color="black"
-          style="display:block"
+          style={
+            Object {
+              "display": "block",
+            }
+          }
         >
           <div
-            class="Box-sc-1qu1edy-0 ilQgHG"
+            className="c7"
             data-testid="field-label"
           >
             <span
-              class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+              className="c8"
             >
               Label
             </span>
           </div>
           <textarea
-            aria-invalid="false"
-            aria-required="true"
-            class="Textarea__StyledTextarea-sc-1tyrhr0-0 JjIln"
-            required=""
-            rows="3"
+            aria-invalid={false}
+            aria-required={true}
+            className="c9"
+            disabled={false}
+            id={null}
+            onBlur={[Function]}
+            onChange={[Function]}
+            required={true}
+            rows={3}
           />
         </label>
       </div>
       <button
-        class="Button__WrapperButton-sc-1omxup2-0 hkfOQr PrimaryButton-qz78sb-0 cGyyDq"
+        className="c10 c11"
+        disabled={false}
+        size="medium"
       >
         Send
       </button>
@@ -258,50 +949,193 @@ exports[`Storyshots Textarea set to required 1`] = `
 `;
 
 exports[`Storyshots Textarea with error list 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c6 {
+  color: #cc1439;
+  margin-top: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c7 {
+  margin-right: 8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c10 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c13 {
+  margin-bottom: 8px;
+  color: currentColor;
+}
+
+.c13:last-child {
+  margin-bottom: 0;
+}
+
+.c11 {
+  color: currentColor;
+  margin: 0;
+  padding-left: 18px;
+}
+
+.c11 .c12 {
+  margin-bottom: 0;
+}
+
+.c8 .c9 {
+  margin-bottom: 8px;
+}
+
+.c8 > *:last-child {
+  margin-bottom: 0;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c5 {
+  display: block;
+  width: 100%;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  min-height: 40px;
+  min-width: 20em;
+  color: #cc1439;
+  border-color: #cc1439;
+}
+
+.c5:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c5::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c5::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c5:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c5::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Label
           </span>
         </div>
         <textarea
-          aria-invalid="true"
-          aria-required="false"
-          class="Textarea__StyledTextarea-sc-1tyrhr0-0 glwRhU"
-          rows="3"
+          aria-invalid={true}
+          aria-required={false}
+          className="c5"
+          disabled={false}
+          id={null}
+          onChange={[Function]}
+          required={false}
+          rows={3}
         />
       </label>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 ycNbA"
+        className="c6"
         color="red"
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 QuoIa"
+          aria-hidden={true}
+          className="c7"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="error"
           mr="x1"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -310,27 +1144,28 @@ exports[`Storyshots Textarea with error list 1`] = `
           />
         </svg>
         <div
-          class="InlineValidation__Wrapper-sc-1jic7dw-0 kqhCKM"
+          className="c8"
         >
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c9 c10"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Please fill this out
           </p>
           <ul
-            class="List-sc-1cqkmnl-0 diqcEx"
+            className="c11"
             color="currentColor"
           >
             <li
-              class="ListItem-qqenhw-0 gzsWDK"
+              className="c12 c13"
               color="currentColor"
             >
               Error message 1
             </li>
             <li
-              class="ListItem-qqenhw-0 gzsWDK"
+              className="c12 c13"
               color="currentColor"
             >
               Error message 2
@@ -344,50 +1179,175 @@ exports[`Storyshots Textarea with error list 1`] = `
 `;
 
 exports[`Storyshots Textarea with error message 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c6 {
+  color: #cc1439;
+  margin-top: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c7 {
+  margin-right: 8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c10 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c8 .c9 {
+  margin-bottom: 8px;
+}
+
+.c8 > *:last-child {
+  margin-bottom: 0;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c5 {
+  display: block;
+  width: 100%;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  min-height: 40px;
+  min-width: 20em;
+  color: #cc1439;
+  border-color: #cc1439;
+}
+
+.c5:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c5::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c5::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c5:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c5::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Label
           </span>
         </div>
         <textarea
-          aria-invalid="true"
-          aria-required="false"
-          class="Textarea__StyledTextarea-sc-1tyrhr0-0 glwRhU"
-          rows="3"
+          aria-invalid={true}
+          aria-required={false}
+          className="c5"
+          disabled={false}
+          id={null}
+          onBlur={[Function]}
+          onChange={[Function]}
+          required={false}
+          rows={3}
         />
       </label>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 ycNbA"
+        className="c6"
         color="red"
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 QuoIa"
+          aria-hidden={true}
+          className="c7"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="error"
           mr="x1"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -396,12 +1356,13 @@ exports[`Storyshots Textarea with error message 1`] = `
           />
         </svg>
         <div
-          class="InlineValidation__Wrapper-sc-1jic7dw-0 kqhCKM"
+          className="c8"
         >
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c9 c10"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Please fill this out
           </p>

--- a/components/src/TimePicker/__snapshots__/TimePicker.story.storyshot
+++ b/components/src/TimePicker/__snapshots__/TimePicker.story.storyshot
@@ -1,26 +1,85 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots TimePicker default 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c5 {
+  color: currentColor;
+  min-width: 22px;
+  color: #434d59;
+}
+
+.c5:hover {
+  color: #434d59;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Start Time
           </span>
@@ -29,19 +88,22 @@ exports[`Storyshots TimePicker default 1`] = `
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker css-2b097c-container"
+            className="nds-time-picker css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1liu8yu-Control"
+                className=" css-1liu8yu-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    className=" css-1yhx6vz-Placeholder"
                   >
                     HH:MM
                   </div>
@@ -49,50 +111,87 @@ exports[`Storyshots TimePicker default 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
                           aria-label="Select a time"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          id="react-select-30-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
+                          id="react-select-32-input"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      aria-hidden={true}
+                      className="Icon-fc7twp-0 c5"
                       color="currentColor"
                       fill="currentColor"
-                      focusable="false"
+                      focusable={false}
                       height="22px"
                       icon="queryBuilder"
+                      size="22px"
+                      title={null}
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -113,26 +212,85 @@ exports[`Storyshots TimePicker default 1`] = `
 `;
 
 exports[`Storyshots TimePicker with custom placeholder 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c5 {
+  color: currentColor;
+  min-width: 22px;
+  color: #434d59;
+}
+
+.c5:hover {
+  color: #434d59;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Duration
           </span>
@@ -141,19 +299,22 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker css-2b097c-container"
+            className="nds-time-picker css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1liu8yu-Control"
+                className=" css-1liu8yu-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    className=" css-1yhx6vz-Placeholder"
                   >
                     --:--
                   </div>
@@ -161,50 +322,87 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
                           aria-label="Select a time"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          id="react-select-33-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
+                          id="react-select-35-input"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      aria-hidden={true}
+                      className="Icon-fc7twp-0 c5"
                       color="currentColor"
                       fill="currentColor"
-                      focusable="false"
+                      focusable={false}
                       height="22px"
                       icon="queryBuilder"
+                      size="22px"
+                      title={null}
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -225,26 +423,85 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
 `;
 
 exports[`Storyshots TimePicker with custom time format 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c5 {
+  color: currentColor;
+  min-width: 22px;
+  color: #434d59;
+}
+
+.c5:hover {
+  color: #434d59;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Duration
           </span>
@@ -253,19 +510,22 @@ exports[`Storyshots TimePicker with custom time format 1`] = `
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker css-2b097c-container"
+            className="nds-time-picker css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1liu8yu-Control"
+                className=" css-1liu8yu-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-r447wv-singleValue"
+                    className=" css-r447wv-singleValue"
                   >
                     03:30
                   </div>
@@ -273,50 +533,87 @@ exports[`Storyshots TimePicker with custom time format 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
                           aria-label="Select a time"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          id="react-select-31-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
+                          id="react-select-33-input"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      aria-hidden={true}
+                      className="Icon-fc7twp-0 c5"
                       color="currentColor"
                       fill="currentColor"
-                      focusable="false"
+                      focusable={false}
                       height="22px"
                       icon="queryBuilder"
+                      size="22px"
+                      title={null}
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -337,26 +634,85 @@ exports[`Storyshots TimePicker with custom time format 1`] = `
 `;
 
 exports[`Storyshots TimePicker with custom time interval 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c5 {
+  color: currentColor;
+  min-width: 22px;
+  color: #434d59;
+}
+
+.c5:hover {
+  color: #434d59;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             Duration
           </span>
@@ -365,19 +721,22 @@ exports[`Storyshots TimePicker with custom time interval 1`] = `
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker css-2b097c-container"
+            className="nds-time-picker css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1liu8yu-Control"
+                className=" css-1liu8yu-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-r447wv-singleValue"
+                    className=" css-r447wv-singleValue"
                   >
                     03:30
                   </div>
@@ -385,50 +744,87 @@ exports[`Storyshots TimePicker with custom time interval 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
                           aria-label="Select a time"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          id="react-select-32-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
+                          id="react-select-34-input"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      aria-hidden={true}
+                      className="Icon-fc7twp-0 c5"
                       color="currentColor"
                       fill="currentColor"
-                      focusable="false"
+                      focusable={false}
                       height="22px"
                       icon="queryBuilder"
+                      size="22px"
+                      title={null}
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -449,26 +845,116 @@ exports[`Storyshots TimePicker with custom time interval 1`] = `
 `;
 
 exports[`Storyshots TimePicker with error state 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c6 {
+  color: #cc1439;
+  margin-top: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c7 {
+  margin-right: 8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c10 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c8 .c9 {
+  margin-bottom: 8px;
+}
+
+.c8 > *:last-child {
+  margin-bottom: 0;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c5 {
+  color: currentColor;
+  min-width: 22px;
+  color: #434d59;
+}
+
+.c5:hover {
+  color: #434d59;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             End Time
           </span>
@@ -477,19 +963,22 @@ exports[`Storyshots TimePicker with error state 1`] = `
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker css-2b097c-container"
+            className="nds-time-picker css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1j4q2ea-Control"
+                className=" css-1j4q2ea-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    className=" css-1yhx6vz-Placeholder"
                   >
                     HH:MM
                   </div>
@@ -497,50 +986,87 @@ exports[`Storyshots TimePicker with error state 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
                           aria-label="Select a time"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          id="react-select-34-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
+                          id="react-select-36-input"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      aria-hidden={true}
+                      className="c5"
                       color="currentColor"
                       fill="currentColor"
-                      focusable="false"
+                      focusable={false}
                       height="22px"
                       icon="queryBuilder"
+                      size="22px"
+                      title={null}
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -555,18 +1081,20 @@ exports[`Storyshots TimePicker with error state 1`] = `
           </div>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 ycNbA"
+          className="c6"
           color="red"
         >
           <svg
-            aria-hidden="true"
-            class="Icon-fc7twp-0 QuoIa"
+            aria-hidden={true}
+            className="c7"
             color="currentColor"
             fill="currentColor"
-            focusable="false"
+            focusable={false}
             height="24px"
             icon="error"
             mr="x1"
+            size="24px"
+            title={null}
             viewBox="0 0 24 24"
             width="24px"
           >
@@ -575,12 +1103,13 @@ exports[`Storyshots TimePicker with error state 1`] = `
             />
           </svg>
           <div
-            class="InlineValidation__Wrapper-sc-1jic7dw-0 kqhCKM"
+            className="c8"
           >
             <p
-              class="Text-sc-1wu7vpu-0 RbfMK"
+              className="c9 c10"
               color="currentColor"
-              font-size="medium"
+              disabled={false}
+              fontSize="medium"
             >
               This time is invalid
             </p>
@@ -593,26 +1122,85 @@ exports[`Storyshots TimePicker with error state 1`] = `
 `;
 
 exports[`Storyshots TimePicker with min and max time 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c2 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c4 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c5 {
+  color: currentColor;
+  min-width: 22px;
+  color: #434d59;
+}
+
+.c5:hover {
+  color: #434d59;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+      className="c1"
     >
       <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        className="c2 "
         color="black"
-        style="display:block"
+        style={
+          Object {
+            "display": "block",
+          }
+        }
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
           data-testid="field-label"
         >
           <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+            className="c4"
           >
             End Time
           </span>
@@ -621,19 +1209,22 @@ exports[`Storyshots TimePicker with min and max time 1`] = `
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker css-2b097c-container"
+            className="nds-time-picker css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1liu8yu-Control"
+                className=" css-1liu8yu-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    className=" css-1yhx6vz-Placeholder"
                   >
                     HH:MM
                   </div>
@@ -641,50 +1232,87 @@ exports[`Storyshots TimePicker with min and max time 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
                           aria-label="Select a time"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          id="react-select-35-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
+                          id="react-select-37-input"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      aria-hidden={true}
+                      className="Icon-fc7twp-0 c5"
                       color="currentColor"
                       fill="currentColor"
-                      focusable="false"
+                      focusable={false}
                       height="22px"
                       icon="queryBuilder"
+                      size="22px"
+                      title={null}
                       viewBox="0 0 24 24"
                       width="22px"
                     >

--- a/components/src/TimeRange/__snapshots__/TimeRange.story.storyshot
+++ b/components/src/TimeRange/__snapshots__/TimeRange.story.storyshot
@@ -1,52 +1,141 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots TimeRange default 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c6 {
+  padding-left: 4px;
+  padding-right: 4px;
+  max-height: 38px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c1 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c2 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c4 {
+  width: 100%;
+}
+
+.c5 {
+  color: currentColor;
+  min-width: 22px;
+  color: #434d59;
+}
+
+.c5:hover {
+  color: #434d59;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      className="c1 "
       color="black"
-      style="display:block"
+      style={
+        Object {
+          "display": "block",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
+        className=""
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          className="c2"
         >
           Time range
         </span>
       </div>
     </label>
     <div
-      class="Box-sc-1qu1edy-0 iyjdMT"
+      className="c3"
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+        className="c4"
       >
         <div
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker css-2b097c-container"
+            className="nds-time-picker css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1liu8yu-Control"
+                className=" css-1liu8yu-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    className=" css-1yhx6vz-Placeholder"
                   >
                     HH:MM
                   </div>
@@ -54,50 +143,87 @@ exports[`Storyshots TimeRange default 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
                           aria-label="Select a start time"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          id="react-select-36-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
+                          id="react-select-38-input"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      aria-hidden={true}
+                      className="Icon-fc7twp-0 c5"
                       color="currentColor"
                       fill="currentColor"
-                      focusable="false"
+                      focusable={false}
                       height="22px"
                       icon="queryBuilder"
+                      size="22px"
+                      title={null}
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -113,36 +239,40 @@ exports[`Storyshots TimeRange default 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hYUuLW"
+        className="c6"
       >
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c7"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           -
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+        className="c4"
       >
         <div
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker css-2b097c-container"
+            className="nds-time-picker css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1liu8yu-Control"
+                className=" css-1liu8yu-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    className=" css-1yhx6vz-Placeholder"
                   >
                     HH:MM
                   </div>
@@ -150,50 +280,87 @@ exports[`Storyshots TimeRange default 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
                           aria-label="Select an end time"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          id="react-select-37-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
+                          id="react-select-39-input"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      aria-hidden={true}
+                      className="Icon-fc7twp-0 c5"
                       color="currentColor"
                       fill="currentColor"
-                      focusable="false"
+                      focusable={false}
                       height="22px"
                       icon="queryBuilder"
+                      size="22px"
+                      title={null}
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -214,52 +381,141 @@ exports[`Storyshots TimeRange default 1`] = `
 `;
 
 exports[`Storyshots TimeRange default selections 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c6 {
+  padding-left: 4px;
+  padding-right: 4px;
+  max-height: 38px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c1 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c2 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c4 {
+  width: 100%;
+}
+
+.c5 {
+  color: currentColor;
+  min-width: 22px;
+  color: #434d59;
+}
+
+.c5:hover {
+  color: #434d59;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      className="c1 "
       color="black"
-      style="display:block"
+      style={
+        Object {
+          "display": "block",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
+        className=""
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          className="c2"
         >
           Time range
         </span>
       </div>
     </label>
     <div
-      class="Box-sc-1qu1edy-0 iyjdMT"
+      className="c3"
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+        className="c4"
       >
         <div
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker css-2b097c-container"
+            className="nds-time-picker css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1liu8yu-Control"
+                className=" css-1liu8yu-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-r447wv-singleValue"
+                    className=" css-r447wv-singleValue"
                   >
                     12:00 PM
                   </div>
@@ -267,50 +523,87 @@ exports[`Storyshots TimeRange default selections 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
                           aria-label="Select a start time"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          id="react-select-38-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
+                          id="react-select-40-input"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      aria-hidden={true}
+                      className="Icon-fc7twp-0 c5"
                       color="currentColor"
                       fill="currentColor"
-                      focusable="false"
+                      focusable={false}
                       height="22px"
                       icon="queryBuilder"
+                      size="22px"
+                      title={null}
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -326,36 +619,40 @@ exports[`Storyshots TimeRange default selections 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hYUuLW"
+        className="c6"
       >
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c7"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           -
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+        className="c4"
       >
         <div
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker css-2b097c-container"
+            className="nds-time-picker css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1liu8yu-Control"
+                className=" css-1liu8yu-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-r447wv-singleValue"
+                    className=" css-r447wv-singleValue"
                   >
                     01:30 PM
                   </div>
@@ -363,50 +660,87 @@ exports[`Storyshots TimeRange default selections 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
                           aria-label="Select an end time"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          id="react-select-39-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
+                          id="react-select-41-input"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      aria-hidden={true}
+                      className="Icon-fc7twp-0 c5"
                       color="currentColor"
                       fill="currentColor"
-                      focusable="false"
+                      focusable={false}
                       height="22px"
                       icon="queryBuilder"
+                      size="22px"
+                      title={null}
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -427,52 +761,141 @@ exports[`Storyshots TimeRange default selections 1`] = `
 `;
 
 exports[`Storyshots TimeRange with min and max time range 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c6 {
+  padding-left: 4px;
+  padding-right: 4px;
+  max-height: 38px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c1 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c2 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c4 {
+  width: 100%;
+}
+
+.c5 {
+  color: currentColor;
+  min-width: 22px;
+  color: #434d59;
+}
+
+.c5:hover {
+  color: #434d59;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      className="c1 "
       color="black"
-      style="display:block"
+      style={
+        Object {
+          "display": "block",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
+        className=""
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          className="c2"
         >
           Time range
         </span>
       </div>
     </label>
     <div
-      class="Box-sc-1qu1edy-0 iyjdMT"
+      className="c3"
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+        className="c4"
       >
         <div
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker css-2b097c-container"
+            className="nds-time-picker css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1liu8yu-Control"
+                className=" css-1liu8yu-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    className=" css-1yhx6vz-Placeholder"
                   >
                     HH:MM
                   </div>
@@ -480,50 +903,87 @@ exports[`Storyshots TimeRange with min and max time range 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
                           aria-label="Select a start time"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          id="react-select-42-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
+                          id="react-select-44-input"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      aria-hidden={true}
+                      className="Icon-fc7twp-0 c5"
                       color="currentColor"
                       fill="currentColor"
-                      focusable="false"
+                      focusable={false}
                       height="22px"
                       icon="queryBuilder"
+                      size="22px"
+                      title={null}
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -539,36 +999,40 @@ exports[`Storyshots TimeRange with min and max time range 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hYUuLW"
+        className="c6"
       >
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c7"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           -
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+        className="c4"
       >
         <div
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker css-2b097c-container"
+            className="nds-time-picker css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1liu8yu-Control"
+                className=" css-1liu8yu-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    className=" css-1yhx6vz-Placeholder"
                   >
                     HH:MM
                   </div>
@@ -576,50 +1040,87 @@ exports[`Storyshots TimeRange with min and max time range 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
                           aria-label="Select an end time"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          id="react-select-43-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
+                          id="react-select-45-input"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      aria-hidden={true}
+                      className="Icon-fc7twp-0 c5"
                       color="currentColor"
                       fill="currentColor"
-                      focusable="false"
+                      focusable={false}
                       height="22px"
                       icon="queryBuilder"
+                      size="22px"
+                      title={null}
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -640,52 +1141,141 @@ exports[`Storyshots TimeRange with min and max time range 1`] = `
 `;
 
 exports[`Storyshots TimeRange with range validation 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-top: 8px;
+  margin-bottom: 8px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c6 {
+  padding-left: 4px;
+  padding-right: 4px;
+  max-height: 38px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c1 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c2 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c4 {
+  width: 100%;
+}
+
+.c5 {
+  color: currentColor;
+  min-width: 22px;
+  color: #434d59;
+}
+
+.c5:hover {
+  color: #434d59;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <label
-      class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+      className="c1 "
       color="black"
-      style="display:block"
+      style={
+        Object {
+          "display": "block",
+        }
+      }
     >
       <div
-        class="Box-sc-1qu1edy-0 jlPsmj"
+        className=""
         data-testid="field-label"
       >
         <span
-          class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          className="c2"
         >
           Time range
         </span>
       </div>
     </label>
     <div
-      class="Box-sc-1qu1edy-0 iyjdMT"
+      className="c3"
       display="inline-flex"
     >
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+        className="c4"
       >
         <div
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker css-2b097c-container"
+            className="nds-time-picker css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1liu8yu-Control"
+                className=" css-1liu8yu-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-r447wv-singleValue"
+                    className=" css-r447wv-singleValue"
                   >
                     12:00 PM
                   </div>
@@ -693,50 +1283,87 @@ exports[`Storyshots TimeRange with range validation 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
                           aria-label="Select a start time"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          id="react-select-40-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
+                          id="react-select-42-input"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      aria-hidden={true}
+                      className="Icon-fc7twp-0 c5"
                       color="currentColor"
                       fill="currentColor"
-                      focusable="false"
+                      focusable={false}
                       height="22px"
                       icon="queryBuilder"
+                      size="22px"
+                      title={null}
                       viewBox="0 0 24 24"
                       width="22px"
                     >
@@ -752,36 +1379,40 @@ exports[`Storyshots TimeRange with range validation 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hYUuLW"
+        className="c6"
       >
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c7"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           -
         </p>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+        className="c4"
       >
         <div
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker css-2b097c-container"
+            className="nds-time-picker css-2b097c-container"
+            onKeyDown={[Function]}
           >
             <div
               data-testid="select-control"
             >
               <div
-                class=" css-1liu8yu-Control"
+                className=" css-1liu8yu-Control"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
               >
                 <div
-                  class=" css-7zc8my"
+                  className=" css-7zc8my"
                 >
                   <div
-                    class=" css-r447wv-singleValue"
+                    className=" css-r447wv-singleValue"
                   >
                     03:30 AM
                   </div>
@@ -789,50 +1420,87 @@ exports[`Storyshots TimeRange with range validation 1`] = `
                     data-testid="select-input"
                   >
                     <div
-                      class="css-17yls17-Input"
+                      className="css-17yls17-Input"
                     >
                       <div
-                        class=""
-                        style="display:inline-block"
+                        className=""
+                        style={
+                          Object {
+                            "display": "inline-block",
+                          }
+                        }
                       >
                         <input
                           aria-autocomplete="list"
                           aria-label="Select an end time"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          id="react-select-41-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
+                          autoCapitalize="none"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          disabled={null}
+                          id="react-select-43-input"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          spellCheck="false"
+                          style={
+                            Object {
+                              "background": 0,
+                              "border": 0,
+                              "boxSizing": "content-box",
+                              "color": "inherit",
+                              "fontSize": "inherit",
+                              "label": "input",
+                              "opacity": 1,
+                              "outline": 0,
+                              "padding": 0,
+                              "width": "1px",
+                            }
+                          }
+                          tabIndex="0"
                           type="text"
                           value=""
                         />
                         <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "scroll",
+                              "position": "absolute",
+                              "top": 0,
+                              "visibility": "hidden",
+                              "whiteSpace": "pre",
+                            }
+                          }
+                        >
+                          
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div
-                  class=" css-173cxbq-IndicatorsContainer"
+                  className=" css-173cxbq-IndicatorsContainer"
                 >
                   <span
-                    class=" css-4z5mi-indicatorSeparator"
+                    className=" css-4z5mi-indicatorSeparator"
                   />
                   <div
                     aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
+                    className=" css-19phze7-indicatorContainer"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
                   >
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      aria-hidden={true}
+                      className="Icon-fc7twp-0 c5"
                       color="currentColor"
                       fill="currentColor"
-                      focusable="false"
+                      focusable={false}
                       height="22px"
                       icon="queryBuilder"
+                      size="22px"
+                      title={null}
                       viewBox="0 0 24 24"
                       width="22px"
                     >

--- a/components/src/Toast/__snapshots__/Toast.story.storyshot
+++ b/components/src/Toast/__snapshots__/Toast.story.storyshot
@@ -1,26 +1,168 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Toast Toast 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c5 {
+  margin-right: auto;
+}
+
+.c3 {
+  background-color: #e1ebfa;
+  padding: 16px;
+  border-radius: 4px;
+  border-left-width: half;
+  border-left-color: #216beb;
+  border-left-style: solid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c1:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c1:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
+.c4 {
+  box-shadow: 0px 1px 4px 0px rgba(1,30,56,0.15);
+  min-width: 200px;
+  max-width: 600px;
+  opacity: 0;
+  -webkit-transition: opacity 1s linear;
+  transition: opacity 1s linear;
+}
+
+.c4 .Link-sc-1lpx3d0-0 {
+  color: #011e38;
+}
+
+.c2 {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  margin-left: auto;
+  margin-right: auto;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  -webkit-tranform: translateY(-32px);
+  tranform: translateY(-32px);
+  -webkit-transform: translateY(0px);
+  -ms-transform: translateY(0px);
+  transform: translateY(0px);
+  -webkit-transition: -webkit-transform 0.9s ease-in;
+  -webkit-transition: transform 0.9s ease-in;
+  transition: transform 0.9s ease-in;
+  z-index: 1;
+  pointer-events: none;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
-      class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+      className="c1"
+      disabled={false}
+      onClick={[Function]}
+      size="medium"
     >
       Save Changes
     </button>
     <div
-      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 kVXqtj"
+      className="c2"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 eBpEPp Alert-u8lbe-0 Toast__AnimatedAlert-sc-1gp7eev-0 bHKHgD"
+        className="c3 Alert-u8lbe-0 c4"
         role="alert"
       >
         <div
-          class="Box-sc-1qu1edy-0 iDnpba"
+          className="c5"
         >
           Saved
         </div>
@@ -31,26 +173,168 @@ exports[`Storyshots Toast Toast 1`] = `
 `;
 
 exports[`Storyshots Toast customize length of time toast is visible 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c5 {
+  margin-right: auto;
+}
+
+.c3 {
+  background-color: #e1ebfa;
+  padding: 16px;
+  border-radius: 4px;
+  border-left-width: half;
+  border-left-color: #216beb;
+  border-left-style: solid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c1:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c1:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
+.c4 {
+  box-shadow: 0px 1px 4px 0px rgba(1,30,56,0.15);
+  min-width: 200px;
+  max-width: 600px;
+  opacity: 0;
+  -webkit-transition: opacity 1s linear;
+  transition: opacity 1s linear;
+}
+
+.c4 .Link-sc-1lpx3d0-0 {
+  color: #011e38;
+}
+
+.c2 {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  margin-left: auto;
+  margin-right: auto;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  -webkit-tranform: translateY(-32px);
+  tranform: translateY(-32px);
+  -webkit-transform: translateY(0px);
+  -ms-transform: translateY(0px);
+  transform: translateY(0px);
+  -webkit-transition: -webkit-transform 0.9s ease-in;
+  -webkit-transition: transform 0.9s ease-in;
+  transition: transform 0.9s ease-in;
+  z-index: 1;
+  pointer-events: none;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
-      class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+      className="c1"
+      disabled={false}
+      onClick={[Function]}
+      size="medium"
     >
       Save Changes
     </button>
     <div
-      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 kVXqtj"
+      className="c2"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 eBpEPp Alert-u8lbe-0 Toast__AnimatedAlert-sc-1gp7eev-0 bHKHgD"
+        className="c3 Alert-u8lbe-0 c4"
         role="alert"
       >
         <div
-          class="Box-sc-1qu1edy-0 iDnpba"
+          className="c5"
         >
           Saved
         </div>
@@ -61,43 +345,362 @@ exports[`Storyshots Toast customize length of time toast is visible 1`] = `
 `;
 
 exports[`Storyshots Toast multiple closeable toasts example 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c14 {
+  margin-right: auto;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c11 {
+  background-color: #fae6ea;
+  padding: 16px;
+  border-radius: 4px;
+  border-left-width: half;
+  border-left-color: #cc1439;
+  border-left-style: solid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c7 {
+  padding: 4px;
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c13 {
+  margin-right: 8px;
+  color: #cc1439;
+  min-width: 24px;
+}
+
+.c17 {
+  color: currentColor;
+  min-width: 16;
+}
+
+.c9 {
+  margin-right: 4px;
+  margin-left: 4px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c2 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+  margin-right: 16px;
+}
+
+.c2:hover {
+  background-color: #e1ebfa;
+}
+
+.c2:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c2:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c2:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c2:disabled {
+  opacity: .5;
+}
+
+.c3 {
+  color: #ffffff;
+  border-color: #216beb;
+  background-color: #216beb;
+}
+
+.c3:hover {
+  background-color: #1254c7;
+  border-color: #1254c7;
+}
+
+.c3:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #216beb;
+}
+
+.c3:focus:hover {
+  background-color: #1254c7;
+}
+
+.c4 {
+  color: #ffffff;
+  border-color: #cc1439;
+  background-color: #cc1439;
+}
+
+.c4:hover {
+  background-color: #9e0f2c;
+  border-color: #9e0f2c;
+}
+
+.c4:focus {
+  outline: none;
+  background-color: #cc1439;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c4:focus:hover {
+  background-color: #9e0f2c;
+}
+
+.c5 {
+  background: transparent;
+  border: none;
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px 0px;
+  color: #00438f;
+  cursor: pointer;
+}
+
+.c5 .c6 {
+  border-radius: 50%;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c5 .c8 {
+  display: block;
+  font-weight: 500;
+  text-align: left;
+}
+
+.c5 .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 0;
+}
+
+.c5:hover .c6 {
+  background-color: #e1ebfa;
+}
+
+.c5:hover .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c5:active .c6 {
+  -webkit-transform: scale(0.875);
+  -ms-transform: scale(0.875);
+  transform: scale(0.875);
+  -webkit-transition: .2s ease-in;
+  transition: .2s ease-in;
+}
+
+.c5:disabled {
+  opacity: .5;
+}
+
+.c5:disabled:hover .c6,
+.c5:disabled:active .c6 {
+  background: none;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus .c6 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c5:focus .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c16 {
+  color: #434d59;
+  font-size: 16px;
+  background: none;
+  border: none;
+  padding: 0;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c16:hover {
+  cursor: pointer;
+  color: #216beb;
+}
+
+.c12 {
+  box-shadow: 0px 1px 4px 0px rgba(1,30,56,0.15);
+  min-width: 200px;
+  max-width: 600px;
+  opacity: 0;
+  -webkit-transition: opacity 1s linear;
+  transition: opacity 1s linear;
+}
+
+.c12 .c15 {
+  color: #011e38;
+}
+
+.c10 {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  margin-left: auto;
+  margin-right: auto;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  -webkit-tranform: translateY(-32px);
+  tranform: translateY(-32px);
+  -webkit-transform: translateY(0px);
+  -ms-transform: translateY(0px);
+  transform: translateY(0px);
+  -webkit-transition: -webkit-transform 0.9s ease-in;
+  -webkit-transition: transform 0.9s ease-in;
+  transition: transform 0.9s ease-in;
+  z-index: 1;
+  pointer-events: none;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 geyRYt"
+      className="c1"
     >
       <button
-        class="Button__WrapperButton-sc-1omxup2-0 bclWrW PrimaryButton-qz78sb-0 cGyyDq"
+        className="c2 c3"
+        disabled={false}
+        onClick={[Function]}
+        size="medium"
       >
         Save Changes
       </button>
       <button
-        class="Button__WrapperButton-sc-1omxup2-0 bclWrW"
+        className="c2"
+        disabled={false}
+        onClick={[Function]}
+        size="medium"
       >
         Reset
       </button>
       <button
-        class="Button__WrapperButton-sc-1omxup2-0 bclWrW DangerButton-sc-1220u5k-0 ehzMsl"
+        className="c2 c4"
+        disabled={false}
+        onClick={[Function]}
+        size="medium"
       >
         Trigger Error
       </button>
       <button
         aria-label="Delete"
-        class="IconicButton__WrapperButton-sc-1u3dojp-1 UMPof IconicButton-sc-1u3dojp-2 gZASNp"
+        className="c5 "
+        disabled={false}
+        onClick={[Function]}
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 cwKdbD"
+          aria-hidden={true}
+          className="c6 c7"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="32px"
           icon="delete"
           p="half"
+          size="32px"
+          title={null}
           viewBox="0 0 24 24"
           width="32px"
         >
@@ -106,30 +709,37 @@ exports[`Storyshots Toast multiple closeable toasts example 1`] = `
           />
         </svg>
         <p
-          class="Text-sc-1wu7vpu-0 hHlnON"
+          className="c8 c9"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           Delete
         </p>
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 kVXqtj"
+      className="c10"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 gjRpuy Alert-u8lbe-0 Toast__AnimatedAlert-sc-1gp7eev-0 bHKHgD"
+        className="c11 Alert-u8lbe-0 c12"
         role="alert"
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 ewGQci"
+          aria-hidden={true}
+          className="c6 c13"
           color="red"
           fill="#cc1439"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="error"
           mr="x1"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -138,28 +748,30 @@ exports[`Storyshots Toast multiple closeable toasts example 1`] = `
           />
         </svg>
         <div
-          class="Box-sc-1qu1edy-0 iDnpba"
+          className="c14"
         >
           Error saving all your changes
         </div>
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
+          className=""
         >
           <button
             aria-label="Close"
-            class="Link-sc-1lpx3d0-0 eyTmUh"
+            className="c15 c16"
             color="darkGrey"
-            font-size="medium"
+            fontSize="medium"
+            onClick={[Function]}
           >
             <svg
-              aria-hidden="true"
-              class="Icon-fc7twp-0 gNwFhh"
+              aria-hidden={true}
+              className="c6 c17"
               color="currentColor"
               fill="currentColor"
-              focusable="false"
+              focusable={false}
               height="16"
               icon="close"
               size="16"
+              title={null}
               viewBox="0 0 24 24"
               width="16"
             >
@@ -172,21 +784,27 @@ exports[`Storyshots Toast multiple closeable toasts example 1`] = `
       </div>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 kVXqtj"
+      className="c10"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 gjRpuy Alert-u8lbe-0 Toast__AnimatedAlert-sc-1gp7eev-0 bHKHgD"
+        className="c11 Alert-u8lbe-0 c12"
         role="alert"
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 ewGQci"
+          aria-hidden={true}
+          className="c6 c13"
           color="red"
           fill="#cc1439"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="error"
           mr="x1"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -195,28 +813,30 @@ exports[`Storyshots Toast multiple closeable toasts example 1`] = `
           />
         </svg>
         <div
-          class="Box-sc-1qu1edy-0 iDnpba"
+          className="c14"
         >
           Error: changes were reset
         </div>
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
+          className=""
         >
           <button
             aria-label="Close"
-            class="Link-sc-1lpx3d0-0 eyTmUh"
+            className="c15 c16"
             color="darkGrey"
-            font-size="medium"
+            fontSize="medium"
+            onClick={[Function]}
           >
             <svg
-              aria-hidden="true"
-              class="Icon-fc7twp-0 gNwFhh"
+              aria-hidden={true}
+              className="c6 c17"
               color="currentColor"
               fill="currentColor"
-              focusable="false"
+              focusable={false}
               height="16"
               icon="close"
               size="16"
+              title={null}
               viewBox="0 0 24 24"
               width="16"
             >
@@ -229,21 +849,27 @@ exports[`Storyshots Toast multiple closeable toasts example 1`] = `
       </div>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 kVXqtj"
+      className="c10"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 gjRpuy Alert-u8lbe-0 Toast__AnimatedAlert-sc-1gp7eev-0 bHKHgD"
+        className="c11 Alert-u8lbe-0 c12"
         role="alert"
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 ewGQci"
+          aria-hidden={true}
+          className="c6 c13"
           color="red"
           fill="#cc1439"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="error"
           mr="x1"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -252,28 +878,30 @@ exports[`Storyshots Toast multiple closeable toasts example 1`] = `
           />
         </svg>
         <div
-          class="Box-sc-1qu1edy-0 iDnpba"
+          className="c14"
         >
           An error occurred, could not deleted
         </div>
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
+          className=""
         >
           <button
             aria-label="Close"
-            class="Link-sc-1lpx3d0-0 eyTmUh"
+            className="c15 c16"
             color="darkGrey"
-            font-size="medium"
+            fontSize="medium"
+            onClick={[Function]}
           >
             <svg
-              aria-hidden="true"
-              class="Icon-fc7twp-0 gNwFhh"
+              aria-hidden={true}
+              className="c6 c17"
               color="currentColor"
               fill="currentColor"
-              focusable="false"
+              focusable={false}
               height="16"
               icon="close"
               size="16"
+              title={null}
               viewBox="0 0 24 24"
               width="16"
             >
@@ -286,21 +914,27 @@ exports[`Storyshots Toast multiple closeable toasts example 1`] = `
       </div>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 kVXqtj"
+      className="c10"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 gjRpuy Alert-u8lbe-0 Toast__AnimatedAlert-sc-1gp7eev-0 bHKHgD"
+        className="c11 Alert-u8lbe-0 c12"
         role="alert"
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 ewGQci"
+          aria-hidden={true}
+          className="c6 c13"
           color="red"
           fill="#cc1439"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="error"
           mr="x1"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -309,28 +943,30 @@ exports[`Storyshots Toast multiple closeable toasts example 1`] = `
           />
         </svg>
         <div
-          class="Box-sc-1qu1edy-0 iDnpba"
+          className="c14"
         >
           An error occurred, please retry
         </div>
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
+          className=""
         >
           <button
             aria-label="Close"
-            class="Link-sc-1lpx3d0-0 eyTmUh"
+            className="c15 c16"
             color="darkGrey"
-            font-size="medium"
+            fontSize="medium"
+            onClick={[Function]}
           >
             <svg
-              aria-hidden="true"
-              class="Icon-fc7twp-0 gNwFhh"
+              aria-hidden={true}
+              className="c6 c17"
               color="currentColor"
               fill="currentColor"
-              focusable="false"
+              focusable={false}
               height="16"
               icon="close"
               size="16"
+              title={null}
               viewBox="0 0 24 24"
               width="16"
             >
@@ -347,43 +983,361 @@ exports[`Storyshots Toast multiple closeable toasts example 1`] = `
 `;
 
 exports[`Storyshots Toast multiple toasts example 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c14 {
+  margin-right: auto;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c11 {
+  background-color: #e9f7f2;
+  padding: 16px;
+  border-radius: 4px;
+  border-left-width: half;
+  border-left-color: #008059;
+  border-left-style: solid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c15 {
+  background-color: #fae6ea;
+  padding: 16px;
+  border-radius: 4px;
+  border-left-width: half;
+  border-left-color: #cc1439;
+  border-left-style: solid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c7 {
+  padding: 4px;
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c13 {
+  margin-right: 8px;
+  color: #008059;
+  min-width: 24px;
+}
+
+.c16 {
+  margin-right: 8px;
+  color: #cc1439;
+  min-width: 24px;
+}
+
+.c9 {
+  margin-right: 4px;
+  margin-left: 4px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c2 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+  margin-right: 16px;
+}
+
+.c2:hover {
+  background-color: #e1ebfa;
+}
+
+.c2:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c2:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c2:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c2:disabled {
+  opacity: .5;
+}
+
+.c3 {
+  color: #ffffff;
+  border-color: #216beb;
+  background-color: #216beb;
+}
+
+.c3:hover {
+  background-color: #1254c7;
+  border-color: #1254c7;
+}
+
+.c3:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #216beb;
+}
+
+.c3:focus:hover {
+  background-color: #1254c7;
+}
+
+.c4 {
+  color: #ffffff;
+  border-color: #cc1439;
+  background-color: #cc1439;
+}
+
+.c4:hover {
+  background-color: #9e0f2c;
+  border-color: #9e0f2c;
+}
+
+.c4:focus {
+  outline: none;
+  background-color: #cc1439;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c4:focus:hover {
+  background-color: #9e0f2c;
+}
+
+.c5 {
+  background: transparent;
+  border: none;
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px 0px;
+  color: #00438f;
+  cursor: pointer;
+}
+
+.c5 .c6 {
+  border-radius: 50%;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c5 .c8 {
+  display: block;
+  font-weight: 500;
+  text-align: left;
+}
+
+.c5 .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 0;
+}
+
+.c5:hover .c6 {
+  background-color: #e1ebfa;
+}
+
+.c5:hover .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c5:active .c6 {
+  -webkit-transform: scale(0.875);
+  -ms-transform: scale(0.875);
+  transform: scale(0.875);
+  -webkit-transition: .2s ease-in;
+  transition: .2s ease-in;
+}
+
+.c5:disabled {
+  opacity: .5;
+}
+
+.c5:disabled:hover .c6,
+.c5:disabled:active .c6 {
+  background: none;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus .c6 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c5:focus .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c12 {
+  box-shadow: 0px 1px 4px 0px rgba(1,30,56,0.15);
+  min-width: 200px;
+  max-width: 600px;
+  opacity: 0;
+  -webkit-transition: opacity 1s linear;
+  transition: opacity 1s linear;
+}
+
+.c12 .Link-sc-1lpx3d0-0 {
+  color: #011e38;
+}
+
+.c10 {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  margin-left: auto;
+  margin-right: auto;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  -webkit-tranform: translateY(-32px);
+  tranform: translateY(-32px);
+  -webkit-transform: translateY(0px);
+  -ms-transform: translateY(0px);
+  transform: translateY(0px);
+  -webkit-transition: -webkit-transform 0.9s ease-in;
+  -webkit-transition: transform 0.9s ease-in;
+  transition: transform 0.9s ease-in;
+  z-index: 1;
+  pointer-events: none;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 geyRYt"
+      className="c1"
     >
       <button
-        class="Button__WrapperButton-sc-1omxup2-0 bclWrW PrimaryButton-qz78sb-0 cGyyDq"
+        className="c2 c3"
+        disabled={false}
+        onClick={[Function]}
+        size="medium"
       >
         Save Changes
       </button>
       <button
-        class="Button__WrapperButton-sc-1omxup2-0 bclWrW"
+        className="c2"
+        disabled={false}
+        onClick={[Function]}
+        size="medium"
       >
         Reset
       </button>
       <button
-        class="Button__WrapperButton-sc-1omxup2-0 bclWrW DangerButton-sc-1220u5k-0 ehzMsl"
+        className="c2 c4"
+        disabled={false}
+        onClick={[Function]}
+        size="medium"
       >
         Trigger Error
       </button>
       <button
         aria-label="Delete"
-        class="IconicButton__WrapperButton-sc-1u3dojp-1 UMPof IconicButton-sc-1u3dojp-2 gZASNp"
+        className="c5 "
+        disabled={false}
+        onClick={[Function]}
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 cwKdbD"
+          aria-hidden={true}
+          className="c6 c7"
           color="currentColor"
           fill="currentColor"
-          focusable="false"
+          focusable={false}
           height="32px"
           icon="delete"
           p="half"
+          size="32px"
+          title={null}
           viewBox="0 0 24 24"
           width="32px"
         >
@@ -392,30 +1346,37 @@ exports[`Storyshots Toast multiple toasts example 1`] = `
           />
         </svg>
         <p
-          class="Text-sc-1wu7vpu-0 hHlnON"
+          className="c8 c9"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           Delete
         </p>
       </button>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 kVXqtj"
+      className="c10"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 jumLLM Alert-u8lbe-0 Toast__AnimatedAlert-sc-1gp7eev-0 bHKHgD"
+        className="c11 Alert-u8lbe-0 c12"
         role="alert"
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 dqoulF"
+          aria-hidden={true}
+          className="c6 c13"
           color="green"
           fill="#008059"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="check"
           mr="x1"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -424,28 +1385,34 @@ exports[`Storyshots Toast multiple toasts example 1`] = `
           />
         </svg>
         <div
-          class="Box-sc-1qu1edy-0 iDnpba"
+          className="c14"
         >
           Saved all your changes
         </div>
       </div>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 kVXqtj"
+      className="c10"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 jumLLM Alert-u8lbe-0 Toast__AnimatedAlert-sc-1gp7eev-0 bHKHgD"
+        className="c11 Alert-u8lbe-0 c12"
         role="alert"
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 dqoulF"
+          aria-hidden={true}
+          className="c6 c13"
           color="green"
           fill="#008059"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="check"
           mr="x1"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -454,28 +1421,34 @@ exports[`Storyshots Toast multiple toasts example 1`] = `
           />
         </svg>
         <div
-          class="Box-sc-1qu1edy-0 iDnpba"
+          className="c14"
         >
           Reset all your changes
         </div>
       </div>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 kVXqtj"
+      className="c10"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 jumLLM Alert-u8lbe-0 Toast__AnimatedAlert-sc-1gp7eev-0 bHKHgD"
+        className="c11 Alert-u8lbe-0 c12"
         role="alert"
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 dqoulF"
+          aria-hidden={true}
+          className="c6 c13"
           color="green"
           fill="#008059"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="check"
           mr="x1"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -484,28 +1457,34 @@ exports[`Storyshots Toast multiple toasts example 1`] = `
           />
         </svg>
         <div
-          class="Box-sc-1qu1edy-0 iDnpba"
+          className="c14"
         >
           Ok, it's deleted
         </div>
       </div>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 kVXqtj"
+      className="c10"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 gjRpuy Alert-u8lbe-0 Toast__AnimatedAlert-sc-1gp7eev-0 bHKHgD"
+        className="c15 Alert-u8lbe-0 c12"
         role="alert"
       >
         <svg
-          aria-hidden="true"
-          class="Icon-fc7twp-0 ewGQci"
+          aria-hidden={true}
+          className="c6 c16"
           color="red"
           fill="#cc1439"
-          focusable="false"
+          focusable={false}
           height="24px"
           icon="error"
           mr="x1"
+          size="24px"
+          title={null}
           viewBox="0 0 24 24"
           width="24px"
         >
@@ -514,7 +1493,7 @@ exports[`Storyshots Toast multiple toasts example 1`] = `
           />
         </svg>
         <div
-          class="Box-sc-1qu1edy-0 iDnpba"
+          className="c14"
         >
           An error occurred, please retry
         </div>
@@ -525,47 +1504,211 @@ exports[`Storyshots Toast multiple toasts example 1`] = `
 `;
 
 exports[`Storyshots Toast with close button 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c5 {
+  margin-right: auto;
+}
+
+.c3 {
+  background-color: #e1ebfa;
+  padding: 16px;
+  border-radius: 4px;
+  border-left-width: half;
+  border-left-color: #216beb;
+  border-left-style: solid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c8 {
+  color: currentColor;
+  min-width: 16;
+}
+
+.c1 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c1:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c1:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
+.c7 {
+  color: #434d59;
+  font-size: 16px;
+  background: none;
+  border: none;
+  padding: 0;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c7:hover {
+  cursor: pointer;
+  color: #216beb;
+}
+
+.c4 {
+  box-shadow: 0px 1px 4px 0px rgba(1,30,56,0.15);
+  min-width: 200px;
+  max-width: 600px;
+  opacity: 0;
+  -webkit-transition: opacity 1s linear;
+  transition: opacity 1s linear;
+}
+
+.c4 .c6 {
+  color: #011e38;
+}
+
+.c2 {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  margin-left: auto;
+  margin-right: auto;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  -webkit-tranform: translateY(-32px);
+  tranform: translateY(-32px);
+  -webkit-transform: translateY(0px);
+  -ms-transform: translateY(0px);
+  transform: translateY(0px);
+  -webkit-transition: -webkit-transform 0.9s ease-in;
+  -webkit-transition: transform 0.9s ease-in;
+  transition: transform 0.9s ease-in;
+  z-index: 1;
+  pointer-events: none;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
-      class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+      className="c1"
+      disabled={false}
+      onClick={[Function]}
+      size="medium"
     >
       Save Changes
     </button>
     <div
-      class="Box-sc-1qu1edy-0 Toast__AnimatedBoxBottom-sc-1gp7eev-1 kVXqtj"
+      className="c2"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 eBpEPp Alert-u8lbe-0 Toast__AnimatedAlert-sc-1gp7eev-0 bHKHgD"
+        className="c3 Alert-u8lbe-0 c4"
         role="alert"
       >
         <div
-          class="Box-sc-1qu1edy-0 iDnpba"
+          className="c5"
         >
           Saved
         </div>
         <div
-          class="Box-sc-1qu1edy-0 jlPsmj"
+          className=""
         >
           <button
             aria-label="Close"
-            class="Link-sc-1lpx3d0-0 eyTmUh"
+            className="c6 c7"
             color="darkGrey"
-            font-size="medium"
+            fontSize="medium"
+            onClick={[Function]}
           >
             <svg
-              aria-hidden="true"
-              class="Icon-fc7twp-0 gNwFhh"
+              aria-hidden={true}
+              className="c8"
               color="currentColor"
               fill="currentColor"
-              focusable="false"
+              focusable={false}
               height="16"
               icon="close"
               size="16"
+              title={null}
               viewBox="0 0 24 24"
               width="16"
             >

--- a/components/src/Toggle/__snapshots__/Toggle.story.storyshot
+++ b/components/src/Toggle/__snapshots__/Toggle.story.storyshot
@@ -1,49 +1,199 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Toggle Controlled Toggle 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c9 {
+  margin-bottom: 0px;
+  margin-left: 8px;
+  margin-top: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c4 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c8 {
+  position: absolute;
+  height: 24px;
+  width: 48px;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: #e4e7eb;
+  border-radius: 12px;
+  -webkit-transition: .2s ease;
+  transition: .2s ease;
+  cursor: pointer;
+}
+
+.c8:before {
+  content: '';
+  position: absolute;
+  height: 24px;
+  width: 24px;
+  left: 0px;
+  top: 0px;
+  border-radius: 50%;
+  box-sizing: border-box;
+  border: solid 1px;
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+  -webkit-transition: .2s ease;
+  transition: .2s ease;
+}
+
+.c5 {
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  min-width: 48px;
+  min-height: 24px;
+}
+
+.c5 input {
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+}
+
+.c6:checked + .c7:before {
+  -webkit-transform: translateX(24px);
+  -ms-transform: translateX(24px);
+  transform: translateX(24px);
+  background-color: #00438f;
+  border-color: #00438f;
+}
+
+.c6:checked + .c7 {
+  background-color: #e1ebfa;
+}
+
+.c6:focus + .c7:before {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c2 {
+  padding: 4px 0;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle__StyledToggle-sc-1oqd206-0 tNttj"
+      className="c1 c2"
     >
       <div
         id="Controlled Toggle-label"
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
         >
           <span
-            style="font-size:14px;font-weight:600;line-height:1.71428571"
+            style={
+              Object {
+                "fontSize": "14px",
+                "fontWeight": "600",
+                "lineHeight": "1.71428571",
+              }
+            }
           >
             Controlled Toggle
           </span>
         </div>
         <div
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c4"
+          disabled={false}
+          onClick={[Function]}
         >
           <div
-            class="ToggleButton__Switch-asgrb8-1 hOMJxD"
+            className="c5"
           >
             <input
-              aria-invalid="false"
+              aria-invalid={false}
               aria-labelledby="Controlled Toggle-label"
-              aria-required="false"
-              class="ToggleButton__ToggleInput-asgrb8-2 lcDvtB"
+              aria-required={false}
+              checked={false}
+              className="c6"
+              disabled={false}
+              id={null}
+              onChange={[Function]}
+              onClick={[Function]}
+              required={false}
               type="checkbox"
               value="on"
             />
             <span
-              class="ToggleButton__Slider-asgrb8-0 bLvWmF"
+              className="c7 c8"
+              disabled={false}
             />
           </div>
           <p
-            class="Text-sc-1wu7vpu-0 cOGezP"
+            className="c9"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             off
           </p>
@@ -55,30 +205,160 @@ exports[`Storyshots Toggle Controlled Toggle 1`] = `
 `;
 
 exports[`Storyshots Toggle Toggle 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c7 {
+  position: absolute;
+  height: 24px;
+  width: 48px;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: #e4e7eb;
+  border-radius: 12px;
+  -webkit-transition: .2s ease;
+  transition: .2s ease;
+  cursor: pointer;
+}
+
+.c7:before {
+  content: '';
+  position: absolute;
+  height: 24px;
+  width: 24px;
+  left: 0px;
+  top: 0px;
+  border-radius: 50%;
+  box-sizing: border-box;
+  border: solid 1px;
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+  -webkit-transition: .2s ease;
+  transition: .2s ease;
+}
+
+.c4 {
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  min-width: 48px;
+  min-height: 24px;
+}
+
+.c4 input {
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+}
+
+.c5:checked + .c6:before {
+  -webkit-transform: translateX(24px);
+  -ms-transform: translateX(24px);
+  transform: translateX(24px);
+  background-color: #00438f;
+  border-color: #00438f;
+}
+
+.c5:checked + .c6 {
+  background-color: #e1ebfa;
+}
+
+.c5:focus + .c6:before {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c2 {
+  padding: 4px 0;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle__StyledToggle-sc-1oqd206-0 tNttj"
+      className="Box-sc-1qu1edy-0 c1 c2"
     >
       <div
-        class="ClickInputLabel-j2axnv-0 kemUmZ"
+        className="c3"
+        disabled={false}
+        onClick={[Function]}
       >
         <div
-          class="ToggleButton__Switch-asgrb8-1 hOMJxD"
+          className="c4"
         >
           <input
-            aria-invalid="false"
-            aria-required="false"
-            class="ToggleButton__ToggleInput-asgrb8-2 lcDvtB"
+            aria-invalid={false}
+            aria-labelledby={null}
+            aria-required={false}
+            className="c5"
+            disabled={false}
+            id={null}
+            onChange={[Function]}
+            onClick={[Function]}
+            required={false}
             type="checkbox"
             value="on"
           />
           <span
-            class="ToggleButton__Slider-asgrb8-0 bLvWmF"
+            className="c6 c7"
+            disabled={false}
           />
         </div>
       </div>
@@ -88,44 +368,183 @@ exports[`Storyshots Toggle Toggle 1`] = `
 `;
 
 exports[`Storyshots Toggle Toggle set to defaultToggled 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c4 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c8 {
+  position: absolute;
+  height: 24px;
+  width: 48px;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: #e4e7eb;
+  border-radius: 12px;
+  -webkit-transition: .2s ease;
+  transition: .2s ease;
+  cursor: pointer;
+}
+
+.c8:before {
+  content: '';
+  position: absolute;
+  height: 24px;
+  width: 24px;
+  left: 0px;
+  top: 0px;
+  border-radius: 50%;
+  box-sizing: border-box;
+  border: solid 1px;
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+  -webkit-transition: .2s ease;
+  transition: .2s ease;
+}
+
+.c5 {
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  min-width: 48px;
+  min-height: 24px;
+}
+
+.c5 input {
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+}
+
+.c6:checked + .c7:before {
+  -webkit-transform: translateX(24px);
+  -ms-transform: translateX(24px);
+  transform: translateX(24px);
+  background-color: #00438f;
+  border-color: #00438f;
+}
+
+.c6:checked + .c7 {
+  background-color: #e1ebfa;
+}
+
+.c6:focus + .c7:before {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c2 {
+  padding: 4px 0;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle__StyledToggle-sc-1oqd206-0 tNttj"
+      className="c1 c2"
     >
       <div
         id="Toggle-label"
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
         >
           <span
-            style="font-size:14px;font-weight:600;line-height:1.71428571"
+            style={
+              Object {
+                "fontSize": "14px",
+                "fontWeight": "600",
+                "lineHeight": "1.71428571",
+              }
+            }
           >
             Toggle
           </span>
         </div>
         <div
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c4"
+          disabled={false}
+          onClick={[Function]}
         >
           <div
-            class="ToggleButton__Switch-asgrb8-1 hOMJxD"
+            className="c5"
           >
             <input
-              aria-invalid="false"
+              aria-invalid={false}
               aria-labelledby="Toggle-label"
-              aria-required="false"
-              checked=""
-              class="ToggleButton__ToggleInput-asgrb8-2 lcDvtB"
+              aria-required={false}
+              checked={true}
+              className="c6"
+              disabled={false}
+              id={null}
+              onChange={[Function]}
+              onClick={[Function]}
+              required={false}
               type="checkbox"
               value="on"
             />
             <span
-              class="ToggleButton__Slider-asgrb8-0 bLvWmF"
+              className="c7 c8"
+              disabled={false}
             />
           </div>
         </div>
@@ -136,53 +555,193 @@ exports[`Storyshots Toggle Toggle set to defaultToggled 1`] = `
 `;
 
 exports[`Storyshots Toggle Toggle set to disabled 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c9 {
+  margin-bottom: 0px;
+  margin-left: 8px;
+  margin-top: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+  opacity: 0.3333;
+}
+
+.c4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c8 {
+  position: absolute;
+  height: 24px;
+  width: 48px;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: #e4e7eb;
+  border-radius: 12px;
+  -webkit-transition: .2s ease;
+  transition: .2s ease;
+}
+
+.c8:before {
+  content: '';
+  position: absolute;
+  height: 24px;
+  width: 24px;
+  left: 0px;
+  top: 0px;
+  border-radius: 50%;
+  box-sizing: border-box;
+  border: solid 1px;
+  border-color: #e4e7eb;
+  background-color: #f0f2f5;
+  -webkit-transition: .2s ease;
+  transition: .2s ease;
+}
+
+.c5 {
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  min-width: 48px;
+  min-height: 24px;
+}
+
+.c5 input {
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+}
+
+.c6:checked + .c7:before {
+  -webkit-transform: translateX(24px);
+  -ms-transform: translateX(24px);
+  transform: translateX(24px);
+  background-color: #e4e7eb;
+  border-color: #f0f2f5;
+}
+
+.c6:checked + .c7 {
+  background-color: #f0f2f5;
+}
+
+.c2 {
+  padding: 4px 0;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle__StyledToggle-sc-1oqd206-0 tNttj"
+      className="c1 c2"
     >
       <div
         id="Toggle-label"
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
         >
           <span
-            style="font-size:14px;font-weight:600;line-height:1.71428571"
+            style={
+              Object {
+                "fontSize": "14px",
+                "fontWeight": "600",
+                "lineHeight": "1.71428571",
+              }
+            }
           >
             Toggle
           </span>
         </div>
         <div
-          class="ClickInputLabel-j2axnv-0 kjxgat"
-          disabled=""
+          className="c4"
+          disabled={true}
+          onClick={[Function]}
         >
           <div
-            class="ToggleButton__Switch-asgrb8-1 hOMJxD"
+            className="c5"
           >
             <input
-              aria-invalid="false"
+              aria-invalid={false}
               aria-labelledby="Toggle-label"
-              aria-required="false"
-              class="ToggleButton__ToggleInput-asgrb8-2 gajnWZ"
-              disabled=""
+              aria-required={false}
+              className="c6"
+              disabled={true}
+              id={null}
+              onChange={[Function]}
+              onClick={[Function]}
+              required={false}
               type="checkbox"
               value="on"
             />
             <span
-              class="ToggleButton__Slider-asgrb8-0 bQpZex"
-              disabled=""
+              className="c7 c8"
+              disabled={true}
             />
           </div>
           <p
-            class="Text-sc-1wu7vpu-0 jVsGHh"
+            className="c9"
             color="currentColor"
-            disabled=""
-            font-size="medium"
+            disabled={true}
+            fontSize="medium"
           >
             off
           </p>
@@ -190,48 +749,58 @@ exports[`Storyshots Toggle Toggle set to disabled 1`] = `
       </div>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle__StyledToggle-sc-1oqd206-0 tNttj"
+      className="c1 c2"
     >
       <div
         id="Toggle-label"
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
         >
           <span
-            style="font-size:14px;font-weight:600;line-height:1.71428571"
+            style={
+              Object {
+                "fontSize": "14px",
+                "fontWeight": "600",
+                "lineHeight": "1.71428571",
+              }
+            }
           >
             Toggle
           </span>
         </div>
         <div
-          class="ClickInputLabel-j2axnv-0 kjxgat"
-          disabled=""
+          className="c4"
+          disabled={true}
+          onClick={[Function]}
         >
           <div
-            class="ToggleButton__Switch-asgrb8-1 hOMJxD"
+            className="c5"
           >
             <input
-              aria-invalid="false"
+              aria-invalid={false}
               aria-labelledby="Toggle-label"
-              aria-required="false"
-              checked=""
-              class="ToggleButton__ToggleInput-asgrb8-2 gajnWZ"
-              disabled=""
+              aria-required={false}
+              checked={true}
+              className="c6"
+              disabled={true}
               id="toggle-2"
+              onChange={[Function]}
+              onClick={[Function]}
+              required={false}
               type="checkbox"
               value="on"
             />
             <span
-              class="ToggleButton__Slider-asgrb8-0 bQpZex"
-              disabled=""
+              className="c7 c8"
+              disabled={true}
             />
           </div>
           <p
-            class="Text-sc-1wu7vpu-0 jVsGHh"
+            className="c9"
             color="currentColor"
-            disabled=""
-            font-size="medium"
+            disabled={true}
+            fontSize="medium"
           >
             on
           </p>
@@ -243,65 +812,238 @@ exports[`Storyshots Toggle Toggle set to disabled 1`] = `
 `;
 
 exports[`Storyshots Toggle Toggle with all props 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c4 {
+  margin-left: 8px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #434d59;
+}
+
+.c11 {
+  margin-bottom: 0px;
+  margin-left: 8px;
+  margin-top: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c6 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c5 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+  font-size: 14px;
+  line-height: 1.71428571;
+}
+
+.c5 .Link-sc-1lpx3d0-0 {
+  font-size: 14px;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c10 {
+  position: absolute;
+  height: 24px;
+  width: 48px;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: #e4e7eb;
+  border-radius: 12px;
+  -webkit-transition: .2s ease;
+  transition: .2s ease;
+  cursor: pointer;
+}
+
+.c10:before {
+  content: '';
+  position: absolute;
+  height: 24px;
+  width: 24px;
+  left: 0px;
+  top: 0px;
+  border-radius: 50%;
+  box-sizing: border-box;
+  border: solid 1px;
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+  -webkit-transition: .2s ease;
+  transition: .2s ease;
+}
+
+.c7 {
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  min-width: 48px;
+  min-height: 24px;
+}
+
+.c7 input {
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+}
+
+.c8:checked + .c9:before {
+  -webkit-transform: translateX(24px);
+  -ms-transform: translateX(24px);
+  transform: translateX(24px);
+  background-color: #00438f;
+  border-color: #00438f;
+}
+
+.c8:checked + .c9 {
+  background-color: #e1ebfa;
+}
+
+.c8:focus + .c9:before {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c2 {
+  padding: 4px 0;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle__StyledToggle-sc-1oqd206-0 tNttj"
+      className="c1 c2"
     >
       <div
         id="Toggle-label"
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
         >
           <span
-            style="font-size:14px;font-weight:600;line-height:1.71428571"
+            style={
+              Object {
+                "fontSize": "14px",
+                "fontWeight": "600",
+                "lineHeight": "1.71428571",
+              }
+            }
           >
             Toggle
           </span>
           <span
-            class="Text-sc-1wu7vpu-0 bphWXP"
+            className="c4"
             color="darkGrey"
-            font-size="12px"
+            disabled={false}
+            fontSize="12px"
           >
             (Required)
           </span>
           <p
-            class="Text-sc-1wu7vpu-0 HelpText__HelpTextContent-sc-1jzmq2g-0 feAJVX"
+            className="c5"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             Turns setting on/off
           </p>
         </div>
         <div
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c6"
+          disabled={false}
+          onClick={[Function]}
         >
           <div
-            class="ToggleButton__Switch-asgrb8-1 hOMJxD"
+            className="c7"
           >
             <input
-              aria-invalid="false"
+              aria-invalid={false}
               aria-labelledby="Toggle-label"
-              aria-required="true"
-              checked=""
-              class="ToggleButton__ToggleInput-asgrb8-2 lcDvtB"
-              required=""
+              aria-required={true}
+              checked={true}
+              className="c8"
+              disabled={false}
+              id={null}
+              onChange={[Function]}
+              onClick={[Function]}
+              required={true}
               type="checkbox"
               value="on"
             />
             <span
-              class="ToggleButton__Slider-asgrb8-0 bLvWmF"
+              className="c9 c10"
+              disabled={false}
             />
           </div>
           <p
-            class="Text-sc-1wu7vpu-0 cOGezP"
+            className="c11"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             on
           </p>
@@ -313,50 +1055,198 @@ exports[`Storyshots Toggle Toggle with all props 1`] = `
 `;
 
 exports[`Storyshots Toggle With custom id 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c9 {
+  margin-bottom: 0px;
+  margin-left: 8px;
+  margin-top: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c4 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c8 {
+  position: absolute;
+  height: 24px;
+  width: 48px;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: #e4e7eb;
+  border-radius: 12px;
+  -webkit-transition: .2s ease;
+  transition: .2s ease;
+  cursor: pointer;
+}
+
+.c8:before {
+  content: '';
+  position: absolute;
+  height: 24px;
+  width: 24px;
+  left: 0px;
+  top: 0px;
+  border-radius: 50%;
+  box-sizing: border-box;
+  border: solid 1px;
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+  -webkit-transition: .2s ease;
+  transition: .2s ease;
+}
+
+.c5 {
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  min-width: 48px;
+  min-height: 24px;
+}
+
+.c5 input {
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+}
+
+.c6:checked + .c7:before {
+  -webkit-transform: translateX(24px);
+  -ms-transform: translateX(24px);
+  transform: translateX(24px);
+  background-color: #00438f;
+  border-color: #00438f;
+}
+
+.c6:checked + .c7 {
+  background-color: #e1ebfa;
+}
+
+.c6:focus + .c7:before {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c2 {
+  padding: 4px 0;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle__StyledToggle-sc-1oqd206-0 tNttj"
+      className="c1 c2"
     >
       <div
         id="Toggle-label"
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
         >
           <span
-            style="font-size:14px;font-weight:600;line-height:1.71428571"
+            style={
+              Object {
+                "fontSize": "14px",
+                "fontWeight": "600",
+                "lineHeight": "1.71428571",
+              }
+            }
           >
             Toggle
           </span>
         </div>
         <div
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c4"
+          disabled={false}
+          onClick={[Function]}
         >
           <div
-            class="ToggleButton__Switch-asgrb8-1 hOMJxD"
+            className="c5"
           >
             <input
-              aria-invalid="false"
+              aria-invalid={false}
               aria-labelledby="Toggle-label"
-              aria-required="false"
-              class="ToggleButton__ToggleInput-asgrb8-2 lcDvtB"
+              aria-required={false}
+              className="c6"
+              disabled={false}
               id="my-custom-id"
+              onChange={[Function]}
+              onClick={[Function]}
+              required={false}
               type="checkbox"
               value="on"
             />
             <span
-              class="ToggleButton__Slider-asgrb8-0 bLvWmF"
+              className="c7 c8"
+              disabled={false}
             />
           </div>
           <p
-            class="Text-sc-1wu7vpu-0 cOGezP"
+            className="c9"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             off
           </p>
@@ -368,50 +1258,199 @@ exports[`Storyshots Toggle With custom id 1`] = `
 `;
 
 exports[`Storyshots Toggle With long text 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c9 {
+  margin-bottom: 0px;
+  margin-left: 8px;
+  margin-top: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c4 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c8 {
+  position: absolute;
+  height: 24px;
+  width: 48px;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: #e4e7eb;
+  border-radius: 12px;
+  -webkit-transition: .2s ease;
+  transition: .2s ease;
+  cursor: pointer;
+}
+
+.c8:before {
+  content: '';
+  position: absolute;
+  height: 24px;
+  width: 24px;
+  left: 0px;
+  top: 0px;
+  border-radius: 50%;
+  box-sizing: border-box;
+  border: solid 1px;
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+  -webkit-transition: .2s ease;
+  transition: .2s ease;
+}
+
+.c5 {
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  min-width: 48px;
+  min-height: 24px;
+}
+
+.c5 input {
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+}
+
+.c6:checked + .c7:before {
+  -webkit-transform: translateX(24px);
+  -ms-transform: translateX(24px);
+  transform: translateX(24px);
+  background-color: #00438f;
+  border-color: #00438f;
+}
+
+.c6:checked + .c7 {
+  background-color: #e1ebfa;
+}
+
+.c6:focus + .c7:before {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c2 {
+  padding: 4px 0;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle__StyledToggle-sc-1oqd206-0 tNttj"
+      className="c1 c2"
     >
       <div
         id="Toggle-label"
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
         >
           <span
-            style="font-size:14px;font-weight:600;line-height:1.71428571"
+            style={
+              Object {
+                "fontSize": "14px",
+                "fontWeight": "600",
+                "lineHeight": "1.71428571",
+              }
+            }
           >
             Toggle
           </span>
         </div>
         <div
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c4"
+          disabled={false}
+          onClick={[Function]}
         >
           <div
-            class="ToggleButton__Switch-asgrb8-1 hOMJxD"
+            className="c5"
           >
             <input
-              aria-invalid="false"
+              aria-invalid={false}
               aria-labelledby="Toggle-label"
-              aria-required="false"
-              checked=""
-              class="ToggleButton__ToggleInput-asgrb8-2 lcDvtB"
+              aria-required={false}
+              checked={true}
+              className="c6"
+              disabled={false}
+              id={null}
+              onChange={[Function]}
+              onClick={[Function]}
+              required={false}
               type="checkbox"
               value="on"
             />
             <span
-              class="ToggleButton__Slider-asgrb8-0 bLvWmF"
+              className="c7 c8"
+              disabled={false}
             />
           </div>
           <p
-            class="Text-sc-1wu7vpu-0 cOGezP"
+            className="c9"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             this state has a very long text label to explain it's state
           </p>
@@ -423,49 +1462,198 @@ exports[`Storyshots Toggle With long text 1`] = `
 `;
 
 exports[`Storyshots Toggle With text 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 8px;
+}
+
+.c9 {
+  margin-bottom: 0px;
+  margin-left: 8px;
+  margin-top: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c4 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c1 {
+  width: 100%;
+}
+
+.c8 {
+  position: absolute;
+  height: 24px;
+  width: 48px;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: #e4e7eb;
+  border-radius: 12px;
+  -webkit-transition: .2s ease;
+  transition: .2s ease;
+  cursor: pointer;
+}
+
+.c8:before {
+  content: '';
+  position: absolute;
+  height: 24px;
+  width: 24px;
+  left: 0px;
+  top: 0px;
+  border-radius: 50%;
+  box-sizing: border-box;
+  border: solid 1px;
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+  -webkit-transition: .2s ease;
+  transition: .2s ease;
+}
+
+.c5 {
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  min-width: 48px;
+  min-height: 24px;
+}
+
+.c5 input {
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+}
+
+.c6:checked + .c7:before {
+  -webkit-transform: translateX(24px);
+  -ms-transform: translateX(24px);
+  transform: translateX(24px);
+  background-color: #00438f;
+  border-color: #00438f;
+}
+
+.c6:checked + .c7 {
+  background-color: #e1ebfa;
+}
+
+.c6:focus + .c7:before {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c2 {
+  padding: 4px 0;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle__StyledToggle-sc-1oqd206-0 tNttj"
+      className="c1 c2"
     >
       <div
         id="Toggle-label"
       >
         <div
-          class="Box-sc-1qu1edy-0 ilQgHG"
+          className="c3"
         >
           <span
-            style="font-size:14px;font-weight:600;line-height:1.71428571"
+            style={
+              Object {
+                "fontSize": "14px",
+                "fontWeight": "600",
+                "lineHeight": "1.71428571",
+              }
+            }
           >
             Toggle
           </span>
         </div>
         <div
-          class="ClickInputLabel-j2axnv-0 kemUmZ"
+          className="c4"
+          disabled={false}
+          onClick={[Function]}
         >
           <div
-            class="ToggleButton__Switch-asgrb8-1 hOMJxD"
+            className="c5"
           >
             <input
-              aria-invalid="false"
+              aria-invalid={false}
               aria-labelledby="Toggle-label"
-              aria-required="false"
-              class="ToggleButton__ToggleInput-asgrb8-2 lcDvtB"
+              aria-required={false}
+              className="c6"
+              disabled={false}
+              id={null}
+              onChange={[Function]}
+              onClick={[Function]}
+              required={false}
               type="checkbox"
               value="on"
             />
             <span
-              class="ToggleButton__Slider-asgrb8-0 bLvWmF"
+              className="c7 c8"
+              disabled={false}
             />
           </div>
           <p
-            class="Text-sc-1wu7vpu-0 cOGezP"
+            className="c9"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             off
           </p>

--- a/components/src/Tooltip/__snapshots__/Tooltip.story.storyshot
+++ b/components/src/Tooltip/__snapshots__/Tooltip.story.storyshot
@@ -1,21 +1,118 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Tooltip Tooltip 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  padding: 64px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c2 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c2:hover {
+  background-color: #e1ebfa;
+}
+
+.c2:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c2:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c2:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c2:disabled {
+  opacity: .5;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 izRVrz"
+      className="Box-sc-1qu1edy-0 c1"
     >
       <button
         aria-describedby="random-id-13"
-        aria-expanded="false"
-        aria-haspopup="true"
+        aria-expanded={false}
+        aria-haspopup={true}
         aria-label="Open"
-        class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+        className="c2"
+        disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        size="medium"
       >
          Button 
       </button>
@@ -25,31 +122,224 @@ exports[`Storyshots Tooltip Tooltip 1`] = `
 `;
 
 exports[`Storyshots Tooltip open by default 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  position: absolute;
+  height: 8px;
+  width: 8px;
+  margin: 12px;
+  margin-top: -7px;
+  top: 0;
+}
+
+.c3:before {
+  border-style: solid;
+  content: '';
+  display: block;
+  height: 0;
+  margin: auto;
+  position: absolute;
+  width: 0;
+}
+
+.c3:after {
+  border-style: solid;
+  content: '';
+  display: block;
+  height: 0;
+  margin: auto;
+  position: absolute;
+  width: 0;
+}
+
+.c3:before {
+  border-color: transparent transparent #c0c8d1 transparent;
+  border-width: 0 8px 8px 8px;
+}
+
+.c3:after {
+  border-color: transparent transparent #ffffff transparent;
+  border-width: 0 8px 8px 8px;
+  left: -4px;
+}
+
+.c3:before {
+  top: -2px;
+  left: -4px;
+}
+
+.c3:after {
+  left: -4px;
+}
+
+.c1 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c1:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c1:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
+.c2 {
+  max-width: 24em;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  font-size: 14px;
+  background-color: #ffffff;
+  border-radius: 4px;
+  border: 1px solid #c0c8d1;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.18);
+  padding: 8px;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+  z-index: 100;
+  margin-top: 4px;
+  top: 0;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
       aria-describedby="random-id-37"
-      aria-expanded="true"
-      aria-haspopup="true"
+      aria-expanded={true}
+      aria-haspopup={true}
       aria-label="Close"
-      class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+      className="c1"
+      disabled={false}
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      size="medium"
     >
       Hover me
     </button>
     <div
-      class="Box-sc-1qu1edy-0 Tooltip__TooltipContainer-sc-1a42ebx-0 byNSVe  nds-popper-pop-up"
+      className="Box-sc-1qu1edy-0 c2  nds-popper-pop-up"
       id="random-id-37"
-      open=""
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      open={true}
       role="tooltip"
-      style="position:absolute;top:0;left:0;opacity:0;pointer-events:none"
+      style={
+        Object {
+          "left": 0,
+          "opacity": 0,
+          "pointerEvents": "none",
+          "position": "absolute",
+          "top": 0,
+        }
+      }
     >
-      I am an open Tooltip!
+      I
+       
+      a
+      m
+       
+      a
+      n
+       
+      o
+      p
+      e
+      n
+       
+      T
+      o
+      o
+      l
+      t
+      i
+      p
+      !
       <div
-        class="PopperArrow-sc-1bcgj4w-0 dVKthg"
+        className="c3"
+        style={Object {}}
       />
     </div>
   </div>
@@ -57,18 +347,107 @@ exports[`Storyshots Tooltip open by default 1`] = `
 `;
 
 exports[`Storyshots Tooltip with Button passed in 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c1:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c1:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
       aria-describedby="random-id-29"
-      aria-expanded="false"
-      aria-haspopup="true"
+      aria-expanded={false}
+      aria-haspopup={true}
       aria-label="Open"
-      class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+      className="c1"
+      disabled={false}
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      size="medium"
     >
        Button 
     </button>
@@ -77,18 +456,107 @@ exports[`Storyshots Tooltip with Button passed in 1`] = `
 `;
 
 exports[`Storyshots Tooltip with Link passed in 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c1:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c1:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
       aria-describedby="random-id-28"
-      aria-expanded="false"
-      aria-haspopup="true"
+      aria-expanded={false}
+      aria-haspopup={true}
       aria-label="Open"
-      class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+      className="c1"
+      disabled={false}
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      size="medium"
     >
        Button 
     </button>
@@ -97,18 +565,107 @@ exports[`Storyshots Tooltip with Link passed in 1`] = `
 `;
 
 exports[`Storyshots Tooltip with custom hideDelay 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c1:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c1:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
       aria-describedby="random-id-31"
-      aria-expanded="false"
-      aria-haspopup="true"
+      aria-expanded={false}
+      aria-haspopup={true}
       aria-label="Open"
-      class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+      className="c1"
+      disabled={false}
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      size="medium"
     >
        Button 
     </button>
@@ -117,34 +674,322 @@ exports[`Storyshots Tooltip with custom hideDelay 1`] = `
 `;
 
 exports[`Storyshots Tooltip with custom maxWidth 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  padding: 64px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c4 {
+  position: absolute;
+  height: 8px;
+  width: 8px;
+  margin: 12px;
+  margin-top: -7px;
+  top: 0;
+}
+
+.c4:before {
+  border-style: solid;
+  content: '';
+  display: block;
+  height: 0;
+  margin: auto;
+  position: absolute;
+  width: 0;
+}
+
+.c4:after {
+  border-style: solid;
+  content: '';
+  display: block;
+  height: 0;
+  margin: auto;
+  position: absolute;
+  width: 0;
+}
+
+.c4:before {
+  border-color: transparent transparent #c0c8d1 transparent;
+  border-width: 0 8px 8px 8px;
+}
+
+.c4:after {
+  border-color: transparent transparent #ffffff transparent;
+  border-width: 0 8px 8px 8px;
+  left: -4px;
+}
+
+.c4:before {
+  top: -2px;
+  left: -4px;
+}
+
+.c4:after {
+  left: -4px;
+}
+
+.c2 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c2:hover {
+  background-color: #e1ebfa;
+}
+
+.c2:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c2:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c2:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c2:disabled {
+  opacity: .5;
+}
+
+.c3 {
+  max-width: 128px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  font-size: 14px;
+  background-color: #ffffff;
+  border-radius: 4px;
+  border: 1px solid #c0c8d1;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.18);
+  padding: 8px;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+  z-index: 100;
+  margin-top: 4px;
+  top: 0;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 izRVrz"
+      className="Box-sc-1qu1edy-0 c1"
     >
       <button
         aria-describedby="random-id-15"
-        aria-expanded="true"
-        aria-haspopup="true"
+        aria-expanded={true}
+        aria-haspopup={true}
         aria-label="Close"
-        class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+        className="c2"
+        disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        size="medium"
       >
          Button 
       </button>
       <div
-        class="Box-sc-1qu1edy-0 Tooltip__TooltipContainer-sc-1a42ebx-0 iBJJpr  nds-popper-pop-up"
+        className="Box-sc-1qu1edy-0 c3  nds-popper-pop-up"
         id="random-id-15"
-        open=""
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        open={true}
         role="tooltip"
-        style="position:absolute;top:0;left:0;opacity:0;pointer-events:none"
+        style={
+          Object {
+            "left": 0,
+            "opacity": 0,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "top": 0,
+          }
+        }
       >
-        I am a Tooltip! I have very long text, but I have a smaller maxWidth prop that causes me to wrap frequently.
+        I
+         
+        a
+        m
+         
+        a
+         
+        T
+        o
+        o
+        l
+        t
+        i
+        p
+        !
+         
+        I
+         
+        h
+        a
+        v
+        e
+         
+        v
+        e
+        r
+        y
+         
+        l
+        o
+        n
+        g
+         
+        t
+        e
+        x
+        t
+        ,
+         
+        b
+        u
+        t
+         
+        I
+         
+        h
+        a
+        v
+        e
+         
+        a
+         
+        s
+        m
+        a
+        l
+        l
+        e
+        r
+         
+        m
+        a
+        x
+        W
+        i
+        d
+        t
+        h
+         
+        p
+        r
+        o
+        p
+         
+        t
+        h
+        a
+        t
+         
+        c
+        a
+        u
+        s
+        e
+        s
+         
+        m
+        e
+         
+        t
+        o
+         
+        w
+        r
+        a
+        p
+         
+        f
+        r
+        e
+        q
+        u
+        e
+        n
+        t
+        l
+        y
+        .
         <div
-          class="PopperArrow-sc-1bcgj4w-0 dVKthg"
+          className="c4"
+          style={Object {}}
         />
       </div>
     </div>
@@ -153,18 +998,107 @@ exports[`Storyshots Tooltip with custom maxWidth 1`] = `
 `;
 
 exports[`Storyshots Tooltip with custom showDelay 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c1:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c1:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
       aria-describedby="random-id-30"
-      aria-expanded="false"
-      aria-haspopup="true"
+      aria-expanded={false}
+      aria-haspopup={true}
       aria-label="Open"
-      class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+      className="c1"
+      disabled={false}
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      size="medium"
     >
        Button 
     </button>
@@ -173,60 +1107,199 @@ exports[`Storyshots Tooltip with custom showDelay 1`] = `
 `;
 
 exports[`Storyshots Tooltip with other focusable elements 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c4 {
+  background-color: #216beb;
+  width: 200px;
+}
+
+.c5 {
+  background-color: #216beb;
+}
+
+.c3 {
+  margin-right: 16px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  background-color: #216beb;
+  color: currentColor;
+}
+
+.c1 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c1:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c1:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c1:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c1:disabled {
+  opacity: .5;
+}
+
+.c2 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c2:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <button
       aria-describedby="random-id-32"
-      aria-expanded="false"
-      aria-haspopup="true"
+      aria-expanded={false}
+      aria-haspopup={true}
       aria-label="Open"
-      class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+      className="c1"
+      disabled={false}
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      size="medium"
     >
        Button 
     </button>
     <a
       aria-describedby="random-id-33"
-      aria-expanded="false"
-      aria-haspopup="true"
+      aria-expanded={false}
+      aria-haspopup={true}
       aria-label="Open"
-      class="Link-sc-1lpx3d0-0 gxbSxg"
+      className="c2"
       color="blue"
-      font-size="medium"
+      fontSize="medium"
       href="/"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
        Link 
     </a>
     <span
       aria-describedby="random-id-34"
-      aria-expanded="false"
-      aria-haspopup="true"
+      aria-expanded={false}
+      aria-haspopup={true}
       aria-label="Open"
-      class="Text-sc-1wu7vpu-0 fSZLdr"
+      className="c3"
       color="currentColor"
-      font-size="medium"
+      disabled={false}
+      fontSize="medium"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       Inline Text
     </span>
     <div
       aria-describedby="random-id-35"
-      aria-expanded="false"
-      aria-haspopup="true"
+      aria-expanded={false}
+      aria-haspopup={true}
       aria-label="Open"
-      class="Box-sc-1qu1edy-0 hmICZS"
+      className="c4"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
       width="200px"
     >
       Box width 200px
     </div>
     <div
       aria-describedby="random-id-36"
-      aria-expanded="false"
-      aria-haspopup="true"
+      aria-expanded={false}
+      aria-haspopup={true}
       aria-label="Open"
-      class="Box-sc-1qu1edy-0 fpEmqv"
+      className="c5"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       Box
     </div>
@@ -235,277 +1308,756 @@ exports[`Storyshots Tooltip with other focusable elements 1`] = `
 `;
 
 exports[`Storyshots Tooltip with placement 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  margin-top: 48px;
+  margin-bottom: 48px;
+  margin-left: 64px;
+  margin-right: 64px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
+}
+
+.c4 {
+  position: absolute;
+  height: 8px;
+  width: 8px;
+  margin: 12px;
+  margin-top: -7px;
+  top: 0;
+}
+
+.c4:before {
+  border-style: solid;
+  content: '';
+  display: block;
+  height: 0;
+  margin: auto;
+  position: absolute;
+  width: 0;
+}
+
+.c4:after {
+  border-style: solid;
+  content: '';
+  display: block;
+  height: 0;
+  margin: auto;
+  position: absolute;
+  width: 0;
+}
+
+.c4:before {
+  border-color: transparent transparent #c0c8d1 transparent;
+  border-width: 0 8px 8px 8px;
+}
+
+.c4:after {
+  border-color: transparent transparent #ffffff transparent;
+  border-width: 0 8px 8px 8px;
+  left: -4px;
+}
+
+.c4:before {
+  top: -2px;
+  left: -4px;
+}
+
+.c4:after {
+  left: -4px;
+}
+
+.c2 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c2:hover {
+  background-color: #e1ebfa;
+}
+
+.c2:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c2:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c2:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c2:disabled {
+  opacity: .5;
+}
+
+.c3 {
+  max-width: 24em;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  font-size: 14px;
+  background-color: #ffffff;
+  border-radius: 4px;
+  border: 1px solid #c0c8d1;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.18);
+  padding: 8px;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+  z-index: 100;
+  margin-top: 4px;
+  top: 0;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 dxTGaz"
+      className="Box-sc-1qu1edy-0 c1"
     >
       <button
         aria-describedby="random-id-16"
-        aria-expanded="true"
-        aria-haspopup="true"
+        aria-expanded={true}
+        aria-haspopup={true}
         aria-label="Close"
-        class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+        className="c2"
+        disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        size="medium"
       >
         Tooltip trigger
       </button>
       <div
-        class="Box-sc-1qu1edy-0 Tooltip__TooltipContainer-sc-1a42ebx-0 byNSVe  nds-popper-pop-up"
+        className="Box-sc-1qu1edy-0 c3  nds-popper-pop-up"
         id="random-id-16"
-        open=""
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        open={true}
         role="tooltip"
-        style="position:absolute;top:0;left:0;opacity:0;pointer-events:none"
+        style={
+          Object {
+            "left": 0,
+            "opacity": 0,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "top": 0,
+          }
+        }
       >
-        top-start
+        t
+        o
+        p
+        -
+        s
+        t
+        a
+        r
+        t
         <div
-          class="PopperArrow-sc-1bcgj4w-0 dVKthg"
+          className="c4"
+          style={Object {}}
         />
       </div>
       <button
         aria-describedby="random-id-17"
-        aria-expanded="true"
-        aria-haspopup="true"
+        aria-expanded={true}
+        aria-haspopup={true}
         aria-label="Close"
-        class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+        className="c2"
+        disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        size="medium"
       >
         Tooltip trigger
       </button>
       <div
-        class="Box-sc-1qu1edy-0 Tooltip__TooltipContainer-sc-1a42ebx-0 byNSVe  nds-popper-pop-up"
+        className="Box-sc-1qu1edy-0 c3  nds-popper-pop-up"
         id="random-id-17"
-        open=""
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        open={true}
         role="tooltip"
-        style="position:absolute;top:0;left:0;opacity:0;pointer-events:none"
+        style={
+          Object {
+            "left": 0,
+            "opacity": 0,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "top": 0,
+          }
+        }
       >
-        top
+        t
+        o
+        p
         <div
-          class="PopperArrow-sc-1bcgj4w-0 dVKthg"
+          className="c4"
+          style={Object {}}
         />
       </div>
       <button
         aria-describedby="random-id-18"
-        aria-expanded="true"
-        aria-haspopup="true"
+        aria-expanded={true}
+        aria-haspopup={true}
         aria-label="Close"
-        class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+        className="c2"
+        disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        size="medium"
       >
         Tooltip trigger
       </button>
       <div
-        class="Box-sc-1qu1edy-0 Tooltip__TooltipContainer-sc-1a42ebx-0 byNSVe  nds-popper-pop-up"
+        className="Box-sc-1qu1edy-0 c3  nds-popper-pop-up"
         id="random-id-18"
-        open=""
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        open={true}
         role="tooltip"
-        style="position:absolute;top:0;left:0;opacity:0;pointer-events:none"
+        style={
+          Object {
+            "left": 0,
+            "opacity": 0,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "top": 0,
+          }
+        }
       >
-        top-end
+        t
+        o
+        p
+        -
+        e
+        n
+        d
         <div
-          class="PopperArrow-sc-1bcgj4w-0 dVKthg"
+          className="c4"
+          style={Object {}}
         />
       </div>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 dxTGaz"
+      className="Box-sc-1qu1edy-0 c1"
     >
       <button
         aria-describedby="random-id-19"
-        aria-expanded="true"
-        aria-haspopup="true"
+        aria-expanded={true}
+        aria-haspopup={true}
         aria-label="Close"
-        class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+        className="c2"
+        disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        size="medium"
       >
         Tooltip trigger
       </button>
       <div
-        class="Box-sc-1qu1edy-0 Tooltip__TooltipContainer-sc-1a42ebx-0 byNSVe  nds-popper-pop-up"
+        className="Box-sc-1qu1edy-0 c3  nds-popper-pop-up"
         id="random-id-19"
-        open=""
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        open={true}
         role="tooltip"
-        style="position:absolute;top:0;left:0;opacity:0;pointer-events:none"
+        style={
+          Object {
+            "left": 0,
+            "opacity": 0,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "top": 0,
+          }
+        }
       >
-        left-start
+        l
+        e
+        f
+        t
+        -
+        s
+        t
+        a
+        r
+        t
         <div
-          class="PopperArrow-sc-1bcgj4w-0 dVKthg"
+          className="c4"
+          style={Object {}}
         />
       </div>
       <button
         aria-describedby="random-id-20"
-        aria-expanded="true"
-        aria-haspopup="true"
+        aria-expanded={true}
+        aria-haspopup={true}
         aria-label="Close"
-        class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+        className="c2"
+        disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        size="medium"
       >
         Tooltip trigger
       </button>
       <div
-        class="Box-sc-1qu1edy-0 Tooltip__TooltipContainer-sc-1a42ebx-0 byNSVe  nds-popper-pop-up"
+        className="Box-sc-1qu1edy-0 c3  nds-popper-pop-up"
         id="random-id-20"
-        open=""
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        open={true}
         role="tooltip"
-        style="position:absolute;top:0;left:0;opacity:0;pointer-events:none"
+        style={
+          Object {
+            "left": 0,
+            "opacity": 0,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "top": 0,
+          }
+        }
       >
-        left
+        l
+        e
+        f
+        t
         <div
-          class="PopperArrow-sc-1bcgj4w-0 dVKthg"
+          className="c4"
+          style={Object {}}
         />
       </div>
       <button
         aria-describedby="random-id-21"
-        aria-expanded="true"
-        aria-haspopup="true"
+        aria-expanded={true}
+        aria-haspopup={true}
         aria-label="Close"
-        class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+        className="c2"
+        disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        size="medium"
       >
         Tooltip trigger
       </button>
       <div
-        class="Box-sc-1qu1edy-0 Tooltip__TooltipContainer-sc-1a42ebx-0 byNSVe  nds-popper-pop-up"
+        className="Box-sc-1qu1edy-0 c3  nds-popper-pop-up"
         id="random-id-21"
-        open=""
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        open={true}
         role="tooltip"
-        style="position:absolute;top:0;left:0;opacity:0;pointer-events:none"
+        style={
+          Object {
+            "left": 0,
+            "opacity": 0,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "top": 0,
+          }
+        }
       >
-        left-end
+        l
+        e
+        f
+        t
+        -
+        e
+        n
+        d
         <div
-          class="PopperArrow-sc-1bcgj4w-0 dVKthg"
+          className="c4"
+          style={Object {}}
         />
       </div>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 dxTGaz"
+      className="Box-sc-1qu1edy-0 c1"
     >
       <button
         aria-describedby="random-id-22"
-        aria-expanded="true"
-        aria-haspopup="true"
+        aria-expanded={true}
+        aria-haspopup={true}
         aria-label="Close"
-        class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+        className="c2"
+        disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        size="medium"
       >
         Tooltip trigger
       </button>
       <div
-        class="Box-sc-1qu1edy-0 Tooltip__TooltipContainer-sc-1a42ebx-0 byNSVe  nds-popper-pop-up"
+        className="Box-sc-1qu1edy-0 c3  nds-popper-pop-up"
         id="random-id-22"
-        open=""
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        open={true}
         role="tooltip"
-        style="position:absolute;top:0;left:0;opacity:0;pointer-events:none"
+        style={
+          Object {
+            "left": 0,
+            "opacity": 0,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "top": 0,
+          }
+        }
       >
-        right-start
+        r
+        i
+        g
+        h
+        t
+        -
+        s
+        t
+        a
+        r
+        t
         <div
-          class="PopperArrow-sc-1bcgj4w-0 dVKthg"
+          className="c4"
+          style={Object {}}
         />
       </div>
       <button
         aria-describedby="random-id-23"
-        aria-expanded="true"
-        aria-haspopup="true"
+        aria-expanded={true}
+        aria-haspopup={true}
         aria-label="Close"
-        class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+        className="c2"
+        disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        size="medium"
       >
         Tooltip trigger
       </button>
       <div
-        class="Box-sc-1qu1edy-0 Tooltip__TooltipContainer-sc-1a42ebx-0 byNSVe  nds-popper-pop-up"
+        className="Box-sc-1qu1edy-0 c3  nds-popper-pop-up"
         id="random-id-23"
-        open=""
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        open={true}
         role="tooltip"
-        style="position:absolute;top:0;left:0;opacity:0;pointer-events:none"
+        style={
+          Object {
+            "left": 0,
+            "opacity": 0,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "top": 0,
+          }
+        }
       >
-        right
+        r
+        i
+        g
+        h
+        t
         <div
-          class="PopperArrow-sc-1bcgj4w-0 dVKthg"
+          className="c4"
+          style={Object {}}
         />
       </div>
       <button
         aria-describedby="random-id-24"
-        aria-expanded="true"
-        aria-haspopup="true"
+        aria-expanded={true}
+        aria-haspopup={true}
         aria-label="Close"
-        class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+        className="c2"
+        disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        size="medium"
       >
         Tooltip trigger
       </button>
       <div
-        class="Box-sc-1qu1edy-0 Tooltip__TooltipContainer-sc-1a42ebx-0 byNSVe  nds-popper-pop-up"
+        className="Box-sc-1qu1edy-0 c3  nds-popper-pop-up"
         id="random-id-24"
-        open=""
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        open={true}
         role="tooltip"
-        style="position:absolute;top:0;left:0;opacity:0;pointer-events:none"
+        style={
+          Object {
+            "left": 0,
+            "opacity": 0,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "top": 0,
+          }
+        }
       >
-        right-end
+        r
+        i
+        g
+        h
+        t
+        -
+        e
+        n
+        d
         <div
-          class="PopperArrow-sc-1bcgj4w-0 dVKthg"
+          className="c4"
+          style={Object {}}
         />
       </div>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 dxTGaz"
+      className="Box-sc-1qu1edy-0 c1"
     >
       <button
         aria-describedby="random-id-25"
-        aria-expanded="true"
-        aria-haspopup="true"
+        aria-expanded={true}
+        aria-haspopup={true}
         aria-label="Close"
-        class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+        className="c2"
+        disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        size="medium"
       >
         Tooltip trigger
       </button>
       <div
-        class="Box-sc-1qu1edy-0 Tooltip__TooltipContainer-sc-1a42ebx-0 byNSVe  nds-popper-pop-up"
+        className="Box-sc-1qu1edy-0 c3  nds-popper-pop-up"
         id="random-id-25"
-        open=""
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        open={true}
         role="tooltip"
-        style="position:absolute;top:0;left:0;opacity:0;pointer-events:none"
+        style={
+          Object {
+            "left": 0,
+            "opacity": 0,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "top": 0,
+          }
+        }
       >
-        bottom-start
+        b
+        o
+        t
+        t
+        o
+        m
+        -
+        s
+        t
+        a
+        r
+        t
         <div
-          class="PopperArrow-sc-1bcgj4w-0 dVKthg"
+          className="c4"
+          style={Object {}}
         />
       </div>
       <button
         aria-describedby="random-id-26"
-        aria-expanded="true"
-        aria-haspopup="true"
+        aria-expanded={true}
+        aria-haspopup={true}
         aria-label="Close"
-        class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+        className="c2"
+        disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        size="medium"
       >
         Tooltip trigger
       </button>
       <div
-        class="Box-sc-1qu1edy-0 Tooltip__TooltipContainer-sc-1a42ebx-0 byNSVe  nds-popper-pop-up"
+        className="Box-sc-1qu1edy-0 c3  nds-popper-pop-up"
         id="random-id-26"
-        open=""
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        open={true}
         role="tooltip"
-        style="position:absolute;top:0;left:0;opacity:0;pointer-events:none"
+        style={
+          Object {
+            "left": 0,
+            "opacity": 0,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "top": 0,
+          }
+        }
       >
-        bottom
+        b
+        o
+        t
+        t
+        o
+        m
         <div
-          class="PopperArrow-sc-1bcgj4w-0 dVKthg"
+          className="c4"
+          style={Object {}}
         />
       </div>
       <button
         aria-describedby="random-id-27"
-        aria-expanded="true"
-        aria-haspopup="true"
+        aria-expanded={true}
+        aria-haspopup={true}
         aria-label="Close"
-        class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+        className="c2"
+        disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        size="medium"
       >
         Tooltip trigger
       </button>
       <div
-        class="Box-sc-1qu1edy-0 Tooltip__TooltipContainer-sc-1a42ebx-0 byNSVe  nds-popper-pop-up"
+        className="Box-sc-1qu1edy-0 c3  nds-popper-pop-up"
         id="random-id-27"
-        open=""
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        open={true}
         role="tooltip"
-        style="position:absolute;top:0;left:0;opacity:0;pointer-events:none"
+        style={
+          Object {
+            "left": 0,
+            "opacity": 0,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "top": 0,
+          }
+        }
       >
-        bottom-end
+        b
+        o
+        t
+        t
+        o
+        m
+        -
+        e
+        n
+        d
         <div
-          class="PopperArrow-sc-1bcgj4w-0 dVKthg"
+          className="c4"
+          style={Object {}}
         />
       </div>
     </div>
@@ -514,34 +2066,369 @@ exports[`Storyshots Tooltip with placement 1`] = `
 `;
 
 exports[`Storyshots Tooltip with wrapped text 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  padding: 64px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c4 {
+  position: absolute;
+  height: 8px;
+  width: 8px;
+  margin: 12px;
+  margin-top: -7px;
+  top: 0;
+}
+
+.c4:before {
+  border-style: solid;
+  content: '';
+  display: block;
+  height: 0;
+  margin: auto;
+  position: absolute;
+  width: 0;
+}
+
+.c4:after {
+  border-style: solid;
+  content: '';
+  display: block;
+  height: 0;
+  margin: auto;
+  position: absolute;
+  width: 0;
+}
+
+.c4:before {
+  border-color: transparent transparent #c0c8d1 transparent;
+  border-width: 0 8px 8px 8px;
+}
+
+.c4:after {
+  border-color: transparent transparent #ffffff transparent;
+  border-width: 0 8px 8px 8px;
+  left: -4px;
+}
+
+.c4:before {
+  top: -2px;
+  left: -4px;
+}
+
+.c4:after {
+  left: -4px;
+}
+
+.c2 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c2:hover {
+  background-color: #e1ebfa;
+}
+
+.c2:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c2:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c2:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c2:disabled {
+  opacity: .5;
+}
+
+.c3 {
+  max-width: 24em;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  font-size: 14px;
+  background-color: #ffffff;
+  border-radius: 4px;
+  border: 1px solid #c0c8d1;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.18);
+  padding: 8px;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+  z-index: 100;
+  margin-top: 4px;
+  top: 0;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 izRVrz"
+      className="Box-sc-1qu1edy-0 c1"
     >
       <button
         aria-describedby="random-id-14"
-        aria-expanded="true"
-        aria-haspopup="true"
+        aria-expanded={true}
+        aria-haspopup={true}
         aria-label="Close"
-        class="Button__WrapperButton-sc-1omxup2-0 hkfOQr"
+        className="c2"
+        disabled={false}
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        size="medium"
       >
          Button 
       </button>
       <div
-        class="Box-sc-1qu1edy-0 Tooltip__TooltipContainer-sc-1a42ebx-0 byNSVe  nds-popper-pop-up"
+        className="Box-sc-1qu1edy-0 c3  nds-popper-pop-up"
         id="random-id-14"
-        open=""
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        open={true}
         role="tooltip"
-        style="position:absolute;top:0;left:0;opacity:0;pointer-events:none"
+        style={
+          Object {
+            "left": 0,
+            "opacity": 0,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "top": 0,
+          }
+        }
       >
-        I am a Tooltip! I have very long text, and my default max-width is 24em (based on 14px font-size), which is equal to 336px, or approximately 45 characters.
+        I
+         
+        a
+        m
+         
+        a
+         
+        T
+        o
+        o
+        l
+        t
+        i
+        p
+        !
+         
+        I
+         
+        h
+        a
+        v
+        e
+         
+        v
+        e
+        r
+        y
+         
+        l
+        o
+        n
+        g
+         
+        t
+        e
+        x
+        t
+        ,
+         
+        a
+        n
+        d
+         
+        m
+        y
+         
+        d
+        e
+        f
+        a
+        u
+        l
+        t
+         
+        m
+        a
+        x
+        -
+        w
+        i
+        d
+        t
+        h
+         
+        i
+        s
+         
+        2
+        4
+        e
+        m
+         
+        (
+        b
+        a
+        s
+        e
+        d
+         
+        o
+        n
+         
+        1
+        4
+        p
+        x
+         
+        f
+        o
+        n
+        t
+        -
+        s
+        i
+        z
+        e
+        )
+        ,
+         
+        w
+        h
+        i
+        c
+        h
+         
+        i
+        s
+         
+        e
+        q
+        u
+        a
+        l
+         
+        t
+        o
+         
+        3
+        3
+        6
+        p
+        x
+        ,
+         
+        o
+        r
+         
+        a
+        p
+        p
+        r
+        o
+        x
+        i
+        m
+        a
+        t
+        e
+        l
+        y
+         
+        4
+        5
+         
+        c
+        h
+        a
+        r
+        a
+        c
+        t
+        e
+        r
+        s
+        .
         <div
-          class="PopperArrow-sc-1bcgj4w-0 dVKthg"
+          className="c4"
+          style={Object {}}
         />
       </div>
     </div>

--- a/components/src/TruncatedText/__snapshots__/TruncatedText.story.storyshot
+++ b/components/src/TruncatedText/__snapshots__/TruncatedText.story.storyshot
@@ -1,20 +1,66 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots TruncatedText TruncatedText 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c2 {
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  cursor: pointer;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <p
       aria-describedby="random-id-38"
-      aria-expanded="false"
-      aria-haspopup="true"
+      aria-expanded={false}
+      aria-haspopup={true}
       aria-label="Open"
-      class="Text-sc-1wu7vpu-0 RbfMK TruncatedText__StyledWrapper-noy865-0 jYAXtT"
+      className="c1 c2"
       color="currentColor"
-      font-size="medium"
+      disabled={false}
+      fontSize="medium"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       Special instructions...
     </p>
@@ -23,20 +69,65 @@ exports[`Storyshots TruncatedText TruncatedText 1`] = `
 `;
 
 exports[`Storyshots TruncatedText as title 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  margin-top: 0;
+  margin-bottom: 48px;
+  font-size: 46px;
+  line-height: 1.04347826;
+  font-weight: 300;
+}
+
+.c2 {
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  cursor: pointer;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <h1
       aria-describedby="random-id-41"
-      aria-expanded="false"
-      aria-haspopup="true"
+      aria-expanded={false}
+      aria-haspopup={true}
       aria-label="Open"
-      class="Text-sc-1wu7vpu-0-h1 VooJu TruncatedText__StyledWrapper-noy865-0 jYAXtT"
-      font-size="largest"
-      font-weight="light"
+      className="c1 c2"
+      fontSize="largest"
+      fontWeight="light"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       Special instructions...
     </h1>
@@ -45,16 +136,58 @@ exports[`Storyshots TruncatedText as title 1`] = `
 `;
 
 exports[`Storyshots TruncatedText under max characters 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c2 {
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  cursor: default;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <p
-      class="Text-sc-1wu7vpu-0 RbfMK TruncatedText__StyledWrapper-noy865-0 heuHsr"
+      className="c1 c2"
       color="currentColor"
-      font-size="medium"
+      disabled={false}
+      fontSize="medium"
     >
       Item is available
     </p>
@@ -63,20 +196,66 @@ exports[`Storyshots TruncatedText under max characters 1`] = `
 `;
 
 exports[`Storyshots TruncatedText with custom truncation indicator 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c2 {
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  cursor: pointer;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <p
       aria-describedby="random-id-40"
-      aria-expanded="false"
-      aria-haspopup="true"
+      aria-expanded={false}
+      aria-haspopup={true}
       aria-label="Open"
-      class="Text-sc-1wu7vpu-0 RbfMK TruncatedText__StyledWrapper-noy865-0 jYAXtT"
+      className="c1 c2"
       color="currentColor"
-      font-size="medium"
+      disabled={false}
+      fontSize="medium"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       Special instructions + 2...
     </p>
@@ -85,20 +264,66 @@ exports[`Storyshots TruncatedText with custom truncation indicator 1`] = `
 `;
 
 exports[`Storyshots TruncatedText with max characters 10 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c2 {
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  cursor: pointer;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <p
       aria-describedby="random-id-39"
-      aria-expanded="false"
-      aria-haspopup="true"
+      aria-expanded={false}
+      aria-haspopup={true}
       aria-label="Open"
-      class="Text-sc-1wu7vpu-0 RbfMK TruncatedText__StyledWrapper-noy865-0 jYAXtT"
+      className="c1 c2"
       color="currentColor"
-      font-size="medium"
+      disabled={false}
+      fontSize="medium"
+      onBlur={[Function]}
+      onFocus={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
       Item is av...
     </p>
@@ -107,16 +332,58 @@ exports[`Storyshots TruncatedText with max characters 10 1`] = `
 `;
 
 exports[`Storyshots TruncatedText without tooltip 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c2 {
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  cursor: default;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <p
-      class="Text-sc-1wu7vpu-0 RbfMK TruncatedText__StyledWrapper-noy865-0 heuHsr"
+      className="c1 c2"
       color="currentColor"
-      font-size="medium"
+      disabled={false}
+      fontSize="medium"
     >
       Special instructions...
     </p>

--- a/components/src/Type/__snapshots__/Headings.story.storyshot
+++ b/components/src/Type/__snapshots__/Headings.story.storyshot
@@ -1,16 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Headings Section Title 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  margin-top: 0;
+  margin-bottom: 16px;
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.23076923;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <h2
-      class="Text-sc-1wu7vpu-0-h2 heWDlS"
-      font-size="larger"
-      font-weight="medium"
+      className="c1"
+      fontSize="larger"
+      fontWeight="medium"
     >
       Section Title
     </h2>
@@ -19,16 +53,50 @@ exports[`Storyshots Headings Section Title 1`] = `
 `;
 
 exports[`Storyshots Headings Subsection Title 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  margin-top: 0;
+  margin-bottom: 8px;
+  font-weight: 500;
+  font-size: 20px;
+  line-height: 1.2;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <h3
-      class="Text-sc-1wu7vpu-0-h3 Headings__SubsectionTitle-igpciy-0 hTTFeG"
-      font-size="large"
-      font-weight="medium"
+      className="Text-sc-1wu7vpu-0-h3 c1"
+      fontSize="large"
+      fontWeight="medium"
     >
       SubsectionTitle
     </h3>
@@ -37,16 +105,50 @@ exports[`Storyshots Headings Subsection Title 1`] = `
 `;
 
 exports[`Storyshots Headings Title 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  margin-top: 0;
+  margin-bottom: 48px;
+  font-size: 46px;
+  line-height: 1.04347826;
+  font-weight: 300;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <h1
-      class="Text-sc-1wu7vpu-0-h1 VooJu"
-      font-size="largest"
-      font-weight="light"
+      className="c1"
+      fontSize="largest"
+      fontWeight="light"
     >
       Title
     </h1>
@@ -55,23 +157,66 @@ exports[`Storyshots Headings Title 1`] = `
 `;
 
 exports[`Storyshots Headings With a custom margin 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c2 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c1 {
+  margin-bottom: 48px;
+  margin-top: 0;
+  font-size: 46px;
+  line-height: 1.04347826;
+  font-weight: 300;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <h1
-      class="Text-sc-1wu7vpu-0-h1 fKaScO"
-      font-size="largest"
-      font-weight="light"
+      className="c1"
+      fontSize="largest"
+      fontWeight="light"
     >
       Title
     </h1>
     <p
-      class="Text-sc-1wu7vpu-0 RbfMK"
+      className="c2"
       color="currentColor"
-      font-size="medium"
+      disabled={false}
+      fontSize="medium"
     >
       Lorem ipsum
     </p>

--- a/components/src/Type/__snapshots__/Text.story.storyshot
+++ b/components/src/Type/__snapshots__/Text.story.storyshot
@@ -1,44 +1,106 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Text Set to disabled 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  background-color: #ffffff;
+  padding: 16px;
+  margin: 16px;
+}
+
+.c3 {
+  background-color: #00438f;
+  padding: 16px;
+  margin: 16px;
+}
+
+.c5 {
+  background-color: #011e38;
+  padding: 16px;
+  margin: 16px;
+}
+
+.c2 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+  opacity: 0.3333;
+}
+
+.c4 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: #ffffff;
+  opacity: 0.3333;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 duXuoY"
+      className="c1"
     >
       <p
-        class="Text-sc-1wu7vpu-0 hdrQgs"
+        className="c2"
         color="currentColor"
-        disabled=""
-        font-size="medium"
+        disabled={true}
+        fontSize="medium"
       >
         Disabled text
       </p>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 fXRdUR"
+      className="c3"
     >
       <p
-        class="Text-sc-1wu7vpu-0 kUDEbP"
+        className="c4"
         color="white"
-        disabled=""
-        font-size="medium"
+        disabled={true}
+        fontSize="medium"
       >
         Disabled text
       </p>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 ffhBHW"
+      className="c5"
     >
       <p
-        class="Text-sc-1wu7vpu-0 kUDEbP"
+        className="c4"
         color="white"
-        disabled=""
-        font-size="medium"
+        disabled={true}
+        fontSize="medium"
       >
         Disabled text
       </p>
@@ -48,23 +110,68 @@ exports[`Storyshots Text Set to disabled 1`] = `
 `;
 
 exports[`Storyshots Text Set to inline 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  margin-right: 8px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c2 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <span
-      class="Text-sc-1wu7vpu-0 ipzFTA"
+      className="c1"
       color="currentColor"
-      font-size="medium"
+      disabled={false}
+      fontSize="medium"
     >
       Inline text
     </span>
     <span
-      class="Text-sc-1wu7vpu-0 RbfMK"
+      className="c2"
       color="currentColor"
-      font-size="medium"
+      disabled={false}
+      fontSize="medium"
     >
       Inline text
     </span>
@@ -73,16 +180,51 @@ exports[`Storyshots Text Set to inline 1`] = `
 `;
 
 exports[`Storyshots Text Text 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <p
-      class="Text-sc-1wu7vpu-0 RbfMK"
+      className="c1"
       color="currentColor"
-      font-size="medium"
+      disabled={false}
+      fontSize="medium"
     >
       Default text
     </p>
@@ -91,16 +233,51 @@ exports[`Storyshots Text Text 1`] = `
 `;
 
 exports[`Storyshots Text With a color 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: #216beb;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <p
-      class="Text-sc-1wu7vpu-0 dXhWql"
+      className="c1"
       color="blue"
-      font-size="medium"
+      disabled={false}
+      fontSize="medium"
     >
       Blue text
     </p>
@@ -109,23 +286,67 @@ exports[`Storyshots Text With a color 1`] = `
 `;
 
 exports[`Storyshots Text With a custom margin 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  margin-bottom: 24px;
+  margin-top: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c2 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <p
-      class="Text-sc-1wu7vpu-0 kLhDpw"
+      className="c1"
       color="currentColor"
-      font-size="medium"
+      disabled={false}
+      fontSize="medium"
     >
       Text 24px bottom margin.
     </p>
     <p
-      class="Text-sc-1wu7vpu-0 RbfMK"
+      className="c2"
       color="currentColor"
-      font-size="medium"
+      disabled={false}
+      fontSize="medium"
     >
       Text with default (0px) bottom margin.
     </p>
@@ -134,48 +355,116 @@ exports[`Storyshots Text With a custom margin 1`] = `
 `;
 
 exports[`Storyshots Text With a size 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  background-color: #f0f2f5;
+  padding: 16px;
+  margin-bottom: 24px;
+}
+
+.c2 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c3 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 14px;
+  line-height: 1.71428571;
+  color: currentColor;
+}
+
+.c4 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 14px;
+  line-height: 1.14285714;
+  color: currentColor;
+}
+
+.c5 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 12px;
+  line-height: 1.33333333;
+  color: currentColor;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 eBHmui"
+      className="c1"
     >
       <p
-        class="Text-sc-1wu7vpu-0 RbfMK"
+        className="c2"
         color="currentColor"
-        font-size="medium"
+        disabled={false}
+        fontSize="medium"
       >
         Default (16px/24px)
       </p>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 eBHmui"
+      className="c1"
     >
       <p
-        class="Text-sc-1wu7vpu-0 hsSevS"
+        className="c3"
         color="currentColor"
-        font-size="small"
+        disabled={false}
+        fontSize="small"
       >
         Small (14px/24px)
       </p>
       <p
-        class="Text-sc-1wu7vpu-0 gQDLhx"
+        className="c4"
         color="currentColor"
-        font-size="small"
+        disabled={false}
+        fontSize="small"
       >
         Small Compressed (14px/16px)
       </p>
     </div>
     <div
-      class="Box-sc-1qu1edy-0 eBHmui"
+      className="c1"
     >
       <p
-        class="Text-sc-1wu7vpu-0 kLNwfz"
+        className="c5"
         color="currentColor"
-        font-size="smaller"
+        disabled={false}
+        fontSize="smaller"
       >
         Smaller (12px/16px)
       </p>

--- a/components/src/Type/__snapshots__/Typography.story.storyshot
+++ b/components/src/Type/__snapshots__/Typography.story.storyshot
@@ -1,144 +1,244 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Typography Article 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c3 {
+  margin-bottom: 24px;
+  margin-top: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c8 {
+  margin-bottom: 24px;
+  margin-top: 0;
+  font-size: 0;
+  line-height: 1.71428571;
+  color: currentColor;
+}
+
+.c9 {
+  margin-bottom: 24px;
+  margin-top: 0;
+  font-size: 14px;
+  line-height: 1.14285714;
+  color: currentColor;
+}
+
+.c1 {
+  margin-top: 0;
+  margin-bottom: 48px;
+  font-size: 46px;
+  line-height: 1.04347826;
+  font-weight: 300;
+}
+
+.c2 {
+  margin-top: 0;
+  margin-bottom: 16px;
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.23076923;
+}
+
+.c4 {
+  margin-top: 0;
+  margin-bottom: 8px;
+  font-weight: 500;
+  font-size: 20px;
+  line-height: 1.2;
+}
+
+.c7 {
+  margin-bottom: 8px;
+  color: currentColor;
+}
+
+.c7:last-child {
+  margin-bottom: 0;
+}
+
+.c5 {
+  color: currentColor;
+  margin: 0;
+}
+
+.c5 .c6 {
+  margin-bottom: 8px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <h1
-      class="Text-sc-1wu7vpu-0-h1 VooJu"
-      font-size="largest"
-      font-weight="light"
+      className="c1"
+      fontSize="largest"
+      fontWeight="light"
     >
       Nunc vitae nisl vestibulum vitae nisl vestibulum vitae nisl vestibulum
     </h1>
     <h2
-      class="Text-sc-1wu7vpu-0-h2 heWDlS"
-      font-size="larger"
-      font-weight="medium"
+      className="c2"
+      fontSize="larger"
+      fontWeight="medium"
     >
       Donec leo felis vitae nisl vestibulum vitae nisl vestibulum vitae nisl vestibulum
     </h2>
     <p
-      class="Text-sc-1wu7vpu-0 kLhDpw"
+      className="c3"
       color="currentColor"
-      font-size="medium"
+      disabled={false}
+      fontSize="medium"
     >
       Nunc tempor eget mauris id facilisis. Morbi convallis mauris at fermentum gravida. Nunc lacinia a odio eu rutrum. Etiam in libero vestibulum, lobortis mi fermentum, pharetra lacus. Aliquam commodo molestie dolor, vel tristique orci efficitur eu. Nullam eleifend malesuada. Nam luctus blandit dignissim. Mauris eu odio tristique, lorem quis, lobortis nulla. Interdum et malesuada fames ac ante ipsum primis in faucibus. Nunc quis lacus felis. Ut convallis rhoncus orci. Maecenas sit amet leo dui. Integer semper porta dignissim.
     </p>
     <h3
-      class="Text-sc-1wu7vpu-0-h3 Headings__SubsectionTitle-igpciy-0 hTTFeG"
-      font-size="large"
-      font-weight="medium"
+      className="-h3 c4"
+      fontSize="large"
+      fontWeight="medium"
     >
       Long Titile that Hopefully wraps. Maybe now? How About Now? Now? Now? Now? Now? Now? Now?
     </h3>
     <p
-      class="Text-sc-1wu7vpu-0 kLhDpw"
+      className="c3"
       color="currentColor"
-      font-size="medium"
+      disabled={false}
+      fontSize="medium"
     >
       Porttitor urna sit amet, congue nulla. Etiam in posuere nibh. Nam pellentesque, lacus id elementum posuere, neque purus ullamcorper nunc, consequat mi velit eget mi. Duis ipsum augue, pulvinar ullamcorper fringilla in, dignissim congue velit.
     </p>
     <h2
-      class="Text-sc-1wu7vpu-0-h2 heWDlS"
-      font-size="larger"
-      font-weight="medium"
+      className="c2"
+      fontSize="larger"
+      fontWeight="medium"
     >
       Donec leo felis
     </h2>
     <h3
-      class="Text-sc-1wu7vpu-0-h3 Headings__SubsectionTitle-igpciy-0 hTTFeG"
-      font-size="large"
-      font-weight="medium"
+      className="-h3 c4"
+      fontSize="large"
+      fontWeight="medium"
     >
       Two pargraphs and moderatly long title
     </h3>
     <p
-      class="Text-sc-1wu7vpu-0 kLhDpw"
+      className="c3"
       color="currentColor"
-      font-size="medium"
+      disabled={false}
+      fontSize="medium"
     >
       Nunc tempor eget mauris id facilisis. Morbi convallis mauris at fermentum gravida. Nunc lacinia a odio eu rutrum. Etiam in libero vestibulum, lobortis mi fermentum, pharetra lacus. Aliquam commodo molestie dolor, vel tristique orci efficitur eu. Nullam eleifend malesuada. Nam luctus blandit dignissim. Mauris eu odio tristique, lorem quis, lobortis nulla. Interdum et malesuada fames ac ante ipsum primis in faucibus. Nunc quis lacus felis. Ut convallis rhoncus orci. Maecenas sit amet leo dui. Integer semper porta dignissim.
     </p>
     <h3
-      class="Text-sc-1wu7vpu-0-h3 Headings__SubsectionTitle-igpciy-0 hTTFeG"
-      font-size="large"
-      font-weight="medium"
+      className="-h3 c4"
+      fontSize="large"
+      fontWeight="medium"
     >
       Two pargraphs with List
     </h3>
     <p
-      class="Text-sc-1wu7vpu-0 kLhDpw"
+      className="c3"
       color="currentColor"
-      font-size="medium"
+      disabled={false}
+      fontSize="medium"
     >
       Nunc tempor eget mauris id facilisis. Morbi convallis mauris at fermentum gravida. Nunc lacinia a odio eu rutrum. Etiam in libero vestibulum, lobortis mi fermentum, pharetra lacus. Aliquam commodo molestie dolor, vel tristique orci efficitur eu. Nullam eleifend malesuada. Nam luctus blandit dignissim. Mauris eu odio tristique, lorem quis, lobortis nulla. Interdum et malesuada fames ac ante ipsum primis in faucibus. Nunc quis lacus felis. Ut convallis rhoncus orci. Maecenas sit amet leo dui. Integer semper porta dignissim.
     </p>
     <ul
-      class="List-sc-1cqkmnl-0 jrhpm"
+      className="c5"
       color="currentColor"
     >
       <li
-        class="ListItem-qqenhw-0 gzsWDK"
+        className="c6 c7"
         color="currentColor"
       >
         List Item 1
       </li>
       <li
-        class="ListItem-qqenhw-0 gzsWDK"
+        className="c6 c7"
         color="currentColor"
       >
         List Item 2 that is really really really really really really really really really long
       </li>
       <li
-        class="ListItem-qqenhw-0 gzsWDK"
+        className="c6 c7"
         color="currentColor"
       >
         List Item 3
       </li>
     </ul>
     <p
-      class="Text-sc-1wu7vpu-0 kLhDpw"
+      className="c3"
       color="currentColor"
-      font-size="medium"
+      disabled={false}
+      fontSize="medium"
     >
       Nam luctus blandit dignissim. Mauris eu odio tristique, lorem quis, lobortis nulla. Interdum et malesuada fames ac ante ipsum primis in faucibus. Nunc quis lacus felis. Ut convallis rhoncus orci. Maecenas sit amet leo dui. Integer semper porta dignissim.
     </p>
     <p
-      class="Text-sc-1wu7vpu-0 kLhDpw"
+      className="c3"
       color="currentColor"
-      font-size="medium"
+      disabled={false}
+      fontSize="medium"
     >
       Nunc id arcu sagittis, volutpat sit amet, accumsan diam. Pellentesque luctus, nulla a ornare semper, dui mollis nisi, vel lacinia neque velit eget sapien. Etiam sodales dolor, vel dictum libero cursus ac. Nam vulputate tempor mauris vel. Nam tristique metus et dignissim pretium. Aliquam erat volutpat.
     </p>
     <h3
-      class="Text-sc-1wu7vpu-0-h3 Headings__SubsectionTitle-igpciy-0 hTTFeG"
-      font-size="large"
-      font-weight="medium"
+      className="-h3 c4"
+      fontSize="large"
+      fontWeight="medium"
     >
       This is small text (14px) with medium(default) line height (24px).
     </h3>
     <p
-      class="Text-sc-1wu7vpu-0 dbKbDF"
+      className="c8"
       color="currentColor"
-      font-size="0"
+      disabled={false}
+      fontSize={0}
     >
       Porttitor urna sit amet, congue nulla. Etiam in posuere nibh. Nam pellentesque, lacus id elementum posuere, neque purus ullamcorper nunc, consequat mi velit eget mi. Duis ipsum augue, pulvinar ullamcorper fringilla in, dignissim congue velit. Nunc id arcu sagittis, volutpat sit amet, accumsan diam. Pellentesque luctus, nulla a ornare semper, dui mollis nisi, vel lacinia neque velit eget sapien. Etiam sodales dolor, vel dictum libero cursus ac. Nam vulputate tempor mauris vel. Nam tristique metus et dignissim pretium. Aliquam erat volutpat.
     </p>
     <h3
-      class="Text-sc-1wu7vpu-0-h3 Headings__SubsectionTitle-igpciy-0 hTTFeG"
-      font-size="large"
-      font-weight="medium"
+      className="-h3 c4"
+      fontSize="large"
+      fontWeight="medium"
     >
       This is small text (14px) with small line height (16px). Reserved for buttons, inputs ...
     </h3>
     <p
-      class="Text-sc-1wu7vpu-0 gNBXdH"
+      className="c9"
       color="currentColor"
-      font-size="small"
+      disabled={false}
+      fontSize="small"
     >
       Porttitor urna sit amet, congue nulla. Etiam in posuere nibh. Nam pellentesque, lacus id elementum posuere, neque purus ullamcorper nunc, consequat mi velit eget mi. Duis ipsum augue, pulvinar ullamcorper fringilla in, dignissim congue velit.
     </p>

--- a/components/src/Validation/__snapshots__/InlineValidation.story.storyshot
+++ b/components/src/Validation/__snapshots__/InlineValidation.story.storyshot
@@ -1,25 +1,83 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Inline Validation Inline Validation 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  color: #cc1439;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c2 {
+  margin-right: 8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c5 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c3 .c4 {
+  margin-bottom: 8px;
+}
+
+.c3 > *:last-child {
+  margin-bottom: 0;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 bXREHd"
+      className="Box-sc-1qu1edy-0 c1"
       color="red"
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 QuoIa"
+        aria-hidden={true}
+        className="c2"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="error"
         mr="x1"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -28,12 +86,13 @@ exports[`Storyshots Inline Validation Inline Validation 1`] = `
         />
       </svg>
       <div
-        class="InlineValidation__Wrapper-sc-1jic7dw-0 kqhCKM"
+        className="c3"
       >
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c4 c5"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           Something has gone wrong
         </p>
@@ -44,25 +103,116 @@ exports[`Storyshots Inline Validation Inline Validation 1`] = `
 `;
 
 exports[`Storyshots Inline Validation with custom content 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  color: #cc1439;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c2 {
+  margin-right: 8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c5 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c9 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c9:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
+.c8 {
+  margin-bottom: 8px;
+  color: currentColor;
+}
+
+.c8:last-child {
+  margin-bottom: 0;
+}
+
+.c6 {
+  color: currentColor;
+  margin: 0;
+  padding-left: 18px;
+}
+
+.c6 .c7 {
+  margin-bottom: 0;
+}
+
+.c3 .c4 {
+  margin-bottom: 8px;
+}
+
+.c3 > *:last-child {
+  margin-bottom: 0;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 bXREHd"
+      className="Box-sc-1qu1edy-0 c1"
       color="red"
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 QuoIa"
+        aria-hidden={true}
+        className="c2"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="error"
         mr="x1"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -71,39 +221,40 @@ exports[`Storyshots Inline Validation with custom content 1`] = `
         />
       </svg>
       <div
-        class="InlineValidation__Wrapper-sc-1jic7dw-0 kqhCKM"
+        className="c3"
       >
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c4 c5"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           Something has gone wrong.
         </p>
         <ul
-          class="List-sc-1cqkmnl-0 diqcEx"
+          className="c6"
           color="currentColor"
         >
           <li
-            class="ListItem-qqenhw-0 gzsWDK"
+            className="c7 c8"
             color="currentColor"
           >
             Entry must be at least 3 characters long.
           </li>
           <li
-            class="ListItem-qqenhw-0 gzsWDK"
+            className="c7 c8"
             color="currentColor"
           >
             Entry must contain a number
           </li>
           <li
-            class="ListItem-qqenhw-0 gzsWDK"
+            className="c7 c8"
             color="currentColor"
           >
             <a
-              class="Link-sc-1lpx3d0-0 gxbSxg"
+              className="c9"
               color="blue"
-              font-size="medium"
+              fontSize="medium"
               href="https://nulogy.design/"
             >
               Custom Link
@@ -117,25 +268,102 @@ exports[`Storyshots Inline Validation with custom content 1`] = `
 `;
 
 exports[`Storyshots Inline Validation with list items 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  color: #cc1439;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c2 {
+  margin-right: 8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c5 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c8 {
+  margin-bottom: 8px;
+  color: currentColor;
+}
+
+.c8:last-child {
+  margin-bottom: 0;
+}
+
+.c6 {
+  color: currentColor;
+  margin: 0;
+  padding-left: 18px;
+}
+
+.c6 .c7 {
+  margin-bottom: 0;
+}
+
+.c3 .c4 {
+  margin-bottom: 8px;
+}
+
+.c3 > *:last-child {
+  margin-bottom: 0;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 bXREHd"
+      className="Box-sc-1qu1edy-0 c1"
       color="red"
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 QuoIa"
+        aria-hidden={true}
+        className="c2"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="error"
         mr="x1"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -144,27 +372,28 @@ exports[`Storyshots Inline Validation with list items 1`] = `
         />
       </svg>
       <div
-        class="InlineValidation__Wrapper-sc-1jic7dw-0 kqhCKM"
+        className="c3"
       >
         <p
-          class="Text-sc-1wu7vpu-0 RbfMK"
+          className="c4 c5"
           color="currentColor"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           Something has gone wrong
         </p>
         <ul
-          class="List-sc-1cqkmnl-0 diqcEx"
+          className="c6"
           color="currentColor"
         >
           <li
-            class="ListItem-qqenhw-0 gzsWDK"
+            className="c7 c8"
             color="currentColor"
           >
             Entry must be at least 3 characters long.
           </li>
           <li
-            class="ListItem-qqenhw-0 gzsWDK"
+            className="c7 c8"
             color="currentColor"
           >
             Entry must contain a number.
@@ -177,25 +406,94 @@ exports[`Storyshots Inline Validation with list items 1`] = `
 `;
 
 exports[`Storyshots Inline Validation with only list items 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c1 {
+  color: #cc1439;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c2 {
+  margin-right: 8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c6 {
+  margin-bottom: 8px;
+  color: currentColor;
+}
+
+.c6:last-child {
+  margin-bottom: 0;
+}
+
+.c4 {
+  color: currentColor;
+  margin: 0;
+  padding-left: 18px;
+}
+
+.c4 .c5 {
+  margin-bottom: 0;
+}
+
+.c3 .Text-sc-1wu7vpu-0 {
+  margin-bottom: 8px;
+}
+
+.c3 > *:last-child {
+  margin-bottom: 0;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 bXREHd"
+      className="Box-sc-1qu1edy-0 c1"
       color="red"
     >
       <svg
-        aria-hidden="true"
-        class="Icon-fc7twp-0 QuoIa"
+        aria-hidden={true}
+        className="c2"
         color="currentColor"
         fill="currentColor"
-        focusable="false"
+        focusable={false}
         height="24px"
         icon="error"
         mr="x1"
+        size="24px"
+        title={null}
         viewBox="0 0 24 24"
         width="24px"
       >
@@ -204,20 +502,20 @@ exports[`Storyshots Inline Validation with only list items 1`] = `
         />
       </svg>
       <div
-        class="InlineValidation__Wrapper-sc-1jic7dw-0 kqhCKM"
+        className="c3"
       >
         <ul
-          class="List-sc-1cqkmnl-0 diqcEx"
+          className="c4"
           color="currentColor"
         >
           <li
-            class="ListItem-qqenhw-0 gzsWDK"
+            className="c5 c6"
             color="currentColor"
           >
             Entry must be at least 3 characters long.
           </li>
           <li
-            class="ListItem-qqenhw-0 gzsWDK"
+            className="c5 c6"
             color="currentColor"
           >
             Entry must contain a number.

--- a/components/src/pages/__snapshots__/Custom.story.storyshot
+++ b/components/src/pages/__snapshots__/Custom.story.storyshot
@@ -1,35 +1,272 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Pages/Custom Default 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c13 {
+  padding: 24px;
+  -webkit-box-flex: 2;
+  -webkit-flex-grow: 2;
+  -ms-flex-positive: 2;
+  flex-grow: 2;
+}
+
+.c1 {
+  background-color: #f0f2f5;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-content: flex-end;
+  -ms-flex-line-pack: end;
+  align-content: flex-end;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c12 {
+  background-color: #ffffff;
+  margin: 8px;
+  min-height: calc(100vh - 72px - 48px - 16px);
+  border-radius: 4px;
+  box-shadow: 0px 3px 5px 0px rgba(1,30,56,0.1);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c9 {
+  padding: 2px;
+  color: #ffffff;
+  min-width: 20px;
+}
+
+.c15 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c14 {
+  margin-bottom: 48px;
+  margin-top: 0;
+  font-size: 46px;
+  line-height: 1.04347826;
+  font-weight: 300;
+}
+
+.c3 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
+.c4 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding: 2px 0;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  color: #ffffff;
+  border: none;
+  background-color: transparent;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  line-height: 1.5;
+  -webkit-transition: background-color .2s;
+  transition: background-color .2s;
+  font-size: 16px;
+  padding: 8px 28px 8px 16px;
+  border-radius: 4px;
+}
+
+.c8:hover,
+.c8:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c8:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c8:disabled {
+  opacity: .5;
+}
+
+.c10 {
+  display: block;
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: none;
+  background-color: transparent;
+  vertical-align: middle;
+  line-height: 1.5;
+  font-size: 16px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c10:hover,
+.c10:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c10:disabled {
+  opacity: .5;
+}
+
+.c10:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c7 div:not(:last-of-type) {
+  margin-right: 8px;
+}
+
+.c2 {
+  background-color: #122b47;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: #122b47;
+  padding: 16px 24px;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 irqwJg"
+      className="c1"
     >
       <header
-        class="NavBar-iayrjp-3 bwrKUV"
+        className=""
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 NavBar__NavBarBackground-iayrjp-0 btupnB"
+          className="c2"
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 clvBNI"
+            className="c3"
             color="blue"
-            font-size="medium"
+            fontSize="medium"
             href="/"
-            style="display:block;height:40px"
+            style={
+              Object {
+                "display": "block",
+                "height": "40px",
+              }
+            }
           >
             <div
-              class="Branding__BrandingWrap-ranqri-0 gACiZG Branding-ranqri-2 kQRWHN"
+              className="c4 "
+              size="medium"
             >
               <svg
                 height="32px"
-                style="display:block;margin:2px 0"
+                style={
+                  Object {
+                    "display": "block",
+                    "margin": "2px 0",
+                  }
+                }
                 viewBox="0 0 133 32"
                 width="133px"
               >
@@ -65,33 +302,52 @@ exports[`Storyshots Pages/Custom Default 1`] = `
             </div>
           </a>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 cDPANM"
-            style="flex-grow:1;margin:0 0 0 24px"
+            className="c5"
+            style={
+              Object {
+                "flexGrow": "1",
+                "margin": "0 0 0 24px",
+              }
+            }
           >
             <nav
               aria-label="Primary navigation"
-              class="DesktopMenu__Nav-e4dzdq-3 bWwdcq DesktopMenu-e4dzdq-4 irbObu"
-              style="padding-right:24px"
+              className="c6 c7"
+              style={
+                Object {
+                  "paddingRight": "24px",
+                }
+              }
             >
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c8"
                   color="#ffffff"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Dashboard
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    aria-hidden={true}
+                    className="c9"
                     color="#ffffff"
                     fill="#ffffff"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -103,7 +359,7 @@ exports[`Storyshots Pages/Custom Default 1`] = `
               </div>
               <div>
                 <a
-                  class="DesktopMenu__MenuLink-e4dzdq-1 kgAySz"
+                  className="c10"
                   color="#ffffff"
                   href="/"
                 >
@@ -112,32 +368,46 @@ exports[`Storyshots Pages/Custom Default 1`] = `
               </div>
             </nav>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
-              style="float:right"
+              className="c11"
+              style={
+                Object {
+                  "float": "right",
+                }
+              }
             >
               <nav
                 aria-label="Secondary navigation"
-                class="DesktopMenu__Nav-e4dzdq-3 bWwdcq DesktopMenu-e4dzdq-4 irbObu"
+                className="c6 c7"
               >
                 <div>
                   <button
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="c8"
                     color="#ffffff"
+                    onBlur={[Function]}
+                    onClick={[Function]}
                     type="button"
                   >
                     Settings
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 hIxIEB"
+                      aria-hidden={true}
+                      className="c9"
                       color="#ffffff"
                       fill="#ffffff"
-                      focusable="false"
+                      focusable={false}
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px;right:8px"
+                      size="20px"
+                      style={
+                        Object {
+                          "position": "absolute",
+                          "right": "8px",
+                          "top": "11px",
+                        }
+                      }
+                      title={null}
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -153,22 +423,23 @@ exports[`Storyshots Pages/Custom Default 1`] = `
         </div>
       </header>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 jKfurj"
+        className="c12"
       >
         <div
-          class="Box-sc-1qu1edy-0 jXTIl"
+          className="c13"
         >
           <h1
-            class="Text-sc-1wu7vpu-0-h1 fKaScO"
-            font-size="largest"
-            font-weight="light"
+            className="c14"
+            fontSize="largest"
+            fontWeight="light"
           >
             I am title
           </h1>
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c15"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             I am main content.
           </p>
@@ -180,35 +451,558 @@ exports[`Storyshots Pages/Custom Default 1`] = `
 `;
 
 exports[`Storyshots Pages/Custom With breadcrumbs and actions 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c14 {
+  padding-top: 8px;
+  padding-right: 24px;
+  padding-bottom: 24px;
+  padding-left: 24px;
+  -webkit-box-flex: 2;
+  -webkit-flex-grow: 2;
+  -ms-flex-positive: 2;
+  flex-grow: 2;
+}
+
+.c24 {
+  background-color: #ffffff;
+  padding-top: 24px;
+  padding-right: 16px;
+  padding-bottom: 24px;
+  padding-left: 24px;
+  border-radius: 4px;
+}
+
+.c1 {
+  background-color: #f0f2f5;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-content: flex-end;
+  -ms-flex-line-pack: end;
+  align-content: flex-end;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c13 {
+  background-color: #ffffff;
+  margin: 8px;
+  min-height: calc(100vh - 72px - 48px - 16px);
+  border-radius: 4px;
+  box-shadow: 0px 3px 5px 0px rgba(1,30,56,0.1);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c15 {
+  height: 32px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c16 {
+  padding-top: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c25 {
+  margin-bottom: 32px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c10 {
+  padding: 2px;
+  color: #ffffff;
+  min-width: 20px;
+}
+
+.c18 {
+  margin-right: 4px;
+  color: #434d59;
+  min-width: 20px;
+}
+
+.c20 {
+  padding: 4px;
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c23 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c21 {
+  margin-bottom: 48px;
+  margin-top: 0;
+  font-size: 46px;
+  line-height: 1.04347826;
+  font-weight: 300;
+}
+
+.c26 {
+  margin-top: 4px;
+  margin-bottom: 16px;
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.23076923;
+}
+
+.c19 {
+  background: transparent;
+  border: none;
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px 0px;
+  color: #00438f;
+  cursor: pointer;
+  margin-top: 16px;
+}
+
+.c19 .c9 {
+  border-radius: 50%;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c19 .c22 {
+  display: block;
+  font-weight: 500;
+  text-align: left;
+}
+
+.c19 .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 0;
+}
+
+.c19:hover .c9 {
+  background-color: #e1ebfa;
+}
+
+.c19:hover .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c19:active .c9 {
+  -webkit-transform: scale(0.875);
+  -ms-transform: scale(0.875);
+  transform: scale(0.875);
+  -webkit-transition: .2s ease-in;
+  transition: .2s ease-in;
+}
+
+.c19:disabled {
+  opacity: .5;
+}
+
+.c19:disabled:hover .c9,
+.c19:disabled:active .c9 {
+  background: none;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.c19:focus {
+  outline: none;
+}
+
+.c19:focus .c9 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c19:focus .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c27 {
+  background: transparent;
+  border: none;
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px 0px;
+  color: #00438f;
+  cursor: pointer;
+}
+
+.c27 .c9 {
+  border-radius: 50%;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c27 .c22 {
+  display: block;
+  font-weight: 500;
+  text-align: left;
+}
+
+.c27 .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 0;
+}
+
+.c27:hover .c9 {
+  background-color: #e1ebfa;
+}
+
+.c27:hover .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c27:active .c9 {
+  -webkit-transform: scale(0.875);
+  -ms-transform: scale(0.875);
+  transform: scale(0.875);
+  -webkit-transition: .2s ease-in;
+  transition: .2s ease-in;
+}
+
+.c27:disabled {
+  opacity: .5;
+}
+
+.c27:disabled:hover .c9,
+.c27:disabled:active .c9 {
+  background: none;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.c27:focus {
+  outline: none;
+}
+
+.c27:focus .c9 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c27:focus .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c3 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
+.c17 {
+  color: #00438f;
+  margin-right: 4px;
+  font-size: 12px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c17:hover {
+  cursor: pointer;
+  color: #002b5c;
+}
+
+.c4 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding: 2px 0;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  color: #ffffff;
+  border: none;
+  background-color: transparent;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  line-height: 1.5;
+  -webkit-transition: background-color .2s;
+  transition: background-color .2s;
+  font-size: 16px;
+  padding: 8px 28px 8px 16px;
+  border-radius: 4px;
+}
+
+.c8:hover,
+.c8:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c8:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c8:disabled {
+  opacity: .5;
+}
+
+.c11 {
+  display: block;
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: none;
+  background-color: transparent;
+  vertical-align: middle;
+  line-height: 1.5;
+  font-size: 16px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c11:hover,
+.c11:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c11:disabled {
+  opacity: .5;
+}
+
+.c11:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c7 div:not(:last-of-type) {
+  margin-right: 8px;
+}
+
+.c2 {
+  background-color: #122b47;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: #122b47;
+  padding: 16px 24px;
+}
+
+@media screen and (min-width:0px) {
+  .c24 {
+    width: calc(100vw - 48px - 16px);
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c24 {
+    width: 400px;
+  }
+}
+
+@media screen and (min-width:1360px) {
+  .c24 {
+    width: 472px;
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c24 {
+    border-left: solid 1px #e4e7eb;
+  }
+}
+
+@media screen and (min-width:0px) {
+  .c24 {
+    position: absolute;
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c24 {
+    position: static;
+  }
+}
+
+@media screen and (min-width:0px) {
+  .c16 {
+    width: calc(100vw - 96px - 16px);
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c16 {
+    width: auto;
+  }
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 irqwJg"
+      className="c1"
     >
       <header
-        class="NavBar-iayrjp-3 bwrKUV"
+        className=""
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 NavBar__NavBarBackground-iayrjp-0 btupnB"
+          className="c2"
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 clvBNI"
+            className="c3"
             color="blue"
-            font-size="medium"
+            fontSize="medium"
             href="/"
-            style="display:block;height:40px"
+            style={
+              Object {
+                "display": "block",
+                "height": "40px",
+              }
+            }
           >
             <div
-              class="Branding__BrandingWrap-ranqri-0 gACiZG Branding-ranqri-2 kQRWHN"
+              className="c4 "
+              size="medium"
             >
               <svg
                 height="32px"
-                style="display:block;margin:2px 0"
+                style={
+                  Object {
+                    "display": "block",
+                    "margin": "2px 0",
+                  }
+                }
                 viewBox="0 0 133 32"
                 width="133px"
               >
@@ -244,33 +1038,52 @@ exports[`Storyshots Pages/Custom With breadcrumbs and actions 1`] = `
             </div>
           </a>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 cDPANM"
-            style="flex-grow:1;margin:0 0 0 24px"
+            className="c5"
+            style={
+              Object {
+                "flexGrow": "1",
+                "margin": "0 0 0 24px",
+              }
+            }
           >
             <nav
               aria-label="Primary navigation"
-              class="DesktopMenu__Nav-e4dzdq-3 bWwdcq DesktopMenu-e4dzdq-4 irbObu"
-              style="padding-right:24px"
+              className="c6 c7"
+              style={
+                Object {
+                  "paddingRight": "24px",
+                }
+              }
             >
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c8"
                   color="#ffffff"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Dashboard
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    aria-hidden={true}
+                    className="c9 c10"
                     color="#ffffff"
                     fill="#ffffff"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -282,7 +1095,7 @@ exports[`Storyshots Pages/Custom With breadcrumbs and actions 1`] = `
               </div>
               <div>
                 <a
-                  class="DesktopMenu__MenuLink-e4dzdq-1 kgAySz"
+                  className="c11"
                   color="#ffffff"
                   href="/"
                 >
@@ -291,32 +1104,46 @@ exports[`Storyshots Pages/Custom With breadcrumbs and actions 1`] = `
               </div>
             </nav>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
-              style="float:right"
+              className="c12"
+              style={
+                Object {
+                  "float": "right",
+                }
+              }
             >
               <nav
                 aria-label="Secondary navigation"
-                class="DesktopMenu__Nav-e4dzdq-3 bWwdcq DesktopMenu-e4dzdq-4 irbObu"
+                className="c6 c7"
               >
                 <div>
                   <button
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="c8"
                     color="#ffffff"
+                    onBlur={[Function]}
+                    onClick={[Function]}
                     type="button"
                   >
                     Settings
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 hIxIEB"
+                      aria-hidden={true}
+                      className="c9 c10"
                       color="#ffffff"
                       fill="#ffffff"
-                      focusable="false"
+                      focusable={false}
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px;right:8px"
+                      size="20px"
+                      style={
+                        Object {
+                          "position": "absolute",
+                          "right": "8px",
+                          "top": "11px",
+                        }
+                      }
+                      title={null}
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -332,35 +1159,42 @@ exports[`Storyshots Pages/Custom With breadcrumbs and actions 1`] = `
         </div>
       </header>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 jKfurj"
+        className="c13"
       >
         <div
-          class="Box-sc-1qu1edy-0 hkydKC"
+          className="c14"
         >
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 guWDrb"
+            className="c15"
             height="32px"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fvgzBv"
-              width="[object Object]"
+              className="c16"
+              width={
+                Object {
+                  "extraSmall": "calc(100vw - 96px - 16px)",
+                  "medium": "auto",
+                }
+              }
             >
               <a
-                class="Link-sc-1lpx3d0-0 fEeoTP"
+                className="c17"
                 color="darkBlue"
-                font-size="smaller"
+                fontSize="smaller"
               >
                 Breadcrumb
               </a>
               <svg
-                aria-hidden="true"
-                class="Icon-fc7twp-0 fQFStW"
+                aria-hidden={true}
+                className="c9 c18"
                 color="darkGrey"
                 fill="#434d59"
-                focusable="false"
+                focusable={false}
                 height="20px"
                 icon="rightArrow"
                 mr="half"
+                size="20px"
+                title={null}
                 viewBox="0 0 24 24"
                 width="20px"
               >
@@ -369,21 +1203,23 @@ exports[`Storyshots Pages/Custom With breadcrumbs and actions 1`] = `
                 />
               </svg>
               <a
-                class="Link-sc-1lpx3d0-0 fEeoTP"
+                className="c17"
                 color="darkBlue"
-                font-size="smaller"
+                fontSize="smaller"
               >
                 Breadcrumb
               </a>
               <svg
-                aria-hidden="true"
-                class="Icon-fc7twp-0 fQFStW"
+                aria-hidden={true}
+                className="c9 c18"
                 color="darkGrey"
                 fill="#434d59"
-                focusable="false"
+                focusable={false}
                 height="20px"
                 icon="rightArrow"
                 mr="half"
+                size="20px"
+                title={null}
                 viewBox="0 0 24 24"
                 width="20px"
               >
@@ -393,17 +1229,21 @@ exports[`Storyshots Pages/Custom With breadcrumbs and actions 1`] = `
               </svg>
             </div>
             <button
-              class="IconicButton__WrapperButton-sc-1u3dojp-1 dkgdQd IconicButton-sc-1u3dojp-2 gZASNp"
+              aria-label={null}
+              className="c19 "
+              disabled={false}
             >
               <svg
-                aria-hidden="true"
-                class="Icon-fc7twp-0 cwKdbD"
+                aria-hidden={true}
+                className="c9 c20"
                 color="currentColor"
                 fill="currentColor"
-                focusable="false"
+                focusable={false}
                 height="32px"
                 icon="more"
                 p="half"
+                size="32px"
+                title={null}
                 viewBox="0 0 24 24"
                 width="32px"
               >
@@ -414,46 +1254,57 @@ exports[`Storyshots Pages/Custom With breadcrumbs and actions 1`] = `
             </button>
           </div>
           <h1
-            class="Text-sc-1wu7vpu-0-h1 fKaScO"
-            font-size="largest"
-            font-weight="light"
+            className="c22-h1 c21"
+            fontSize="largest"
+            fontWeight="light"
           >
             I am title
           </h1>
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c22 c23"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             I am main content.
           </p>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 cTLuiE"
-          width="[object Object]"
+          className="c24"
+          width={
+            Object {
+              "extraSmall": "calc(100vw - 48px - 16px)",
+              "large": "472px",
+              "medium": "400px",
+            }
+          }
         >
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 ixsBzc"
+            className="c25"
           >
             <h2
-              class="Text-sc-1wu7vpu-0-h2 flYnRO"
-              font-size="larger"
-              font-weight="medium"
+              className="c22-h2 c26"
+              fontSize="larger"
+              fontWeight="medium"
             >
               I am sidebar
             </h2>
             <button
-              class="IconicButton__WrapperButton-sc-1u3dojp-1 UMPof IconicButton-sc-1u3dojp-2 gZASNp"
+              aria-label={null}
+              className="c27 "
+              disabled={false}
             >
               <svg
-                aria-hidden="true"
-                class="Icon-fc7twp-0 cwKdbD"
+                aria-hidden={true}
+                className="c9 c20"
                 color="currentColor"
                 fill="currentColor"
-                focusable="false"
+                focusable={false}
                 height="32px"
                 icon="close"
                 p="half"
+                size="32px"
+                title={null}
                 viewBox="0 0 24 24"
                 width="32px"
               >
@@ -464,9 +1315,10 @@ exports[`Storyshots Pages/Custom With breadcrumbs and actions 1`] = `
             </button>
           </div>
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c22 c23"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             I am sidebar content.
           </p>
@@ -478,35 +1330,420 @@ exports[`Storyshots Pages/Custom With breadcrumbs and actions 1`] = `
 `;
 
 exports[`Storyshots Pages/Custom With sidebar 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c14 {
+  padding: 24px;
+  -webkit-box-flex: 2;
+  -webkit-flex-grow: 2;
+  -ms-flex-positive: 2;
+  flex-grow: 2;
+}
+
+.c18 {
+  background-color: #ffffff;
+  padding-top: 24px;
+  padding-right: 16px;
+  padding-bottom: 24px;
+  padding-left: 24px;
+  border-radius: 4px;
+}
+
+.c1 {
+  background-color: #f0f2f5;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-content: flex-end;
+  -ms-flex-line-pack: end;
+  align-content: flex-end;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c13 {
+  background-color: #ffffff;
+  margin: 8px;
+  min-height: calc(100vh - 72px - 48px - 16px);
+  border-radius: 4px;
+  box-shadow: 0px 3px 5px 0px rgba(1,30,56,0.1);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c19 {
+  margin-bottom: 32px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c10 {
+  padding: 2px;
+  color: #ffffff;
+  min-width: 20px;
+}
+
+.c22 {
+  padding: 4px;
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c17 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c15 {
+  margin-bottom: 48px;
+  margin-top: 0;
+  font-size: 46px;
+  line-height: 1.04347826;
+  font-weight: 300;
+}
+
+.c20 {
+  margin-top: 4px;
+  margin-bottom: 16px;
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.23076923;
+}
+
+.c21 {
+  background: transparent;
+  border: none;
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px 0px;
+  color: #00438f;
+  cursor: pointer;
+}
+
+.c21 .c9 {
+  border-radius: 50%;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c21 .c16 {
+  display: block;
+  font-weight: 500;
+  text-align: left;
+}
+
+.c21 .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 0;
+}
+
+.c21:hover .c9 {
+  background-color: #e1ebfa;
+}
+
+.c21:hover .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c21:active .c9 {
+  -webkit-transform: scale(0.875);
+  -ms-transform: scale(0.875);
+  transform: scale(0.875);
+  -webkit-transition: .2s ease-in;
+  transition: .2s ease-in;
+}
+
+.c21:disabled {
+  opacity: .5;
+}
+
+.c21:disabled:hover .c9,
+.c21:disabled:active .c9 {
+  background: none;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.c21:focus {
+  outline: none;
+}
+
+.c21:focus .c9 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c21:focus .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c3 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
+.c4 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding: 2px 0;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  color: #ffffff;
+  border: none;
+  background-color: transparent;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  line-height: 1.5;
+  -webkit-transition: background-color .2s;
+  transition: background-color .2s;
+  font-size: 16px;
+  padding: 8px 28px 8px 16px;
+  border-radius: 4px;
+}
+
+.c8:hover,
+.c8:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c8:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c8:disabled {
+  opacity: .5;
+}
+
+.c11 {
+  display: block;
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: none;
+  background-color: transparent;
+  vertical-align: middle;
+  line-height: 1.5;
+  font-size: 16px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c11:hover,
+.c11:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c11:disabled {
+  opacity: .5;
+}
+
+.c11:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c7 div:not(:last-of-type) {
+  margin-right: 8px;
+}
+
+.c2 {
+  background-color: #122b47;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: #122b47;
+  padding: 16px 24px;
+}
+
+@media screen and (min-width:0px) {
+  .c18 {
+    width: calc(100vw - 48px - 16px);
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c18 {
+    width: 400px;
+  }
+}
+
+@media screen and (min-width:1360px) {
+  .c18 {
+    width: 472px;
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c18 {
+    border-left: solid 1px #e4e7eb;
+  }
+}
+
+@media screen and (min-width:0px) {
+  .c18 {
+    position: absolute;
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c18 {
+    position: static;
+  }
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 irqwJg"
+      className="c1"
     >
       <header
-        class="NavBar-iayrjp-3 bwrKUV"
+        className=""
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 NavBar__NavBarBackground-iayrjp-0 btupnB"
+          className="c2"
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 clvBNI"
+            className="c3"
             color="blue"
-            font-size="medium"
+            fontSize="medium"
             href="/"
-            style="display:block;height:40px"
+            style={
+              Object {
+                "display": "block",
+                "height": "40px",
+              }
+            }
           >
             <div
-              class="Branding__BrandingWrap-ranqri-0 gACiZG Branding-ranqri-2 kQRWHN"
+              className="c4 "
+              size="medium"
             >
               <svg
                 height="32px"
-                style="display:block;margin:2px 0"
+                style={
+                  Object {
+                    "display": "block",
+                    "margin": "2px 0",
+                  }
+                }
                 viewBox="0 0 133 32"
                 width="133px"
               >
@@ -542,33 +1779,52 @@ exports[`Storyshots Pages/Custom With sidebar 1`] = `
             </div>
           </a>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 cDPANM"
-            style="flex-grow:1;margin:0 0 0 24px"
+            className="c5"
+            style={
+              Object {
+                "flexGrow": "1",
+                "margin": "0 0 0 24px",
+              }
+            }
           >
             <nav
               aria-label="Primary navigation"
-              class="DesktopMenu__Nav-e4dzdq-3 bWwdcq DesktopMenu-e4dzdq-4 irbObu"
-              style="padding-right:24px"
+              className="c6 c7"
+              style={
+                Object {
+                  "paddingRight": "24px",
+                }
+              }
             >
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c8"
                   color="#ffffff"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Dashboard
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    aria-hidden={true}
+                    className="c9 c10"
                     color="#ffffff"
                     fill="#ffffff"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -580,7 +1836,7 @@ exports[`Storyshots Pages/Custom With sidebar 1`] = `
               </div>
               <div>
                 <a
-                  class="DesktopMenu__MenuLink-e4dzdq-1 kgAySz"
+                  className="c11"
                   color="#ffffff"
                   href="/"
                 >
@@ -589,32 +1845,46 @@ exports[`Storyshots Pages/Custom With sidebar 1`] = `
               </div>
             </nav>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
-              style="float:right"
+              className="c12"
+              style={
+                Object {
+                  "float": "right",
+                }
+              }
             >
               <nav
                 aria-label="Secondary navigation"
-                class="DesktopMenu__Nav-e4dzdq-3 bWwdcq DesktopMenu-e4dzdq-4 irbObu"
+                className="c6 c7"
               >
                 <div>
                   <button
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="c8"
                     color="#ffffff"
+                    onBlur={[Function]}
+                    onClick={[Function]}
                     type="button"
                   >
                     Settings
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 hIxIEB"
+                      aria-hidden={true}
+                      className="c9 c10"
                       color="#ffffff"
                       fill="#ffffff"
-                      focusable="false"
+                      focusable={false}
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px;right:8px"
+                      size="20px"
+                      style={
+                        Object {
+                          "position": "absolute",
+                          "right": "8px",
+                          "top": "11px",
+                        }
+                      }
+                      title={null}
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -630,52 +1900,63 @@ exports[`Storyshots Pages/Custom With sidebar 1`] = `
         </div>
       </header>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 jKfurj"
+        className="c13"
       >
         <div
-          class="Box-sc-1qu1edy-0 jXTIl"
+          className="c14"
         >
           <h1
-            class="Text-sc-1wu7vpu-0-h1 fKaScO"
-            font-size="largest"
-            font-weight="light"
+            className="c16-h1 c15"
+            fontSize="largest"
+            fontWeight="light"
           >
             I am title
           </h1>
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c16 c17"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             I am main content.
           </p>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 cTLuiE"
-          width="[object Object]"
+          className="c18"
+          width={
+            Object {
+              "extraSmall": "calc(100vw - 48px - 16px)",
+              "large": "472px",
+              "medium": "400px",
+            }
+          }
         >
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 ixsBzc"
+            className="c19"
           >
             <h2
-              class="Text-sc-1wu7vpu-0-h2 flYnRO"
-              font-size="larger"
-              font-weight="medium"
+              className="c16-h2 c20"
+              fontSize="larger"
+              fontWeight="medium"
             >
               I am sidebar
             </h2>
             <button
-              class="IconicButton__WrapperButton-sc-1u3dojp-1 UMPof IconicButton-sc-1u3dojp-2 gZASNp"
+              aria-label={null}
+              className="c21 "
+              disabled={false}
             >
               <svg
-                aria-hidden="true"
-                class="Icon-fc7twp-0 cwKdbD"
+                aria-hidden={true}
+                className="c9 c22"
                 color="currentColor"
                 fill="currentColor"
-                focusable="false"
+                focusable={false}
                 height="32px"
                 icon="close"
                 p="half"
+                size="32px"
+                title={null}
                 viewBox="0 0 24 24"
                 width="32px"
               >
@@ -686,9 +1967,10 @@ exports[`Storyshots Pages/Custom With sidebar 1`] = `
             </button>
           </div>
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c16 c17"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             I am sidbar content.
           </p>

--- a/components/src/pages/__snapshots__/Details.story.storyshot
+++ b/components/src/pages/__snapshots__/Details.story.storyshot
@@ -1,35 +1,730 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Pages/Details page Default 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c13 {
+  padding: 24px;
+  -webkit-box-flex: 2;
+  -webkit-flex-grow: 2;
+  -ms-flex-positive: 2;
+  flex-grow: 2;
+}
+
+.c19 {
+  padding-top: 16px;
+  margin-bottom: 24px;
+}
+
+.c23 {
+  padding-right: 8px;
+  margin-bottom: 24px;
+  width: 33.33333333333333%;
+}
+
+.c27 {
+  padding-left: 8px;
+  padding-right: 8px;
+  margin-bottom: 24px;
+  width: 33.33333333333333%;
+}
+
+.c28 {
+  padding-left: 8px;
+  margin-bottom: 24px;
+  width: 33.33333333333333%;
+}
+
+.c29 {
+  padding-top: 16px;
+  padding-bottom: 16px;
+}
+
+.c37 {
+  padding-top: 8px;
+}
+
+.c1 {
+  background-color: #f0f2f5;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-content: flex-end;
+  -ms-flex-line-pack: end;
+  align-content: flex-end;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c12 {
+  background-color: #ffffff;
+  margin: 8px;
+  min-height: calc(100vh - 72px - 48px - 16px);
+  border-radius: 4px;
+  box-shadow: 0px 3px 5px 0px rgba(1,30,56,0.1);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c22 {
+  margin-bottom: 24px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c9 {
+  padding: 2px;
+  color: #ffffff;
+  min-width: 20px;
+}
+
+.c36 {
+  margin-right: 4px;
+  color: #cc1439;
+  min-width: 24px;
+}
+
+.c25 {
+  margin-bottom: 8px;
+  margin-top: 0;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+  color: currentColor;
+}
+
+.c26 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c14 {
+  margin-bottom: 48px;
+  margin-top: 0;
+  font-size: 46px;
+  line-height: 1.04347826;
+  font-weight: 300;
+}
+
+.c21 {
+  margin-bottom: 32px;
+  margin-top: 0;
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.23076923;
+}
+
+.c30 {
+  margin-bottom: 16px;
+  margin-top: 0;
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.23076923;
+}
+
+.c38 {
+  margin-bottom: 24px;
+  margin-top: 0;
+  font-weight: 500;
+  font-size: 20px;
+  line-height: 1.2;
+}
+
+.c43 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+  margin-right: 8px;
+}
+
+.c43:hover {
+  background-color: #e1ebfa;
+}
+
+.c43:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c43:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c43:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c43:disabled {
+  opacity: .5;
+}
+
+.c45 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c45:hover {
+  background-color: #e1ebfa;
+}
+
+.c45:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c45:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c45:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c45:disabled {
+  opacity: .5;
+}
+
+.c44 {
+  color: #ffffff;
+  border-color: #216beb;
+  background-color: #216beb;
+}
+
+.c44:hover {
+  background-color: #1254c7;
+  border-color: #1254c7;
+}
+
+.c44:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #216beb;
+}
+
+.c44:focus:hover {
+  background-color: #1254c7;
+}
+
+.c46 {
+  color: #216beb;
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c3 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
+.c4 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding: 2px 0;
+}
+
+.c41 {
+  width: 100%;
+}
+
+.c39 {
+  width: 100%;
+}
+
+.c39 .c20 {
+  margin-bottom: 0;
+}
+
+.c39 .Alert-u8lbe-0 {
+  margin-bottom: 48px;
+}
+
+.c39 .c40,
+.c39 .Fieldset-sc-9aoml1-0 {
+  margin-bottom: 24px;
+}
+
+.c39 .c40:last-child,
+.c39 .Fieldset-sc-9aoml1-0:last-child {
+  margin-bottom: 0;
+}
+
+.c39 .FormSection-sc-5yud6c-1 {
+  margin-bottom: 48px;
+}
+
+.c39 .FormSection-sc-5yud6c-1:last-child {
+  margin-bottom: 0;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  color: #ffffff;
+  border: none;
+  background-color: transparent;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  line-height: 1.5;
+  -webkit-transition: background-color .2s;
+  transition: background-color .2s;
+  font-size: 16px;
+  padding: 8px 28px 8px 16px;
+  border-radius: 4px;
+}
+
+.c8:hover,
+.c8:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c8:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c8:disabled {
+  opacity: .5;
+}
+
+.c10 {
+  display: block;
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: none;
+  background-color: transparent;
+  vertical-align: middle;
+  line-height: 1.5;
+  font-size: 16px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c10:hover,
+.c10:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c10:disabled {
+  opacity: .5;
+}
+
+.c10:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c7 div:not(:last-of-type) {
+  margin-right: 8px;
+}
+
+.c2 {
+  background-color: #122b47;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: #122b47;
+  padding: 16px 24px;
+}
+
+.c42 {
+  margin-bottom: 24px;
+  display: block;
+  width: 100%;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  min-height: 40px;
+  min-width: 20em;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c42:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c42::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c42::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c42:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c42::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c17 {
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 16px;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #00438f;
+  background-color: transparent;
+  border: none;
+  margin: 0px;
+  padding: 8px 24px;
+  position: relative;
+}
+
+.c17:focus {
+  outline: none;
+  background-color: #e1ebfa;
+}
+
+.c17:disabled {
+  opacity: .5;
+}
+
+.c17:before {
+  content: '';
+  background-color: #00438f;
+  height: 3px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  border-radius: 2px 2px 0 0;
+}
+
+.c18 {
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 16px;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #00438f;
+  background-color: transparent;
+  border: none;
+  margin: 0px;
+  padding: 8px 24px;
+  position: relative;
+}
+
+.c18:focus {
+  outline: none;
+  background-color: #e1ebfa;
+}
+
+.c18:disabled {
+  opacity: .5;
+}
+
+.c18:before {
+  content: '';
+  background-color: #c0c8d1;
+  height: 1px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 210;
+}
+
+.c18:hover:before {
+  content: '';
+  background-color: #e1ebfa;
+  height: 3px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  border-radius: 2px 2px 0 0;
+}
+
+.c15 {
+  position: absolute;
+  width: 0;
+  height: 40px;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  white-space: nowrap;
+  overflow-x: scroll;
+  overflow-y: hidden;
+  margin-bottom: 8px;
+  position: relative;
+}
+
+.c16::-webkit-scrollbar {
+  display: none;
+}
+
+.c16:before {
+  content: '';
+  background-color: #c0c8d1;
+  height: 1px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
+.c33 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: auto;
+}
+
+.c33:first-child {
+  padding-left: 16px;
+}
+
+.c32 {
+  color: #434d59;
+  border-bottom: 1px solid #e4e7eb;
+}
+
+.c35 {
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-right: 16px;
+}
+
+.c35:first-child {
+  padding-left: 16px;
+}
+
+.c34:hover {
+  background-color: #f0f2f5;
+}
+
+.c31 {
+  border-collapse: collapse;
+  width: 100%;
+  background: white;
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 irqwJg"
+      className="c1"
     >
       <header
-        class="NavBar-iayrjp-3 bwrKUV"
+        className=""
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 NavBar__NavBarBackground-iayrjp-0 btupnB"
+          className="c2"
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 clvBNI"
+            className="c3"
             color="blue"
-            font-size="medium"
+            fontSize="medium"
             href="/"
-            style="display:block;height:40px"
+            style={
+              Object {
+                "display": "block",
+                "height": "40px",
+              }
+            }
           >
             <div
-              class="Branding__BrandingWrap-ranqri-0 gACiZG Branding-ranqri-2 kQRWHN"
+              className="c4 "
+              size="medium"
             >
               <svg
                 height="32px"
-                style="display:block;margin:2px 0"
+                style={
+                  Object {
+                    "display": "block",
+                    "margin": "2px 0",
+                  }
+                }
                 viewBox="0 0 133 32"
                 width="133px"
               >
@@ -65,33 +760,52 @@ exports[`Storyshots Pages/Details page Default 1`] = `
             </div>
           </a>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 cDPANM"
-            style="flex-grow:1;margin:0 0 0 24px"
+            className="c5"
+            style={
+              Object {
+                "flexGrow": "1",
+                "margin": "0 0 0 24px",
+              }
+            }
           >
             <nav
               aria-label="Primary navigation"
-              class="DesktopMenu__Nav-e4dzdq-3 bWwdcq DesktopMenu-e4dzdq-4 irbObu"
-              style="padding-right:24px"
+              className="c6 c7"
+              style={
+                Object {
+                  "paddingRight": "24px",
+                }
+              }
             >
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c8"
                   color="#ffffff"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Dashboard
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    aria-hidden={true}
+                    className="c9"
                     color="#ffffff"
                     fill="#ffffff"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -103,7 +817,7 @@ exports[`Storyshots Pages/Details page Default 1`] = `
               </div>
               <div>
                 <a
-                  class="DesktopMenu__MenuLink-e4dzdq-1 kgAySz"
+                  className="c10"
                   color="#ffffff"
                   href="/"
                 >
@@ -112,32 +826,46 @@ exports[`Storyshots Pages/Details page Default 1`] = `
               </div>
             </nav>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
-              style="float:right"
+              className="c11"
+              style={
+                Object {
+                  "float": "right",
+                }
+              }
             >
               <nav
                 aria-label="Secondary navigation"
-                class="DesktopMenu__Nav-e4dzdq-3 bWwdcq DesktopMenu-e4dzdq-4 irbObu"
+                className="c6 c7"
               >
                 <div>
                   <button
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="c8"
                     color="#ffffff"
+                    onBlur={[Function]}
+                    onClick={[Function]}
                     type="button"
                   >
                     Settings
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 hIxIEB"
+                      aria-hidden={true}
+                      className="c9"
                       color="#ffffff"
                       fill="#ffffff"
-                      focusable="false"
+                      focusable={false}
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px;right:8px"
+                      size="20px"
+                      style={
+                        Object {
+                          "position": "absolute",
+                          "right": "8px",
+                          "top": "11px",
+                        }
+                      }
+                      title={null}
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -153,186 +881,211 @@ exports[`Storyshots Pages/Details page Default 1`] = `
         </div>
       </header>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 jKfurj"
+        className="c12"
       >
         <div
-          class="Box-sc-1qu1edy-0 jXTIl"
+          className="c13"
         >
           <h1
-            class="Text-sc-1wu7vpu-0-h1 fKaScO"
-            font-size="largest"
-            font-weight="light"
+            className="c24-h1 c14"
+            fontSize="largest"
+            fontWeight="light"
           >
             I am title
           </h1>
           <div
-            class="TabScrollIndicators__TabScrollIndicatorContainer-sc-1cljxwo-0 gsIAKI"
-            width="0"
+            className="c15"
+            width={0}
           />
           <div
-            class="Tabs__TabContainer-o5d5cd-0 giufLG"
+            className="c16"
+            onScroll={[Function]}
             role="tablist"
           >
             <div />
             <button
-              aria-selected="true"
-              class="Tab__TabButton-sc-69abpu-0 kfQsHL"
+              aria-selected={true}
+              className="c17"
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
               role="tab"
-              selected=""
-              tabindex="0"
+              selected={true}
+              tabIndex={0}
             >
               Details
             </button>
             <button
-              aria-selected="false"
-              class="Tab__TabButton-sc-69abpu-0 gcfVpD"
+              aria-selected={false}
+              className="c18"
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
               role="tab"
-              tabindex="-1"
+              selected={false}
+              tabIndex={-1}
             >
               Milestones
             </button>
             <button
-              aria-selected="false"
-              class="Tab__TabButton-sc-69abpu-0 gcfVpD"
+              aria-selected={false}
+              className="c18"
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
               role="tab"
-              tabindex="-1"
+              selected={false}
+              tabIndex={-1}
             >
               Production Records
             </button>
           </div>
           <div
-            aria-hidden="false"
-            selected=""
+            aria-hidden={false}
+            hidden={false}
+            selected={true}
           >
             <div
-              class="Box-sc-1qu1edy-0 EBPVx"
+              className="c19"
             >
               <h2
-                class="Text-sc-1wu7vpu-0-h2 hKxFww"
-                font-size="larger"
-                font-weight="medium"
+                className="c20 c21"
+                fontSize="larger"
+                fontWeight="medium"
               >
                 Details
               </h2>
               <div
-                class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 cOjpeh"
+                className="c22"
               >
                 <div
-                  class="Box-sc-1qu1edy-0 kppLzh"
-                  width="0.3333333333333333"
+                  className="c23"
+                  width={0.3333333333333333}
                 >
                   <p
-                    class="Text-sc-1wu7vpu-0 tVyVn"
+                    className="c24 c25"
                     color="currentColor"
-                    font-size="small"
-                    font-weight="bold"
+                    disabled={false}
+                    fontSize="small"
+                    fontWeight="bold"
                   >
                     Purchase Order Number
                   </p>
                   <p
-                    class="Text-sc-1wu7vpu-0 RbfMK"
+                    className="c24 c26"
                     color="currentColor"
-                    font-size="medium"
+                    disabled={false}
+                    fontSize="medium"
                   >
                     7050007201911
                   </p>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 iNeoFr"
-                  width="0.3333333333333333"
+                  className="c27"
+                  width={0.3333333333333333}
                 >
                   <p
-                    class="Text-sc-1wu7vpu-0 tVyVn"
+                    className="c24 c25"
                     color="currentColor"
-                    font-size="small"
-                    font-weight="bold"
+                    disabled={false}
+                    fontSize="small"
+                    fontWeight="bold"
                   >
                     Purchase Order Number
                   </p>
                   <p
-                    class="Text-sc-1wu7vpu-0 RbfMK"
+                    className="c24 c26"
                     color="currentColor"
-                    font-size="medium"
+                    disabled={false}
+                    fontSize="medium"
                   >
                     7050007201911
                   </p>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 jgRzAy"
-                  width="0.3333333333333333"
+                  className="c28"
+                  width={0.3333333333333333}
                 >
                   <p
-                    class="Text-sc-1wu7vpu-0 tVyVn"
+                    className="c24 c25"
                     color="currentColor"
-                    font-size="small"
-                    font-weight="bold"
+                    disabled={false}
+                    fontSize="small"
+                    fontWeight="bold"
                   >
                     Purchase Order Number
                   </p>
                   <p
-                    class="Text-sc-1wu7vpu-0 RbfMK"
+                    className="c24 c26"
                     color="currentColor"
-                    font-size="medium"
+                    disabled={false}
+                    fontSize="medium"
                   >
                     7050007201911
                   </p>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 kppLzh"
-                  width="0.3333333333333333"
+                  className="c23"
+                  width={0.3333333333333333}
                 >
                   <p
-                    class="Text-sc-1wu7vpu-0 tVyVn"
+                    className="c24 c25"
                     color="currentColor"
-                    font-size="small"
-                    font-weight="bold"
+                    disabled={false}
+                    fontSize="small"
+                    fontWeight="bold"
                   >
                     Purchase Order Number
                   </p>
                   <p
-                    class="Text-sc-1wu7vpu-0 RbfMK"
+                    className="c24 c26"
                     color="currentColor"
-                    font-size="medium"
+                    disabled={false}
+                    fontSize="medium"
                   >
                     7050007201911
                   </p>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 iNeoFr"
-                  width="0.3333333333333333"
+                  className="c27"
+                  width={0.3333333333333333}
                 >
                   <p
-                    class="Text-sc-1wu7vpu-0 tVyVn"
+                    className="c24 c25"
                     color="currentColor"
-                    font-size="small"
-                    font-weight="bold"
+                    disabled={false}
+                    fontSize="small"
+                    fontWeight="bold"
                   >
                     Purchase Order Number
                   </p>
                   <p
-                    class="Text-sc-1wu7vpu-0 RbfMK"
+                    className="c24 c26"
                     color="currentColor"
-                    font-size="medium"
+                    disabled={false}
+                    fontSize="medium"
                   >
                     7050007201911
                   </p>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 jgRzAy"
-                  width="0.3333333333333333"
+                  className="c28"
+                  width={0.3333333333333333}
                 >
                   <p
-                    class="Text-sc-1wu7vpu-0 tVyVn"
+                    className="c24 c25"
                     color="currentColor"
-                    font-size="small"
-                    font-weight="bold"
+                    disabled={false}
+                    fontSize="small"
+                    fontWeight="bold"
                   >
                     Purchase Order Number
                   </p>
                   <p
-                    class="Text-sc-1wu7vpu-0 RbfMK"
+                    className="c24 c26"
                     color="currentColor"
-                    font-size="medium"
+                    disabled={false}
+                    fontSize="medium"
                   >
                     7050007201911
                   </p>
@@ -341,49 +1094,50 @@ exports[`Storyshots Pages/Details page Default 1`] = `
             </div>
           </div>
           <div
-            aria-hidden="true"
-            hidden=""
+            aria-hidden={true}
+            hidden={true}
+            selected={false}
           >
             <div
-              class="Box-sc-1qu1edy-0 cSRExr"
+              className="c29"
             >
               <h2
-                class="Text-sc-1wu7vpu-0-h2 jBTFWi"
-                font-size="larger"
-                font-weight="medium"
+                className="c20 c30"
+                fontSize="larger"
+                fontWeight="medium"
               >
                 Milestone Performance
               </h2>
               <table
-                class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+                className="c31"
               >
                 <thead>
                   <tr
-                    class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
+                    className="c32"
                   >
                     <th
-                      class="StyledTh-sc-10nzyk9-0 sBlyT"
+                      className="c33"
                       data-testid="table-head"
                       scope="col"
                     >
                       Milestone
                     </th>
                     <th
-                      class="StyledTh-sc-10nzyk9-0 sBlyT"
+                      className="c33"
                       data-testid="table-head"
                       scope="col"
                     >
                       Expected Completion
                     </th>
                     <th
-                      class="StyledTh-sc-10nzyk9-0 sBlyT"
+                      className="c33"
                       data-testid="table-head"
                       scope="col"
                     >
                       Actual Completion
                     </th>
                     <th
-                      class="StyledTh-sc-10nzyk9-0 sBlyT"
+                      className="c33"
                       data-testid="table-head"
                       scope="col"
                     >
@@ -395,37 +1149,41 @@ exports[`Storyshots Pages/Details page Default 1`] = `
                   data-testid="table-body"
                 >
                   <tr
-                    class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    className="c34"
                     data-testid="table-row"
                   >
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c35"
                     >
                       PO Line Item Created
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c35"
                     >
                       Nov 3, 2019
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c35"
                     >
                       Dec 13, 2019
                     </td>
-                    <td>
+                    <td
+                      colSpan={null}
+                    >
                       <div
-                        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+                        className="c11"
                       >
                         <svg
-                          aria-hidden="true"
-                          class="Icon-fc7twp-0 bKcUEK"
+                          aria-hidden={true}
+                          className="c36"
                           color="red"
                           fill="#cc1439"
-                          focusable="false"
+                          focusable={false}
                           height="24px"
                           icon="error"
                           mr="half"
+                          size="24px"
+                          title={null}
                           viewBox="0 0 24 24"
                           width="24px"
                         >
@@ -434,9 +1192,10 @@ exports[`Storyshots Pages/Details page Default 1`] = `
                           />
                         </svg>
                         <p
-                          class="Text-sc-1wu7vpu-0 RbfMK"
+                          className="c24 c26"
                           color="currentColor"
-                          font-size="medium"
+                          disabled={false}
+                          fontSize="medium"
                         >
                           10 Days Late
                         </p>
@@ -444,37 +1203,41 @@ exports[`Storyshots Pages/Details page Default 1`] = `
                     </td>
                   </tr>
                   <tr
-                    class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    className="c34"
                     data-testid="table-row"
                   >
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c35"
                     >
                       PO Line Item Created
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c35"
                     >
                       Nov 3, 2019
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c35"
                     >
                       Dec 13, 2019
                     </td>
-                    <td>
+                    <td
+                      colSpan={null}
+                    >
                       <div
-                        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+                        className="c11"
                       >
                         <svg
-                          aria-hidden="true"
-                          class="Icon-fc7twp-0 bKcUEK"
+                          aria-hidden={true}
+                          className="c36"
                           color="red"
                           fill="#cc1439"
-                          focusable="false"
+                          focusable={false}
                           height="24px"
                           icon="error"
                           mr="half"
+                          size="24px"
+                          title={null}
                           viewBox="0 0 24 24"
                           width="24px"
                         >
@@ -483,9 +1246,10 @@ exports[`Storyshots Pages/Details page Default 1`] = `
                           />
                         </svg>
                         <p
-                          class="Text-sc-1wu7vpu-0 RbfMK"
+                          className="c24 c26"
                           color="currentColor"
-                          font-size="medium"
+                          disabled={false}
+                          fontSize="medium"
                         >
                           40 Days Late
                         </p>
@@ -493,37 +1257,41 @@ exports[`Storyshots Pages/Details page Default 1`] = `
                     </td>
                   </tr>
                   <tr
-                    class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    className="c34"
                     data-testid="table-row"
                   >
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c35"
                     >
                       PO Line Item Created
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c35"
                     >
                       Nov 3, 2019
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c35"
                     >
                       Dec 13, 2019
                     </td>
-                    <td>
+                    <td
+                      colSpan={null}
+                    >
                       <div
-                        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+                        className="c11"
                       >
                         <svg
-                          aria-hidden="true"
-                          class="Icon-fc7twp-0 bKcUEK"
+                          aria-hidden={true}
+                          className="c36"
                           color="red"
                           fill="#cc1439"
-                          focusable="false"
+                          focusable={false}
                           height="24px"
                           icon="error"
                           mr="half"
+                          size="24px"
+                          title={null}
                           viewBox="0 0 24 24"
                           width="24px"
                         >
@@ -532,9 +1300,10 @@ exports[`Storyshots Pages/Details page Default 1`] = `
                           />
                         </svg>
                         <p
-                          class="Text-sc-1wu7vpu-0 RbfMK"
+                          className="c24 c26"
                           color="currentColor"
-                          font-size="medium"
+                          disabled={false}
+                          fontSize="medium"
                         >
                           40 Days Late
                         </p>
@@ -542,37 +1311,41 @@ exports[`Storyshots Pages/Details page Default 1`] = `
                     </td>
                   </tr>
                   <tr
-                    class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    className="c34"
                     data-testid="table-row"
                   >
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c35"
                     >
                       PO Line Item Created
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c35"
                     >
                       Nov 3, 2019
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c35"
                     >
                       Dec 13, 2019
                     </td>
-                    <td>
+                    <td
+                      colSpan={null}
+                    >
                       <div
-                        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+                        className="c11"
                       >
                         <svg
-                          aria-hidden="true"
-                          class="Icon-fc7twp-0 bKcUEK"
+                          aria-hidden={true}
+                          className="c36"
                           color="red"
                           fill="#cc1439"
-                          focusable="false"
+                          focusable={false}
                           height="24px"
                           icon="error"
                           mr="half"
+                          size="24px"
+                          title={null}
                           viewBox="0 0 24 24"
                           width="24px"
                         >
@@ -581,9 +1354,10 @@ exports[`Storyshots Pages/Details page Default 1`] = `
                           />
                         </svg>
                         <p
-                          class="Text-sc-1wu7vpu-0 RbfMK"
+                          className="c24 c26"
                           color="currentColor"
-                          font-size="medium"
+                          disabled={false}
+                          fontSize="medium"
                         >
                           40 Days Late
                         </p>
@@ -596,42 +1370,43 @@ exports[`Storyshots Pages/Details page Default 1`] = `
             </div>
           </div>
           <div
-            aria-hidden="true"
-            hidden=""
+            aria-hidden={true}
+            hidden={true}
+            selected={false}
           >
             <div
-              class="Box-sc-1qu1edy-0 EBPVx"
+              className="c19"
             >
               <h2
-                class="Text-sc-1wu7vpu-0-h2 jBTFWi"
-                font-size="larger"
-                font-weight="medium"
+                className="c20 c30"
+                fontSize="larger"
+                fontWeight="medium"
               >
                 Production Records
               </h2>
               <table
-                class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+                className="c31"
               >
                 <thead>
                   <tr
-                    class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
+                    className="c32"
                   >
                     <th
-                      class="StyledTh-sc-10nzyk9-0 sBlyT"
+                      className="c33"
                       data-testid="table-head"
                       scope="col"
                     >
                       Date
                     </th>
                     <th
-                      class="StyledTh-sc-10nzyk9-0 sBlyT"
+                      className="c33"
                       data-testid="table-head"
                       scope="col"
                     >
                       Expected Quantity
                     </th>
                     <th
-                      class="StyledTh-sc-10nzyk9-0 sBlyT"
+                      className="c33"
                       data-testid="table-head"
                       scope="col"
                     >
@@ -643,81 +1418,81 @@ exports[`Storyshots Pages/Details page Default 1`] = `
                   data-testid="table-body"
                 >
                   <tr
-                    class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    className="c34"
                     data-testid="table-row"
                   >
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c35"
                     >
                       2019-10-01
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c35"
                     >
                       2,025 eaches
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c35"
                     >
                       1,800 eaches
                     </td>
                   </tr>
                   <tr
-                    class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    className="c34"
                     data-testid="table-row"
                   >
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c35"
                     >
                       2019-10-02
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c35"
                     >
                       2,475 eaches
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c35"
                     >
                       2,250 eaches
                     </td>
                   </tr>
                   <tr
-                    class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    className="c34"
                     data-testid="table-row"
                   >
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c35"
                     >
                       2019-10-03
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c35"
                     >
                       2,475 eaches
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c35"
                     >
                       1,425 eaches
                     </td>
                   </tr>
                   <tr
-                    class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    className="c34"
                     data-testid="table-row"
                   >
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c35"
                     >
                       2019-10-24
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c35"
                     >
                       2,475 eaches
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c35"
                     >
                       -
                     </td>
@@ -727,39 +1502,46 @@ exports[`Storyshots Pages/Details page Default 1`] = `
               </table>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 cEnpFJ"
+              className="c37"
             >
               <h3
-                class="Text-sc-1wu7vpu-0-h3 Headings__SubsectionTitle-igpciy-0 fKBIog"
-                font-size="large"
-                font-weight="medium"
+                className="c24-h3 c38"
+                fontSize="large"
+                fontWeight="medium"
               >
                 Comments
               </h3>
               <form
-                class="Form-n70q8u-0 ilQSyT"
+                className="c39"
               >
                 <div
-                  class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+                  className="c40 c41"
                 >
                   <textarea
-                    aria-invalid="false"
-                    aria-required="false"
-                    class="Textarea__StyledTextarea-sc-1tyrhr0-0 ktRBsI"
+                    aria-invalid={false}
+                    aria-required={false}
+                    className="c42"
+                    disabled={false}
+                    id={null}
                     placeholder="Leave a comment..."
-                    rows="4"
+                    required={false}
+                    rows={4}
                   />
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 jlPsmj"
+                  className=""
                 >
                   <button
-                    class="Button__WrapperButton-sc-1omxup2-0 kFmWUd PrimaryButton-qz78sb-0 cGyyDq"
+                    className="c43 c44"
+                    disabled={false}
+                    size="medium"
                   >
                     Comment
                   </button>
                   <button
-                    class="Button__WrapperButton-sc-1omxup2-0 hkfOQr QuietButton-sc-1l5k8i4-0 eAbPwX"
+                    className="c45 c46"
+                    disabled={false}
+                    size="medium"
                   >
                     Cancel
                   </button>
@@ -775,35 +1557,1016 @@ exports[`Storyshots Pages/Details page Default 1`] = `
 `;
 
 exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c14 {
+  padding-top: 8px;
+  padding-right: 24px;
+  padding-bottom: 24px;
+  padding-left: 24px;
+  -webkit-box-flex: 2;
+  -webkit-flex-grow: 2;
+  -ms-flex-positive: 2;
+  flex-grow: 2;
+}
+
+.c26 {
+  padding-top: 16px;
+  margin-bottom: 24px;
+}
+
+.c30 {
+  padding-right: 8px;
+  margin-bottom: 24px;
+  width: 33.33333333333333%;
+}
+
+.c34 {
+  padding-left: 8px;
+  padding-right: 8px;
+  margin-bottom: 24px;
+  width: 33.33333333333333%;
+}
+
+.c35 {
+  padding-left: 8px;
+  margin-bottom: 24px;
+  width: 33.33333333333333%;
+}
+
+.c36 {
+  padding-top: 16px;
+  padding-bottom: 16px;
+}
+
+.c44 {
+  padding-top: 8px;
+}
+
+.c54 {
+  background-color: #ffffff;
+  padding-top: 24px;
+  padding-right: 16px;
+  padding-bottom: 24px;
+  padding-left: 24px;
+  border-radius: 4px;
+}
+
+.c1 {
+  background-color: #f0f2f5;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-content: flex-end;
+  -ms-flex-line-pack: end;
+  align-content: flex-end;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c13 {
+  background-color: #ffffff;
+  margin: 8px;
+  min-height: calc(100vh - 72px - 48px - 16px);
+  border-radius: 4px;
+  box-shadow: 0px 3px 5px 0px rgba(1,30,56,0.1);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c15 {
+  height: 32px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c16 {
+  padding-top: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c29 {
+  margin-bottom: 24px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c55 {
+  margin-bottom: 32px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c10 {
+  padding: 2px;
+  color: #ffffff;
+  min-width: 20px;
+}
+
+.c18 {
+  margin-right: 4px;
+  color: #434d59;
+  min-width: 20px;
+}
+
+.c20 {
+  padding: 4px;
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c43 {
+  margin-right: 4px;
+  color: #cc1439;
+  min-width: 24px;
+}
+
+.c32 {
+  margin-bottom: 8px;
+  margin-top: 0;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+  color: currentColor;
+}
+
+.c33 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c21 {
+  margin-bottom: 48px;
+  margin-top: 0;
+  font-size: 46px;
+  line-height: 1.04347826;
+  font-weight: 300;
+}
+
+.c28 {
+  margin-bottom: 32px;
+  margin-top: 0;
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.23076923;
+}
+
+.c37 {
+  margin-bottom: 16px;
+  margin-top: 0;
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.23076923;
+}
+
+.c56 {
+  margin-top: 4px;
+  margin-bottom: 16px;
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.23076923;
+}
+
+.c45 {
+  margin-bottom: 24px;
+  margin-top: 0;
+  font-weight: 500;
+  font-size: 20px;
+  line-height: 1.2;
+}
+
+.c50 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+  margin-right: 8px;
+}
+
+.c50:hover {
+  background-color: #e1ebfa;
+}
+
+.c50:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c50:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c50:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c50:disabled {
+  opacity: .5;
+}
+
+.c52 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c52:hover {
+  background-color: #e1ebfa;
+}
+
+.c52:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c52:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c52:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c52:disabled {
+  opacity: .5;
+}
+
+.c51 {
+  color: #ffffff;
+  border-color: #216beb;
+  background-color: #216beb;
+}
+
+.c51:hover {
+  background-color: #1254c7;
+  border-color: #1254c7;
+}
+
+.c51:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #216beb;
+}
+
+.c51:focus:hover {
+  background-color: #1254c7;
+}
+
+.c53 {
+  color: #216beb;
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c19 {
+  background: transparent;
+  border: none;
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px 0px;
+  color: #00438f;
+  cursor: pointer;
+  margin-top: 16px;
+}
+
+.c19 .c9 {
+  border-radius: 50%;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c19 .c31 {
+  display: block;
+  font-weight: 500;
+  text-align: left;
+}
+
+.c19 .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 0;
+}
+
+.c19:hover .c9 {
+  background-color: #e1ebfa;
+}
+
+.c19:hover .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c19:active .c9 {
+  -webkit-transform: scale(0.875);
+  -ms-transform: scale(0.875);
+  transform: scale(0.875);
+  -webkit-transition: .2s ease-in;
+  transition: .2s ease-in;
+}
+
+.c19:disabled {
+  opacity: .5;
+}
+
+.c19:disabled:hover .c9,
+.c19:disabled:active .c9 {
+  background: none;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.c19:focus {
+  outline: none;
+}
+
+.c19:focus .c9 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c19:focus .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c57 {
+  background: transparent;
+  border: none;
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px 0px;
+  color: #00438f;
+  cursor: pointer;
+}
+
+.c57 .c9 {
+  border-radius: 50%;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c57 .c31 {
+  display: block;
+  font-weight: 500;
+  text-align: left;
+}
+
+.c57 .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 0;
+}
+
+.c57:hover .c9 {
+  background-color: #e1ebfa;
+}
+
+.c57:hover .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c57:active .c9 {
+  -webkit-transform: scale(0.875);
+  -ms-transform: scale(0.875);
+  transform: scale(0.875);
+  -webkit-transition: .2s ease-in;
+  transition: .2s ease-in;
+}
+
+.c57:disabled {
+  opacity: .5;
+}
+
+.c57:disabled:hover .c9,
+.c57:disabled:active .c9 {
+  background: none;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.c57:focus {
+  outline: none;
+}
+
+.c57:focus .c9 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c57:focus .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c3 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c3:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
+.c17 {
+  color: #00438f;
+  margin-right: 4px;
+  font-size: 12px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c17:hover {
+  cursor: pointer;
+  color: #002b5c;
+}
+
+.c4 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding: 2px 0;
+}
+
+.c48 {
+  width: 100%;
+}
+
+.c46 {
+  width: 100%;
+}
+
+.c46 .c27 {
+  margin-bottom: 0;
+}
+
+.c46 .Alert-u8lbe-0 {
+  margin-bottom: 48px;
+}
+
+.c46 .c47,
+.c46 .Fieldset-sc-9aoml1-0 {
+  margin-bottom: 24px;
+}
+
+.c46 .c47:last-child,
+.c46 .Fieldset-sc-9aoml1-0:last-child {
+  margin-bottom: 0;
+}
+
+.c46 .FormSection-sc-5yud6c-1 {
+  margin-bottom: 48px;
+}
+
+.c46 .FormSection-sc-5yud6c-1:last-child {
+  margin-bottom: 0;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  color: #ffffff;
+  border: none;
+  background-color: transparent;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  line-height: 1.5;
+  -webkit-transition: background-color .2s;
+  transition: background-color .2s;
+  font-size: 16px;
+  padding: 8px 28px 8px 16px;
+  border-radius: 4px;
+}
+
+.c8:hover,
+.c8:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c8:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c8:disabled {
+  opacity: .5;
+}
+
+.c11 {
+  display: block;
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: none;
+  background-color: transparent;
+  vertical-align: middle;
+  line-height: 1.5;
+  font-size: 16px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c11:hover,
+.c11:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c11:disabled {
+  opacity: .5;
+}
+
+.c11:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c7 div:not(:last-of-type) {
+  margin-right: 8px;
+}
+
+.c2 {
+  background-color: #122b47;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: #122b47;
+  padding: 16px 24px;
+}
+
+.c49 {
+  margin-bottom: 24px;
+  display: block;
+  width: 100%;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  min-height: 40px;
+  min-width: 20em;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c49:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c49::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c49::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c49:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c49::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c24 {
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 16px;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #00438f;
+  background-color: transparent;
+  border: none;
+  margin: 0px;
+  padding: 8px 24px;
+  position: relative;
+}
+
+.c24:focus {
+  outline: none;
+  background-color: #e1ebfa;
+}
+
+.c24:disabled {
+  opacity: .5;
+}
+
+.c24:before {
+  content: '';
+  background-color: #00438f;
+  height: 3px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  border-radius: 2px 2px 0 0;
+}
+
+.c25 {
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 16px;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #00438f;
+  background-color: transparent;
+  border: none;
+  margin: 0px;
+  padding: 8px 24px;
+  position: relative;
+}
+
+.c25:focus {
+  outline: none;
+  background-color: #e1ebfa;
+}
+
+.c25:disabled {
+  opacity: .5;
+}
+
+.c25:before {
+  content: '';
+  background-color: #c0c8d1;
+  height: 1px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 210;
+}
+
+.c25:hover:before {
+  content: '';
+  background-color: #e1ebfa;
+  height: 3px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  border-radius: 2px 2px 0 0;
+}
+
+.c22 {
+  position: absolute;
+  width: 0;
+  height: 40px;
+}
+
+.c23 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  white-space: nowrap;
+  overflow-x: scroll;
+  overflow-y: hidden;
+  margin-bottom: 8px;
+  position: relative;
+}
+
+.c23::-webkit-scrollbar {
+  display: none;
+}
+
+.c23:before {
+  content: '';
+  background-color: #c0c8d1;
+  height: 1px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
+.c40 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: auto;
+}
+
+.c40:first-child {
+  padding-left: 16px;
+}
+
+.c39 {
+  color: #434d59;
+  border-bottom: 1px solid #e4e7eb;
+}
+
+.c42 {
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-right: 16px;
+}
+
+.c42:first-child {
+  padding-left: 16px;
+}
+
+.c41:hover {
+  background-color: #f0f2f5;
+}
+
+.c38 {
+  border-collapse: collapse;
+  width: 100%;
+  background: white;
+}
+
+@media screen and (min-width:0px) {
+  .c54 {
+    width: calc(100vw - 48px - 16px);
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c54 {
+    width: 400px;
+  }
+}
+
+@media screen and (min-width:1360px) {
+  .c54 {
+    width: 472px;
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c54 {
+    border-left: solid 1px #e4e7eb;
+  }
+}
+
+@media screen and (min-width:0px) {
+  .c54 {
+    position: absolute;
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c54 {
+    position: static;
+  }
+}
+
+@media screen and (min-width:0px) {
+  .c16 {
+    width: calc(100vw - 96px - 16px);
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c16 {
+    width: auto;
+  }
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 irqwJg"
+      className="c1"
     >
       <header
-        class="NavBar-iayrjp-3 bwrKUV"
+        className=""
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 NavBar__NavBarBackground-iayrjp-0 btupnB"
+          className="c2"
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 clvBNI"
+            className="c3"
             color="blue"
-            font-size="medium"
+            fontSize="medium"
             href="/"
-            style="display:block;height:40px"
+            style={
+              Object {
+                "display": "block",
+                "height": "40px",
+              }
+            }
           >
             <div
-              class="Branding__BrandingWrap-ranqri-0 gACiZG Branding-ranqri-2 kQRWHN"
+              className="c4 "
+              size="medium"
             >
               <svg
                 height="32px"
-                style="display:block;margin:2px 0"
+                style={
+                  Object {
+                    "display": "block",
+                    "margin": "2px 0",
+                  }
+                }
                 viewBox="0 0 133 32"
                 width="133px"
               >
@@ -839,33 +2602,52 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
             </div>
           </a>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 cDPANM"
-            style="flex-grow:1;margin:0 0 0 24px"
+            className="c5"
+            style={
+              Object {
+                "flexGrow": "1",
+                "margin": "0 0 0 24px",
+              }
+            }
           >
             <nav
               aria-label="Primary navigation"
-              class="DesktopMenu__Nav-e4dzdq-3 bWwdcq DesktopMenu-e4dzdq-4 irbObu"
-              style="padding-right:24px"
+              className="c6 c7"
+              style={
+                Object {
+                  "paddingRight": "24px",
+                }
+              }
             >
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c8"
                   color="#ffffff"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Dashboard
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    aria-hidden={true}
+                    className="c9 c10"
                     color="#ffffff"
                     fill="#ffffff"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -877,7 +2659,7 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
               </div>
               <div>
                 <a
-                  class="DesktopMenu__MenuLink-e4dzdq-1 kgAySz"
+                  className="c11"
                   color="#ffffff"
                   href="/"
                 >
@@ -886,32 +2668,46 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
               </div>
             </nav>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
-              style="float:right"
+              className="c12"
+              style={
+                Object {
+                  "float": "right",
+                }
+              }
             >
               <nav
                 aria-label="Secondary navigation"
-                class="DesktopMenu__Nav-e4dzdq-3 bWwdcq DesktopMenu-e4dzdq-4 irbObu"
+                className="c6 c7"
               >
                 <div>
                   <button
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="c8"
                     color="#ffffff"
+                    onBlur={[Function]}
+                    onClick={[Function]}
                     type="button"
                   >
                     Settings
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 hIxIEB"
+                      aria-hidden={true}
+                      className="c9 c10"
                       color="#ffffff"
                       fill="#ffffff"
-                      focusable="false"
+                      focusable={false}
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px;right:8px"
+                      size="20px"
+                      style={
+                        Object {
+                          "position": "absolute",
+                          "right": "8px",
+                          "top": "11px",
+                        }
+                      }
+                      title={null}
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -927,35 +2723,42 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
         </div>
       </header>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 jKfurj"
+        className="c13"
       >
         <div
-          class="Box-sc-1qu1edy-0 hkydKC"
+          className="c14"
         >
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 guWDrb"
+            className="c15"
             height="32px"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fvgzBv"
-              width="[object Object]"
+              className="c16"
+              width={
+                Object {
+                  "extraSmall": "calc(100vw - 96px - 16px)",
+                  "medium": "auto",
+                }
+              }
             >
               <a
-                class="Link-sc-1lpx3d0-0 fEeoTP"
+                className="c17"
                 color="darkBlue"
-                font-size="smaller"
+                fontSize="smaller"
               >
                 Breadcrumb
               </a>
               <svg
-                aria-hidden="true"
-                class="Icon-fc7twp-0 fQFStW"
+                aria-hidden={true}
+                className="c9 c18"
                 color="darkGrey"
                 fill="#434d59"
-                focusable="false"
+                focusable={false}
                 height="20px"
                 icon="rightArrow"
                 mr="half"
+                size="20px"
+                title={null}
                 viewBox="0 0 24 24"
                 width="20px"
               >
@@ -964,21 +2767,23 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                 />
               </svg>
               <a
-                class="Link-sc-1lpx3d0-0 fEeoTP"
+                className="c17"
                 color="darkBlue"
-                font-size="smaller"
+                fontSize="smaller"
               >
                 Breadcrumb
               </a>
               <svg
-                aria-hidden="true"
-                class="Icon-fc7twp-0 fQFStW"
+                aria-hidden={true}
+                className="c9 c18"
                 color="darkGrey"
                 fill="#434d59"
-                focusable="false"
+                focusable={false}
                 height="20px"
                 icon="rightArrow"
                 mr="half"
+                size="20px"
+                title={null}
                 viewBox="0 0 24 24"
                 width="20px"
               >
@@ -988,17 +2793,21 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
               </svg>
             </div>
             <button
-              class="IconicButton__WrapperButton-sc-1u3dojp-1 dkgdQd IconicButton-sc-1u3dojp-2 gZASNp"
+              aria-label={null}
+              className="c19 "
+              disabled={false}
             >
               <svg
-                aria-hidden="true"
-                class="Icon-fc7twp-0 cwKdbD"
+                aria-hidden={true}
+                className="c9 c20"
                 color="currentColor"
                 fill="currentColor"
-                focusable="false"
+                focusable={false}
                 height="32px"
                 icon="more"
                 p="half"
+                size="32px"
+                title={null}
                 viewBox="0 0 24 24"
                 width="32px"
               >
@@ -1009,180 +2818,205 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
             </button>
           </div>
           <h1
-            class="Text-sc-1wu7vpu-0-h1 fKaScO"
-            font-size="largest"
-            font-weight="light"
+            className="c31-h1 c21"
+            fontSize="largest"
+            fontWeight="light"
           >
             I am title
           </h1>
           <div
-            class="TabScrollIndicators__TabScrollIndicatorContainer-sc-1cljxwo-0 gsIAKI"
-            width="0"
+            className="c22"
+            width={0}
           />
           <div
-            class="Tabs__TabContainer-o5d5cd-0 giufLG"
+            className="c23"
+            onScroll={[Function]}
             role="tablist"
           >
             <div />
             <button
-              aria-selected="true"
-              class="Tab__TabButton-sc-69abpu-0 kfQsHL"
+              aria-selected={true}
+              className="c24"
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
               role="tab"
-              selected=""
-              tabindex="0"
+              selected={true}
+              tabIndex={0}
             >
               Details
             </button>
             <button
-              aria-selected="false"
-              class="Tab__TabButton-sc-69abpu-0 gcfVpD"
+              aria-selected={false}
+              className="c25"
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
               role="tab"
-              tabindex="-1"
+              selected={false}
+              tabIndex={-1}
             >
               Milestones
             </button>
             <button
-              aria-selected="false"
-              class="Tab__TabButton-sc-69abpu-0 gcfVpD"
+              aria-selected={false}
+              className="c25"
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
               role="tab"
-              tabindex="-1"
+              selected={false}
+              tabIndex={-1}
             >
               Production Records
             </button>
           </div>
           <div
-            aria-hidden="false"
-            selected=""
+            aria-hidden={false}
+            hidden={false}
+            selected={true}
           >
             <div
-              class="Box-sc-1qu1edy-0 EBPVx"
+              className="c26"
             >
               <h2
-                class="Text-sc-1wu7vpu-0-h2 hKxFww"
-                font-size="larger"
-                font-weight="medium"
+                className="c27 c28"
+                fontSize="larger"
+                fontWeight="medium"
               >
                 Details
               </h2>
               <div
-                class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 cOjpeh"
+                className="c29"
               >
                 <div
-                  class="Box-sc-1qu1edy-0 kppLzh"
-                  width="0.3333333333333333"
+                  className="c30"
+                  width={0.3333333333333333}
                 >
                   <p
-                    class="Text-sc-1wu7vpu-0 tVyVn"
+                    className="c31 c32"
                     color="currentColor"
-                    font-size="small"
-                    font-weight="bold"
+                    disabled={false}
+                    fontSize="small"
+                    fontWeight="bold"
                   >
                     Purchase Order Number
                   </p>
                   <p
-                    class="Text-sc-1wu7vpu-0 RbfMK"
+                    className="c31 c33"
                     color="currentColor"
-                    font-size="medium"
+                    disabled={false}
+                    fontSize="medium"
                   >
                     7050007201911
                   </p>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 iNeoFr"
-                  width="0.3333333333333333"
+                  className="c34"
+                  width={0.3333333333333333}
                 >
                   <p
-                    class="Text-sc-1wu7vpu-0 tVyVn"
+                    className="c31 c32"
                     color="currentColor"
-                    font-size="small"
-                    font-weight="bold"
+                    disabled={false}
+                    fontSize="small"
+                    fontWeight="bold"
                   >
                     Purchase Order Number
                   </p>
                   <p
-                    class="Text-sc-1wu7vpu-0 RbfMK"
+                    className="c31 c33"
                     color="currentColor"
-                    font-size="medium"
+                    disabled={false}
+                    fontSize="medium"
                   >
                     7050007201911
                   </p>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 jgRzAy"
-                  width="0.3333333333333333"
+                  className="c35"
+                  width={0.3333333333333333}
                 >
                   <p
-                    class="Text-sc-1wu7vpu-0 tVyVn"
+                    className="c31 c32"
                     color="currentColor"
-                    font-size="small"
-                    font-weight="bold"
+                    disabled={false}
+                    fontSize="small"
+                    fontWeight="bold"
                   >
                     Purchase Order Number
                   </p>
                   <p
-                    class="Text-sc-1wu7vpu-0 RbfMK"
+                    className="c31 c33"
                     color="currentColor"
-                    font-size="medium"
+                    disabled={false}
+                    fontSize="medium"
                   >
                     7050007201911
                   </p>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 kppLzh"
-                  width="0.3333333333333333"
+                  className="c30"
+                  width={0.3333333333333333}
                 >
                   <p
-                    class="Text-sc-1wu7vpu-0 tVyVn"
+                    className="c31 c32"
                     color="currentColor"
-                    font-size="small"
-                    font-weight="bold"
+                    disabled={false}
+                    fontSize="small"
+                    fontWeight="bold"
                   >
                     Purchase Order Number
                   </p>
                   <p
-                    class="Text-sc-1wu7vpu-0 RbfMK"
+                    className="c31 c33"
                     color="currentColor"
-                    font-size="medium"
+                    disabled={false}
+                    fontSize="medium"
                   >
                     7050007201911
                   </p>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 iNeoFr"
-                  width="0.3333333333333333"
+                  className="c34"
+                  width={0.3333333333333333}
                 >
                   <p
-                    class="Text-sc-1wu7vpu-0 tVyVn"
+                    className="c31 c32"
                     color="currentColor"
-                    font-size="small"
-                    font-weight="bold"
+                    disabled={false}
+                    fontSize="small"
+                    fontWeight="bold"
                   >
                     Purchase Order Number
                   </p>
                   <p
-                    class="Text-sc-1wu7vpu-0 RbfMK"
+                    className="c31 c33"
                     color="currentColor"
-                    font-size="medium"
+                    disabled={false}
+                    fontSize="medium"
                   >
                     7050007201911
                   </p>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 jgRzAy"
-                  width="0.3333333333333333"
+                  className="c35"
+                  width={0.3333333333333333}
                 >
                   <p
-                    class="Text-sc-1wu7vpu-0 tVyVn"
+                    className="c31 c32"
                     color="currentColor"
-                    font-size="small"
-                    font-weight="bold"
+                    disabled={false}
+                    fontSize="small"
+                    fontWeight="bold"
                   >
                     Purchase Order Number
                   </p>
                   <p
-                    class="Text-sc-1wu7vpu-0 RbfMK"
+                    className="c31 c33"
                     color="currentColor"
-                    font-size="medium"
+                    disabled={false}
+                    fontSize="medium"
                   >
                     7050007201911
                   </p>
@@ -1191,49 +3025,50 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
             </div>
           </div>
           <div
-            aria-hidden="true"
-            hidden=""
+            aria-hidden={true}
+            hidden={true}
+            selected={false}
           >
             <div
-              class="Box-sc-1qu1edy-0 cSRExr"
+              className="c36"
             >
               <h2
-                class="Text-sc-1wu7vpu-0-h2 jBTFWi"
-                font-size="larger"
-                font-weight="medium"
+                className="c27 c37"
+                fontSize="larger"
+                fontWeight="medium"
               >
                 Milestone Performance
               </h2>
               <table
-                class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+                className="c38"
               >
                 <thead>
                   <tr
-                    class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
+                    className="c39"
                   >
                     <th
-                      class="StyledTh-sc-10nzyk9-0 sBlyT"
+                      className="c40"
                       data-testid="table-head"
                       scope="col"
                     >
                       Milestone
                     </th>
                     <th
-                      class="StyledTh-sc-10nzyk9-0 sBlyT"
+                      className="c40"
                       data-testid="table-head"
                       scope="col"
                     >
                       Expected Completion
                     </th>
                     <th
-                      class="StyledTh-sc-10nzyk9-0 sBlyT"
+                      className="c40"
                       data-testid="table-head"
                       scope="col"
                     >
                       Actual Completion
                     </th>
                     <th
-                      class="StyledTh-sc-10nzyk9-0 sBlyT"
+                      className="c40"
                       data-testid="table-head"
                       scope="col"
                     >
@@ -1245,37 +3080,41 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                   data-testid="table-body"
                 >
                   <tr
-                    class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    className="c41"
                     data-testid="table-row"
                   >
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c42"
                     >
                       PO Line Item Created
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c42"
                     >
                       Nov 3, 2019
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c42"
                     >
                       Dec 13, 2019
                     </td>
-                    <td>
+                    <td
+                      colSpan={null}
+                    >
                       <div
-                        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+                        className="c12"
                       >
                         <svg
-                          aria-hidden="true"
-                          class="Icon-fc7twp-0 bKcUEK"
+                          aria-hidden={true}
+                          className="c9 c43"
                           color="red"
                           fill="#cc1439"
-                          focusable="false"
+                          focusable={false}
                           height="24px"
                           icon="error"
                           mr="half"
+                          size="24px"
+                          title={null}
                           viewBox="0 0 24 24"
                           width="24px"
                         >
@@ -1284,9 +3123,10 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                           />
                         </svg>
                         <p
-                          class="Text-sc-1wu7vpu-0 RbfMK"
+                          className="c31 c33"
                           color="currentColor"
-                          font-size="medium"
+                          disabled={false}
+                          fontSize="medium"
                         >
                           10 Days Late
                         </p>
@@ -1294,37 +3134,41 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                     </td>
                   </tr>
                   <tr
-                    class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    className="c41"
                     data-testid="table-row"
                   >
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c42"
                     >
                       PO Line Item Created
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c42"
                     >
                       Nov 3, 2019
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c42"
                     >
                       Dec 13, 2019
                     </td>
-                    <td>
+                    <td
+                      colSpan={null}
+                    >
                       <div
-                        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+                        className="c12"
                       >
                         <svg
-                          aria-hidden="true"
-                          class="Icon-fc7twp-0 bKcUEK"
+                          aria-hidden={true}
+                          className="c9 c43"
                           color="red"
                           fill="#cc1439"
-                          focusable="false"
+                          focusable={false}
                           height="24px"
                           icon="error"
                           mr="half"
+                          size="24px"
+                          title={null}
                           viewBox="0 0 24 24"
                           width="24px"
                         >
@@ -1333,9 +3177,10 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                           />
                         </svg>
                         <p
-                          class="Text-sc-1wu7vpu-0 RbfMK"
+                          className="c31 c33"
                           color="currentColor"
-                          font-size="medium"
+                          disabled={false}
+                          fontSize="medium"
                         >
                           40 Days Late
                         </p>
@@ -1343,37 +3188,41 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                     </td>
                   </tr>
                   <tr
-                    class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    className="c41"
                     data-testid="table-row"
                   >
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c42"
                     >
                       PO Line Item Created
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c42"
                     >
                       Nov 3, 2019
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c42"
                     >
                       Dec 13, 2019
                     </td>
-                    <td>
+                    <td
+                      colSpan={null}
+                    >
                       <div
-                        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+                        className="c12"
                       >
                         <svg
-                          aria-hidden="true"
-                          class="Icon-fc7twp-0 bKcUEK"
+                          aria-hidden={true}
+                          className="c9 c43"
                           color="red"
                           fill="#cc1439"
-                          focusable="false"
+                          focusable={false}
                           height="24px"
                           icon="error"
                           mr="half"
+                          size="24px"
+                          title={null}
                           viewBox="0 0 24 24"
                           width="24px"
                         >
@@ -1382,9 +3231,10 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                           />
                         </svg>
                         <p
-                          class="Text-sc-1wu7vpu-0 RbfMK"
+                          className="c31 c33"
                           color="currentColor"
-                          font-size="medium"
+                          disabled={false}
+                          fontSize="medium"
                         >
                           40 Days Late
                         </p>
@@ -1392,37 +3242,41 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                     </td>
                   </tr>
                   <tr
-                    class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    className="c41"
                     data-testid="table-row"
                   >
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c42"
                     >
                       PO Line Item Created
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c42"
                     >
                       Nov 3, 2019
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c42"
                     >
                       Dec 13, 2019
                     </td>
-                    <td>
+                    <td
+                      colSpan={null}
+                    >
                       <div
-                        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+                        className="c12"
                       >
                         <svg
-                          aria-hidden="true"
-                          class="Icon-fc7twp-0 bKcUEK"
+                          aria-hidden={true}
+                          className="c9 c43"
                           color="red"
                           fill="#cc1439"
-                          focusable="false"
+                          focusable={false}
                           height="24px"
                           icon="error"
                           mr="half"
+                          size="24px"
+                          title={null}
                           viewBox="0 0 24 24"
                           width="24px"
                         >
@@ -1431,9 +3285,10 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                           />
                         </svg>
                         <p
-                          class="Text-sc-1wu7vpu-0 RbfMK"
+                          className="c31 c33"
                           color="currentColor"
-                          font-size="medium"
+                          disabled={false}
+                          fontSize="medium"
                         >
                           40 Days Late
                         </p>
@@ -1446,42 +3301,43 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
             </div>
           </div>
           <div
-            aria-hidden="true"
-            hidden=""
+            aria-hidden={true}
+            hidden={true}
+            selected={false}
           >
             <div
-              class="Box-sc-1qu1edy-0 EBPVx"
+              className="c26"
             >
               <h2
-                class="Text-sc-1wu7vpu-0-h2 jBTFWi"
-                font-size="larger"
-                font-weight="medium"
+                className="c27 c37"
+                fontSize="larger"
+                fontWeight="medium"
               >
                 Production Records
               </h2>
               <table
-                class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+                className="c38"
               >
                 <thead>
                   <tr
-                    class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
+                    className="c39"
                   >
                     <th
-                      class="StyledTh-sc-10nzyk9-0 sBlyT"
+                      className="c40"
                       data-testid="table-head"
                       scope="col"
                     >
                       Date
                     </th>
                     <th
-                      class="StyledTh-sc-10nzyk9-0 sBlyT"
+                      className="c40"
                       data-testid="table-head"
                       scope="col"
                     >
                       Expected Quantity
                     </th>
                     <th
-                      class="StyledTh-sc-10nzyk9-0 sBlyT"
+                      className="c40"
                       data-testid="table-head"
                       scope="col"
                     >
@@ -1493,81 +3349,81 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                   data-testid="table-body"
                 >
                   <tr
-                    class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    className="c41"
                     data-testid="table-row"
                   >
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c42"
                     >
                       2019-10-01
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c42"
                     >
                       2,025 eaches
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c42"
                     >
                       1,800 eaches
                     </td>
                   </tr>
                   <tr
-                    class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    className="c41"
                     data-testid="table-row"
                   >
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c42"
                     >
                       2019-10-02
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c42"
                     >
                       2,475 eaches
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c42"
                     >
                       2,250 eaches
                     </td>
                   </tr>
                   <tr
-                    class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    className="c41"
                     data-testid="table-row"
                   >
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c42"
                     >
                       2019-10-03
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c42"
                     >
                       2,475 eaches
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c42"
                     >
                       1,425 eaches
                     </td>
                   </tr>
                   <tr
-                    class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    className="c41"
                     data-testid="table-row"
                   >
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c42"
                     >
                       2019-10-24
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c42"
                     >
                       2,475 eaches
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c42"
                     >
                       -
                     </td>
@@ -1577,39 +3433,46 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
               </table>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 cEnpFJ"
+              className="c44"
             >
               <h3
-                class="Text-sc-1wu7vpu-0-h3 Headings__SubsectionTitle-igpciy-0 fKBIog"
-                font-size="large"
-                font-weight="medium"
+                className="c31-h3 c45"
+                fontSize="large"
+                fontWeight="medium"
               >
                 Comments
               </h3>
               <form
-                class="Form-n70q8u-0 ilQSyT"
+                className="c46"
               >
                 <div
-                  class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+                  className="c47 c48"
                 >
                   <textarea
-                    aria-invalid="false"
-                    aria-required="false"
-                    class="Textarea__StyledTextarea-sc-1tyrhr0-0 ktRBsI"
+                    aria-invalid={false}
+                    aria-required={false}
+                    className="c49"
+                    disabled={false}
+                    id={null}
                     placeholder="Leave a comment..."
-                    rows="4"
+                    required={false}
+                    rows={4}
                   />
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 jlPsmj"
+                  className=""
                 >
                   <button
-                    class="Button__WrapperButton-sc-1omxup2-0 kFmWUd PrimaryButton-qz78sb-0 cGyyDq"
+                    className="c50 c51"
+                    disabled={false}
+                    size="medium"
                   >
                     Comment
                   </button>
                   <button
-                    class="Button__WrapperButton-sc-1omxup2-0 hkfOQr QuietButton-sc-1l5k8i4-0 eAbPwX"
+                    className="c52 c53"
+                    disabled={false}
+                    size="medium"
                   >
                     Cancel
                   </button>
@@ -1619,31 +3482,41 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
           </div>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 cTLuiE"
-          width="[object Object]"
+          className="c54"
+          width={
+            Object {
+              "extraSmall": "calc(100vw - 48px - 16px)",
+              "large": "472px",
+              "medium": "400px",
+            }
+          }
         >
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 ixsBzc"
+            className="c55"
           >
             <h2
-              class="Text-sc-1wu7vpu-0-h2 flYnRO"
-              font-size="larger"
-              font-weight="medium"
+              className="c27 c56"
+              fontSize="larger"
+              fontWeight="medium"
             >
               I am sidebar
             </h2>
             <button
-              class="IconicButton__WrapperButton-sc-1u3dojp-1 UMPof IconicButton-sc-1u3dojp-2 gZASNp"
+              aria-label={null}
+              className="c57 "
+              disabled={false}
             >
               <svg
-                aria-hidden="true"
-                class="Icon-fc7twp-0 cwKdbD"
+                aria-hidden={true}
+                className="c9 c20"
                 color="currentColor"
                 fill="currentColor"
-                focusable="false"
+                focusable={false}
                 height="32px"
                 icon="close"
                 p="half"
+                size="32px"
+                title={null}
                 viewBox="0 0 24 24"
                 width="32px"
               >
@@ -1654,9 +3527,10 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
             </button>
           </div>
           <p
-            class="Text-sc-1wu7vpu-0 RbfMK"
+            className="c31 c33"
             color="currentColor"
-            font-size="medium"
+            disabled={false}
+            fontSize="medium"
           >
             I am sidebar content.
           </p>
@@ -1668,35 +3542,1514 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
 `;
 
 exports[`Storyshots Pages/Details page With sidebar 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c15 {
+  padding: 24px;
+  -webkit-box-flex: 2;
+  -webkit-flex-grow: 2;
+  -ms-flex-positive: 2;
+  flex-grow: 2;
+}
+
+.c21 {
+  padding-top: 16px;
+  margin-bottom: 24px;
+}
+
+.c25 {
+  padding-right: 8px;
+  margin-bottom: 24px;
+  width: 33.33333333333333%;
+}
+
+.c29 {
+  padding-left: 8px;
+  padding-right: 8px;
+  margin-bottom: 24px;
+  width: 33.33333333333333%;
+}
+
+.c30 {
+  padding-left: 8px;
+  margin-bottom: 24px;
+  width: 33.33333333333333%;
+}
+
+.c31 {
+  padding-top: 16px;
+  padding-bottom: 16px;
+}
+
+.c39 {
+  padding-top: 8px;
+}
+
+.c49 {
+  background-color: #ffffff;
+  padding-top: 24px;
+  padding-right: 16px;
+  padding-bottom: 24px;
+  padding-left: 24px;
+  border-radius: 4px;
+}
+
+.c59 {
+  margin-bottom: 8px;
+}
+
+.c62 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c1 {
+  background-color: #f0f2f5;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-content: flex-end;
+  -ms-flex-line-pack: end;
+  align-content: flex-end;
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c14 {
+  background-color: #ffffff;
+  margin: 8px;
+  min-height: calc(100vh - 72px - 48px - 16px);
+  border-radius: 4px;
+  box-shadow: 0px 3px 5px 0px rgba(1,30,56,0.1);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c24 {
+  margin-bottom: 24px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c50 {
+  margin-bottom: 32px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c61 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c67 {
+  color: #cc1439;
+  margin-top: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c11 {
+  padding: 2px;
+  color: #ffffff;
+  min-width: 20px;
+}
+
+.c38 {
+  margin-right: 4px;
+  color: #cc1439;
+  min-width: 24px;
+}
+
+.c53 {
+  padding: 4px;
+  color: currentColor;
+  min-width: 32px;
+}
+
+.c68 {
+  margin-right: 8px;
+  color: currentColor;
+  min-width: 24px;
+}
+
+.c27 {
+  margin-bottom: 8px;
+  margin-top: 0;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+  color: currentColor;
+}
+
+.c28 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c64 {
+  margin-left: 8px;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #434d59;
+}
+
+.c82 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+  opacity: 0.3333;
+}
+
+.c94 {
+  margin-bottom: 0px;
+  margin-left: 8px;
+  margin-top: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c97 {
+  margin-bottom: 0px;
+  margin-left: 8px;
+  margin-top: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+  opacity: 0.3333;
+}
+
+.c16 {
+  margin-bottom: 48px;
+  margin-top: 0;
+  font-size: 46px;
+  line-height: 1.04347826;
+  font-weight: 300;
+}
+
+.c23 {
+  margin-bottom: 32px;
+  margin-top: 0;
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.23076923;
+}
+
+.c32 {
+  margin-bottom: 16px;
+  margin-top: 0;
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.23076923;
+}
+
+.c51 {
+  margin-top: 4px;
+  margin-bottom: 16px;
+  font-weight: 500;
+  font-size: 26px;
+  line-height: 1.23076923;
+}
+
+.c40 {
+  margin-bottom: 24px;
+  margin-top: 0;
+  font-weight: 500;
+  font-size: 20px;
+  line-height: 1.2;
+}
+
+.c76 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c80 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c45 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+  margin-right: 8px;
+}
+
+.c45:hover {
+  background-color: #e1ebfa;
+}
+
+.c45:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c45:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c45:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c45:disabled {
+  opacity: .5;
+}
+
+.c47 {
+  width: auto;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c47:hover {
+  background-color: #e1ebfa;
+}
+
+.c47:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c47:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c47:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c47:disabled {
+  opacity: .5;
+}
+
+.c46 {
+  color: #ffffff;
+  border-color: #216beb;
+  background-color: #216beb;
+}
+
+.c46:hover {
+  background-color: #1254c7;
+  border-color: #1254c7;
+}
+
+.c46:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #216beb;
+}
+
+.c46:focus:hover {
+  background-color: #1254c7;
+}
+
+.c48 {
+  color: #216beb;
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.c52 {
+  background: transparent;
+  border: none;
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 4px 0px;
+  color: #00438f;
+  cursor: pointer;
+}
+
+.c52 .c10 {
+  border-radius: 50%;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c52 .c26 {
+  display: block;
+  font-weight: 500;
+  text-align: left;
+}
+
+.c52 .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 0;
+}
+
+.c52:hover .c10 {
+  background-color: #e1ebfa;
+}
+
+.c52:hover .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c52:active .c10 {
+  -webkit-transform: scale(0.875);
+  -ms-transform: scale(0.875);
+  transform: scale(0.875);
+  -webkit-transition: .2s ease-in;
+  transition: .2s ease-in;
+}
+
+.c52:disabled {
+  opacity: .5;
+}
+
+.c52:disabled:hover .c10,
+.c52:disabled:active .c10 {
+  background: none;
+  -webkit-transform: none;
+  -ms-transform: none;
+  transform: none;
+}
+
+.c52:focus {
+  outline: none;
+}
+
+.c52:focus .c10 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c52:focus .IconicButton__HoverText-sc-1u3dojp-0 {
+  opacity: 1;
+}
+
+.c4 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c4:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
+.c69 .c26 {
+  margin-bottom: 8px;
+}
+
+.c69 > *:last-child {
+  margin-bottom: 0;
+}
+
+.c5 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding: 2px 0;
+}
+
+.c65 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+  font-size: 14px;
+  line-height: 1.71428571;
+}
+
+.c65 .c3 {
+  font-size: 14px;
+}
+
+.c58 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c60 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c43 {
+  width: 100%;
+}
+
+.c72 {
+  padding: 0;
+  border: 0;
+  margin: 0;
+  width: 100%;
+}
+
+.c72 legend {
+  padding: 0;
+}
+
+.c57 {
+  margin-top: 0;
+  margin-bottom: 8px;
+  font-weight: 500;
+  font-size: 20px;
+  line-height: 1.2;
+}
+
+.c55 {
+  width: 100%;
+  padding: 0;
+  margin: 0;
+  border: none;
+}
+
+.c55 .c56 {
+  padding: 0;
+  margin-bottom: 24px;
+}
+
+.c55 .c42,
+.c55 .c71 {
+  margin-bottom: 24px;
+}
+
+.c55 .c42:last-child,
+.c55 .c71:last-child {
+  margin-bottom: 0;
+}
+
+.c41 {
+  width: 100%;
+}
+
+.c41 .c22 {
+  margin-bottom: 0;
+}
+
+.c41 .Alert-u8lbe-0 {
+  margin-bottom: 48px;
+}
+
+.c41 .c42,
+.c41 .c71 {
+  margin-bottom: 24px;
+}
+
+.c41 .c42:last-child,
+.c41 .c71:last-child {
+  margin-bottom: 0;
+}
+
+.c41 .c54 {
+  margin-bottom: 48px;
+}
+
+.c41 .c54:last-child {
+  margin-bottom: 0;
+}
+
+.c63 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c63:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c63:focus ~ svg {
+  fill: #00438f;
+}
+
+.c63::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c63::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c63:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c63::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c66 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #cc1439;
+  border-color: #cc1439;
+}
+
+.c66:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c66:focus ~ svg {
+  fill: #00438f;
+}
+
+.c66::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c66::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c66:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c66::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c70 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: rgba(1,30,56,0.3333);
+  border-color: #e4e7eb;
+  background-color: #f0f2f5;
+}
+
+.c70:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c70:focus ~ svg {
+  fill: #00438f;
+}
+
+.c70::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c70::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c70:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c70::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  color: #ffffff;
+  border: none;
+  background-color: transparent;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  line-height: 1.5;
+  -webkit-transition: background-color .2s;
+  transition: background-color .2s;
+  font-size: 16px;
+  padding: 8px 28px 8px 16px;
+  border-radius: 4px;
+}
+
+.c9:hover,
+.c9:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c9:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c9:disabled {
+  opacity: .5;
+}
+
+.c12 {
+  display: block;
+  color: #ffffff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border: none;
+  background-color: transparent;
+  vertical-align: middle;
+  line-height: 1.5;
+  font-size: 16px;
+  padding: 8px 16px;
+  border-radius: 4px;
+  -webkit-transition: .2s;
+  transition: .2s;
+}
+
+.c12:hover,
+.c12:focus {
+  outline: none;
+  color: #e1ebfa;
+  background-color: #011e38;
+  cursor: pointer;
+}
+
+.c12:disabled {
+  opacity: .5;
+}
+
+.c12:focus {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c8 div:not(:last-of-type) {
+  margin-right: 8px;
+}
+
+.c2 {
+  background-color: #122b47;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: #122b47;
+  padding: 16px 24px;
+}
+
+.c79 {
+  min-width: 16px;
+  height: 16px;
+  border-radius: 2px;
+  border: solid 1px;
+  position: relative;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c79:before {
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  width: 3px;
+  height: 9px;
+  border: solid #ffffff;
+  border-radius: 1px;
+  border-width: 0 3px 3px 0;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.c77 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c77:focus + .c78 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c77:checked + .c78 {
+  border-color: #00438f;
+  background-color: #00438f;
+}
+
+.c77:checked + .c78:before {
+  display: block;
+}
+
+.c77:not(:checked) + .c78 {
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+}
+
+.c81 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c81:focus + .c78 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c81:checked + .c78 {
+  border-color: #e4e7eb;
+  background-color: #e4e7eb;
+}
+
+.c81:checked + .c78:before {
+  display: block;
+}
+
+.c81:not(:checked) + .c78 {
+  border-color: #e4e7eb;
+  background-color: #f0f2f5;
+}
+
+.c75 {
+  padding: 4px 0;
+}
+
+.c75 .c26 {
+  margin-left: 8px;
+}
+
+.c74 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c73 {
+  margin-bottom: 8px;
+}
+
+.c86 {
+  min-width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  border-radius: 50%;
+  border: solid 1px;
+  position: relative;
+  top: 4px;
+}
+
+.c86:before {
+  cursor: pointer;
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  top: 4px;
+  width: 2px;
+  height: 2px;
+  background: #ffffff;
+  border: 2px solid #ffffff;
+  border-radius: 50%;
+}
+
+.c88 {
+  min-width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  border-radius: 50%;
+  border: solid 1px;
+  position: relative;
+  top: 4px;
+}
+
+.c88:before {
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  top: 4px;
+  width: 2px;
+  height: 2px;
+  background: #ffffff;
+  border: 2px solid #ffffff;
+  border-radius: 50%;
+}
+
+.c84 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c84:focus + .c85 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c84:checked + .c85 {
+  border-color: #cc1439;
+  background-color: #cc1439;
+}
+
+.c84:checked + .c85:before {
+  display: block;
+}
+
+.c84:not(:checked) + .c85 {
+  border-color: #cc1439;
+  background-color: #ffffff;
+}
+
+.c87 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c87:focus + .c85 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c87:checked + .c85 {
+  border-color: #e4e7eb;
+  background-color: #e4e7eb;
+}
+
+.c87:checked + .c85:before {
+  display: block;
+}
+
+.c87:not(:checked) + .c85 {
+  border-color: #e4e7eb;
+  background-color: #f0f2f5;
+}
+
+.c83 {
+  padding: 4px 0;
+}
+
+.c93 {
+  position: absolute;
+  height: 24px;
+  width: 48px;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: #e4e7eb;
+  border-radius: 12px;
+  -webkit-transition: .2s ease;
+  transition: .2s ease;
+  cursor: pointer;
+}
+
+.c93:before {
+  content: '';
+  position: absolute;
+  height: 24px;
+  width: 24px;
+  left: 0px;
+  top: 0px;
+  border-radius: 50%;
+  box-sizing: border-box;
+  border: solid 1px;
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+  -webkit-transition: .2s ease;
+  transition: .2s ease;
+}
+
+.c96 {
+  position: absolute;
+  height: 24px;
+  width: 48px;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: #e4e7eb;
+  border-radius: 12px;
+  -webkit-transition: .2s ease;
+  transition: .2s ease;
+}
+
+.c96:before {
+  content: '';
+  position: absolute;
+  height: 24px;
+  width: 24px;
+  left: 0px;
+  top: 0px;
+  border-radius: 50%;
+  box-sizing: border-box;
+  border: solid 1px;
+  border-color: #e4e7eb;
+  background-color: #f0f2f5;
+  -webkit-transition: .2s ease;
+  transition: .2s ease;
+}
+
+.c90 {
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  min-width: 48px;
+  min-height: 24px;
+}
+
+.c90 input {
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+}
+
+.c91:checked + .c92:before {
+  -webkit-transform: translateX(24px);
+  -ms-transform: translateX(24px);
+  transform: translateX(24px);
+  background-color: #00438f;
+  border-color: #00438f;
+}
+
+.c91:checked + .c92 {
+  background-color: #e1ebfa;
+}
+
+.c91:focus + .c92:before {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c95:checked + .c92:before {
+  -webkit-transform: translateX(24px);
+  -ms-transform: translateX(24px);
+  transform: translateX(24px);
+  background-color: #e4e7eb;
+  border-color: #f0f2f5;
+}
+
+.c95:checked + .c92 {
+  background-color: #f0f2f5;
+}
+
+.c89 {
+  padding: 4px 0;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c44 {
+  margin-bottom: 24px;
+  display: block;
+  width: 100%;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  min-height: 40px;
+  min-width: 20em;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c44:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c44::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c44::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c44:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c44::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c19 {
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 16px;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #00438f;
+  background-color: transparent;
+  border: none;
+  margin: 0px;
+  padding: 8px 24px;
+  position: relative;
+}
+
+.c19:focus {
+  outline: none;
+  background-color: #e1ebfa;
+}
+
+.c19:disabled {
+  opacity: .5;
+}
+
+.c19:before {
+  content: '';
+  background-color: #00438f;
+  height: 3px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  border-radius: 2px 2px 0 0;
+}
+
+.c20 {
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-size: 16px;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #00438f;
+  background-color: transparent;
+  border: none;
+  margin: 0px;
+  padding: 8px 24px;
+  position: relative;
+}
+
+.c20:focus {
+  outline: none;
+  background-color: #e1ebfa;
+}
+
+.c20:disabled {
+  opacity: .5;
+}
+
+.c20:before {
+  content: '';
+  background-color: #c0c8d1;
+  height: 1px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 210;
+}
+
+.c20:hover:before {
+  content: '';
+  background-color: #e1ebfa;
+  height: 3px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  border-radius: 2px 2px 0 0;
+}
+
+.c17 {
+  position: absolute;
+  width: 0;
+  height: 40px;
+}
+
+.c18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  white-space: nowrap;
+  overflow-x: scroll;
+  overflow-y: hidden;
+  margin-bottom: 8px;
+  position: relative;
+}
+
+.c18::-webkit-scrollbar {
+  display: none;
+}
+
+.c18:before {
+  content: '';
+  background-color: #c0c8d1;
+  height: 1px;
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
+.c35 {
+  font-weight: normal;
+  text-align: left;
+  padding: 16px 0;
+  padding-right: 16px;
+  color: #434d59;
+  width: auto;
+}
+
+.c35:first-child {
+  padding-left: 16px;
+}
+
+.c34 {
+  color: #434d59;
+  border-bottom: 1px solid #e4e7eb;
+}
+
+.c37 {
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-right: 16px;
+}
+
+.c37:first-child {
+  padding-left: 16px;
+}
+
+.c36:hover {
+  background-color: #f0f2f5;
+}
+
+.c33 {
+  border-collapse: collapse;
+  width: 100%;
+  background: white;
+}
+
+@media screen and (min-width:0px) {
+  .c49 {
+    width: calc(100vw - 48px - 16px);
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c49 {
+    width: 400px;
+  }
+}
+
+@media screen and (min-width:1360px) {
+  .c49 {
+    width: 472px;
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c49 {
+    border-left: solid 1px #e4e7eb;
+  }
+}
+
+@media screen and (min-width:0px) {
+  .c49 {
+    position: absolute;
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c49 {
+    position: static;
+  }
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 irqwJg"
+      className="c1"
     >
       <header
-        class="NavBar-iayrjp-3 bwrKUV"
+        className=""
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 NavBar__NavBarBackground-iayrjp-0 btupnB"
+          className="c2"
         >
           <a
             aria-label="Nulogy logo"
-            class="Link-sc-1lpx3d0-0 clvBNI"
+            className="c3 c4"
             color="blue"
-            font-size="medium"
+            fontSize="medium"
             href="/"
-            style="display:block;height:40px"
+            style={
+              Object {
+                "display": "block",
+                "height": "40px",
+              }
+            }
           >
             <div
-              class="Branding__BrandingWrap-ranqri-0 gACiZG Branding-ranqri-2 kQRWHN"
+              className="c5 "
+              size="medium"
             >
               <svg
                 height="32px"
-                style="display:block;margin:2px 0"
+                style={
+                  Object {
+                    "display": "block",
+                    "margin": "2px 0",
+                  }
+                }
                 viewBox="0 0 133 32"
                 width="133px"
               >
@@ -1732,33 +5085,52 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
             </div>
           </a>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 cDPANM"
-            style="flex-grow:1;margin:0 0 0 24px"
+            className="c6"
+            style={
+              Object {
+                "flexGrow": "1",
+                "margin": "0 0 0 24px",
+              }
+            }
           >
             <nav
               aria-label="Primary navigation"
-              class="DesktopMenu__Nav-e4dzdq-3 bWwdcq DesktopMenu-e4dzdq-4 irbObu"
-              style="padding-right:24px"
+              className="c7 c8"
+              style={
+                Object {
+                  "paddingRight": "24px",
+                }
+              }
             >
               <div>
                 <button
-                  aria-expanded="false"
-                  aria-haspopup="true"
-                  class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="c9"
                   color="#ffffff"
+                  onBlur={[Function]}
+                  onClick={[Function]}
                   type="button"
                 >
                   Dashboard
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 hIxIEB"
+                    aria-hidden={true}
+                    className="c10 c11"
                     color="#ffffff"
                     fill="#ffffff"
-                    focusable="false"
+                    focusable={false}
                     height="20px"
                     icon="downArrow"
                     p="2px"
-                    style="position:absolute;top:11px;right:8px"
+                    size="20px"
+                    style={
+                      Object {
+                        "position": "absolute",
+                        "right": "8px",
+                        "top": "11px",
+                      }
+                    }
+                    title={null}
                     viewBox="0 0 24 24"
                     width="20px"
                   >
@@ -1770,7 +5142,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
               </div>
               <div>
                 <a
-                  class="DesktopMenu__MenuLink-e4dzdq-1 kgAySz"
+                  className="c12"
                   color="#ffffff"
                   href="/"
                 >
@@ -1779,32 +5151,46 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
               </div>
             </nav>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
-              style="float:right"
+              className="c13"
+              style={
+                Object {
+                  "float": "right",
+                }
+              }
             >
               <nav
                 aria-label="Secondary navigation"
-                class="DesktopMenu__Nav-e4dzdq-3 bWwdcq DesktopMenu-e4dzdq-4 irbObu"
+                className="c7 c8"
               >
                 <div>
                   <button
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    class="MenuTrigger__StyledButton-sm3xx0-0 cwxQnB"
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="c9"
                     color="#ffffff"
+                    onBlur={[Function]}
+                    onClick={[Function]}
                     type="button"
                   >
                     Settings
                     <svg
-                      aria-hidden="true"
-                      class="Icon-fc7twp-0 hIxIEB"
+                      aria-hidden={true}
+                      className="c10 c11"
                       color="#ffffff"
                       fill="#ffffff"
-                      focusable="false"
+                      focusable={false}
                       height="20px"
                       icon="downArrow"
                       p="2px"
-                      style="position:absolute;top:11px;right:8px"
+                      size="20px"
+                      style={
+                        Object {
+                          "position": "absolute",
+                          "right": "8px",
+                          "top": "11px",
+                        }
+                      }
+                      title={null}
                       viewBox="0 0 24 24"
                       width="20px"
                     >
@@ -1820,186 +5206,211 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
         </div>
       </header>
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 jKfurj"
+        className="c14"
       >
         <div
-          class="Box-sc-1qu1edy-0 jXTIl"
+          className="c15"
         >
           <h1
-            class="Text-sc-1wu7vpu-0-h1 fKaScO"
-            font-size="largest"
-            font-weight="light"
+            className="c26-h1 c16"
+            fontSize="largest"
+            fontWeight="light"
           >
             I am title
           </h1>
           <div
-            class="TabScrollIndicators__TabScrollIndicatorContainer-sc-1cljxwo-0 gsIAKI"
-            width="0"
+            className="c17"
+            width={0}
           />
           <div
-            class="Tabs__TabContainer-o5d5cd-0 giufLG"
+            className="c18"
+            onScroll={[Function]}
             role="tablist"
           >
             <div />
             <button
-              aria-selected="true"
-              class="Tab__TabButton-sc-69abpu-0 kfQsHL"
+              aria-selected={true}
+              className="c19"
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
               role="tab"
-              selected=""
-              tabindex="0"
+              selected={true}
+              tabIndex={0}
             >
               Details
             </button>
             <button
-              aria-selected="false"
-              class="Tab__TabButton-sc-69abpu-0 gcfVpD"
+              aria-selected={false}
+              className="c20"
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
               role="tab"
-              tabindex="-1"
+              selected={false}
+              tabIndex={-1}
             >
               Milestones
             </button>
             <button
-              aria-selected="false"
-              class="Tab__TabButton-sc-69abpu-0 gcfVpD"
+              aria-selected={false}
+              className="c20"
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
               role="tab"
-              tabindex="-1"
+              selected={false}
+              tabIndex={-1}
             >
               Production Records
             </button>
           </div>
           <div
-            aria-hidden="false"
-            selected=""
+            aria-hidden={false}
+            hidden={false}
+            selected={true}
           >
             <div
-              class="Box-sc-1qu1edy-0 EBPVx"
+              className="c21"
             >
               <h2
-                class="Text-sc-1wu7vpu-0-h2 hKxFww"
-                font-size="larger"
-                font-weight="medium"
+                className="c22 c23"
+                fontSize="larger"
+                fontWeight="medium"
               >
                 Details
               </h2>
               <div
-                class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 cOjpeh"
+                className="c24"
               >
                 <div
-                  class="Box-sc-1qu1edy-0 kppLzh"
-                  width="0.3333333333333333"
+                  className="c25"
+                  width={0.3333333333333333}
                 >
                   <p
-                    class="Text-sc-1wu7vpu-0 tVyVn"
+                    className="c26 c27"
                     color="currentColor"
-                    font-size="small"
-                    font-weight="bold"
+                    disabled={false}
+                    fontSize="small"
+                    fontWeight="bold"
                   >
                     Purchase Order Number
                   </p>
                   <p
-                    class="Text-sc-1wu7vpu-0 RbfMK"
+                    className="c26 c28"
                     color="currentColor"
-                    font-size="medium"
+                    disabled={false}
+                    fontSize="medium"
                   >
                     7050007201911
                   </p>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 iNeoFr"
-                  width="0.3333333333333333"
+                  className="c29"
+                  width={0.3333333333333333}
                 >
                   <p
-                    class="Text-sc-1wu7vpu-0 tVyVn"
+                    className="c26 c27"
                     color="currentColor"
-                    font-size="small"
-                    font-weight="bold"
+                    disabled={false}
+                    fontSize="small"
+                    fontWeight="bold"
                   >
                     Purchase Order Number
                   </p>
                   <p
-                    class="Text-sc-1wu7vpu-0 RbfMK"
+                    className="c26 c28"
                     color="currentColor"
-                    font-size="medium"
+                    disabled={false}
+                    fontSize="medium"
                   >
                     7050007201911
                   </p>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 jgRzAy"
-                  width="0.3333333333333333"
+                  className="c30"
+                  width={0.3333333333333333}
                 >
                   <p
-                    class="Text-sc-1wu7vpu-0 tVyVn"
+                    className="c26 c27"
                     color="currentColor"
-                    font-size="small"
-                    font-weight="bold"
+                    disabled={false}
+                    fontSize="small"
+                    fontWeight="bold"
                   >
                     Purchase Order Number
                   </p>
                   <p
-                    class="Text-sc-1wu7vpu-0 RbfMK"
+                    className="c26 c28"
                     color="currentColor"
-                    font-size="medium"
+                    disabled={false}
+                    fontSize="medium"
                   >
                     7050007201911
                   </p>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 kppLzh"
-                  width="0.3333333333333333"
+                  className="c25"
+                  width={0.3333333333333333}
                 >
                   <p
-                    class="Text-sc-1wu7vpu-0 tVyVn"
+                    className="c26 c27"
                     color="currentColor"
-                    font-size="small"
-                    font-weight="bold"
+                    disabled={false}
+                    fontSize="small"
+                    fontWeight="bold"
                   >
                     Purchase Order Number
                   </p>
                   <p
-                    class="Text-sc-1wu7vpu-0 RbfMK"
+                    className="c26 c28"
                     color="currentColor"
-                    font-size="medium"
+                    disabled={false}
+                    fontSize="medium"
                   >
                     7050007201911
                   </p>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 iNeoFr"
-                  width="0.3333333333333333"
+                  className="c29"
+                  width={0.3333333333333333}
                 >
                   <p
-                    class="Text-sc-1wu7vpu-0 tVyVn"
+                    className="c26 c27"
                     color="currentColor"
-                    font-size="small"
-                    font-weight="bold"
+                    disabled={false}
+                    fontSize="small"
+                    fontWeight="bold"
                   >
                     Purchase Order Number
                   </p>
                   <p
-                    class="Text-sc-1wu7vpu-0 RbfMK"
+                    className="c26 c28"
                     color="currentColor"
-                    font-size="medium"
+                    disabled={false}
+                    fontSize="medium"
                   >
                     7050007201911
                   </p>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 jgRzAy"
-                  width="0.3333333333333333"
+                  className="c30"
+                  width={0.3333333333333333}
                 >
                   <p
-                    class="Text-sc-1wu7vpu-0 tVyVn"
+                    className="c26 c27"
                     color="currentColor"
-                    font-size="small"
-                    font-weight="bold"
+                    disabled={false}
+                    fontSize="small"
+                    fontWeight="bold"
                   >
                     Purchase Order Number
                   </p>
                   <p
-                    class="Text-sc-1wu7vpu-0 RbfMK"
+                    className="c26 c28"
                     color="currentColor"
-                    font-size="medium"
+                    disabled={false}
+                    fontSize="medium"
                   >
                     7050007201911
                   </p>
@@ -2008,49 +5419,50 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
             </div>
           </div>
           <div
-            aria-hidden="true"
-            hidden=""
+            aria-hidden={true}
+            hidden={true}
+            selected={false}
           >
             <div
-              class="Box-sc-1qu1edy-0 cSRExr"
+              className="c31"
             >
               <h2
-                class="Text-sc-1wu7vpu-0-h2 jBTFWi"
-                font-size="larger"
-                font-weight="medium"
+                className="c22 c32"
+                fontSize="larger"
+                fontWeight="medium"
               >
                 Milestone Performance
               </h2>
               <table
-                class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+                className="c33"
               >
                 <thead>
                   <tr
-                    class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
+                    className="c34"
                   >
                     <th
-                      class="StyledTh-sc-10nzyk9-0 sBlyT"
+                      className="c35"
                       data-testid="table-head"
                       scope="col"
                     >
                       Milestone
                     </th>
                     <th
-                      class="StyledTh-sc-10nzyk9-0 sBlyT"
+                      className="c35"
                       data-testid="table-head"
                       scope="col"
                     >
                       Expected Completion
                     </th>
                     <th
-                      class="StyledTh-sc-10nzyk9-0 sBlyT"
+                      className="c35"
                       data-testid="table-head"
                       scope="col"
                     >
                       Actual Completion
                     </th>
                     <th
-                      class="StyledTh-sc-10nzyk9-0 sBlyT"
+                      className="c35"
                       data-testid="table-head"
                       scope="col"
                     >
@@ -2062,37 +5474,41 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                   data-testid="table-body"
                 >
                   <tr
-                    class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    className="c36"
                     data-testid="table-row"
                   >
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c37"
                     >
                       PO Line Item Created
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c37"
                     >
                       Nov 3, 2019
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c37"
                     >
                       Dec 13, 2019
                     </td>
-                    <td>
+                    <td
+                      colSpan={null}
+                    >
                       <div
-                        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+                        className="c13"
                       >
                         <svg
-                          aria-hidden="true"
-                          class="Icon-fc7twp-0 bKcUEK"
+                          aria-hidden={true}
+                          className="c10 c38"
                           color="red"
                           fill="#cc1439"
-                          focusable="false"
+                          focusable={false}
                           height="24px"
                           icon="error"
                           mr="half"
+                          size="24px"
+                          title={null}
                           viewBox="0 0 24 24"
                           width="24px"
                         >
@@ -2101,9 +5517,10 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                           />
                         </svg>
                         <p
-                          class="Text-sc-1wu7vpu-0 RbfMK"
+                          className="c26 c28"
                           color="currentColor"
-                          font-size="medium"
+                          disabled={false}
+                          fontSize="medium"
                         >
                           10 Days Late
                         </p>
@@ -2111,37 +5528,41 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                     </td>
                   </tr>
                   <tr
-                    class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    className="c36"
                     data-testid="table-row"
                   >
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c37"
                     >
                       PO Line Item Created
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c37"
                     >
                       Nov 3, 2019
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c37"
                     >
                       Dec 13, 2019
                     </td>
-                    <td>
+                    <td
+                      colSpan={null}
+                    >
                       <div
-                        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+                        className="c13"
                       >
                         <svg
-                          aria-hidden="true"
-                          class="Icon-fc7twp-0 bKcUEK"
+                          aria-hidden={true}
+                          className="c10 c38"
                           color="red"
                           fill="#cc1439"
-                          focusable="false"
+                          focusable={false}
                           height="24px"
                           icon="error"
                           mr="half"
+                          size="24px"
+                          title={null}
                           viewBox="0 0 24 24"
                           width="24px"
                         >
@@ -2150,9 +5571,10 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                           />
                         </svg>
                         <p
-                          class="Text-sc-1wu7vpu-0 RbfMK"
+                          className="c26 c28"
                           color="currentColor"
-                          font-size="medium"
+                          disabled={false}
+                          fontSize="medium"
                         >
                           40 Days Late
                         </p>
@@ -2160,37 +5582,41 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                     </td>
                   </tr>
                   <tr
-                    class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    className="c36"
                     data-testid="table-row"
                   >
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c37"
                     >
                       PO Line Item Created
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c37"
                     >
                       Nov 3, 2019
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c37"
                     >
                       Dec 13, 2019
                     </td>
-                    <td>
+                    <td
+                      colSpan={null}
+                    >
                       <div
-                        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+                        className="c13"
                       >
                         <svg
-                          aria-hidden="true"
-                          class="Icon-fc7twp-0 bKcUEK"
+                          aria-hidden={true}
+                          className="c10 c38"
                           color="red"
                           fill="#cc1439"
-                          focusable="false"
+                          focusable={false}
                           height="24px"
                           icon="error"
                           mr="half"
+                          size="24px"
+                          title={null}
                           viewBox="0 0 24 24"
                           width="24px"
                         >
@@ -2199,9 +5625,10 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                           />
                         </svg>
                         <p
-                          class="Text-sc-1wu7vpu-0 RbfMK"
+                          className="c26 c28"
                           color="currentColor"
-                          font-size="medium"
+                          disabled={false}
+                          fontSize="medium"
                         >
                           40 Days Late
                         </p>
@@ -2209,37 +5636,41 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                     </td>
                   </tr>
                   <tr
-                    class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    className="c36"
                     data-testid="table-row"
                   >
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c37"
                     >
                       PO Line Item Created
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c37"
                     >
                       Nov 3, 2019
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c37"
                     >
                       Dec 13, 2019
                     </td>
-                    <td>
+                    <td
+                      colSpan={null}
+                    >
                       <div
-                        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+                        className="c13"
                       >
                         <svg
-                          aria-hidden="true"
-                          class="Icon-fc7twp-0 bKcUEK"
+                          aria-hidden={true}
+                          className="c10 c38"
                           color="red"
                           fill="#cc1439"
-                          focusable="false"
+                          focusable={false}
                           height="24px"
                           icon="error"
                           mr="half"
+                          size="24px"
+                          title={null}
                           viewBox="0 0 24 24"
                           width="24px"
                         >
@@ -2248,9 +5679,10 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                           />
                         </svg>
                         <p
-                          class="Text-sc-1wu7vpu-0 RbfMK"
+                          className="c26 c28"
                           color="currentColor"
-                          font-size="medium"
+                          disabled={false}
+                          fontSize="medium"
                         >
                           40 Days Late
                         </p>
@@ -2263,42 +5695,43 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
             </div>
           </div>
           <div
-            aria-hidden="true"
-            hidden=""
+            aria-hidden={true}
+            hidden={true}
+            selected={false}
           >
             <div
-              class="Box-sc-1qu1edy-0 EBPVx"
+              className="c21"
             >
               <h2
-                class="Text-sc-1wu7vpu-0-h2 jBTFWi"
-                font-size="larger"
-                font-weight="medium"
+                className="c22 c32"
+                fontSize="larger"
+                fontWeight="medium"
               >
                 Production Records
               </h2>
               <table
-                class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+                className="c33"
               >
                 <thead>
                   <tr
-                    class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
+                    className="c34"
                   >
                     <th
-                      class="StyledTh-sc-10nzyk9-0 sBlyT"
+                      className="c35"
                       data-testid="table-head"
                       scope="col"
                     >
                       Date
                     </th>
                     <th
-                      class="StyledTh-sc-10nzyk9-0 sBlyT"
+                      className="c35"
                       data-testid="table-head"
                       scope="col"
                     >
                       Expected Quantity
                     </th>
                     <th
-                      class="StyledTh-sc-10nzyk9-0 sBlyT"
+                      className="c35"
                       data-testid="table-head"
                       scope="col"
                     >
@@ -2310,81 +5743,81 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                   data-testid="table-body"
                 >
                   <tr
-                    class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    className="c36"
                     data-testid="table-row"
                   >
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c37"
                     >
                       2019-10-01
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c37"
                     >
                       2,025 eaches
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c37"
                     >
                       1,800 eaches
                     </td>
                   </tr>
                   <tr
-                    class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    className="c36"
                     data-testid="table-row"
                   >
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c37"
                     >
                       2019-10-02
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c37"
                     >
                       2,475 eaches
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c37"
                     >
                       2,250 eaches
                     </td>
                   </tr>
                   <tr
-                    class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    className="c36"
                     data-testid="table-row"
                   >
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c37"
                     >
                       2019-10-03
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c37"
                     >
                       2,475 eaches
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c37"
                     >
                       1,425 eaches
                     </td>
                   </tr>
                   <tr
-                    class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+                    className="c36"
                     data-testid="table-row"
                   >
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c37"
                     >
                       2019-10-24
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c37"
                     >
                       2,475 eaches
                     </td>
                     <td
-                      class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+                      className="c37"
                     >
                       -
                     </td>
@@ -2394,39 +5827,46 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
               </table>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 cEnpFJ"
+              className="c39"
             >
               <h3
-                class="Text-sc-1wu7vpu-0-h3 Headings__SubsectionTitle-igpciy-0 fKBIog"
-                font-size="large"
-                font-weight="medium"
+                className="c26-h3 c40"
+                fontSize="large"
+                fontWeight="medium"
               >
                 Comments
               </h3>
               <form
-                class="Form-n70q8u-0 ilQSyT"
+                className="c41"
               >
                 <div
-                  class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+                  className="c42 c43"
                 >
                   <textarea
-                    aria-invalid="false"
-                    aria-required="false"
-                    class="Textarea__StyledTextarea-sc-1tyrhr0-0 ktRBsI"
+                    aria-invalid={false}
+                    aria-required={false}
+                    className="c44"
+                    disabled={false}
+                    id={null}
                     placeholder="Leave a comment..."
-                    rows="4"
+                    required={false}
+                    rows={4}
                   />
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 jlPsmj"
+                  className=""
                 >
                   <button
-                    class="Button__WrapperButton-sc-1omxup2-0 kFmWUd PrimaryButton-qz78sb-0 cGyyDq"
+                    className="c45 c46"
+                    disabled={false}
+                    size="medium"
                   >
                     Comment
                   </button>
                   <button
-                    class="Button__WrapperButton-sc-1omxup2-0 hkfOQr QuietButton-sc-1l5k8i4-0 eAbPwX"
+                    className="c47 c48"
+                    disabled={false}
+                    size="medium"
                   >
                     Cancel
                   </button>
@@ -2436,31 +5876,41 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
           </div>
         </div>
         <div
-          class="Box-sc-1qu1edy-0 cTLuiE"
-          width="[object Object]"
+          className="c49"
+          width={
+            Object {
+              "extraSmall": "calc(100vw - 48px - 16px)",
+              "large": "472px",
+              "medium": "400px",
+            }
+          }
         >
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 ixsBzc"
+            className="c50"
           >
             <h2
-              class="Text-sc-1wu7vpu-0-h2 flYnRO"
-              font-size="larger"
-              font-weight="medium"
+              className="c22 c51"
+              fontSize="larger"
+              fontWeight="medium"
             >
               Job 324400
             </h2>
             <button
-              class="IconicButton__WrapperButton-sc-1u3dojp-1 UMPof IconicButton-sc-1u3dojp-2 gZASNp"
+              aria-label={null}
+              className="c52 "
+              disabled={false}
             >
               <svg
-                aria-hidden="true"
-                class="Icon-fc7twp-0 cwKdbD"
+                aria-hidden={true}
+                className="c10 c53"
                 color="currentColor"
                 fill="currentColor"
-                focusable="false"
+                focusable={false}
                 height="32px"
                 icon="close"
                 p="half"
+                size="32px"
+                title={null}
                 viewBox="0 0 24 24"
                 width="32px"
               >
@@ -2471,117 +5921,135 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
             </button>
           </div>
           <form
-            class="Form-n70q8u-0 ilQSyT"
+            className="c41"
           >
             <fieldset
-              class="FormSection-sc-5yud6c-1 cJYtnA"
+              className="c54 c55"
             >
               <legend
-                class="Text-sc-1wu7vpu-0-h3 Headings__SubsectionTitle-igpciy-0 FormSection__FormSectionTitle-sc-5yud6c-0 gaHdwg"
-                font-size="large"
-                font-weight="medium"
+                className="c26-h3 c56 c57"
+                fontSize="large"
+                fontWeight="medium"
               >
                 Job Information
               </legend>
               <div
-                class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+                className="c42 c43"
               >
                 <label
-                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                  className="c58 "
                   color="black"
-                  style="display:block"
+                  style={
+                    Object {
+                      "display": "block",
+                    }
+                  }
                 >
                   <div
-                    class="Box-sc-1qu1edy-0 ilQgHG"
+                    className="c59"
                     data-testid="field-label"
                   >
                     <span
-                      class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                      className="c60"
                     >
                       Project
                     </span>
                   </div>
                   <div
-                    class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+                    className="c61"
                   >
                     <div
-                      class="Box-sc-1qu1edy-0 hxUhcg"
+                      className="c62"
                       display="flex"
                     >
                       <input
-                        aria-invalid="false"
-                        aria-required="false"
-                        class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                        aria-invalid={false}
+                        aria-required={false}
+                        className="c63"
+                        disabled={false}
                         id="project"
                         placeholder="Project 128703"
+                        required={false}
                       />
                     </div>
                   </div>
                 </label>
               </div>
               <div
-                class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+                className="c42 c43"
               >
                 <label
-                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                  className="c58 "
                   color="black"
-                  style="display:block"
+                  style={
+                    Object {
+                      "display": "block",
+                    }
+                  }
                 >
                   <div
-                    class="Box-sc-1qu1edy-0 ilQgHG"
+                    className="c59"
                     data-testid="field-label"
                   >
                     <span
-                      class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                      className="c60"
                     >
                       Project description
                     </span>
                     <span
-                      class="Text-sc-1wu7vpu-0 bphWXP"
+                      className="c26 c64"
                       color="darkGrey"
-                      font-size="12px"
+                      disabled={false}
+                      fontSize="12px"
                     >
                       (Optional)
                     </span>
                     <p
-                      class="Text-sc-1wu7vpu-0 HelpText__HelpTextContent-sc-1jzmq2g-0 feAJVX"
+                      className="c26 c65"
                       color="currentColor"
-                      font-size="medium"
+                      disabled={false}
+                      fontSize="medium"
                     >
                       Project description helps identify the project.
                     </p>
                   </div>
                   <div
-                    class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+                    className="c61"
                   >
                     <div
-                      class="Box-sc-1qu1edy-0 hxUhcg"
+                      className="c62"
                       display="flex"
                     >
                       <input
-                        aria-invalid="false"
-                        aria-required="false"
-                        class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                        aria-invalid={false}
+                        aria-required={false}
+                        className="c63"
+                        disabled={false}
                         id="project-description"
+                        required={false}
                       />
                     </div>
                   </div>
                 </label>
               </div>
               <div
-                class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+                className="c42 c43"
               >
                 <label
-                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                  className="c58 "
                   color="black"
-                  style="display:block"
+                  style={
+                    Object {
+                      "display": "block",
+                    }
+                  }
                 >
                   <div
-                    class="Box-sc-1qu1edy-0 ilQgHG"
+                    className="c59"
                     data-testid="field-label"
                   >
                     <span
-                      class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                      className="c60"
                     >
                       Project status
                     </span>
@@ -2590,19 +6058,22 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                     data-testid="select-container"
                   >
                     <div
-                      class=" css-2b097c-container"
+                      className=" css-2b097c-container"
+                      onKeyDown={[Function]}
                     >
                       <div
                         data-testid="select-control"
                       >
                         <div
-                          class=" css-1liu8yu-Control"
+                          className=" css-1liu8yu-Control"
+                          onMouseDown={[Function]}
+                          onTouchEnd={[Function]}
                         >
                           <div
-                            class=" css-7zc8my"
+                            className=" css-7zc8my"
                           >
                             <div
-                              class=" css-1yhx6vz-Placeholder"
+                              className=" css-1yhx6vz-Placeholder"
                             >
                               Select...
                             </div>
@@ -2610,48 +6081,83 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                               data-testid="select-input"
                             >
                               <div
-                                class="css-17yls17-Input"
+                                className="css-17yls17-Input"
                               >
                                 <div
-                                  class=""
-                                  style="display:inline-block"
+                                  className=""
+                                  style={
+                                    Object {
+                                      "display": "inline-block",
+                                    }
+                                  }
                                 >
                                   <input
                                     aria-autocomplete="list"
-                                    autocapitalize="none"
-                                    autocomplete="off"
-                                    autocorrect="off"
+                                    autoCapitalize="none"
+                                    autoComplete="off"
+                                    autoCorrect="off"
+                                    disabled={null}
                                     id="project-status"
-                                    spellcheck="false"
-                                    style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                                    tabindex="0"
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onFocus={[Function]}
+                                    spellCheck="false"
+                                    style={
+                                      Object {
+                                        "background": 0,
+                                        "border": 0,
+                                        "boxSizing": "content-box",
+                                        "color": "inherit",
+                                        "fontSize": "inherit",
+                                        "label": "input",
+                                        "opacity": 1,
+                                        "outline": 0,
+                                        "padding": 0,
+                                        "width": "1px",
+                                      }
+                                    }
+                                    tabIndex="0"
                                     type="text"
                                     value=""
                                   />
                                   <div
-                                    style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                                  />
+                                    style={
+                                      Object {
+                                        "height": 0,
+                                        "left": 0,
+                                        "overflow": "scroll",
+                                        "position": "absolute",
+                                        "top": 0,
+                                        "visibility": "hidden",
+                                        "whiteSpace": "pre",
+                                      }
+                                    }
+                                  >
+                                    
+                                  </div>
                                 </div>
                               </div>
                             </div>
                           </div>
                           <div
-                            class=" css-173cxbq-IndicatorsContainer"
+                            className=" css-173cxbq-IndicatorsContainer"
                           >
                             <span
-                              class=" css-4z5mi-indicatorSeparator"
+                              className=" css-4z5mi-indicatorSeparator"
                             />
                             <div
                               aria-hidden="true"
-                              class=" css-19phze7-indicatorContainer"
+                              className=" css-19phze7-indicatorContainer"
+                              onMouseDown={[Function]}
+                              onTouchEnd={[Function]}
                             >
                               <svg
                                 aria-hidden="true"
-                                class="css-6q0nyr-Svg"
+                                className="css-6q0nyr-Svg"
                                 focusable="false"
-                                height="20"
+                                height={20}
                                 viewBox="0 0 20 20"
-                                width="20"
+                                width={20}
                               >
                                 <path
                                   d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
@@ -2666,53 +6172,61 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 </label>
               </div>
               <div
-                class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+                className="c42 c43"
               >
                 <label
-                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                  className="c58 "
                   color="black"
-                  style="display:block"
+                  style={
+                    Object {
+                      "display": "block",
+                    }
+                  }
                 >
                   <div
-                    class="Box-sc-1qu1edy-0 ilQgHG"
+                    className="c59"
                     data-testid="field-label"
                   >
                     <span
-                      class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                      className="c60"
                     >
                       Item code
                     </span>
                   </div>
                   <div
-                    class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+                    className="c61"
                   >
                     <div
-                      class="Box-sc-1qu1edy-0 hxUhcg"
+                      className="c62"
                       display="flex"
                     >
                       <input
-                        aria-invalid="true"
-                        aria-required="false"
-                        class="InputField__StyledInput-sc-6cu4mg-0 jMjRjb"
+                        aria-invalid={true}
+                        aria-required={false}
+                        className="c66"
+                        defaultValue="WS2SB6"
+                        disabled={false}
                         id="item-code"
-                        value="WS2SB6"
+                        required={false}
                       />
                     </div>
                   </div>
                 </label>
                 <div
-                  class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 ycNbA"
+                  className="c67"
                   color="red"
                 >
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 QuoIa"
+                    aria-hidden={true}
+                    className="c10 c68"
                     color="currentColor"
                     fill="currentColor"
-                    focusable="false"
+                    focusable={false}
                     height="24px"
                     icon="error"
                     mr="x1"
+                    size="24px"
+                    title={null}
                     viewBox="0 0 24 24"
                     width="24px"
                   >
@@ -2721,12 +6235,13 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                     />
                   </svg>
                   <div
-                    class="InlineValidation__Wrapper-sc-1jic7dw-0 kqhCKM"
+                    className="c69"
                   >
                     <p
-                      class="Text-sc-1wu7vpu-0 RbfMK"
+                      className="c26 c28"
                       color="currentColor"
-                      font-size="medium"
+                      disabled={false}
+                      fontSize="medium"
                     >
                       Item WS2SB6 does not exist.
                     </p>
@@ -2734,280 +6249,320 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 </div>
               </div>
               <div
-                class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+                className="c42 c43"
               >
                 <label
-                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                  className="c58 "
                   color="black"
-                  style="display:block"
+                  style={
+                    Object {
+                      "display": "block",
+                    }
+                  }
                 >
                   <div
-                    class="Box-sc-1qu1edy-0 ilQgHG"
+                    className="c59"
                     data-testid="field-label"
                   >
                     <span
-                      class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                      className="c60"
                     >
                       Eaches expected on Job
                     </span>
                   </div>
                   <div
-                    class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+                    className="c61"
                   >
                     <div
-                      class="Box-sc-1qu1edy-0 hxUhcg"
+                      className="c62"
                       display="flex"
                     >
                       <input
-                        aria-invalid="false"
-                        aria-required="false"
-                        class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                        aria-invalid={false}
+                        aria-required={false}
+                        className="c63"
+                        disabled={false}
                         id="eaches-expected"
                         placeholder="2 000"
+                        required={false}
                       />
                     </div>
                   </div>
                 </label>
               </div>
               <div
-                class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+                className="c42 c43"
               >
                 <label
-                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                  className="c58 "
                   color="black"
-                  style="display:block"
+                  style={
+                    Object {
+                      "display": "block",
+                    }
+                  }
                 >
                   <div
-                    class="Box-sc-1qu1edy-0 ilQgHG"
+                    className="c59"
                     data-testid="field-label"
                   >
                     <span
-                      class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                      className="c60"
                     >
                       Eaches remaining on Project
                     </span>
                   </div>
                   <div
-                    class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+                    className="c61"
                   >
                     <div
-                      class="Box-sc-1qu1edy-0 hxUhcg"
+                      className="c62"
                       display="flex"
                     >
                       <input
-                        aria-invalid="false"
-                        aria-required="false"
-                        class="InputField__StyledInput-sc-6cu4mg-0 fdcdYd"
-                        disabled=""
+                        aria-invalid={false}
+                        aria-required={false}
+                        className="c70"
+                        defaultValue="18 000"
+                        disabled={true}
                         id="eaches-remaining"
-                        value="18 000"
+                        required={false}
                       />
                     </div>
                   </div>
                 </label>
               </div>
               <div
-                class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+                className="c42 c43"
               >
                 <label
-                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                  className="c58 "
                   color="black"
-                  style="display:block"
+                  style={
+                    Object {
+                      "display": "block",
+                    }
+                  }
                 >
                   <div
-                    class="Box-sc-1qu1edy-0 ilQgHG"
+                    className="c59"
                     data-testid="field-label"
                   >
                     <span
-                      class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                      className="c60"
                     >
                       Scheduled start
                     </span>
                   </div>
                   <div
-                    class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+                    className="c61"
                   >
                     <div
-                      class="Box-sc-1qu1edy-0 hxUhcg"
+                      className="c62"
                       display="flex"
                     >
                       <input
-                        aria-invalid="false"
-                        aria-required="false"
-                        class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                        aria-invalid={false}
+                        aria-required={false}
+                        className="c63"
+                        disabled={false}
                         id="scheduled-start"
                         placeholder="MMM-DD-YYYY"
+                        required={false}
                       />
                     </div>
                   </div>
                 </label>
               </div>
               <div
-                class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+                className="c42 c43"
               >
                 <label
-                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                  className="c58 "
                   color="black"
-                  style="display:block"
+                  style={
+                    Object {
+                      "display": "block",
+                    }
+                  }
                 >
                   <div
-                    class="Box-sc-1qu1edy-0 ilQgHG"
+                    className="c59"
                     data-testid="field-label"
                   >
                     <span
-                      class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                      className="c60"
                     >
                       Scheduled end
                     </span>
                   </div>
                   <div
-                    class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+                    className="c61"
                   >
                     <div
-                      class="Box-sc-1qu1edy-0 hxUhcg"
+                      className="c62"
                       display="flex"
                     >
                       <input
-                        aria-invalid="false"
-                        aria-required="false"
-                        class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                        aria-invalid={false}
+                        aria-required={false}
+                        className="c63"
+                        disabled={false}
                         id="scheduled-end"
                         placeholder="MMM-DD-YYYY"
+                        required={false}
                       />
                     </div>
                   </div>
                 </label>
               </div>
               <fieldset
-                class="Fieldset-sc-9aoml1-0 eiFgjk CheckboxGroup-sc-16y7xr8-2 bfgHHz"
+                className="c71 c72 "
               >
                 <legend
-                  class="CheckboxGroup__Legend-sc-16y7xr8-1 FZknE"
+                  className="c73"
                 >
                   <span
-                    class="CheckboxGroup__LabelText-sc-16y7xr8-0 srOjp"
+                    className="c74"
                   >
                     Line Lead
                   </span>
                   <span
-                    class="Text-sc-1wu7vpu-0 bphWXP"
+                    className="c26 c64"
                     color="darkGrey"
-                    font-size="12px"
+                    disabled={false}
+                    fontSize="12px"
                   >
                     (Optional)
                   </span>
                 </legend>
                 <div
-                  class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+                  className="c75"
                 >
                   <label
-                    class="ClickInputLabel-j2axnv-0 kemUmZ"
+                    className="c76"
+                    disabled={false}
                   >
                     <input
-                      aria-invalid="false"
-                      aria-required="false"
-                      class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                      aria-invalid={false}
+                      aria-required={false}
+                      className="c77 c75"
+                      disabled={false}
+                      id={null}
                       name="linelead"
+                      required={false}
                       type="checkbox"
                       value="christiaan"
                     />
                     <div
-                      class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                      className="c78 c79"
                       data-testid="visual-checkbox"
+                      disabled={false}
                     />
                     <p
-                      class="Text-sc-1wu7vpu-0 RbfMK"
+                      className="c26 c28"
                       color="currentColor"
-                      font-size="medium"
+                      disabled={false}
+                      fontSize="medium"
                     >
                       Christiaan Oostenbrug
                     </p>
                   </label>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+                  className="c75"
                 >
                   <label
-                    class="ClickInputLabel-j2axnv-0 kemUmZ"
+                    className="c76"
+                    disabled={false}
                   >
                     <input
-                      aria-invalid="false"
-                      aria-required="false"
-                      class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 eJJycu"
+                      aria-invalid={false}
+                      aria-required={false}
+                      className="c77 c75"
+                      disabled={false}
+                      id={null}
                       name="linelead"
+                      required={false}
                       type="checkbox"
                       value="matt"
                     />
                     <div
-                      class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                      className="c78 c79"
                       data-testid="visual-checkbox"
+                      disabled={false}
                     />
                     <p
-                      class="Text-sc-1wu7vpu-0 RbfMK"
+                      className="c26 c28"
                       color="currentColor"
-                      font-size="medium"
+                      disabled={false}
+                      fontSize="medium"
                     >
                       Matt Dunn
                     </p>
                   </label>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+                  className="c75"
                 >
                   <label
-                    class="ClickInputLabel-j2axnv-0 kjxgat"
-                    disabled=""
+                    className="c80"
+                    disabled={true}
                   >
                     <input
-                      aria-invalid="false"
-                      aria-required="false"
-                      class="Checkbox__CheckboxInput-sc-1nm58f1-1 jdAeaf Checkbox-sc-1nm58f1-2 eJJycu"
-                      disabled=""
+                      aria-invalid={false}
+                      aria-required={false}
+                      className="c81 c75"
+                      disabled={true}
+                      id={null}
                       name="linelead"
+                      required={false}
                       type="checkbox"
                       value="clemens"
                     />
                     <div
-                      class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                      className="c78 c79"
                       data-testid="visual-checkbox"
-                      disabled=""
+                      disabled={true}
                     />
                     <p
-                      class="Text-sc-1wu7vpu-0 hdrQgs"
+                      className="c26 c82"
                       color="currentColor"
-                      disabled=""
-                      font-size="medium"
+                      disabled={true}
+                      fontSize="medium"
                     >
                       Clemens Park
                     </p>
                   </label>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 eJJycu"
+                  className="c75"
                 >
                   <label
-                    class="ClickInputLabel-j2axnv-0 kjxgat"
-                    disabled=""
+                    className="c80"
+                    disabled={true}
                   >
                     <input
-                      aria-invalid="false"
-                      aria-required="false"
-                      class="Checkbox__CheckboxInput-sc-1nm58f1-1 jdAeaf Checkbox-sc-1nm58f1-2 eJJycu"
-                      disabled=""
+                      aria-invalid={false}
+                      aria-required={false}
+                      className="c81 c75"
+                      disabled={true}
+                      id={null}
                       name="linelead"
+                      required={false}
                       type="checkbox"
                       value="nikola"
                     />
                     <div
-                      class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                      className="c78 c79"
                       data-testid="visual-checkbox"
-                      disabled=""
+                      disabled={true}
                     />
                     <p
-                      class="Text-sc-1wu7vpu-0 hdrQgs"
+                      className="c26 c82"
                       color="currentColor"
-                      disabled=""
-                      font-size="medium"
+                      disabled={true}
+                      fontSize="medium"
                     >
                       Nikola Pejcic
                     </p>
@@ -3015,114 +6570,146 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 </div>
               </fieldset>
               <fieldset
-                class="Fieldset-sc-9aoml1-0 eiFgjk RadioGroup-pgv2w1-0 hFKzrk"
+                className="c71 c72 "
                 id="reconcile"
               >
                 <legend
-                  style="margin-bottom:8px"
+                  style={
+                    Object {
+                      "marginBottom": "8px",
+                    }
+                  }
                 >
                   <span
-                    style="font-size:14px;font-weight:600;line-height:1.71428571"
+                    style={
+                      Object {
+                        "fontSize": "14px",
+                        "fontWeight": "600",
+                        "lineHeight": "1.71428571",
+                      }
+                    }
                   >
                     Reconcile
                   </span>
                 </legend>
                 <div
-                  class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+                  className="c83"
                 >
                   <label
-                    class="ClickInputLabel-j2axnv-0 kemUmZ"
+                    className="c76"
+                    disabled={false}
                   >
                     <input
-                      aria-invalid="true"
-                      aria-required="false"
-                      checked=""
-                      class="Radio__RadioInput-sc-82dpxx-1 iSoGgh Radio-sc-82dpxx-2 jeIhWi"
+                      aria-invalid={true}
+                      aria-required={false}
+                      className="c84 c83"
+                      defaultChecked={true}
+                      disabled={false}
+                      id={null}
                       name="settingSelection"
+                      required={false}
                       type="radio"
                       value="yes"
                     />
                     <div
-                      class="Radio__VisualRadio-sc-82dpxx-0 cMunLd"
+                      className="c85 c86"
+                      disabled={false}
                     />
                     <span
-                      class="Text-sc-1wu7vpu-0 RbfMK"
+                      className="c26 c28"
                       color="currentColor"
-                      font-size="medium"
+                      disabled={false}
+                      fontSize="medium"
                     >
-                       Yes 
+                       
+                      Yes
+                       
                     </span>
                   </label>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+                  className="c83"
                 >
                   <label
-                    class="ClickInputLabel-j2axnv-0 kemUmZ"
+                    className="c76"
+                    disabled={false}
                   >
                     <input
-                      aria-invalid="true"
-                      aria-required="false"
-                      class="Radio__RadioInput-sc-82dpxx-1 iSoGgh Radio-sc-82dpxx-2 jeIhWi"
+                      aria-invalid={true}
+                      aria-required={false}
+                      className="c84 c83"
+                      disabled={false}
+                      id={null}
                       name="settingSelection"
+                      required={false}
                       type="radio"
                       value="no"
                     />
                     <div
-                      class="Radio__VisualRadio-sc-82dpxx-0 cMunLd"
+                      className="c85 c86"
+                      disabled={false}
                     />
                     <span
-                      class="Text-sc-1wu7vpu-0 RbfMK"
+                      className="c26 c28"
                       color="currentColor"
-                      font-size="medium"
+                      disabled={false}
+                      fontSize="medium"
                     >
-                       No 
+                       
+                      No
+                       
                     </span>
                   </label>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 jlPsmj Radio-sc-82dpxx-2 jeIhWi"
+                  className="c83"
                 >
                   <label
-                    class="ClickInputLabel-j2axnv-0 kjxgat"
-                    disabled=""
+                    className="c80"
+                    disabled={true}
                   >
                     <input
-                      aria-invalid="true"
-                      aria-required="false"
-                      class="Radio__RadioInput-sc-82dpxx-1 hBtCEn Radio-sc-82dpxx-2 jeIhWi"
-                      disabled=""
+                      aria-invalid={true}
+                      aria-required={false}
+                      className="c87 c83"
+                      disabled={true}
+                      id={null}
                       name="settingSelection"
+                      required={false}
                       type="radio"
                       value="maybe"
                     />
                     <div
-                      class="Radio__VisualRadio-sc-82dpxx-0 bCyppR"
-                      disabled=""
+                      className="c85 c88"
+                      disabled={true}
                     />
                     <span
-                      class="Text-sc-1wu7vpu-0 hdrQgs"
+                      className="c26 c82"
                       color="currentColor"
-                      disabled=""
-                      font-size="medium"
+                      disabled={true}
+                      fontSize="medium"
                     >
-                       Maybe 
+                       
+                      Maybe
+                       
                     </span>
                   </label>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 ycNbA"
+                  className="c67"
                   color="red"
                 >
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 QuoIa"
+                    aria-hidden={true}
+                    className="c10 c68"
                     color="currentColor"
                     fill="currentColor"
-                    focusable="false"
+                    focusable={false}
                     height="24px"
                     icon="error"
                     mr="x1"
+                    size="24px"
+                    title={null}
                     viewBox="0 0 24 24"
                     width="24px"
                   >
@@ -3131,12 +6718,13 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                     />
                   </svg>
                   <div
-                    class="InlineValidation__Wrapper-sc-1jic7dw-0 kqhCKM"
+                    className="c69"
                   >
                     <p
-                      class="Text-sc-1wu7vpu-0 RbfMK"
+                      className="c26 c28"
                       color="currentColor"
-                      font-size="medium"
+                      disabled={false}
+                      fontSize="medium"
                     >
                       Only yes can be selected...
                     </p>
@@ -3144,43 +6732,57 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 </div>
               </fieldset>
               <div
-                class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle__StyledToggle-sc-1oqd206-0 tNttj"
+                className="c42 c43 c89"
               >
                 <div
                   id="Job Visibility-label"
                 >
                   <div
-                    class="Box-sc-1qu1edy-0 ilQgHG"
+                    className="c59"
                   >
                     <span
-                      style="font-size:14px;font-weight:600;line-height:1.71428571"
+                      style={
+                        Object {
+                          "fontSize": "14px",
+                          "fontWeight": "600",
+                          "lineHeight": "1.71428571",
+                        }
+                      }
                     >
                       Job Visibility
                     </span>
                   </div>
                   <div
-                    class="ClickInputLabel-j2axnv-0 kemUmZ"
+                    className="c76"
+                    disabled={false}
+                    onClick={[Function]}
                   >
                     <div
-                      class="ToggleButton__Switch-asgrb8-1 hOMJxD"
+                      className="c90"
                     >
                       <input
-                        aria-invalid="false"
+                        aria-invalid={false}
                         aria-labelledby="Job Visibility-label"
-                        aria-required="false"
-                        class="ToggleButton__ToggleInput-asgrb8-2 lcDvtB"
+                        aria-required={false}
+                        className="c91"
+                        disabled={false}
                         id="job-visibility"
+                        onChange={[Function]}
+                        onClick={[Function]}
+                        required={false}
                         type="checkbox"
                         value="on"
                       />
                       <span
-                        class="ToggleButton__Slider-asgrb8-0 bLvWmF"
+                        className="c92 c93"
+                        disabled={false}
                       />
                     </div>
                     <p
-                      class="Text-sc-1wu7vpu-0 cOGezP"
+                      className="c26 c94"
                       color="currentColor"
-                      font-size="medium"
+                      disabled={false}
+                      fontSize="medium"
                     >
                       Hidden
                     </p>
@@ -3189,63 +6791,71 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
               </div>
             </fieldset>
             <fieldset
-              class="FormSection-sc-5yud6c-1 cJYtnA"
+              className="c54 c55"
             >
               <legend
-                class="Text-sc-1wu7vpu-0-h3 Headings__SubsectionTitle-igpciy-0 FormSection__FormSectionTitle-sc-5yud6c-0 gaHdwg"
-                font-size="large"
-                font-weight="medium"
+                className="c26-h3 c56 c57"
+                fontSize="large"
+                fontWeight="medium"
               >
                 Rejects
               </legend>
               <div
-                class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+                className="c42 c43"
               >
                 <label
-                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                  className="c58 "
                   color="black"
-                  style="display:block"
+                  style={
+                    Object {
+                      "display": "block",
+                    }
+                  }
                 >
                   <div
-                    class="Box-sc-1qu1edy-0 ilQgHG"
+                    className="c59"
                     data-testid="field-label"
                   >
                     <span
-                      class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                      className="c60"
                     >
                       Item
                     </span>
                   </div>
                   <div
-                    class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+                    className="c61"
                   >
                     <div
-                      class="Box-sc-1qu1edy-0 hxUhcg"
+                      className="c62"
                       display="flex"
                     >
                       <input
-                        aria-invalid="true"
-                        aria-required="false"
-                        class="InputField__StyledInput-sc-6cu4mg-0 jMjRjb"
+                        aria-invalid={true}
+                        aria-required={false}
+                        className="c66"
+                        defaultValue="235432"
+                        disabled={false}
                         id="items"
-                        value="235432"
+                        required={false}
                       />
                     </div>
                   </div>
                 </label>
                 <div
-                  class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 ycNbA"
+                  className="c67"
                   color="red"
                 >
                   <svg
-                    aria-hidden="true"
-                    class="Icon-fc7twp-0 QuoIa"
+                    aria-hidden={true}
+                    className="c10 c68"
                     color="currentColor"
                     fill="currentColor"
-                    focusable="false"
+                    focusable={false}
                     height="24px"
                     icon="error"
                     mr="x1"
+                    size="24px"
+                    title={null}
                     viewBox="0 0 24 24"
                     width="24px"
                   >
@@ -3254,12 +6864,13 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                     />
                   </svg>
                   <div
-                    class="InlineValidation__Wrapper-sc-1jic7dw-0 kqhCKM"
+                    className="c69"
                   >
                     <p
-                      class="Text-sc-1wu7vpu-0 RbfMK"
+                      className="c26 c28"
                       color="currentColor"
-                      font-size="medium"
+                      disabled={false}
+                      fontSize="medium"
                     >
                       Item 235432 is not a valid entry.
                     </p>
@@ -3267,82 +6878,98 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 </div>
               </div>
               <div
-                class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+                className="c42 c43"
               >
                 <label
-                  class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                  className="c58 "
                   color="black"
-                  style="display:block"
+                  style={
+                    Object {
+                      "display": "block",
+                    }
+                  }
                 >
                   <div
-                    class="Box-sc-1qu1edy-0 ilQgHG"
+                    className="c59"
                     data-testid="field-label"
                   >
                     <span
-                      class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                      className="c60"
                     >
                       Quantity
                     </span>
                   </div>
                   <div
-                    class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+                    className="c61"
                   >
                     <div
-                      class="Box-sc-1qu1edy-0 hxUhcg"
+                      className="c62"
                       display="flex"
                     >
                       <input
-                        aria-invalid="false"
-                        aria-required="false"
-                        class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                        aria-invalid={false}
+                        aria-required={false}
+                        className="c63"
+                        disabled={false}
                         id="quantity"
+                        required={false}
                       />
                     </div>
                   </div>
                 </label>
               </div>
               <div
-                class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB Toggle__StyledToggle-sc-1oqd206-0 tNttj"
+                className="c42 c43 c89"
               >
                 <div
                   id="Reject visibility-label"
                 >
                   <div
-                    class="Box-sc-1qu1edy-0 ilQgHG"
+                    className="c59"
                   >
                     <span
-                      style="font-size:14px;font-weight:600;line-height:1.71428571"
+                      style={
+                        Object {
+                          "fontSize": "14px",
+                          "fontWeight": "600",
+                          "lineHeight": "1.71428571",
+                        }
+                      }
                     >
                       Reject visibility
                     </span>
                   </div>
                   <div
-                    class="ClickInputLabel-j2axnv-0 kjxgat"
-                    disabled=""
+                    className="c80"
+                    disabled={true}
+                    onClick={[Function]}
                   >
                     <div
-                      class="ToggleButton__Switch-asgrb8-1 hOMJxD"
+                      className="c90"
                     >
                       <input
-                        aria-invalid="false"
+                        aria-invalid={false}
                         aria-labelledby="Reject visibility-label"
-                        aria-required="false"
-                        class="ToggleButton__ToggleInput-asgrb8-2 gajnWZ"
-                        disabled=""
+                        aria-required={false}
+                        className="c95"
+                        disabled={true}
                         id="reject-visibility"
+                        onChange={[Function]}
+                        onClick={[Function]}
+                        required={false}
                         type="checkbox"
                         value="on"
                       />
                       <span
-                        class="ToggleButton__Slider-asgrb8-0 bQpZex"
-                        disabled=""
+                        className="c92 c96"
+                        disabled={true}
                       />
                     </div>
                     <p
-                      class="Text-sc-1wu7vpu-0 jVsGHh"
+                      className="c26 c97"
                       color="currentColor"
-                      disabled=""
-                      font-size="medium"
+                      disabled={true}
+                      fontSize="medium"
                     >
                       Hidden
                     </p>

--- a/components/src/pages/__snapshots__/ErrorPage.story.storyshot
+++ b/components/src/pages/__snapshots__/ErrorPage.story.storyshot
@@ -1,32 +1,219 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Pages/ErrorPage Base 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c6 {
+  max-width: 432px;
+}
+
+.c10 {
+  margin-right: auto;
+}
+
+.c12 {
+  padding-top: 16px;
+  text-align: center;
+}
+
+.c1 {
+  padding-top: 24px;
+  padding-right: 16px;
+  padding-bottom: 16px;
+  padding-left: 16px;
+  height: 100vh;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  margin: 0 auto;
+  max-width: 672px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c3 {
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  background-color: #fae6ea;
+  padding: 16px;
+  border-radius: 4px;
+  border-left-width: half;
+  border-left-color: #cc1439;
+  border-left-style: solid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c9 {
+  margin-right: 8px;
+  color: #cc1439;
+  min-width: 24px;
+}
+
+.c11 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c13 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 14px;
+  line-height: 1.5;
+  color: #434d59;
+}
+
+.c8 .Link-sc-1lpx3d0-0 {
+  color: #011e38;
+}
+
+.c5 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+@media screen and (min-width:0px) {
+  .c4 {
+    margin-bottom: 40px;
+    margin-top: 16px;
+    margin-right: 0;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c4 {
+    margin-bottom: 32px;
+    margin-top: 80px;
+  }
+}
+
+@media screen and (min-width:1360px) {
+  .c4 {
+    margin-bottom: 0;
+    margin-top: 0;
+    margin-right: 24px;
+  }
+}
+
+@media screen and (min-width:0px) {
+  .c3 {
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+}
+
+@media screen and (min-width:1360px) {
+  .c3 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 eNuWpu"
+      className="c1"
       height="100vh"
     >
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 eUPAic"
+        className="c2"
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 bCieNK"
+          className="c3"
           width="100%"
         >
           <div
-            class="Box-sc-1qu1edy-0 eEgbxx"
+            className="c4"
           >
             <div
-              class="Branding__BrandingWrap-ranqri-0 kLCNLY Branding-ranqri-2 kQRWHN"
+              className="c5 "
+              size="large"
             >
               <svg
                 height="48px"
-                style="display:block"
+                style={
+                  Object {
+                    "display": "block",
+                    "margin": null,
+                  }
+                }
                 viewBox="0 0 133 32"
                 width="200px"
               >
@@ -62,21 +249,23 @@ exports[`Storyshots Pages/ErrorPage Base 1`] = `
             </div>
           </div>
           <div
-            class="Box-sc-1qu1edy-0 dKEgdE"
+            className="c6"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 gjRpuy Alert-u8lbe-0 kjZZUq"
+              className="c7 c8"
               role="alert"
             >
               <svg
-                aria-hidden="true"
-                class="Icon-fc7twp-0 ewGQci"
+                aria-hidden={true}
+                className="c9"
                 color="red"
                 fill="#cc1439"
-                focusable="false"
+                focusable={false}
                 height="24px"
                 icon="error"
                 mr="x1"
+                size="24px"
+                title={null}
                 viewBox="0 0 24 24"
                 width="24px"
               >
@@ -85,13 +274,14 @@ exports[`Storyshots Pages/ErrorPage Base 1`] = `
                 />
               </svg>
               <div
-                class="Box-sc-1qu1edy-0 iDnpba"
+                className="c10"
               >
                 <p
-                  class="Text-sc-1wu7vpu-0 dFPjNj"
+                  className="c11"
                   color="currentColor"
-                  font-size="medium"
-                  font-weight="bold"
+                  disabled={false}
+                  fontSize="medium"
+                  fontWeight="bold"
                 >
                   We're sorry, but something went wrong.
                 </p>
@@ -102,13 +292,18 @@ exports[`Storyshots Pages/ErrorPage Base 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 eUEsHJ"
-        style="border-top:solid 1px #e4e7eb"
+        className="c12"
+        style={
+          Object {
+            "borderTop": "solid 1px #e4e7eb",
+          }
+        }
       >
         <p
-          class="Text-sc-1wu7vpu-0 keXslM"
+          className="c13"
           color="darkGrey"
-          font-size="small"
+          disabled={false}
+          fontSize="small"
         >
           © 2007-2019 Nulogy Corporation
         </p>
@@ -119,32 +314,204 @@ exports[`Storyshots Pages/ErrorPage Base 1`] = `
 `;
 
 exports[`Storyshots Pages/ErrorPage Maintenance 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c6 {
+  max-width: 432px;
+}
+
+.c9 {
+  margin-right: auto;
+}
+
+.c10 {
+  padding-top: 16px;
+  text-align: center;
+}
+
+.c1 {
+  padding-top: 24px;
+  padding-right: 16px;
+  padding-bottom: 16px;
+  padding-left: 16px;
+  height: 100vh;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  margin: 0 auto;
+  max-width: 672px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c3 {
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  background-color: #e1ebfa;
+  padding: 16px;
+  border-radius: 4px;
+  border-left-width: half;
+  border-left-color: #216beb;
+  border-left-style: solid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c11 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 14px;
+  line-height: 1.5;
+  color: #434d59;
+}
+
+.c8 .Link-sc-1lpx3d0-0 {
+  color: #011e38;
+}
+
+.c5 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+@media screen and (min-width:0px) {
+  .c4 {
+    margin-bottom: 40px;
+    margin-top: 16px;
+    margin-right: 0;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c4 {
+    margin-bottom: 32px;
+    margin-top: 80px;
+  }
+}
+
+@media screen and (min-width:1360px) {
+  .c4 {
+    margin-bottom: 0;
+    margin-top: 0;
+    margin-right: 24px;
+  }
+}
+
+@media screen and (min-width:0px) {
+  .c3 {
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+}
+
+@media screen and (min-width:1360px) {
+  .c3 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 eNuWpu"
+      className="c1"
       height="100vh"
     >
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 eUPAic"
+        className="c2"
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 bCieNK"
+          className="c3"
           width="100%"
         >
           <div
-            class="Box-sc-1qu1edy-0 eEgbxx"
+            className="c4"
           >
             <div
-              class="Branding__BrandingWrap-ranqri-0 kLCNLY Branding-ranqri-2 kQRWHN"
+              className="c5 "
+              size="large"
             >
               <svg
                 height="48px"
-                style="display:block"
+                style={
+                  Object {
+                    "display": "block",
+                    "margin": null,
+                  }
+                }
                 viewBox="0 0 133 32"
                 width="200px"
               >
@@ -180,14 +547,14 @@ exports[`Storyshots Pages/ErrorPage Maintenance 1`] = `
             </div>
           </div>
           <div
-            class="Box-sc-1qu1edy-0 dKEgdE"
+            className="c6"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 eBpEPp Alert-u8lbe-0 kjZZUq"
+              className="c7 c8"
               role="alert"
             >
               <div
-                class="Box-sc-1qu1edy-0 iDnpba"
+                className="c9"
               >
                 We are currently adding new features to Nulogy Quality Control. We should be online shortly.
               </div>
@@ -196,13 +563,18 @@ exports[`Storyshots Pages/ErrorPage Maintenance 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 eUEsHJ"
-        style="border-top:solid 1px #e4e7eb"
+        className="c10"
+        style={
+          Object {
+            "borderTop": "solid 1px #e4e7eb",
+          }
+        }
       >
         <p
-          class="Text-sc-1wu7vpu-0 keXslM"
+          className="c11"
           color="darkGrey"
-          font-size="small"
+          disabled={false}
+          fontSize="small"
         >
           © 2007-2019 Nulogy Corporation
         </p>
@@ -213,32 +585,238 @@ exports[`Storyshots Pages/ErrorPage Maintenance 1`] = `
 `;
 
 exports[`Storyshots Pages/ErrorPage With a link 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c6 {
+  max-width: 432px;
+}
+
+.c10 {
+  margin-right: auto;
+}
+
+.c14 {
+  padding-top: 16px;
+  text-align: center;
+}
+
+.c1 {
+  padding-top: 24px;
+  padding-right: 16px;
+  padding-bottom: 16px;
+  padding-left: 16px;
+  height: 100vh;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  margin: 0 auto;
+  max-width: 672px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c3 {
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  background-color: #fae6ea;
+  padding: 16px;
+  margin-bottom: 16px;
+  border-radius: 4px;
+  border-left-width: half;
+  border-left-color: #cc1439;
+  border-left-style: solid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c9 {
+  margin-right: 8px;
+  color: #cc1439;
+  min-width: 24px;
+}
+
+.c11 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c15 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 14px;
+  line-height: 1.5;
+  color: #434d59;
+}
+
+.c13 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c13:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
+.c8 {
+  margin-bottom: 16px;
+}
+
+.c8 .c12 {
+  color: #011e38;
+}
+
+.c5 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+@media screen and (min-width:0px) {
+  .c4 {
+    margin-bottom: 40px;
+    margin-top: 16px;
+    margin-right: 0;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c4 {
+    margin-bottom: 32px;
+    margin-top: 80px;
+  }
+}
+
+@media screen and (min-width:1360px) {
+  .c4 {
+    margin-bottom: 0;
+    margin-top: -32px;
+    margin-right: 24px;
+  }
+}
+
+@media screen and (min-width:0px) {
+  .c3 {
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+}
+
+@media screen and (min-width:1360px) {
+  .c3 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 eNuWpu"
+      className="c1"
       height="100vh"
     >
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 eUPAic"
+        className="c2"
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 bCieNK"
+          className="c3"
           width="100%"
         >
           <div
-            class="Box-sc-1qu1edy-0 lokTmN"
+            className="c4"
           >
             <div
-              class="Branding__BrandingWrap-ranqri-0 kLCNLY Branding-ranqri-2 kQRWHN"
+              className="c5 "
+              size="large"
             >
               <svg
                 height="48px"
-                style="display:block"
+                style={
+                  Object {
+                    "display": "block",
+                    "margin": null,
+                  }
+                }
                 viewBox="0 0 133 32"
                 width="200px"
               >
@@ -274,21 +852,23 @@ exports[`Storyshots Pages/ErrorPage With a link 1`] = `
             </div>
           </div>
           <div
-            class="Box-sc-1qu1edy-0 dKEgdE"
+            className="c6"
           >
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 eMpWng Alert-u8lbe-0 yTvFo"
+              className="c7 c8"
               role="alert"
             >
               <svg
-                aria-hidden="true"
-                class="Icon-fc7twp-0 ewGQci"
+                aria-hidden={true}
+                className="c9"
                 color="red"
                 fill="#cc1439"
-                focusable="false"
+                focusable={false}
                 height="24px"
                 icon="error"
                 mr="x1"
+                size="24px"
+                title={null}
                 viewBox="0 0 24 24"
                 width="24px"
               >
@@ -297,13 +877,14 @@ exports[`Storyshots Pages/ErrorPage With a link 1`] = `
                 />
               </svg>
               <div
-                class="Box-sc-1qu1edy-0 iDnpba"
+                className="c10"
               >
                 <p
-                  class="Text-sc-1wu7vpu-0 dFPjNj"
+                  className="c11"
                   color="currentColor"
-                  font-size="medium"
-                  font-weight="bold"
+                  disabled={false}
+                  fontSize="medium"
+                  fontWeight="bold"
                 >
                   We're sorry, but something went wrong.
                 </p>
@@ -311,9 +892,9 @@ exports[`Storyshots Pages/ErrorPage With a link 1`] = `
               </div>
             </div>
             <a
-              class="Link-sc-1lpx3d0-0 gxbSxg"
+              className="c12 c13"
               color="blue"
-              font-size="medium"
+              fontSize="medium"
               href="#"
             >
               Back to homepage
@@ -322,13 +903,18 @@ exports[`Storyshots Pages/ErrorPage With a link 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 eUEsHJ"
-        style="border-top:solid 1px #e4e7eb"
+        className="c14"
+        style={
+          Object {
+            "borderTop": "solid 1px #e4e7eb",
+          }
+        }
       >
         <p
-          class="Text-sc-1wu7vpu-0 keXslM"
+          className="c15"
           color="darkGrey"
-          font-size="small"
+          disabled={false}
+          fontSize="small"
         >
           © 2007-2019 Nulogy Corporation
         </p>

--- a/components/src/pages/__snapshots__/LoginPage.story.storyshot
+++ b/components/src/pages/__snapshots__/LoginPage.story.storyshot
@@ -1,32 +1,503 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Pages/LoginPage Base 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c14 {
+  margin-bottom: 8px;
+}
+
+.c17 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c21 {
+  padding-top: 16px;
+  margin-bottom: 32px;
+  text-align: center;
+}
+
+.c1 {
+  min-height: 100vh;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c2 {
+  width: 100%;
+  max-width: 384px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c3 {
+  background-color: #ffffff;
+  margin-bottom: 16px;
+  margin-top: 16px;
+  max-width: 384px;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c5 {
+  padding-top: 6px;
+  padding-bottom: 6px;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c9 {
+  margin-bottom: 32px;
+  margin-top: 0;
+  font-size: 14px;
+  line-height: 1.71428571;
+  color: #434d59;
+}
+
+.c22 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: #434d59;
+}
+
+.c19 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c19:hover {
+  background-color: #e1ebfa;
+}
+
+.c19:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c19:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c19:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c19:disabled {
+  opacity: .5;
+}
+
+.c20 {
+  color: #ffffff;
+  border-color: #216beb;
+  background-color: #216beb;
+}
+
+.c20:hover {
+  background-color: #1254c7;
+  border-color: #1254c7;
+}
+
+.c20:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #216beb;
+}
+
+.c20:focus:hover {
+  background-color: #1254c7;
+}
+
+.c7 {
+  color: #0E77D2;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 500;
+  -webkit-letter-spacing: 0.0333em;
+  -moz-letter-spacing: 0.0333em;
+  -ms-letter-spacing: 0.0333em;
+  letter-spacing: 0.0333em;
+  text-transform: uppercase;
+  font-size: 11px;
+  line-height: 12px;
+  white-space: nowrap;
+}
+
+.c7 active {
+  color: #0E77D2;
+}
+
+.c7 visited {
+  color: #0E77D2;
+}
+
+.c4 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c6 {
+  position: relative;
+  width: 100%;
+}
+
+.c6:before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 0;
+  border-top: 1px solid #e1ebfa;
+  background: #e1ebfa;
+  width: 100%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+}
+
+.c13 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c15 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c12 {
+  width: 100%;
+}
+
+.c10 {
+  width: 100%;
+}
+
+.c10 .c8-h2 {
+  margin-bottom: 0;
+}
+
+.c10 .Alert-u8lbe-0 {
+  margin-bottom: 48px;
+}
+
+.c10 .c11,
+.c10 .Fieldset-sc-9aoml1-0 {
+  margin-bottom: 24px;
+}
+
+.c10 .c11:last-child,
+.c10 .Fieldset-sc-9aoml1-0:last-child {
+  margin-bottom: 0;
+}
+
+.c10 .FormSection-sc-5yud6c-1 {
+  margin-bottom: 48px;
+}
+
+.c10 .FormSection-sc-5yud6c-1:last-child {
+  margin-bottom: 0;
+}
+
+.c18 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c18:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c18:focus ~ svg {
+  fill: #00438f;
+}
+
+.c18::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c18::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c18:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c18::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+@media screen and (min-width:0px) {
+  .c21 {
+    width: calc(100% - 32px);
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c21 {
+    width: calc(100% - 64px);
+  }
+}
+
+@media screen and (min-width:0px) {
+  .c1 {
+    background-color: #ffffff;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c1 {
+    background-color: #f0f2f5;
+  }
+}
+
+@media screen and (min-width:0px) {
+  .c3 {
+    padding-left: 16px;
+    padding-right: 16px;
+    padding-top: 24px;
+    padding-bottom: 24px;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c3 {
+    padding-left: 32px;
+    padding-right: 32px;
+    padding-top: 40px;
+    padding-bottom: 40px;
+  }
+}
+
+@media screen and (min-width:0px) {
+  .c3 {
+    height: 100%;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c3 {
+    height: auto;
+  }
+}
+
+@media screen and (min-width:0px) {
+
+}
+
+@media screen and (min-width:768px) {
+  .c3 {
+    border-radius: 4px;
+  }
+}
+
+@media screen and (min-width:0px) {
+
+}
+
+@media screen and (min-width:768px) {
+  .c3 {
+    box-shadow: 0px 0px 3px 0px rgba(1,30,56,0.2);
+  }
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iQpQtI"
+      className="c1"
       width="100%"
     >
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hHfqqr"
+        className="c2"
         width="100%"
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hAwusC"
-          height="[object Object]"
+          className="c3"
+          height={
+            Object {
+              "extraSmall": "100%",
+              "small": "auto",
+            }
+          }
           width="100%"
         >
           <div
-            class="Branding__BrandingWrap-ranqri-0 yiUfZ Branding-ranqri-2 kQRWHN"
-            style="margin-bottom:16px"
+            className="c4 "
+            size="large"
+            style={
+              Object {
+                "marginBottom": "16px",
+              }
+            }
           >
             <svg
               height="48px"
-              style="display:block"
+              style={
+                Object {
+                  "display": "block",
+                  "margin": null,
+                }
+              }
               viewBox="0 0 133 32"
               width="200px"
             >
@@ -60,97 +531,120 @@ exports[`Storyshots Pages/LoginPage Base 1`] = `
               </g>
             </svg>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 kBVTzS"
+              className="c5"
               width="100%"
             >
               <div
-                class="Branding__Line-ranqri-1 gfZuug"
+                className="c6"
               />
               <span
-                class="BrandingText-nluvkd-0 TxcJr"
-                style="margin-left:4px;margin-right:4px"
+                className="c7"
+                size="large"
+                style={
+                  Object {
+                    "marginLeft": "4px",
+                    "marginRight": "4px",
+                  }
+                }
               >
                 Logo Subtext
               </span>
               <div
-                class="Branding__Line-ranqri-1 gfZuug"
+                className="c6"
               />
             </div>
           </div>
           <p
-            class="Text-sc-1wu7vpu-0 gcgjYT"
+            className="c8 c9"
             color="darkGrey"
-            font-size="small"
+            disabled={false}
+            fontSize="small"
           >
             Additional Text
           </p>
           <form
-            class="Form-n70q8u-0 ilQSyT"
-            style="width:100%"
+            className="c10"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+              className="c11 c12"
             >
               <label
-                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                className="c13 "
                 color="black"
-                style="display:block"
+                style={
+                  Object {
+                    "display": "block",
+                  }
+                }
               >
                 <div
-                  class="Box-sc-1qu1edy-0 ilQgHG"
+                  className="c14"
                   data-testid="field-label"
                 >
                   <span
-                    class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                    className="c15"
                   >
                     Email
                   </span>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+                  className="c16"
                 >
                   <div
-                    class="Box-sc-1qu1edy-0 hxUhcg"
+                    className="c17"
                     display="flex"
                   >
                     <input
-                      aria-invalid="false"
-                      aria-required="false"
-                      class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                      aria-invalid={false}
+                      aria-required={false}
+                      className="c18"
+                      disabled={false}
+                      required={false}
                     />
                   </div>
                 </div>
               </label>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+              className="c11 c12"
             >
               <label
-                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                className="c13 "
                 color="black"
-                style="display:block"
+                style={
+                  Object {
+                    "display": "block",
+                  }
+                }
               >
                 <div
-                  class="Box-sc-1qu1edy-0 ilQgHG"
+                  className="c14"
                   data-testid="field-label"
                 >
                   <span
-                    class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                    className="c15"
                   >
                     Password
                   </span>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+                  className="c16"
                 >
                   <div
-                    class="Box-sc-1qu1edy-0 hxUhcg"
+                    className="c17"
                     display="flex"
                   >
                     <input
-                      aria-invalid="false"
-                      aria-required="false"
-                      class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                      aria-invalid={false}
+                      aria-required={false}
+                      className="c18"
+                      disabled={false}
+                      required={false}
                       type="password"
                     />
                   </div>
@@ -158,7 +652,9 @@ exports[`Storyshots Pages/LoginPage Base 1`] = `
               </label>
             </div>
             <button
-              class="Button__WrapperButton-sc-1omxup2-0 bkRlmc PrimaryButton-qz78sb-0 cGyyDq"
+              className="c19 c20"
+              disabled={false}
+              size="medium"
             >
               Sign In
             </button>
@@ -166,14 +662,24 @@ exports[`Storyshots Pages/LoginPage Base 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 iZcQLf"
-        style="border-top:solid 1px #e4e7eb"
-        width="[object Object]"
+        className="c21"
+        style={
+          Object {
+            "borderTop": "solid 1px #e4e7eb",
+          }
+        }
+        width={
+          Object {
+            "extraSmall": "calc(100% - 32px)",
+            "small": "calc(100% - 64px)",
+          }
+        }
       >
         <p
-          class="Text-sc-1wu7vpu-0 fRSYFu"
+          className="c8 c22"
           color="darkGrey"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           © 2007-2019 Nulogy Corporation
         </p>
@@ -184,32 +690,535 @@ exports[`Storyshots Pages/LoginPage Base 1`] = `
 `;
 
 exports[`Storyshots Pages/LoginPage with error 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c14 {
+  margin-right: auto;
+}
+
+.c19 {
+  margin-bottom: 8px;
+}
+
+.c22 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c26 {
+  padding-top: 16px;
+  margin-bottom: 32px;
+  text-align: center;
+}
+
+.c1 {
+  min-height: 100vh;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c2 {
+  width: 100%;
+  max-width: 384px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c3 {
+  background-color: #ffffff;
+  margin-bottom: 16px;
+  margin-top: 16px;
+  max-width: 384px;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c5 {
+  padding-top: 6px;
+  padding-bottom: 6px;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c10 {
+  background-color: #fae6ea;
+  padding: 16px;
+  margin-bottom: 32px;
+  border-radius: 4px;
+  border-left-width: half;
+  border-left-color: #cc1439;
+  border-left-style: solid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c21 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c13 {
+  margin-right: 8px;
+  color: #cc1439;
+  min-width: 24px;
+}
+
+.c9 {
+  margin-bottom: 32px;
+  margin-top: 0;
+  font-size: 14px;
+  line-height: 1.71428571;
+  color: currentColor;
+}
+
+.c27 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: #434d59;
+}
+
+.c24 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c24:hover {
+  background-color: #e1ebfa;
+}
+
+.c24:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c24:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c24:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c24:disabled {
+  opacity: .5;
+}
+
+.c25 {
+  color: #ffffff;
+  border-color: #216beb;
+  background-color: #216beb;
+}
+
+.c25:hover {
+  background-color: #1254c7;
+  border-color: #1254c7;
+}
+
+.c25:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #216beb;
+}
+
+.c25:focus:hover {
+  background-color: #1254c7;
+}
+
+.c12 {
+  margin-bottom: 32px;
+}
+
+.c12 .Link-sc-1lpx3d0-0 {
+  color: #011e38;
+}
+
+.c7 {
+  color: #0E77D2;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 500;
+  -webkit-letter-spacing: 0.0333em;
+  -moz-letter-spacing: 0.0333em;
+  -ms-letter-spacing: 0.0333em;
+  letter-spacing: 0.0333em;
+  text-transform: uppercase;
+  font-size: 11px;
+  line-height: 12px;
+  white-space: nowrap;
+}
+
+.c7 active {
+  color: #0E77D2;
+}
+
+.c7 visited {
+  color: #0E77D2;
+}
+
+.c4 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c6 {
+  position: relative;
+  width: 100%;
+}
+
+.c6:before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 0;
+  border-top: 1px solid #e1ebfa;
+  background: #e1ebfa;
+  width: 100%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+}
+
+.c18 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c20 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c17 {
+  width: 100%;
+}
+
+.c15 {
+  width: 100%;
+}
+
+.c15 .c8-h2 {
+  margin-bottom: 0;
+}
+
+.c15 .c11 {
+  margin-bottom: 48px;
+}
+
+.c15 .c16,
+.c15 .Fieldset-sc-9aoml1-0 {
+  margin-bottom: 24px;
+}
+
+.c15 .c16:last-child,
+.c15 .Fieldset-sc-9aoml1-0:last-child {
+  margin-bottom: 0;
+}
+
+.c15 .FormSection-sc-5yud6c-1 {
+  margin-bottom: 48px;
+}
+
+.c15 .FormSection-sc-5yud6c-1:last-child {
+  margin-bottom: 0;
+}
+
+.c23 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c23:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c23:focus ~ svg {
+  fill: #00438f;
+}
+
+.c23::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c23::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c23:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c23::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+@media screen and (min-width:0px) {
+  .c26 {
+    width: calc(100% - 32px);
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c26 {
+    width: calc(100% - 64px);
+  }
+}
+
+@media screen and (min-width:0px) {
+  .c1 {
+    background-color: #ffffff;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c1 {
+    background-color: #f0f2f5;
+  }
+}
+
+@media screen and (min-width:0px) {
+  .c3 {
+    padding-left: 16px;
+    padding-right: 16px;
+    padding-top: 24px;
+    padding-bottom: 24px;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c3 {
+    padding-left: 32px;
+    padding-right: 32px;
+    padding-top: 40px;
+    padding-bottom: 40px;
+  }
+}
+
+@media screen and (min-width:0px) {
+  .c3 {
+    height: 100%;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c3 {
+    height: auto;
+  }
+}
+
+@media screen and (min-width:0px) {
+
+}
+
+@media screen and (min-width:768px) {
+  .c3 {
+    border-radius: 4px;
+  }
+}
+
+@media screen and (min-width:0px) {
+
+}
+
+@media screen and (min-width:768px) {
+  .c3 {
+    box-shadow: 0px 0px 3px 0px rgba(1,30,56,0.2);
+  }
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iQpQtI"
+      className="c1"
       width="100%"
     >
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hHfqqr"
+        className="c2"
         width="100%"
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hAwusC"
-          height="[object Object]"
+          className="c3"
+          height={
+            Object {
+              "extraSmall": "100%",
+              "small": "auto",
+            }
+          }
           width="100%"
         >
           <div
-            class="Branding__BrandingWrap-ranqri-0 yiUfZ Branding-ranqri-2 kQRWHN"
-            style="margin-bottom:16px"
+            className="c4 "
+            size="large"
+            style={
+              Object {
+                "marginBottom": "16px",
+              }
+            }
           >
             <svg
               height="48px"
-              style="display:block"
+              style={
+                Object {
+                  "display": "block",
+                  "margin": null,
+                }
+              }
               viewBox="0 0 133 32"
               width="200px"
             >
@@ -243,44 +1252,57 @@ exports[`Storyshots Pages/LoginPage with error 1`] = `
               </g>
             </svg>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 kBVTzS"
+              className="c5"
               width="100%"
             >
               <div
-                class="Branding__Line-ranqri-1 gfZuug"
+                className="c6"
               />
               <span
-                class="BrandingText-nluvkd-0 TxcJr"
-                style="margin-left:4px;margin-right:4px"
+                className="c7"
+                size="large"
+                style={
+                  Object {
+                    "marginLeft": "4px",
+                    "marginRight": "4px",
+                  }
+                }
               >
                 Logo Subtext
               </span>
               <div
-                class="Branding__Line-ranqri-1 gfZuug"
+                className="c6"
               />
             </div>
           </div>
           <p
-            class="Text-sc-1wu7vpu-0 hkGNDv"
+            className="c8 c9"
             color="currentColor"
-            font-size="small"
+            disabled={false}
+            fontSize="small"
           >
             Additional Text
           </p>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fzQnVq Alert-u8lbe-0 lbMrhW"
+            className="c10 c11 c12"
             role="alert"
-            style="width:100%"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
           >
             <svg
-              aria-hidden="true"
-              class="Icon-fc7twp-0 ewGQci"
+              aria-hidden={true}
+              className="c13"
               color="red"
               fill="#cc1439"
-              focusable="false"
+              focusable={false}
               height="24px"
               icon="error"
               mr="x1"
+              size="24px"
+              title={null}
               viewBox="0 0 24 24"
               width="24px"
             >
@@ -289,78 +1311,94 @@ exports[`Storyshots Pages/LoginPage with error 1`] = `
               />
             </svg>
             <div
-              class="Box-sc-1qu1edy-0 iDnpba"
+              className="c14"
             >
               text
             </div>
           </div>
           <form
-            class="Form-n70q8u-0 ilQSyT"
-            style="width:100%"
+            className="c15"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+              className="c16 c17"
             >
               <label
-                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                className="c18 "
                 color="black"
-                style="display:block"
+                style={
+                  Object {
+                    "display": "block",
+                  }
+                }
               >
                 <div
-                  class="Box-sc-1qu1edy-0 ilQgHG"
+                  className="c19"
                   data-testid="field-label"
                 >
                   <span
-                    class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                    className="c20"
                   >
                     Email
                   </span>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+                  className="c21"
                 >
                   <div
-                    class="Box-sc-1qu1edy-0 hxUhcg"
+                    className="c22"
                     display="flex"
                   >
                     <input
-                      aria-invalid="false"
-                      aria-required="false"
-                      class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                      aria-invalid={false}
+                      aria-required={false}
+                      className="c23"
+                      disabled={false}
+                      required={false}
                     />
                   </div>
                 </div>
               </label>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+              className="c16 c17"
             >
               <label
-                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                className="c18 "
                 color="black"
-                style="display:block"
+                style={
+                  Object {
+                    "display": "block",
+                  }
+                }
               >
                 <div
-                  class="Box-sc-1qu1edy-0 ilQgHG"
+                  className="c19"
                   data-testid="field-label"
                 >
                   <span
-                    class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                    className="c20"
                   >
                     Password
                   </span>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+                  className="c21"
                 >
                   <div
-                    class="Box-sc-1qu1edy-0 hxUhcg"
+                    className="c22"
                     display="flex"
                   >
                     <input
-                      aria-invalid="false"
-                      aria-required="false"
-                      class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                      aria-invalid={false}
+                      aria-required={false}
+                      className="c23"
+                      disabled={false}
+                      required={false}
                       type="password"
                     />
                   </div>
@@ -368,7 +1406,9 @@ exports[`Storyshots Pages/LoginPage with error 1`] = `
               </label>
             </div>
             <button
-              class="Button__WrapperButton-sc-1omxup2-0 bkRlmc PrimaryButton-qz78sb-0 cGyyDq"
+              className="c24 c25"
+              disabled={false}
+              size="medium"
             >
               Sign In
             </button>
@@ -376,14 +1416,24 @@ exports[`Storyshots Pages/LoginPage with error 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 iZcQLf"
-        style="border-top:solid 1px #e4e7eb"
-        width="[object Object]"
+        className="c26"
+        style={
+          Object {
+            "borderTop": "solid 1px #e4e7eb",
+          }
+        }
+        width={
+          Object {
+            "extraSmall": "calc(100% - 32px)",
+            "small": "calc(100% - 64px)",
+          }
+        }
       >
         <p
-          class="Text-sc-1wu7vpu-0 fRSYFu"
+          className="c8 c27"
           color="darkGrey"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           © 2007-2019 Nulogy Corporation
         </p>
@@ -394,32 +1444,527 @@ exports[`Storyshots Pages/LoginPage with error 1`] = `
 `;
 
 exports[`Storyshots Pages/LoginPage with error and no additional text 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c12 {
+  margin-right: auto;
+}
+
+.c17 {
+  margin-bottom: 8px;
+}
+
+.c20 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c24 {
+  padding-top: 16px;
+  margin-bottom: 32px;
+  text-align: center;
+}
+
+.c1 {
+  min-height: 100vh;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c2 {
+  width: 100%;
+  max-width: 384px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c3 {
+  background-color: #ffffff;
+  margin-bottom: 16px;
+  margin-top: 16px;
+  max-width: 384px;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c5 {
+  padding-top: 6px;
+  padding-bottom: 6px;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c8 {
+  background-color: #fae6ea;
+  padding: 16px;
+  margin-bottom: 32px;
+  border-radius: 4px;
+  border-left-width: half;
+  border-left-color: #cc1439;
+  border-left-style: solid;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c11 {
+  margin-right: 8px;
+  color: #cc1439;
+  min-width: 24px;
+}
+
+.c26 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: #434d59;
+}
+
+.c22 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c22:hover {
+  background-color: #e1ebfa;
+}
+
+.c22:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c22:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c22:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c22:disabled {
+  opacity: .5;
+}
+
+.c23 {
+  color: #ffffff;
+  border-color: #216beb;
+  background-color: #216beb;
+}
+
+.c23:hover {
+  background-color: #1254c7;
+  border-color: #1254c7;
+}
+
+.c23:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #216beb;
+}
+
+.c23:focus:hover {
+  background-color: #1254c7;
+}
+
+.c10 {
+  margin-bottom: 32px;
+}
+
+.c10 .Link-sc-1lpx3d0-0 {
+  color: #011e38;
+}
+
+.c7 {
+  color: #0E77D2;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 500;
+  -webkit-letter-spacing: 0.0333em;
+  -moz-letter-spacing: 0.0333em;
+  -ms-letter-spacing: 0.0333em;
+  letter-spacing: 0.0333em;
+  text-transform: uppercase;
+  font-size: 11px;
+  line-height: 12px;
+  white-space: nowrap;
+}
+
+.c7 active {
+  color: #0E77D2;
+}
+
+.c7 visited {
+  color: #0E77D2;
+}
+
+.c4 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c6 {
+  position: relative;
+  width: 100%;
+}
+
+.c6:before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 0;
+  border-top: 1px solid #e1ebfa;
+  background: #e1ebfa;
+  width: 100%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+}
+
+.c16 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c18 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c15 {
+  width: 100%;
+}
+
+.c13 {
+  width: 100%;
+}
+
+.c13 .c25-h2 {
+  margin-bottom: 0;
+}
+
+.c13 .c9 {
+  margin-bottom: 48px;
+}
+
+.c13 .c14,
+.c13 .Fieldset-sc-9aoml1-0 {
+  margin-bottom: 24px;
+}
+
+.c13 .c14:last-child,
+.c13 .Fieldset-sc-9aoml1-0:last-child {
+  margin-bottom: 0;
+}
+
+.c13 .FormSection-sc-5yud6c-1 {
+  margin-bottom: 48px;
+}
+
+.c13 .FormSection-sc-5yud6c-1:last-child {
+  margin-bottom: 0;
+}
+
+.c21 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c21:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c21:focus ~ svg {
+  fill: #00438f;
+}
+
+.c21::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c21::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c21:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c21::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+@media screen and (min-width:0px) {
+  .c24 {
+    width: calc(100% - 32px);
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c24 {
+    width: calc(100% - 64px);
+  }
+}
+
+@media screen and (min-width:0px) {
+  .c1 {
+    background-color: #ffffff;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c1 {
+    background-color: #f0f2f5;
+  }
+}
+
+@media screen and (min-width:0px) {
+  .c3 {
+    padding-left: 16px;
+    padding-right: 16px;
+    padding-top: 24px;
+    padding-bottom: 24px;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c3 {
+    padding-left: 32px;
+    padding-right: 32px;
+    padding-top: 40px;
+    padding-bottom: 40px;
+  }
+}
+
+@media screen and (min-width:0px) {
+  .c3 {
+    height: 100%;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c3 {
+    height: auto;
+  }
+}
+
+@media screen and (min-width:0px) {
+
+}
+
+@media screen and (min-width:768px) {
+  .c3 {
+    border-radius: 4px;
+  }
+}
+
+@media screen and (min-width:0px) {
+
+}
+
+@media screen and (min-width:768px) {
+  .c3 {
+    box-shadow: 0px 0px 3px 0px rgba(1,30,56,0.2);
+  }
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iQpQtI"
+      className="c1"
       width="100%"
     >
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hHfqqr"
+        className="c2"
         width="100%"
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hAwusC"
-          height="[object Object]"
+          className="c3"
+          height={
+            Object {
+              "extraSmall": "100%",
+              "small": "auto",
+            }
+          }
           width="100%"
         >
           <div
-            class="Branding__BrandingWrap-ranqri-0 yiUfZ Branding-ranqri-2 kQRWHN"
-            style="margin-bottom:32px"
+            className="c4 "
+            size="large"
+            style={
+              Object {
+                "marginBottom": "32px",
+              }
+            }
           >
             <svg
               height="48px"
-              style="display:block"
+              style={
+                Object {
+                  "display": "block",
+                  "margin": null,
+                }
+              }
               viewBox="0 0 133 32"
               width="200px"
             >
@@ -453,37 +1998,49 @@ exports[`Storyshots Pages/LoginPage with error and no additional text 1`] = `
               </g>
             </svg>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 kBVTzS"
+              className="c5"
               width="100%"
             >
               <div
-                class="Branding__Line-ranqri-1 gfZuug"
+                className="c6"
               />
               <span
-                class="BrandingText-nluvkd-0 TxcJr"
-                style="margin-left:4px;margin-right:4px"
+                className="c7"
+                size="large"
+                style={
+                  Object {
+                    "marginLeft": "4px",
+                    "marginRight": "4px",
+                  }
+                }
               >
                 Logo Subtext
               </span>
               <div
-                class="Branding__Line-ranqri-1 gfZuug"
+                className="c6"
               />
             </div>
           </div>
           <div
-            class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fzQnVq Alert-u8lbe-0 lbMrhW"
+            className="c8 c9 c10"
             role="alert"
-            style="width:100%"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
           >
             <svg
-              aria-hidden="true"
-              class="Icon-fc7twp-0 ewGQci"
+              aria-hidden={true}
+              className="c11"
               color="red"
               fill="#cc1439"
-              focusable="false"
+              focusable={false}
               height="24px"
               icon="error"
               mr="x1"
+              size="24px"
+              title={null}
               viewBox="0 0 24 24"
               width="24px"
             >
@@ -492,78 +2049,94 @@ exports[`Storyshots Pages/LoginPage with error and no additional text 1`] = `
               />
             </svg>
             <div
-              class="Box-sc-1qu1edy-0 iDnpba"
+              className="c12"
             >
               text
             </div>
           </div>
           <form
-            class="Form-n70q8u-0 ilQSyT"
-            style="width:100%"
+            className="c13"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+              className="c14 c15"
             >
               <label
-                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                className="c16 "
                 color="black"
-                style="display:block"
+                style={
+                  Object {
+                    "display": "block",
+                  }
+                }
               >
                 <div
-                  class="Box-sc-1qu1edy-0 ilQgHG"
+                  className="c17"
                   data-testid="field-label"
                 >
                   <span
-                    class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                    className="c18"
                   >
                     Email
                   </span>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+                  className="c19"
                 >
                   <div
-                    class="Box-sc-1qu1edy-0 hxUhcg"
+                    className="c20"
                     display="flex"
                   >
                     <input
-                      aria-invalid="false"
-                      aria-required="false"
-                      class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                      aria-invalid={false}
+                      aria-required={false}
+                      className="c21"
+                      disabled={false}
+                      required={false}
                     />
                   </div>
                 </div>
               </label>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+              className="c14 c15"
             >
               <label
-                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                className="c16 "
                 color="black"
-                style="display:block"
+                style={
+                  Object {
+                    "display": "block",
+                  }
+                }
               >
                 <div
-                  class="Box-sc-1qu1edy-0 ilQgHG"
+                  className="c17"
                   data-testid="field-label"
                 >
                   <span
-                    class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                    className="c18"
                   >
                     Password
                   </span>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+                  className="c19"
                 >
                   <div
-                    class="Box-sc-1qu1edy-0 hxUhcg"
+                    className="c20"
                     display="flex"
                   >
                     <input
-                      aria-invalid="false"
-                      aria-required="false"
-                      class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                      aria-invalid={false}
+                      aria-required={false}
+                      className="c21"
+                      disabled={false}
+                      required={false}
                       type="password"
                     />
                   </div>
@@ -571,7 +2144,9 @@ exports[`Storyshots Pages/LoginPage with error and no additional text 1`] = `
               </label>
             </div>
             <button
-              class="Button__WrapperButton-sc-1omxup2-0 bkRlmc PrimaryButton-qz78sb-0 cGyyDq"
+              className="c22 c23"
+              disabled={false}
+              size="medium"
             >
               Sign In
             </button>
@@ -579,14 +2154,24 @@ exports[`Storyshots Pages/LoginPage with error and no additional text 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 iZcQLf"
-        style="border-top:solid 1px #e4e7eb"
-        width="[object Object]"
+        className="c24"
+        style={
+          Object {
+            "borderTop": "solid 1px #e4e7eb",
+          }
+        }
+        width={
+          Object {
+            "extraSmall": "calc(100% - 32px)",
+            "small": "calc(100% - 64px)",
+          }
+        }
       >
         <p
-          class="Text-sc-1wu7vpu-0 fRSYFu"
+          className="c25 c26"
           color="darkGrey"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           © 2007-2019 Nulogy Corporation
         </p>
@@ -597,32 +2182,523 @@ exports[`Storyshots Pages/LoginPage with error and no additional text 1`] = `
 `;
 
 exports[`Storyshots Pages/LoginPage with forgot password link 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c14 {
+  margin-bottom: 8px;
+}
+
+.c17 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c21 {
+  padding-top: 8px;
+  padding-bottom: 8px;
+  margin-top: 8px;
+}
+
+.c23 {
+  padding-top: 16px;
+  margin-bottom: 32px;
+  text-align: center;
+}
+
+.c1 {
+  min-height: 100vh;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c2 {
+  width: 100%;
+  max-width: 384px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c3 {
+  background-color: #ffffff;
+  margin-bottom: 16px;
+  margin-top: 16px;
+  max-width: 384px;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c5 {
+  padding-top: 6px;
+  padding-bottom: 6px;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c9 {
+  margin-bottom: 32px;
+  margin-top: 0;
+  font-size: 14px;
+  line-height: 1.71428571;
+  color: #434d59;
+}
+
+.c24 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: #434d59;
+}
+
+.c19 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c19:hover {
+  background-color: #e1ebfa;
+}
+
+.c19:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c19:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c19:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c19:disabled {
+  opacity: .5;
+}
+
+.c20 {
+  color: #ffffff;
+  border-color: #216beb;
+  background-color: #216beb;
+}
+
+.c20:hover {
+  background-color: #1254c7;
+  border-color: #1254c7;
+}
+
+.c20:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #216beb;
+}
+
+.c20:focus:hover {
+  background-color: #1254c7;
+}
+
+.c22 {
+  color: #216beb;
+  font-size: 16px;
+  background: none;
+  border: none;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c22:hover {
+  cursor: pointer;
+  color: #1254c7;
+}
+
+.c7 {
+  color: #0E77D2;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 500;
+  -webkit-letter-spacing: 0.0333em;
+  -moz-letter-spacing: 0.0333em;
+  -ms-letter-spacing: 0.0333em;
+  letter-spacing: 0.0333em;
+  text-transform: uppercase;
+  font-size: 11px;
+  line-height: 12px;
+  white-space: nowrap;
+}
+
+.c7 active {
+  color: #0E77D2;
+}
+
+.c7 visited {
+  color: #0E77D2;
+}
+
+.c4 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c6 {
+  position: relative;
+  width: 100%;
+}
+
+.c6:before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 0;
+  border-top: 1px solid #e1ebfa;
+  background: #e1ebfa;
+  width: 100%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+}
+
+.c13 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c15 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c12 {
+  width: 100%;
+}
+
+.c10 {
+  width: 100%;
+}
+
+.c10 .c8-h2 {
+  margin-bottom: 0;
+}
+
+.c10 .Alert-u8lbe-0 {
+  margin-bottom: 48px;
+}
+
+.c10 .c11,
+.c10 .Fieldset-sc-9aoml1-0 {
+  margin-bottom: 24px;
+}
+
+.c10 .c11:last-child,
+.c10 .Fieldset-sc-9aoml1-0:last-child {
+  margin-bottom: 0;
+}
+
+.c10 .FormSection-sc-5yud6c-1 {
+  margin-bottom: 48px;
+}
+
+.c10 .FormSection-sc-5yud6c-1:last-child {
+  margin-bottom: 0;
+}
+
+.c18 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c18:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c18:focus ~ svg {
+  fill: #00438f;
+}
+
+.c18::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c18::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c18:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c18::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+@media screen and (min-width:0px) {
+  .c23 {
+    width: calc(100% - 32px);
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c23 {
+    width: calc(100% - 64px);
+  }
+}
+
+@media screen and (min-width:0px) {
+  .c1 {
+    background-color: #ffffff;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c1 {
+    background-color: #f0f2f5;
+  }
+}
+
+@media screen and (min-width:0px) {
+  .c3 {
+    padding-left: 16px;
+    padding-right: 16px;
+    padding-top: 24px;
+    padding-bottom: 24px;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c3 {
+    padding-left: 32px;
+    padding-right: 32px;
+    padding-top: 40px;
+    padding-bottom: 40px;
+  }
+}
+
+@media screen and (min-width:0px) {
+  .c3 {
+    height: 100%;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c3 {
+    height: auto;
+  }
+}
+
+@media screen and (min-width:0px) {
+
+}
+
+@media screen and (min-width:768px) {
+  .c3 {
+    border-radius: 4px;
+  }
+}
+
+@media screen and (min-width:0px) {
+
+}
+
+@media screen and (min-width:768px) {
+  .c3 {
+    box-shadow: 0px 0px 3px 0px rgba(1,30,56,0.2);
+  }
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iQpQtI"
+      className="c1"
       width="100%"
     >
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hHfqqr"
+        className="c2"
         width="100%"
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hAwusC"
-          height="[object Object]"
+          className="c3"
+          height={
+            Object {
+              "extraSmall": "100%",
+              "small": "auto",
+            }
+          }
           width="100%"
         >
           <div
-            class="Branding__BrandingWrap-ranqri-0 yiUfZ Branding-ranqri-2 kQRWHN"
-            style="margin-bottom:16px"
+            className="c4 "
+            size="large"
+            style={
+              Object {
+                "marginBottom": "16px",
+              }
+            }
           >
             <svg
               height="48px"
-              style="display:block"
+              style={
+                Object {
+                  "display": "block",
+                  "margin": null,
+                }
+              }
               viewBox="0 0 133 32"
               width="200px"
             >
@@ -656,97 +2732,120 @@ exports[`Storyshots Pages/LoginPage with forgot password link 1`] = `
               </g>
             </svg>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 kBVTzS"
+              className="c5"
               width="100%"
             >
               <div
-                class="Branding__Line-ranqri-1 gfZuug"
+                className="c6"
               />
               <span
-                class="BrandingText-nluvkd-0 TxcJr"
-                style="margin-left:4px;margin-right:4px"
+                className="c7"
+                size="large"
+                style={
+                  Object {
+                    "marginLeft": "4px",
+                    "marginRight": "4px",
+                  }
+                }
               >
                 Logo Subtext
               </span>
               <div
-                class="Branding__Line-ranqri-1 gfZuug"
+                className="c6"
               />
             </div>
           </div>
           <p
-            class="Text-sc-1wu7vpu-0 gcgjYT"
+            className="c8 c9"
             color="darkGrey"
-            font-size="small"
+            disabled={false}
+            fontSize="small"
           >
             Additional Text
           </p>
           <form
-            class="Form-n70q8u-0 ilQSyT"
-            style="width:100%"
+            className="c10"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+              className="c11 c12"
             >
               <label
-                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                className="c13 "
                 color="black"
-                style="display:block"
+                style={
+                  Object {
+                    "display": "block",
+                  }
+                }
               >
                 <div
-                  class="Box-sc-1qu1edy-0 ilQgHG"
+                  className="c14"
                   data-testid="field-label"
                 >
                   <span
-                    class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                    className="c15"
                   >
                     Email
                   </span>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+                  className="c16"
                 >
                   <div
-                    class="Box-sc-1qu1edy-0 hxUhcg"
+                    className="c17"
                     display="flex"
                   >
                     <input
-                      aria-invalid="false"
-                      aria-required="false"
-                      class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                      aria-invalid={false}
+                      aria-required={false}
+                      className="c18"
+                      disabled={false}
+                      required={false}
                     />
                   </div>
                 </div>
               </label>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+              className="c11 c12"
             >
               <label
-                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                className="c13 "
                 color="black"
-                style="display:block"
+                style={
+                  Object {
+                    "display": "block",
+                  }
+                }
               >
                 <div
-                  class="Box-sc-1qu1edy-0 ilQgHG"
+                  className="c14"
                   data-testid="field-label"
                 >
                   <span
-                    class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                    className="c15"
                   >
                     Password
                   </span>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+                  className="c16"
                 >
                   <div
-                    class="Box-sc-1qu1edy-0 hxUhcg"
+                    className="c17"
                     display="flex"
                   >
                     <input
-                      aria-invalid="false"
-                      aria-required="false"
-                      class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                      aria-invalid={false}
+                      aria-required={false}
+                      className="c18"
+                      disabled={false}
+                      required={false}
                       type="password"
                     />
                   </div>
@@ -754,18 +2853,20 @@ exports[`Storyshots Pages/LoginPage with forgot password link 1`] = `
               </label>
             </div>
             <button
-              class="Button__WrapperButton-sc-1omxup2-0 bkRlmc PrimaryButton-qz78sb-0 cGyyDq"
+              className="c19 c20"
+              disabled={false}
+              size="medium"
             >
               Sign In
             </button>
           </form>
           <div
-            class="Box-sc-1qu1edy-0 csERpy"
+            className="c21"
           >
             <a
-              class="Link-sc-1lpx3d0-0 gxbSxg"
+              className="c22"
               color="blue"
-              font-size="medium"
+              fontSize="medium"
               href="/"
             >
               Forgot your password?
@@ -774,14 +2875,24 @@ exports[`Storyshots Pages/LoginPage with forgot password link 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 iZcQLf"
-        style="border-top:solid 1px #e4e7eb"
-        width="[object Object]"
+        className="c23"
+        style={
+          Object {
+            "borderTop": "solid 1px #e4e7eb",
+          }
+        }
+        width={
+          Object {
+            "extraSmall": "calc(100% - 32px)",
+            "small": "calc(100% - 64px)",
+          }
+        }
       >
         <p
-          class="Text-sc-1wu7vpu-0 fRSYFu"
+          className="c8 c24"
           color="darkGrey"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           © 2007-2019 Nulogy Corporation
         </p>
@@ -792,32 +2903,607 @@ exports[`Storyshots Pages/LoginPage with forgot password link 1`] = `
 `;
 
 exports[`Storyshots Pages/LoginPage with remember me 1`] = `
+.c0 {
+  color: #011e38;
+  font-family: 'IBM Plex Sans',sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c0 button {
+  font-family: 'IBM Plex Sans',sans-serif;
+}
+
+.c0 * {
+  box-sizing: border-box;
+}
+
+.c0 img {
+  max-width: 100%;
+  height: auto;
+}
+
+.c12 {
+  margin-bottom: 8px;
+}
+
+.c15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  position: relative;
+}
+
+.c26 {
+  padding-top: 16px;
+  margin-bottom: 32px;
+  text-align: center;
+}
+
+.c1 {
+  min-height: 100vh;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c2 {
+  width: 100%;
+  max-width: 384px;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c3 {
+  background-color: #ffffff;
+  margin-bottom: 16px;
+  margin-top: 16px;
+  max-width: 384px;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c5 {
+  padding-top: 6px;
+  padding-bottom: 6px;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c9 {
+  margin-bottom: 32px;
+  margin-top: 0;
+  font-size: 14px;
+  line-height: 1.71428571;
+  color: #434d59;
+}
+
+.c23 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: currentColor;
+}
+
+.c27 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  color: #434d59;
+}
+
+.c19 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: auto;
+  min-height: 24px;
+  vertical-align: top;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 4px 0;
+}
+
+.c24 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: 500;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  vertical-align: middle;
+  line-height: 1.5;
+  cursor: pointer;
+  color: #216beb;
+  background-color: #ffffff;
+  border: 1px solid #216beb;
+  border-radius: 4px;
+  margin: 0px;
+  -webkit-transition: background-color .2s,-webkit-transform .2s ease-in;
+  -webkit-transition: background-color .2s,transform .2s ease-in;
+  transition: background-color .2s,transform .2s ease-in;
+  font-size: 16px;
+  padding: 7px 16px;
+}
+
+.c24:hover {
+  background-color: #e1ebfa;
+}
+
+.c24:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #ffffff;
+}
+
+.c24:focus:hover {
+  background-color: #e1ebfa;
+}
+
+.c24:active {
+  -webkit-transform: scale(0.98);
+  -ms-transform: scale(0.98);
+  transform: scale(0.98);
+}
+
+.c24:disabled {
+  opacity: .5;
+}
+
+.c25 {
+  color: #ffffff;
+  border-color: #216beb;
+  background-color: #216beb;
+}
+
+.c25:hover {
+  background-color: #1254c7;
+  border-color: #1254c7;
+}
+
+.c25:focus {
+  outline: none;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+  background-color: #216beb;
+}
+
+.c25:focus:hover {
+  background-color: #1254c7;
+}
+
+.c7 {
+  color: #0E77D2;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 500;
+  -webkit-letter-spacing: 0.0333em;
+  -moz-letter-spacing: 0.0333em;
+  -ms-letter-spacing: 0.0333em;
+  letter-spacing: 0.0333em;
+  text-transform: uppercase;
+  font-size: 11px;
+  line-height: 12px;
+  white-space: nowrap;
+}
+
+.c7 active {
+  color: #0E77D2;
+}
+
+.c7 visited {
+  color: #0E77D2;
+}
+
+.c4 {
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c6 {
+  position: relative;
+  width: 100%;
+}
+
+.c6:before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 0;
+  border-top: 1px solid #e1ebfa;
+  background: #e1ebfa;
+  width: 100%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+}
+
+.c11 {
+  color: #011e38;
+  display: inline-block;
+}
+
+.c13 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.71428571;
+}
+
+.c10 {
+  width: 100%;
+}
+
+.c16 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  margin-bottom: 24px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c16:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c16:focus ~ svg {
+  fill: #00438f;
+}
+
+.c16::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c16::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c16:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c16::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c17 {
+  display: block;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 7px;
+  font-size: 16px;
+  font-family: 'IBM Plex Sans',sans-serif;
+  line-height: 1.5;
+  margin: 0px;
+  min-height: 40px;
+  color: #011e38;
+  border-color: #c0c8d1;
+}
+
+.c17:focus {
+  outline: none;
+  color: #011e38;
+  border-color: #216beb;
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c17:focus ~ svg {
+  fill: #00438f;
+}
+
+.c17::-webkit-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c17::-moz-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c17:-ms-input-placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c17::placeholder {
+  color: rgba(1,30,56,0.6);
+}
+
+.c22 {
+  min-width: 16px;
+  height: 16px;
+  border-radius: 2px;
+  border: solid 1px;
+  position: relative;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+}
+
+.c22:before {
+  content: '';
+  display: none;
+  position: relative;
+  left: 4px;
+  width: 3px;
+  height: 9px;
+  border: solid #ffffff;
+  border-radius: 1px;
+  border-width: 0 3px 3px 0;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.c20 {
+  position: absolute;
+  opacity: 0;
+  height: 1px;
+  width: 1px;
+}
+
+.c20:focus + .c21 {
+  box-shadow: 0px 0px 5px 0px rgba(33,107,235,.9);
+}
+
+.c20:checked + .c21 {
+  border-color: #00438f;
+  background-color: #00438f;
+}
+
+.c20:checked + .c21:before {
+  display: block;
+}
+
+.c20:not(:checked) + .c21 {
+  border-color: #c0c8d1;
+  background-color: #ffffff;
+}
+
+.c18 {
+  padding: 4px 0;
+  margin-bottom: 24px;
+}
+
+.c18 .c8 {
+  margin-left: 8px;
+}
+
+@media screen and (min-width:0px) {
+  .c26 {
+    width: calc(100% - 32px);
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c26 {
+    width: calc(100% - 64px);
+  }
+}
+
+@media screen and (min-width:0px) {
+  .c1 {
+    background-color: #ffffff;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c1 {
+    background-color: #f0f2f5;
+  }
+}
+
+@media screen and (min-width:0px) {
+  .c3 {
+    padding-left: 16px;
+    padding-right: 16px;
+    padding-top: 24px;
+    padding-bottom: 24px;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c3 {
+    padding-left: 32px;
+    padding-right: 32px;
+    padding-top: 40px;
+    padding-bottom: 40px;
+  }
+}
+
+@media screen and (min-width:0px) {
+  .c3 {
+    height: 100%;
+  }
+}
+
+@media screen and (min-width:768px) {
+  .c3 {
+    height: auto;
+  }
+}
+
+@media screen and (min-width:0px) {
+
+}
+
+@media screen and (min-width:768px) {
+  .c3 {
+    border-radius: 4px;
+  }
+}
+
+@media screen and (min-width:0px) {
+
+}
+
+@media screen and (min-width:768px) {
+  .c3 {
+    box-shadow: 0px 0px 3px 0px rgba(1,30,56,0.2);
+  }
+}
+
 <div
-  style="padding:24px"
+  style={
+    Object {
+      "padding": "24px",
+    }
+  }
 >
   <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 cQWJEM"
+    className="c0"
   >
     <div
-      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iQpQtI"
+      className="c1"
       width="100%"
     >
       <div
-        class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hHfqqr"
+        className="c2"
         width="100%"
       >
         <div
-          class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 hAwusC"
-          height="[object Object]"
+          className="c3"
+          height={
+            Object {
+              "extraSmall": "100%",
+              "small": "auto",
+            }
+          }
           width="100%"
         >
           <div
-            class="Branding__BrandingWrap-ranqri-0 yiUfZ Branding-ranqri-2 kQRWHN"
-            style="margin-bottom:16px"
+            className="c4 "
+            size="large"
+            style={
+              Object {
+                "marginBottom": "16px",
+              }
+            }
           >
             <svg
               height="48px"
-              style="display:block"
+              style={
+                Object {
+                  "display": "block",
+                  "margin": null,
+                }
+              }
               viewBox="0 0 133 32"
               width="200px"
             >
@@ -851,96 +3537,119 @@ exports[`Storyshots Pages/LoginPage with remember me 1`] = `
               </g>
             </svg>
             <div
-              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 kBVTzS"
+              className="c5"
               width="100%"
             >
               <div
-                class="Branding__Line-ranqri-1 gfZuug"
+                className="c6"
               />
               <span
-                class="BrandingText-nluvkd-0 TxcJr"
-                style="margin-left:4px;margin-right:4px"
+                className="c7"
+                size="large"
+                style={
+                  Object {
+                    "marginLeft": "4px",
+                    "marginRight": "4px",
+                  }
+                }
               >
                 Logo Subtext
               </span>
               <div
-                class="Branding__Line-ranqri-1 gfZuug"
+                className="c6"
               />
             </div>
           </div>
           <p
-            class="Text-sc-1wu7vpu-0 gcgjYT"
+            className="c8 c9"
             color="darkGrey"
-            font-size="small"
+            disabled={false}
+            fontSize="small"
           >
             Additional Text
           </p>
           <form
-            style="width:100%"
+            style={
+              Object {
+                "width": "100%",
+              }
+            }
           >
             <div
-              class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+              className="c10"
             >
               <label
-                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                className="c11 "
                 color="black"
-                style="display:block"
+                style={
+                  Object {
+                    "display": "block",
+                  }
+                }
               >
                 <div
-                  class="Box-sc-1qu1edy-0 ilQgHG"
+                  className="c12"
                   data-testid="field-label"
                 >
                   <span
-                    class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                    className="c13"
                   >
                     Email
                   </span>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+                  className="c14"
                 >
                   <div
-                    class="Box-sc-1qu1edy-0 hxUhcg"
+                    className="c15"
                     display="flex"
                   >
                     <input
-                      aria-invalid="false"
-                      aria-required="false"
-                      class="InputField__StyledInput-sc-6cu4mg-0 YAPpz"
+                      aria-invalid={false}
+                      aria-required={false}
+                      className="c16"
+                      disabled={false}
+                      required={false}
                     />
                   </div>
                 </div>
               </label>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+              className="c10"
             >
               <label
-                class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+                className="c11 "
                 color="black"
-                style="display:block"
+                style={
+                  Object {
+                    "display": "block",
+                  }
+                }
               >
                 <div
-                  class="Box-sc-1qu1edy-0 ilQgHG"
+                  className="c12"
                   data-testid="field-label"
                 >
                   <span
-                    class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+                    className="c13"
                   >
                     Password
                   </span>
                 </div>
                 <div
-                  class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+                  className="c14"
                 >
                   <div
-                    class="Box-sc-1qu1edy-0 hxUhcg"
+                    className="c15"
                     display="flex"
                   >
                     <input
-                      aria-invalid="false"
-                      aria-required="false"
-                      class="InputField__StyledInput-sc-6cu4mg-0 cMrwRk"
+                      aria-invalid={false}
+                      aria-required={false}
+                      className="c17"
+                      disabled={false}
+                      required={false}
                       type="password"
                     />
                   </div>
@@ -948,32 +3657,40 @@ exports[`Storyshots Pages/LoginPage with remember me 1`] = `
               </label>
             </div>
             <div
-              class="Box-sc-1qu1edy-0 jlPsmj Checkbox-sc-1nm58f1-2 gnHfup"
+              className="c18"
             >
               <label
-                class="ClickInputLabel-j2axnv-0 kemUmZ"
+                className="c19"
+                disabled={false}
               >
                 <input
-                  aria-invalid="false"
-                  aria-required="false"
-                  class="Checkbox__CheckboxInput-sc-1nm58f1-1 ejYTGD Checkbox-sc-1nm58f1-2 gnHfup"
+                  aria-invalid={false}
+                  aria-required={false}
+                  className="c20 c18"
+                  disabled={false}
+                  id={null}
+                  required={false}
                   type="checkbox"
                 />
                 <div
-                  class="Checkbox__VisualCheckbox-sc-1nm58f1-0 kUStCo"
+                  className="c21 c22"
                   data-testid="visual-checkbox"
+                  disabled={false}
                 />
                 <p
-                  class="Text-sc-1wu7vpu-0 RbfMK"
+                  className="c8 c23"
                   color="currentColor"
-                  font-size="medium"
+                  disabled={false}
+                  fontSize="medium"
                 >
                   Remember me
                 </p>
               </label>
             </div>
             <button
-              class="Button__WrapperButton-sc-1omxup2-0 bkRlmc PrimaryButton-qz78sb-0 cGyyDq"
+              className="c24 c25"
+              disabled={false}
+              size="medium"
             >
               Sign In
             </button>
@@ -981,14 +3698,24 @@ exports[`Storyshots Pages/LoginPage with remember me 1`] = `
         </div>
       </div>
       <div
-        class="Box-sc-1qu1edy-0 iZcQLf"
-        style="border-top:solid 1px #e4e7eb"
-        width="[object Object]"
+        className="c26"
+        style={
+          Object {
+            "borderTop": "solid 1px #e4e7eb",
+          }
+        }
+        width={
+          Object {
+            "extraSmall": "calc(100% - 32px)",
+            "small": "calc(100% - 64px)",
+          }
+        }
       >
         <p
-          class="Text-sc-1wu7vpu-0 fRSYFu"
+          className="c8 c27"
           color="darkGrey"
-          font-size="medium"
+          disabled={false}
+          fontSize="medium"
         >
           © 2007-2019 Nulogy Corporation
         </p>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1449,6 +1449,16 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
+"@jest/types@^25.5.0":
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.5.0.tgz#4d6a4793f7b9599fc3680877b856a97dbccf2a9d"
+  integrity sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^1.1.1"
+    "@types/yargs" "^15.0.0"
+    chalk "^3.0.0"
+
 "@jimp/bmp@^0.6.8":
   version "0.6.8"
   resolved "https://registry.yarnpkg.com/@jimp/bmp/-/bmp-0.6.8.tgz#8abbfd9e26ba17a47fab311059ea9f7dd82005b6"
@@ -2424,12 +2434,6 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
-
-"@nulogy/icons@^3.0.0":
-  version "2.6.0"
-  dependencies:
-    fs "^0.0.1-security"
-    svgi "^1.1.0"
 
 "@nulogy/tokens@^2.13.1":
   version "2.13.1"
@@ -3706,6 +3710,11 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
+
+"@types/prettier@^1.19.0":
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.1.tgz#33509849f8e679e4add158959fdb086440e9553f"
+  integrity sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==
 
 "@types/prop-types@*":
   version "15.7.3"
@@ -7902,6 +7911,11 @@ diff-sequences@^25.1.0:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.1.0.tgz#fd29a46f1c913fd66c22645dc75bffbe43051f32"
   integrity sha512-nFIfVk5B/NStCsJ+zaPO4vYuLjlzQ6uFvPxzYyHlejNZ/UGa7G/n7peOXVrVNvRuyfstt+mZQYGpjxg9Z6N8Kw==
 
+diff-sequences@^25.2.6:
+  version "25.2.6"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.2.6.tgz#5f467c00edd35352b7bca46d7927d60e687a76dd"
+  integrity sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==
+
 diffie-hellman@^5.0.0:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
@@ -9196,6 +9210,18 @@ expect@^24.9.0:
     jest-matcher-utils "^24.9.0"
     jest-message-util "^24.9.0"
     jest-regex-util "^24.9.0"
+
+expect@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-25.5.0.tgz#f07f848712a2813bb59167da3fb828ca21f58bba"
+  integrity sha512-w7KAXo0+6qqZZhovCaBVPSIqQp7/UTcx4M9uKt2m6pd2VB1voyC8JizLRqeEqud3AAVP02g+hbErDu5gu64tlA==
+  dependencies:
+    "@jest/types" "^25.5.0"
+    ansi-styles "^4.0.0"
+    jest-get-type "^25.2.6"
+    jest-matcher-utils "^25.5.0"
+    jest-message-util "^25.5.0"
+    jest-regex-util "^25.2.6"
 
 express-graphql@^0.9.0:
   version "0.9.0"
@@ -10949,6 +10975,11 @@ graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
+
+graceful-fs@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
+  integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
@@ -12923,6 +12954,16 @@ jest-diff@^25.1.0:
     jest-get-type "^25.1.0"
     pretty-format "^25.1.0"
 
+jest-diff@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.5.0.tgz#1dd26ed64f96667c068cef026b677dfa01afcfa9"
+  integrity sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==
+  dependencies:
+    chalk "^3.0.0"
+    diff-sequences "^25.2.6"
+    jest-get-type "^25.2.6"
+    pretty-format "^25.5.0"
+
 jest-docblock@^24.3.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-24.9.0.tgz#7970201802ba560e1c4092cc25cbedf5af5a8ce2"
@@ -12973,6 +13014,11 @@ jest-get-type@^25.1.0:
   version "25.1.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-25.1.0.tgz#1cfe5fc34f148dc3a8a3b7275f6b9ce9e2e8a876"
   integrity sha512-yWkBnT+5tMr8ANB6V+OjmrIJufHtCAqI5ic2H40v+tRqxDmE0PGnIiTyvRWFOMtmVHYpwRqyazDbTnhpjsGvLw==
+
+jest-get-type@^25.2.6:
+  version "25.2.6"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-25.2.6.tgz#0b0a32fab8908b44d508be81681487dbabb8d877"
+  integrity sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==
 
 jest-haste-map@^24.9.0:
   version "24.9.0"
@@ -13057,6 +13103,16 @@ jest-matcher-utils@^25.1.0:
     jest-get-type "^25.1.0"
     pretty-format "^25.1.0"
 
+jest-matcher-utils@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-25.5.0.tgz#fbc98a12d730e5d2453d7f1ed4a4d948e34b7867"
+  integrity sha512-VWI269+9JS5cpndnpCwm7dy7JtGQT30UHfrnM3mXl22gHGt/b7NkjBqXfbhZ8V4B7ANUsjK18PlSBmG0YH7gjw==
+  dependencies:
+    chalk "^3.0.0"
+    jest-diff "^25.5.0"
+    jest-get-type "^25.2.6"
+    pretty-format "^25.5.0"
+
 jest-message-util@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-24.9.0.tgz#527f54a1e380f5e202a8d1149b0ec872f43119e3"
@@ -13069,6 +13125,20 @@ jest-message-util@^24.9.0:
     chalk "^2.0.1"
     micromatch "^3.1.10"
     slash "^2.0.0"
+    stack-utils "^1.0.1"
+
+jest-message-util@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-25.5.0.tgz#ea11d93204cc7ae97456e1d8716251185b8880ea"
+  integrity sha512-ezddz3YCT/LT0SKAmylVyWWIGYoKHOFOFXx3/nA4m794lfVUskMcwhip6vTgdVrOtYdjeQeis2ypzes9mZb4EA==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@jest/types" "^25.5.0"
+    "@types/stack-utils" "^1.0.1"
+    chalk "^3.0.0"
+    graceful-fs "^4.2.4"
+    micromatch "^4.0.2"
+    slash "^3.0.0"
     stack-utils "^1.0.1"
 
 jest-mock@^24.9.0:
@@ -13087,6 +13157,11 @@ jest-regex-util@^24.3.0, jest-regex-util@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-24.9.0.tgz#c13fb3380bde22bf6575432c493ea8fe37965636"
   integrity sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA==
+
+jest-regex-util@^25.2.6:
+  version "25.2.6"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-25.2.6.tgz#d847d38ba15d2118d3b06390056028d0f2fd3964"
+  integrity sha512-KQqf7a0NrtCkYmZZzodPftn7fL1cq3GQAFVMn5Hg8uKx/fIenLEobNanUxb7abQ1sjADHBseG/2FGpsv/wr+Qw==
 
 jest-resolve-dependencies@^24.9.0:
   version "24.9.0"
@@ -13107,6 +13182,21 @@ jest-resolve@^24.9.0:
     chalk "^2.0.1"
     jest-pnp-resolver "^1.2.1"
     realpath-native "^1.1.0"
+
+jest-resolve@^25.5.1:
+  version "25.5.1"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-25.5.1.tgz#0e6fbcfa7c26d2a5fe8f456088dc332a79266829"
+  integrity sha512-Hc09hYch5aWdtejsUZhA+vSzcotf7fajSlPA6EZPE1RmPBAD39XtJhvHWFStid58iit4IPDLI/Da4cwdDmAHiQ==
+  dependencies:
+    "@jest/types" "^25.5.0"
+    browser-resolve "^1.11.3"
+    chalk "^3.0.0"
+    graceful-fs "^4.2.4"
+    jest-pnp-resolver "^1.2.1"
+    read-pkg-up "^7.0.1"
+    realpath-native "^2.0.0"
+    resolve "^1.17.0"
+    slash "^3.0.0"
 
 jest-runner@^24.9.0:
   version "24.9.0"
@@ -13186,12 +13276,40 @@ jest-snapshot@^24.1.0, jest-snapshot@^24.9.0:
     pretty-format "^24.9.0"
     semver "^6.2.0"
 
+jest-snapshot@^25.1.0:
+  version "25.5.1"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-25.5.1.tgz#1a2a576491f9961eb8d00c2e5fd479bc28e5ff7f"
+  integrity sha512-C02JE1TUe64p2v1auUJ2ze5vcuv32tkv9PyhEb318e8XOKF7MOyXdJ7kdjbvrp3ChPLU2usI7Rjxs97Dj5P0uQ==
+  dependencies:
+    "@babel/types" "^7.0.0"
+    "@jest/types" "^25.5.0"
+    "@types/prettier" "^1.19.0"
+    chalk "^3.0.0"
+    expect "^25.5.0"
+    graceful-fs "^4.2.4"
+    jest-diff "^25.5.0"
+    jest-get-type "^25.2.6"
+    jest-matcher-utils "^25.5.0"
+    jest-message-util "^25.5.0"
+    jest-resolve "^25.5.1"
+    make-dir "^3.0.0"
+    natural-compare "^1.4.0"
+    pretty-format "^25.5.0"
+    semver "^6.3.0"
+
 jest-specific-snapshot@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/jest-specific-snapshot/-/jest-specific-snapshot-2.0.0.tgz#425fe524b25df154aa39f97fa6fe9726faaac273"
   integrity sha512-aXaNqBg/svwEpY5iQEzEHc5I85cUBKgfeVka9KmpznxLnatpjiqjr7QLb/BYNYlsrZjZzgRHTjQJ+Svx+dbdvg==
   dependencies:
     jest-snapshot "^24.1.0"
+
+jest-specific-snapshot@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/jest-specific-snapshot/-/jest-specific-snapshot-3.0.0.tgz#c203a6bccc572832aea0278feeaa3350567a306f"
+  integrity sha512-dMEDxj762XleVVUYnxHbRypWOxRwV3HsolUZugISyFu8jE6Xz58TkeKeXxRfT9oG6U8zxPggrH+1MSNVyLwGqg==
+  dependencies:
+    jest-snapshot "^25.1.0"
 
 jest-styled-components@7:
   version "7.0.2"
@@ -17022,6 +17140,16 @@ pretty-format@^25.1.0:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
+pretty-format@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.5.0.tgz#7873c1d774f682c34b8d48b6743a2bf2ac55791a"
+  integrity sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==
+  dependencies:
+    "@jest/types" "^25.5.0"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^16.12.0"
+
 pretty-hrtime@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
@@ -17956,7 +18084,7 @@ read-pkg-up@^4.0.0:
     find-up "^3.0.0"
     read-pkg "^3.0.0"
 
-read-pkg-up@^7.0.0:
+read-pkg-up@^7.0.0, read-pkg-up@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz#f3a6135758459733ae2b95638056e1854e7ef507"
   integrity sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==
@@ -18082,6 +18210,11 @@ realpath-native@^1.1.0:
   integrity sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
   dependencies:
     util.promisify "^1.0.0"
+
+realpath-native@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-2.0.0.tgz#7377ac429b6e1fd599dc38d08ed942d0d7beb866"
+  integrity sha512-v1SEYUOXXdbBZK8ZuNgO4TBjamPsiSgcFr0aP+tEKpQZK8vooEUqV6nm6Cv502mX4NF2EfsnVqtNAHG+/6Ur1Q==
 
 recast@^0.14.7:
   version "0.14.7"
@@ -18529,7 +18662,7 @@ resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.12.
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.14.2:
+resolve@^1.14.2, resolve@^1.17.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==


### PR DESCRIPTION
## Description
alternative setting that shows the css rules within the storyshot.. unfortunately we lose the component class names which also has its benefits. 

Pending on this issue for now. 
https://github.com/styled-components/jest-styled-components/issues/328

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
