### PR TITLE
feat: Adds info on chinese font to typography page

### DIFF
--- a/docs/src/pages/guides/localization.js
+++ b/docs/src/pages/guides/localization.js
@@ -73,7 +73,7 @@ export default () => (
         need to load the{" "}
         <Link href="https://www.google.com/get/noto/">Noto Sans SC</Link> font.
         For more information, see the{" "}
-        <Link href="https://github.com/nulogy/design-system/blob/master/components/README.md#2-add-fontsd">
+        <Link href="https://github.com/nulogy/design-system/blob/master/components/README.md#2-add-fonts">
           README
         </Link>
         .

--- a/docs/src/pages/style/typography.js
+++ b/docs/src/pages/style/typography.js
@@ -86,6 +86,16 @@ export default () => (
 <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono" rel="stylesheet" />
 `}
       </Highlight>
+      <Text mt="x2">
+        Note that if your application supports Simplified Chinese, you'll also
+        need to load the{" "}
+        <Link href="https://www.google.com/get/noto/">Noto Sans SC</Link> font.
+        For more information, see the{" "}
+        <Link href="https://github.com/nulogy/design-system/blob/master/components/README.md#2-add-fonts">
+          README
+        </Link>
+        .
+      </Text>
     </DocSection>
 
     <DocSection>


### PR DESCRIPTION
## Description

We mention loading fonts on /typography so we should also mention Noto. 

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
