### PR TITLE
feat: Add a new "dark" type to StatusIndicator

### DIFF
--- a/components/src/StatusIndicator/StatusIndicator.js
+++ b/components/src/StatusIndicator/StatusIndicator.js
@@ -9,6 +9,11 @@ const StatusIndicatorColours = theme => ({
     backgroundColor: theme.colors.lightGrey,
     color: theme.colors.darkGrey
   },
+  dark: {
+    borderColor: theme.colors.blackBlue,
+    backgroundColor: theme.colors.blackBlue,
+    color: theme.colors.white
+  },
   quiet: {
     borderColor: theme.colors.white,
     backgroundColor: theme.colors.white,
@@ -55,7 +60,7 @@ const StatusIndicator = styled.p(
 );
 
 StatusIndicator.propTypes = {
-  type: PropTypes.oneOf(["neutral", "danger", "informative", "success", "warning", "quiet"]),
+  type: PropTypes.oneOf(["neutral", "dark", "danger", "informative", "success", "warning", "quiet"]),
   ...propTypes.space,
   ...propTypes.typography,
   ...propTypes.flexbox

--- a/components/src/StatusIndicator/StatusIndicator.story.js
+++ b/components/src/StatusIndicator/StatusIndicator.story.js
@@ -11,6 +11,9 @@ storiesOf("StatusIndicator", module)
       <StatusIndicator type="neutral" mr="half">
         Neutral
       </StatusIndicator>
+      <StatusIndicator type="dark" mr="half">
+        Dark
+      </StatusIndicator>
       <StatusIndicator type="quiet" mr="half">
         Quiet
       </StatusIndicator>
@@ -30,6 +33,7 @@ storiesOf("StatusIndicator", module)
   ))
 
   .add("Neutral", () => <StatusIndicator type="neutral">Neutral</StatusIndicator>)
+  .add("Dark", () => <StatusIndicator type="dark">Dark</StatusIndicator>)
   .add("Quiet", () => <StatusIndicator type="quiet">Quiet</StatusIndicator>)
   .add("Informative", () => <StatusIndicator type="informative">Informative</StatusIndicator>)
   .add("Success", () => <StatusIndicator type="success">Success</StatusIndicator>)

--- a/components/src/StatusIndicator/__snapshots__/StatusIndicator.story.storyshot
+++ b/components/src/StatusIndicator/__snapshots__/StatusIndicator.story.storyshot
@@ -15,6 +15,13 @@ exports[`Storyshots StatusIndicator All 1`] = `
       Neutral
     </p>
     <p
+      class="StatusIndicator-t1vtrp-0 eqLsmz"
+      font-size="smaller"
+      type="dark"
+    >
+      Dark
+    </p>
+    <p
       class="StatusIndicator-t1vtrp-0 bRgec"
       font-size="smaller"
       type="quiet"
@@ -66,6 +73,24 @@ exports[`Storyshots StatusIndicator Danger 1`] = `
       type="danger"
     >
       Danger
+    </p>
+  </div>
+</div>
+`;
+
+exports[`Storyshots StatusIndicator Dark 1`] = `
+<div
+  style="padding:24px"
+>
+  <div
+    class="NDSProvider__GlobalStyles-f28eoq-0 gXOmnU"
+  >
+    <p
+      class="StatusIndicator-t1vtrp-0 jCXXav"
+      font-size="smaller"
+      type="dark"
+    >
+      Dark
     </p>
   </div>
 </div>

--- a/docs/src/pages/components/status-indicator.js
+++ b/docs/src/pages/components/status-indicator.js
@@ -29,7 +29,7 @@ const propsRows = [
     type: "string",
     defaultValue: "neutral",
     description:
-      "The type of Status Indicator. Accepts neutral, informative, danger, warning, success, and quiet."
+      "The type of Status Indicator. Accepts neutral, dark, informative, danger, warning, success, and quiet."
   }
 ];
 
@@ -84,6 +84,19 @@ export default () => (
         <StatusIndicator>In progress</StatusIndicator>
         <Highlight className="js">
           {`<StatusIndicator>In progress</StatusIndicator>`}
+        </Highlight>
+      </Box>
+
+      <Box mb="x6">
+        <SubsectionTitle>Dark</SubsectionTitle>
+        <Text mb="x3">
+          A dark neutral state, which can be used for things like a state being
+          completed, finished or closed. Use when there's no need to signify
+          success or failure.
+        </Text>
+        <StatusIndicator type="dark">Completed</StatusIndicator>
+        <Highlight className="js">
+          {`<StatusIndicator type="dark">Completed</StatusIndicator>`}
         </Highlight>
       </Box>
 


### PR DESCRIPTION
## Description

This PR adds `<StatusIndicator type="dark"/>`.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [x] Storybook updated with examples of new functionality
- [x] Storybook uses variable and realistic data (ex: short and long text)
- [x] Docs updated with correct props and examples
- [x] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
