### PR TITLE
fix: add missing BrandedNavbar showTraining prop documentation

### DIFF
--- a/docs/src/pages/components/branded-navbar.js
+++ b/docs/src/pages/components/branded-navbar.js
@@ -39,6 +39,12 @@ const propsRows = [
     description: "The subtext under the Nulogy logo."
   },
   {
+    name: "showTraining",
+    type: "boolean",
+    defaultValue: "false",
+    description: "Whether or not to show the blue 'Training' bar"
+  },
+  {
     name: "brandingLinkHref",
     type: "string",
     defaultValue: "/",


### PR DESCRIPTION
## Description

**Include what change you're making, why, and link to any relevant JIRA issues**

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
