### PR TITLE
feat: accessible toggle colours

### DIFF
--- a/components/src/Form/__snapshots__/Form.story.storyshot
+++ b/components/src/Form/__snapshots__/Form.story.storyshot
@@ -779,13 +779,13 @@ exports[`Storyshots Form Demo form 1`] = `
                   aria-invalid="false"
                   aria-labelledby="Job Visibility-label"
                   aria-required="false"
-                  class="ToggleButton__ToggleInput-asgrb8-2 lcDvtB"
+                  class="ToggleButton__ToggleInput-asgrb8-2 YjgQG"
                   id="job-visibility"
                   type="checkbox"
                   value="on"
                 />
                 <span
-                  class="ToggleButton__Slider-asgrb8-0 bLvWmF"
+                  class="ToggleButton__Slider-asgrb8-0 kEtIPM"
                 />
               </div>
               <p
@@ -938,14 +938,14 @@ exports[`Storyshots Form Demo form 1`] = `
                   aria-invalid="false"
                   aria-labelledby="Reject visibility-label"
                   aria-required="false"
-                  class="ToggleButton__ToggleInput-asgrb8-2 gajnWZ"
+                  class="ToggleButton__ToggleInput-asgrb8-2 kbFCui"
                   disabled=""
                   id="reject-visibility"
                   type="checkbox"
                   value="on"
                 />
                 <span
-                  class="ToggleButton__Slider-asgrb8-0 bQpZex"
+                  class="ToggleButton__Slider-asgrb8-0 jXzDwv"
                   disabled=""
                 />
               </div>

