### PR TITLE
fix: allow single breadcrumb in Breadcrumbs

### DIFF
--- a/components/src/Breadcrumbs/Breadcrumbs.js
+++ b/components/src/Breadcrumbs/Breadcrumbs.js
@@ -42,7 +42,8 @@ const StyledOl = styled.ol(() => ({
 }));
 
 const Breadcrumbs = ({ children, as }) => {
-  const allItems = [...children].map((child, index) => {
+  const childrenArr = Array.isArray(children) ? children : [children];
+  const allItems = [...childrenArr].map((child, index) => {
     return (
       // eslint-disable-next-line react/no-array-index-key
       <StyledLi key={`child-${index}`}>

--- a/components/src/Breadcrumbs/Breadcrumbs.story.js
+++ b/components/src/Breadcrumbs/Breadcrumbs.story.js
@@ -6,10 +6,15 @@ import { Text } from "../Type";
 
 storiesOf("Breadcrumbs", module)
   .add("Breadcrumbs", () => (
-    <Breadcrumbs>
-      <Link href="/">Home</Link>
-      <Link href="/Tenants">Tenants</Link>
-    </Breadcrumbs>
+    <>
+      <Breadcrumbs>
+        <Link href="/">Home</Link>
+      </Breadcrumbs>
+      <Breadcrumbs>
+        <Link href="/">Home</Link>
+        <Link href="/Tenants">Tenants</Link>
+      </Breadcrumbs>
+    </>
   ))
   .add("without link", () => (
     <Breadcrumbs>

--- a/components/src/Breadcrumbs/__snapshots__/Breadcrumbs.story.storyshot
+++ b/components/src/Breadcrumbs/__snapshots__/Breadcrumbs.story.storyshot
@@ -45,6 +45,46 @@ exports[`Storyshots Breadcrumbs Breadcrumbs 1`] = `
             />
           </svg>
         </li>
+      </ol>
+    </nav>
+    <nav
+      class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 iHUNrd"
+    >
+      <ol
+        class="Breadcrumbs__StyledOl-sc-1l75jcp-1 huaGZO"
+      >
+        <li
+          class="Breadcrumbs__StyledLi-sc-1l75jcp-0 dYpvAr"
+        >
+          <a
+            class="Link-sc-1lpx3d0-0 hcsgot"
+            color="darkBlue"
+            font-size="medium"
+            href="/"
+          >
+            Home
+          </a>
+        </li>
+        <li
+          aria-hidden="true"
+          class="Breadcrumbs__StyledLi-sc-1l75jcp-0 cLdMxg seperator"
+        >
+          <svg
+            aria-hidden="true"
+            class="Icon-fc7twp-0 dkBAgY"
+            color="currentColor"
+            fill="currentColor"
+            focusable="false"
+            height="24px"
+            icon="rightArrow"
+            viewBox="0 0 24 24"
+            width="24px"
+          >
+            <path
+              d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+            />
+          </svg>
+        </li>
         <li
           class="Breadcrumbs__StyledLi-sc-1l75jcp-0 dYpvAr"
         >


### PR DESCRIPTION
## Description

Allow singular child in breadcrumb component, previously an error was triggered if only one child was passed in
<img width="220" alt="Screen Shot 2020-06-29 at 11 53 19 AM" src="https://user-images.githubusercontent.com/8175052/86028303-bd2f1580-b9ff-11ea-893a-0e5bc54d6975.png">


## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [x] Storybook updated with examples of new functionality
- [x] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