--- a/components/src/Toggle/ToggleButton.js
+++ b/components/src/Toggle/ToggleButton.js
@@ -10,21 +10,19 @@ const Slider = styled.span(({ disabled, theme }) => ({
   right: "0",
   bottom: "0",
   left: "0",
-  backgroundColor: theme.colors.lightGrey,
+  backgroundColor: disabled ? theme.colors.grey : theme.colors.darkGrey,
   borderRadius: "12px",
   transition: ".2s ease",
   cursor: disabled ? null : "pointer",
   "&:before": {
     content: "''",
     position: "absolute",
-    height: theme.space.x3,
-    width: theme.space.x3,
-    left: "0px",
-    top: "0px",
+    height: "22px",
+    width: "22px",
+    left: "1px",
+    top: "1px",
     borderRadius: theme.radii.circle,
     boxSizing: "border-box",
-    border: "solid 1px",
-    borderColor: disabled ? theme.colors.lightGrey : theme.colors.grey,
     backgroundColor: disabled ? theme.colors.whiteGrey : theme.colors.white,
     transition: ".2s ease"
   }
@@ -44,12 +42,10 @@ const Switch = styled.div(({ theme }) => ({
 
 const ToggleInput = styled.input(({ disabled, theme }) => ({
   [`&:checked + ${Slider}:before`]: {
-    transform: "translateX(24px)",
-    backgroundColor: disabled ? theme.colors.lightGrey : theme.colors.darkBlue,
-    borderColor: disabled ? theme.colors.whiteGrey : theme.colors.darkBlue
+    transform: "translateX(24px)"
   },
   [`&:checked + ${Slider}`]: {
-    backgroundColor: disabled ? theme.colors.whiteGrey : theme.colors.lightBlue
+    backgroundColor: disabled ? theme.colors.grey : theme.colors.darkBlue
   },
   [`&:focus + ${Slider}:before`]: {
     boxShadow: disabled ? null : theme.shadows.focus

--- a/components/src/Toggle/__snapshots__/Toggle.story.storyshot
+++ b/components/src/Toggle/__snapshots__/Toggle.story.storyshot
@@ -32,12 +32,12 @@ exports[`Storyshots Toggle Controlled Toggle 1`] = `
               aria-invalid="false"
               aria-labelledby="Controlled Toggle-label"
               aria-required="false"
-              class="ToggleButton__ToggleInput-asgrb8-2 lcDvtB"
+              class="ToggleButton__ToggleInput-asgrb8-2 YjgQG"
               type="checkbox"
               value="on"
             />
             <span
-              class="ToggleButton__Slider-asgrb8-0 bLvWmF"
+              class="ToggleButton__Slider-asgrb8-0 kEtIPM"
             />
           </div>
           <p
@@ -73,12 +73,12 @@ exports[`Storyshots Toggle Toggle 1`] = `
           <input
             aria-invalid="false"
             aria-required="false"
-            class="ToggleButton__ToggleInput-asgrb8-2 lcDvtB"
+            class="ToggleButton__ToggleInput-asgrb8-2 YjgQG"
             type="checkbox"
             value="on"
           />
           <span
-            class="ToggleButton__Slider-asgrb8-0 bLvWmF"
+            class="ToggleButton__Slider-asgrb8-0 kEtIPM"
           />
         </div>
       </div>
@@ -120,12 +120,12 @@ exports[`Storyshots Toggle Toggle set to defaultToggled 1`] = `
               aria-labelledby="Toggle-label"
               aria-required="false"
               checked=""
-              class="ToggleButton__ToggleInput-asgrb8-2 lcDvtB"
+              class="ToggleButton__ToggleInput-asgrb8-2 YjgQG"
               type="checkbox"
               value="on"
             />
             <span
-              class="ToggleButton__Slider-asgrb8-0 bLvWmF"
+              class="ToggleButton__Slider-asgrb8-0 kEtIPM"
             />
           </div>
         </div>
@@ -168,13 +168,13 @@ exports[`Storyshots Toggle Toggle set to disabled 1`] = `
               aria-invalid="false"
               aria-labelledby="Toggle-label"
               aria-required="false"
-              class="ToggleButton__ToggleInput-asgrb8-2 gajnWZ"
+              class="ToggleButton__ToggleInput-asgrb8-2 kbFCui"
               disabled=""
               type="checkbox"
               value="on"
             />
             <span
-              class="ToggleButton__Slider-asgrb8-0 bQpZex"
+              class="ToggleButton__Slider-asgrb8-0 jXzDwv"
               disabled=""
             />
           </div>
@@ -216,14 +216,14 @@ exports[`Storyshots Toggle Toggle set to disabled 1`] = `
               aria-labelledby="Toggle-label"
               aria-required="false"
               checked=""
-              class="ToggleButton__ToggleInput-asgrb8-2 gajnWZ"
+              class="ToggleButton__ToggleInput-asgrb8-2 kbFCui"
               disabled=""
               id="toggle-2"
               type="checkbox"
               value="on"
             />
             <span
-              class="ToggleButton__Slider-asgrb8-0 bQpZex"
+              class="ToggleButton__Slider-asgrb8-0 jXzDwv"
               disabled=""
             />
           </div>
@@ -289,13 +289,13 @@ exports[`Storyshots Toggle Toggle with all props 1`] = `
               aria-labelledby="Toggle-label"
               aria-required="true"
               checked=""
-              class="ToggleButton__ToggleInput-asgrb8-2 lcDvtB"
+              class="ToggleButton__ToggleInput-asgrb8-2 YjgQG"
               required=""
               type="checkbox"
               value="on"
             />
             <span
-              class="ToggleButton__Slider-asgrb8-0 bLvWmF"
+              class="ToggleButton__Slider-asgrb8-0 kEtIPM"
             />
           </div>
           <p
@@ -344,13 +344,13 @@ exports[`Storyshots Toggle With custom id 1`] = `
               aria-invalid="false"
               aria-labelledby="Toggle-label"
               aria-required="false"
-              class="ToggleButton__ToggleInput-asgrb8-2 lcDvtB"
+              class="ToggleButton__ToggleInput-asgrb8-2 YjgQG"
               id="my-custom-id"
               type="checkbox"
               value="on"
             />
             <span
-              class="ToggleButton__Slider-asgrb8-0 bLvWmF"
+              class="ToggleButton__Slider-asgrb8-0 kEtIPM"
             />
           </div>
           <p
@@ -400,12 +400,12 @@ exports[`Storyshots Toggle With long text 1`] = `
               aria-labelledby="Toggle-label"
               aria-required="false"
               checked=""
-              class="ToggleButton__ToggleInput-asgrb8-2 lcDvtB"
+              class="ToggleButton__ToggleInput-asgrb8-2 YjgQG"
               type="checkbox"
               value="on"
             />
             <span
-              class="ToggleButton__Slider-asgrb8-0 bLvWmF"
+              class="ToggleButton__Slider-asgrb8-0 kEtIPM"
             />
           </div>
           <p
@@ -454,12 +454,12 @@ exports[`Storyshots Toggle With text 1`] = `
               aria-invalid="false"
               aria-labelledby="Toggle-label"
               aria-required="false"
-              class="ToggleButton__ToggleInput-asgrb8-2 lcDvtB"
+              class="ToggleButton__ToggleInput-asgrb8-2 YjgQG"
               type="checkbox"
               value="on"
             />
             <span
-              class="ToggleButton__Slider-asgrb8-0 bLvWmF"
+              class="ToggleButton__Slider-asgrb8-0 kEtIPM"
             />
           </div>
           <p

--- a/components/src/pages/__snapshots__/Details.story.storyshot
+++ b/components/src/pages/__snapshots__/Details.story.storyshot
@@ -3168,13 +3168,13 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                         aria-invalid="false"
                         aria-labelledby="Job Visibility-label"
                         aria-required="false"
-                        class="ToggleButton__ToggleInput-asgrb8-2 lcDvtB"
+                        class="ToggleButton__ToggleInput-asgrb8-2 YjgQG"
                         id="job-visibility"
                         type="checkbox"
                         value="on"
                       />
                       <span
-                        class="ToggleButton__Slider-asgrb8-0 bLvWmF"
+                        class="ToggleButton__Slider-asgrb8-0 kEtIPM"
                       />
                     </div>
                     <p
@@ -3327,14 +3327,14 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                         aria-invalid="false"
                         aria-labelledby="Reject visibility-label"
                         aria-required="false"
-                        class="ToggleButton__ToggleInput-asgrb8-2 gajnWZ"
+                        class="ToggleButton__ToggleInput-asgrb8-2 kbFCui"
                         disabled=""
                         id="reject-visibility"
                         type="checkbox"
                         value="on"
                       />
                       <span
-                        class="ToggleButton__Slider-asgrb8-0 bQpZex"
+                        class="ToggleButton__Slider-asgrb8-0 jXzDwv"
                         disabled=""
                       />
                     </div>

--- a/css/src/scss/components/_toggle.scss
+++ b/css/src/scss/components/_toggle.scss
@@ -27,11 +27,12 @@ $toggle-width: 48px;
 
 .Toggle__slider {
   cursor: pointer;
-  background-color: $color-base-light-grey;
+  background-color: $color-base-dark-grey;
   transition: 0.2s ease;
   width: $toggle-width;
   height: $toggle-height;
   border-radius: $toggle-height/2;
+  position: relative;
 }
 
 .Toggle__slider:before {
@@ -39,18 +40,15 @@ $toggle-width: 48px;
   content: "";
   height: $toggle-height - 2;
   width: $toggle-height - 2;
-  border: 1px solid $color-base-grey;
+  left: 1px;
+  top: 1px;
   background-color: $color-base-white;
   transition: 0.2s ease;
   border-radius: 50%;
 }
 
 .Toggle__input:checked + .Toggle__slider {
-  background-color: $color-base-light-blue;
-  &:before {
-    background: $color-base-dark-blue;
-    border: 1px solid $color-base-dark-blue;
-  }
+  background-color: $color-base-dark-blue;
 }
 
 .Toggle__input:checked + .Toggle__slider:before {
@@ -73,20 +71,18 @@ $toggle-width: 48px;
   }
   & + .Toggle__slider {
     cursor: default;
-    background-color: $color-base-light-grey;
+    background-color: $color-base-grey;
     &:before {
       background-color: $color-base-white-grey;
-      border-color: $color-base-light-grey;
     }
   }
 }
 
 .Toggle__input:disabled:checked {
   & + .Toggle__slider {
-    background-color: $color-base-white-grey;
+    background-color: $color-base-grey;
     &:before {
-      background-color: $color-base-light-grey;
-      border-color: $color-base-white-grey;
+      background-color: $color-base-white-grey;
     }
   }
 }


### PR DESCRIPTION
## Description

Update toggle to follow newly proposed designs to improve color accessibility.

Enabled:
<img width="145" alt="Screen Shot 2020-06-25 at 11 39 48 AM" src="https://user-images.githubusercontent.com/8175052/85752588-898b7d00-b6d9-11ea-94bd-a1a2809151fa.png">
<img width="160" alt="Screen Shot 2020-06-25 at 11 39 44 AM" src="https://user-images.githubusercontent.com/8175052/85752594-8abcaa00-b6d9-11ea-8dbd-9c831950a8e8.png">

Disabled:
<img width="118" alt="Screen Shot 2020-06-25 at 11 39 35 AM" src="https://user-images.githubusercontent.com/8175052/85752610-8e503100-b6d9-11ea-9553-e17930ff733f.png">

See examples here: https://deploy-preview-695--nds-storybook.netlify.app/?path=/story/toggle--toggle


## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
