### PR TITLE
feat: timepicker default value cannot be set to time between intervals

### DIFF
--- a/components/src/DateRange/__snapshots__/DateRange.story.storyshot
+++ b/components/src/DateRange/__snapshots__/DateRange.story.storyshot
@@ -929,7 +929,7 @@ exports[`Storyshots DateRange with default start and end times 1`] = `
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker DateRange__StyledStartTime-sc-1m2eund-0 bMhikq css-2b097c-container"
+            class="TimePicker__StyledSelect-sc-1r3kwxy-2 eudUkx nds-time-picker DateRange__StyledStartTime-sc-1m2eund-0 bMhikq css-2b097c-container"
           >
             <div
               data-testid="select-control"
@@ -1025,7 +1025,7 @@ exports[`Storyshots DateRange with default start and end times 1`] = `
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker DateRange__StyledEndTime-sc-1m2eund-1 clTvEf css-2b097c-container"
+            class="TimePicker__StyledSelect-sc-1r3kwxy-2 eudUkx nds-time-picker DateRange__StyledEndTime-sc-1m2eund-1 clTvEf css-2b097c-container"
           >
             <div
               data-testid="select-control"
@@ -1037,9 +1037,9 @@ exports[`Storyshots DateRange with default start and end times 1`] = `
                   class=" css-7zc8my"
                 >
                   <div
-                    class=" css-r447wv-singleValue"
+                    class=" css-1yhx6vz-Placeholder"
                   >
-                    01:30 PM
+                    HH:MM
                   </div>
                   <div
                     data-testid="select-input"
@@ -1230,7 +1230,7 @@ exports[`Storyshots DateRange with time error 1`] = `
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker DateRange__StyledStartTime-sc-1m2eund-0 bMhikq css-2b097c-container"
+            class="TimePicker__StyledSelect-sc-1r3kwxy-2 eudUkx nds-time-picker DateRange__StyledStartTime-sc-1m2eund-0 bMhikq css-2b097c-container"
           >
             <div
               data-testid="select-control"
@@ -1242,9 +1242,9 @@ exports[`Storyshots DateRange with time error 1`] = `
                   class=" css-7zc8my"
                 >
                   <div
-                    class=" css-r447wv-singleValue"
+                    class=" css-1yhx6vz-Placeholder"
                   >
-                    01:30 PM
+                    HH:MM
                   </div>
                   <div
                     data-testid="select-input"
@@ -1326,7 +1326,7 @@ exports[`Storyshots DateRange with time error 1`] = `
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker DateRange__StyledEndTime-sc-1m2eund-1 clTvEf css-2b097c-container"
+            class="TimePicker__StyledSelect-sc-1r3kwxy-2 eudUkx nds-time-picker DateRange__StyledEndTime-sc-1m2eund-1 clTvEf css-2b097c-container"
           >
             <div
               data-testid="select-control"
@@ -1531,7 +1531,7 @@ exports[`Storyshots DateRange with times 1`] = `
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker DateRange__StyledStartTime-sc-1m2eund-0 bMhikq css-2b097c-container"
+            class="TimePicker__StyledSelect-sc-1r3kwxy-2 eudUkx nds-time-picker DateRange__StyledStartTime-sc-1m2eund-0 bMhikq css-2b097c-container"
           >
             <div
               data-testid="select-control"
@@ -1627,7 +1627,7 @@ exports[`Storyshots DateRange with times 1`] = `
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker DateRange__StyledEndTime-sc-1m2eund-1 clTvEf css-2b097c-container"
+            class="TimePicker__StyledSelect-sc-1r3kwxy-2 eudUkx nds-time-picker DateRange__StyledEndTime-sc-1m2eund-1 clTvEf css-2b097c-container"
           >
             <div
               data-testid="select-control"

--- a/components/src/DateRange/__snapshots__/DateRange.story.storyshot
+++ b/components/src/DateRange/__snapshots__/DateRange.story.storyshot
@@ -1037,7 +1037,7 @@ exports[`Storyshots DateRange with default start and end times 1`] = `
                   class=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    class=" css-1n91s4n-placeholder"
                   >
                     HH:MM
                   </div>
@@ -1242,7 +1242,7 @@ exports[`Storyshots DateRange with time error 1`] = `
                   class=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    class=" css-1n91s4n-placeholder"
                   >
                     HH:MM
                   </div>

--- a/components/src/Select/SelectOption.js
+++ b/components/src/Select/SelectOption.js
@@ -10,10 +10,12 @@ const StyledOption = styled.div(typography, ({ isSelected, isFocused, theme }) =
     borderBottomLeftRadius: theme.radii.medium,
     borderBottomRightRadius: theme.radii.medium
   },
+  // eslint-disable-next-line no-nested-ternary
+  background: isSelected ? theme.colors.darkBlue : isFocused ? theme.colors.lightBlue : null,
   div: {
     padding: subPx(theme.space.x1),
     fontWeight: isSelected ? theme.fontWeights.medium : theme.fontWeights.normal,
-    background: isFocused ? theme.colors.lightBlue : null,
+    color: isSelected ? theme.colors.white : theme.colors.black,
     minHeight: theme.space.x4,
     minWidth: "max-content",
     whiteSpace: "nowrap",

--- a/components/src/Select/__snapshots__/Select.story.storyshot
+++ b/components/src/Select/__snapshots__/Select.story.storyshot
@@ -218,7 +218,7 @@ exports[`Storyshots Select With wrapping text 1`] = `
                   class=" css-famnlw-MenuList"
                 >
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Onelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstringonelongstring"
@@ -234,7 +234,7 @@ exports[`Storyshots Select With wrapping text 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Many words many words many words many words many words many words many words many words many words many words many words many words many words"
@@ -1759,7 +1759,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                   class=" css-famnlw-MenuList"
                 >
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 blgViL"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 endSvB"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Accepted"
@@ -1775,7 +1775,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Assigned to a line"
@@ -1791,7 +1791,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
                     data="[object Object]"
                     data-testid="select-option"
                     label="On hold"
@@ -1807,7 +1807,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Rejected"
@@ -1823,7 +1823,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Open"
@@ -1839,7 +1839,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
                     data="[object Object]"
                     data-testid="select-option"
                     label="In progress"
@@ -1855,7 +1855,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
                     data="[object Object]"
                     data-testid="select-option"
                     label="In quarantine"
@@ -2238,7 +2238,7 @@ exports[`Storyshots Select with error list 1`] = `
                 class=" css-famnlw-MenuList"
               >
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
                   data="[object Object]"
                   data-testid="select-option"
                   label="Accepted"
@@ -2254,7 +2254,7 @@ exports[`Storyshots Select with error list 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
                   data="[object Object]"
                   data-testid="select-option"
                   label="Assigned to a line"
@@ -2270,7 +2270,7 @@ exports[`Storyshots Select with error list 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
                   data="[object Object]"
                   data-testid="select-option"
                   label="On hold"
@@ -2286,7 +2286,7 @@ exports[`Storyshots Select with error list 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
                   data="[object Object]"
                   data-testid="select-option"
                   label="Rejected"
@@ -2302,7 +2302,7 @@ exports[`Storyshots Select with error list 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
                   data="[object Object]"
                   data-testid="select-option"
                   label="Open"
@@ -2318,7 +2318,7 @@ exports[`Storyshots Select with error list 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
                   data="[object Object]"
                   data-testid="select-option"
                   label="In progress"
@@ -2334,7 +2334,7 @@ exports[`Storyshots Select with error list 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
                   data="[object Object]"
                   data-testid="select-option"
                   label="In quarantine"
@@ -2633,7 +2633,7 @@ exports[`Storyshots Select with error message 1`] = `
                 class=" css-famnlw-MenuList"
               >
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
                   data="[object Object]"
                   data-testid="select-option"
                   label="Accepted"
@@ -2649,7 +2649,7 @@ exports[`Storyshots Select with error message 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
                   data="[object Object]"
                   data-testid="select-option"
                   label="Assigned to a line"
@@ -2665,7 +2665,7 @@ exports[`Storyshots Select with error message 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
                   data="[object Object]"
                   data-testid="select-option"
                   label="On hold"
@@ -2681,7 +2681,7 @@ exports[`Storyshots Select with error message 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
                   data="[object Object]"
                   data-testid="select-option"
                   label="Rejected"
@@ -2697,7 +2697,7 @@ exports[`Storyshots Select with error message 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
                   data="[object Object]"
                   data-testid="select-option"
                   label="Open"
@@ -2713,7 +2713,7 @@ exports[`Storyshots Select with error message 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
                   data="[object Object]"
                   data-testid="select-option"
                   label="In progress"
@@ -2729,7 +2729,7 @@ exports[`Storyshots Select with error message 1`] = `
                   </div>
                 </div>
                 <div
-                  class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
+                  class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
                   data="[object Object]"
                   data-testid="select-option"
                   label="In quarantine"
@@ -3306,7 +3306,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                   class=" css-1hz449x-MenuList"
                 >
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 blgViL"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 endSvB"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Accepted"
@@ -3322,7 +3322,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Assigned to a line"
@@ -3338,7 +3338,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
                     data="[object Object]"
                     data-testid="select-option"
                     label="On hold"
@@ -3354,7 +3354,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Rejected"
@@ -3370,7 +3370,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
                     data="[object Object]"
                     data-testid="select-option"
                     label="Open"
@@ -3386,7 +3386,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
                     data="[object Object]"
                     data-testid="select-option"
                     label="In progress"
@@ -3402,7 +3402,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                     </div>
                   </div>
                   <div
-                    class="SelectOption__StyledOption-sc-3ujurn-0 ngdwK"
+                    class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
                     data="[object Object]"
                     data-testid="select-option"
                     label="In quarantine"

--- a/components/src/Select/__snapshots__/Select.story.storyshot
+++ b/components/src/Select/__snapshots__/Select.story.storyshot
@@ -215,7 +215,7 @@ exports[`Storyshots Select With wrapping text 1`] = `
                 class=" css-1l502d3-Menu"
               >
                 <div
-                  class=" css-famnlw-MenuList"
+                  class=" css-13potcx-MenuList"
                 >
                   <div
                     class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
@@ -1756,7 +1756,7 @@ exports[`Storyshots Select with an option selected 1`] = `
                 class=" css-1l502d3-Menu"
               >
                 <div
-                  class=" css-famnlw-MenuList"
+                  class=" css-13potcx-MenuList"
                 >
                   <div
                     class="SelectOption__StyledOption-sc-3ujurn-0 endSvB"
@@ -2235,7 +2235,7 @@ exports[`Storyshots Select with error list 1`] = `
               class=" css-6mfljk-Menu"
             >
               <div
-                class=" css-famnlw-MenuList"
+                class=" css-13potcx-MenuList"
               >
                 <div
                   class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
@@ -2630,7 +2630,7 @@ exports[`Storyshots Select with error message 1`] = `
               class=" css-6mfljk-Menu"
             >
               <div
-                class=" css-famnlw-MenuList"
+                class=" css-13potcx-MenuList"
               >
                 <div
                   class="SelectOption__StyledOption-sc-3ujurn-0 diHOOn"
@@ -3303,7 +3303,7 @@ exports[`Storyshots Select with smaller maxHeight 1`] = `
                 class=" css-1l502d3-Menu"
               >
                 <div
-                  class=" css-1hz449x-MenuList"
+                  class=" css-hb4twc-MenuList"
                 >
                   <div
                     class="SelectOption__StyledOption-sc-3ujurn-0 endSvB"

--- a/components/src/Select/customReactSelectStyles.js
+++ b/components/src/Select/customReactSelectStyles.js
@@ -100,7 +100,8 @@ const customStyles = ({ theme, error, maxHeight, windowed }) => {
       minWidth: "fit-content",
       padding: 0,
       maxHeight: parseInt(maxHeight, 10),
-      borderRadius: theme.radii.medium,
+      borderBottomLeftRadius: theme.radii.medium,
+      borderBottomRightRadius: theme.radii.medium,
       marginTop: windowed ? "-4px" : 0,
       marginBottom: windowed ? "-4px" : 0
     }),

--- a/components/src/TimePicker/TimePicker.js
+++ b/components/src/TimePicker/TimePicker.js
@@ -27,13 +27,26 @@ const StyledTimeIcon = styled(Icon)(({ theme }) => ({
   }
 }));
 
-const StyledSelectOption = styled(SelectOption)(({ isSelected, theme }) => {
+const StyledSelectOption = styled(SelectOption)(({ isSelected, theme, options }) => {
   return {
     background: isSelected ? theme.colors.darkBlue : null,
     color: isSelected ? theme.colors.white : null,
     fontWeight: theme.fontWeights.normal,
     "&:hover": {
       background: isSelected ? theme.colors.darkBlue : null
+    }
+  };
+});
+
+const StyledSelect = styled(Select)(({ options, value }) => {
+  const hideMenu = options.length === 1 && value === options[0].label;
+  return {
+    "[class*='-Control']": {
+      borderBottomLeftRadius: "4px",
+      borderBottomRightRadius: "4px"
+    },
+    "[class*='-Menu']": {
+      display: hideMenu ? "none" : "block"
     }
   };
 });
@@ -96,6 +109,7 @@ const TimePicker = ({
   maxTime,
   defaultValue,
   onInputChange,
+  onChange,
   "aria-label": ariaLabel,
   ...props
 }) => {
@@ -108,10 +122,8 @@ const TimePicker = ({
     const optionsAtInterval = getTimeOptions(interval, timeFormat, minTime, maxTime, locale) || [];
     const optionsByMinute = getTimeOptions(1, timeFormat, minTime, maxTime, locale) || [];
     const optionsList = inputHasMinutes ? optionsByMinute : optionsAtInterval;
-    const matchingOptions = optionsList.filter(
-      ({ label, value }) =>
-        standardizeTime(label).includes(standardizeTime(input)) ||
-        standardizeTime(value).includes(standardizeTime(input))
+    const matchingOptions = optionsList.filter(({ label, value }) =>
+      standardizeTime(label).includes(standardizeTime(input))
     );
     return matchingOptions;
   };
@@ -122,16 +134,26 @@ const TimePicker = ({
   return (
     <>
       <TimePickerStyles />
-      <Select
+      <StyledSelect
         options={visibleOptions}
         filterOption={overrideInternalFiltering}
+        value={input}
         defaultValue={visibleOptions.length && defaultValue ? visibleOptions[0].value : undefined}
         components={{ DropdownIndicator, Option: StyledSelectOption }}
         aria-label={ariaLabel || t("select a time")}
-        onInputChange={(value, ...args) => {
-          setInput(value);
+        onInputChange={(value, data) => {
+          if (data.action === "input-change") {
+            setInput(value);
+          }
           if (onInputChange) {
-            onInputChange(value, ...args);
+            onInputChange(value, data);
+          }
+        }}
+        onChange={value => {
+          setInput(value);
+
+          if (onChange) {
+            onChange(value);
           }
         }}
         {...props}

--- a/components/src/TimePicker/TimePicker.js
+++ b/components/src/TimePicker/TimePicker.js
@@ -27,7 +27,7 @@ const StyledTimeIcon = styled(Icon)(({ theme }) => ({
   }
 }));
 
-const StyledSelectOption = styled(SelectOption)(({ isSelected, theme, options }) => {
+const StyledSelectOption = styled(SelectOption)(({ isSelected, theme }) => {
   return {
     background: isSelected ? theme.colors.darkBlue : null,
     color: isSelected ? theme.colors.white : null,
@@ -51,6 +51,7 @@ const StyledSelect = styled(Select)(({ options, value }) => {
       }
     };
   }
+  return {};
 });
 
 const DropdownIndicator = props => {
@@ -124,9 +125,7 @@ const TimePicker = ({
     const optionsAtInterval = getTimeOptions(interval, timeFormat, minTime, maxTime, locale) || [];
     const optionsByMinute = getTimeOptions(1, timeFormat, minTime, maxTime, locale) || [];
     const optionsList = inputHasMinutes ? optionsByMinute : optionsAtInterval;
-    const matchingOptions = optionsList.filter(({ label, value }) =>
-      standardizeTime(label).includes(standardizeTime(input))
-    );
+    const matchingOptions = optionsList.filter(({ label }) => standardizeTime(label).includes(standardizeTime(input)));
     return matchingOptions;
   };
 

--- a/components/src/TimePicker/TimePicker.js
+++ b/components/src/TimePicker/TimePicker.js
@@ -40,15 +40,17 @@ const StyledSelectOption = styled(SelectOption)(({ isSelected, theme, options })
 
 const StyledSelect = styled(Select)(({ options, value }) => {
   const hideMenu = options.length === 1 && value === options[0].label;
-  return {
-    "[class*='-Control']": {
-      borderBottomLeftRadius: "4px",
-      borderBottomRightRadius: "4px"
-    },
-    "[class*='-Menu']": {
-      display: hideMenu ? "none" : "block"
-    }
-  };
+  if (hideMenu) {
+    return {
+      "[class*='-Control']": {
+        borderBottomLeftRadius: "4px",
+        borderBottomRightRadius: "4px"
+      },
+      "[class*='-Menu']": {
+        display: "none"
+      }
+    };
+  }
 });
 
 const DropdownIndicator = props => {

--- a/components/src/TimePicker/TimePicker.js
+++ b/components/src/TimePicker/TimePicker.js
@@ -99,7 +99,7 @@ const TimePicker = ({
   "aria-label": ariaLabel,
   ...props
 }) => {
-  const [input, setInput] = useState("");
+  const [input, setInput] = useState(defaultValue || "");
   const { locale } = useContext(LocaleContext);
   const { t } = useTranslation();
 
@@ -108,7 +108,12 @@ const TimePicker = ({
     const optionsAtInterval = getTimeOptions(interval, timeFormat, minTime, maxTime, locale) || [];
     const optionsByMinute = getTimeOptions(1, timeFormat, minTime, maxTime, locale) || [];
     const optionsList = inputHasMinutes ? optionsByMinute : optionsAtInterval;
-    return optionsList.filter(({ label }) => standardizeTime(label).includes(standardizeTime(input)));
+    const matchingOptions = optionsList.filter(
+      ({ label, value }) =>
+        standardizeTime(label).includes(standardizeTime(input)) ||
+        standardizeTime(value).includes(standardizeTime(input))
+    );
+    return matchingOptions;
   };
 
   const overrideInternalFiltering = () => true;
@@ -120,7 +125,7 @@ const TimePicker = ({
       <Select
         options={visibleOptions}
         filterOption={overrideInternalFiltering}
-        defaultValue={defaultValue}
+        defaultValue={visibleOptions.length && defaultValue ? visibleOptions[0].value : undefined}
         components={{ DropdownIndicator, Option: StyledSelectOption }}
         aria-label={ariaLabel || t("select a time")}
         onInputChange={(value, ...args) => {

--- a/components/src/TimePicker/TimePicker.story.js
+++ b/components/src/TimePicker/TimePicker.story.js
@@ -53,4 +53,13 @@ storiesOf("TimePicker", module)
       minTime="09:00"
       maxTime="21:00"
     />
+  ))
+  .add("with set default value", () => (
+    <TimePicker
+      defaultValue="12:16 PM"
+      interval={30}
+      onChange={action("time changed")}
+      onInputChange={action("input changed")}
+      labelText="Duration"
+    />
   ));

--- a/components/src/TimePicker/__snapshots__/TimePicker.story.storyshot
+++ b/components/src/TimePicker/__snapshots__/TimePicker.story.storyshot
@@ -703,3 +703,115 @@ exports[`Storyshots TimePicker with min and max time 1`] = `
   </div>
 </div>
 `;
+
+exports[`Storyshots TimePicker with set default value 1`] = `
+<div
+  style="padding:24px"
+>
+  <div
+    class="NDSProvider__GlobalStyles-f28eoq-0 gXOmnU"
+  >
+    <div
+      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB"
+    >
+      <label
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        color="black"
+        style="display:block"
+      >
+        <div
+          class="Box-sc-1qu1edy-0 ilQgHG"
+          data-testid="field-label"
+        >
+          <span
+            class="FieldLabel__LabelText-sc-1t1cp4f-1 efLeRi"
+          >
+            Duration
+          </span>
+        </div>
+        <div
+          data-testid="select-container"
+        >
+          <div
+            class="nds-time-picker css-2b097c-container"
+          >
+            <div
+              data-testid="select-control"
+            >
+              <div
+                class=" css-16f1mi0-Control"
+              >
+                <div
+                  class=" css-7zc8my"
+                >
+                  <div
+                    class=" css-r447wv-singleValue"
+                  >
+                    12:16 PM
+                  </div>
+                  <div
+                    data-testid="select-input"
+                  >
+                    <div
+                      class="css-17yls17-Input"
+                    >
+                      <div
+                        class=""
+                        style="display:inline-block"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-label="Select a time"
+                          autocapitalize="none"
+                          autocomplete="off"
+                          autocorrect="off"
+                          id="react-select-36-input"
+                          spellcheck="false"
+                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
+                          tabindex="0"
+                          type="text"
+                          value=""
+                        />
+                        <div
+                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class=" css-173cxbq-IndicatorsContainer"
+                >
+                  <span
+                    class=" css-4z5mi-indicatorSeparator"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class=" css-19phze7-indicatorContainer"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="Icon-fc7twp-0 TimePicker__StyledTimeIcon-sc-1r3kwxy-0 dyveZl"
+                      color="currentColor"
+                      fill="currentColor"
+                      focusable="false"
+                      height="22px"
+                      icon="queryBuilder"
+                      viewBox="0 0 24 24"
+                      width="22px"
+                    >
+                      <path
+                        d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </label>
+    </div>
+  </div>
+</div>
+`;

--- a/components/src/TimePicker/__snapshots__/TimePicker.story.storyshot
+++ b/components/src/TimePicker/__snapshots__/TimePicker.story.storyshot
@@ -29,7 +29,7 @@ exports[`Storyshots TimePicker default 1`] = `
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker css-2b097c-container"
+            class="TimePicker__StyledSelect-sc-1r3kwxy-2 eudUkx nds-time-picker css-2b097c-container"
           >
             <div
               data-testid="select-control"
@@ -141,7 +141,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker css-2b097c-container"
+            class="TimePicker__StyledSelect-sc-1r3kwxy-2 eudUkx nds-time-picker css-2b097c-container"
           >
             <div
               data-testid="select-control"
@@ -253,7 +253,7 @@ exports[`Storyshots TimePicker with custom time format 1`] = `
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker css-2b097c-container"
+            class="TimePicker__StyledSelect-sc-1r3kwxy-2 jCoHxL nds-time-picker css-2b097c-container"
           >
             <div
               data-testid="select-control"
@@ -365,7 +365,7 @@ exports[`Storyshots TimePicker with custom time interval 1`] = `
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker css-2b097c-container"
+            class="TimePicker__StyledSelect-sc-1r3kwxy-2 jCoHxL nds-time-picker css-2b097c-container"
           >
             <div
               data-testid="select-control"
@@ -477,7 +477,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker css-2b097c-container"
+            class="TimePicker__StyledSelect-sc-1r3kwxy-2 eudUkx nds-time-picker css-2b097c-container"
           >
             <div
               data-testid="select-control"
@@ -621,7 +621,7 @@ exports[`Storyshots TimePicker with min and max time 1`] = `
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker css-2b097c-container"
+            class="TimePicker__StyledSelect-sc-1r3kwxy-2 eudUkx nds-time-picker css-2b097c-container"
           >
             <div
               data-testid="select-control"
@@ -733,7 +733,7 @@ exports[`Storyshots TimePicker with set default value 1`] = `
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker css-2b097c-container"
+            class="TimePicker__StyledSelect-sc-1r3kwxy-2 jCoHxL nds-time-picker css-2b097c-container"
           >
             <div
               data-testid="select-control"

--- a/components/src/TimeRange/__snapshots__/TimeRange.story.storyshot
+++ b/components/src/TimeRange/__snapshots__/TimeRange.story.storyshot
@@ -66,7 +66,7 @@ exports[`Storyshots TimeRange default 1`] = `
                           autocapitalize="none"
                           autocomplete="off"
                           autocorrect="off"
-                          id="react-select-36-input"
+                          id="react-select-37-input"
                           spellcheck="false"
                           style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
                           tabindex="0"
@@ -162,7 +162,7 @@ exports[`Storyshots TimeRange default 1`] = `
                           autocapitalize="none"
                           autocomplete="off"
                           autocorrect="off"
-                          id="react-select-37-input"
+                          id="react-select-38-input"
                           spellcheck="false"
                           style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
                           tabindex="0"
@@ -261,7 +261,7 @@ exports[`Storyshots TimeRange default selections 1`] = `
                   <div
                     class=" css-r447wv-singleValue"
                   >
-                    12:00 PM
+                    12:00 AM
                   </div>
                   <div
                     data-testid="select-input"
@@ -279,7 +279,7 @@ exports[`Storyshots TimeRange default selections 1`] = `
                           autocapitalize="none"
                           autocomplete="off"
                           autocorrect="off"
-                          id="react-select-38-input"
+                          id="react-select-39-input"
                           spellcheck="false"
                           style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
                           tabindex="0"
@@ -375,7 +375,7 @@ exports[`Storyshots TimeRange default selections 1`] = `
                           autocapitalize="none"
                           autocomplete="off"
                           autocorrect="off"
-                          id="react-select-39-input"
+                          id="react-select-40-input"
                           spellcheck="false"
                           style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
                           tabindex="0"
@@ -492,7 +492,7 @@ exports[`Storyshots TimeRange with min and max time range 1`] = `
                           autocapitalize="none"
                           autocomplete="off"
                           autocorrect="off"
-                          id="react-select-42-input"
+                          id="react-select-43-input"
                           spellcheck="false"
                           style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
                           tabindex="0"
@@ -588,7 +588,7 @@ exports[`Storyshots TimeRange with min and max time range 1`] = `
                           autocapitalize="none"
                           autocomplete="off"
                           autocorrect="off"
-                          id="react-select-43-input"
+                          id="react-select-44-input"
                           spellcheck="false"
                           style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
                           tabindex="0"
@@ -687,7 +687,7 @@ exports[`Storyshots TimeRange with range validation 1`] = `
                   <div
                     class=" css-r447wv-singleValue"
                   >
-                    12:00 PM
+                    12:00 AM
                   </div>
                   <div
                     data-testid="select-input"
@@ -705,7 +705,7 @@ exports[`Storyshots TimeRange with range validation 1`] = `
                           autocapitalize="none"
                           autocomplete="off"
                           autocorrect="off"
-                          id="react-select-40-input"
+                          id="react-select-41-input"
                           spellcheck="false"
                           style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
                           tabindex="0"
@@ -801,7 +801,7 @@ exports[`Storyshots TimeRange with range validation 1`] = `
                           autocapitalize="none"
                           autocomplete="off"
                           autocorrect="off"
-                          id="react-select-41-input"
+                          id="react-select-42-input"
                           spellcheck="false"
                           style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
                           tabindex="0"

--- a/components/src/TimeRange/__snapshots__/TimeRange.story.storyshot
+++ b/components/src/TimeRange/__snapshots__/TimeRange.story.storyshot
@@ -34,7 +34,7 @@ exports[`Storyshots TimeRange default 1`] = `
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker css-2b097c-container"
+            class="TimePicker__StyledSelect-sc-1r3kwxy-2 eudUkx nds-time-picker css-2b097c-container"
           >
             <div
               data-testid="select-control"
@@ -130,7 +130,7 @@ exports[`Storyshots TimeRange default 1`] = `
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker css-2b097c-container"
+            class="TimePicker__StyledSelect-sc-1r3kwxy-2 eudUkx nds-time-picker css-2b097c-container"
           >
             <div
               data-testid="select-control"
@@ -247,7 +247,7 @@ exports[`Storyshots TimeRange default selections 1`] = `
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker css-2b097c-container"
+            class="TimePicker__StyledSelect-sc-1r3kwxy-2 eudUkx nds-time-picker css-2b097c-container"
           >
             <div
               data-testid="select-control"
@@ -261,7 +261,7 @@ exports[`Storyshots TimeRange default selections 1`] = `
                   <div
                     class=" css-r447wv-singleValue"
                   >
-                    12:00 AM
+                    12:00 PM
                   </div>
                   <div
                     data-testid="select-input"
@@ -343,7 +343,7 @@ exports[`Storyshots TimeRange default selections 1`] = `
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker css-2b097c-container"
+            class="TimePicker__StyledSelect-sc-1r3kwxy-2 eudUkx nds-time-picker css-2b097c-container"
           >
             <div
               data-testid="select-control"
@@ -355,9 +355,9 @@ exports[`Storyshots TimeRange default selections 1`] = `
                   class=" css-7zc8my"
                 >
                   <div
-                    class=" css-r447wv-singleValue"
+                    class=" css-1yhx6vz-Placeholder"
                   >
-                    01:30 PM
+                    HH:MM
                   </div>
                   <div
                     data-testid="select-input"
@@ -460,7 +460,7 @@ exports[`Storyshots TimeRange with min and max time range 1`] = `
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker css-2b097c-container"
+            class="TimePicker__StyledSelect-sc-1r3kwxy-2 eudUkx nds-time-picker css-2b097c-container"
           >
             <div
               data-testid="select-control"
@@ -556,7 +556,7 @@ exports[`Storyshots TimeRange with min and max time range 1`] = `
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker css-2b097c-container"
+            class="TimePicker__StyledSelect-sc-1r3kwxy-2 eudUkx nds-time-picker css-2b097c-container"
           >
             <div
               data-testid="select-control"
@@ -673,7 +673,7 @@ exports[`Storyshots TimeRange with range validation 1`] = `
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker css-2b097c-container"
+            class="TimePicker__StyledSelect-sc-1r3kwxy-2 eudUkx nds-time-picker css-2b097c-container"
           >
             <div
               data-testid="select-control"
@@ -687,7 +687,7 @@ exports[`Storyshots TimeRange with range validation 1`] = `
                   <div
                     class=" css-r447wv-singleValue"
                   >
-                    12:00 AM
+                    12:00 PM
                   </div>
                   <div
                     data-testid="select-input"
@@ -769,7 +769,7 @@ exports[`Storyshots TimeRange with range validation 1`] = `
           data-testid="select-container"
         >
           <div
-            class="nds-time-picker css-2b097c-container"
+            class="TimePicker__StyledSelect-sc-1r3kwxy-2 eudUkx nds-time-picker css-2b097c-container"
           >
             <div
               data-testid="select-control"

--- a/components/src/TimeRange/__snapshots__/TimeRange.story.storyshot
+++ b/components/src/TimeRange/__snapshots__/TimeRange.story.storyshot
@@ -355,7 +355,7 @@ exports[`Storyshots TimeRange default selections 1`] = `
                   class=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    class=" css-1n91s4n-placeholder"
                   >
                     HH:MM
                   </div>

--- a/docs/src/pages/components/time-picker.js
+++ b/docs/src/pages/components/time-picker.js
@@ -44,6 +44,12 @@ const propsRows = [
     defaultValue: "undefined",
     description: "The latest time that can be selected."
   },
+  {
+    name: "defaultValue",
+    type: "24 hour time string or the time in the set timeFormat",
+    defaultValue: "undefined",
+    description: "The default value to be shown before selecting a value"
+  },
   ...selectProps.filter(prop => prop.name !== "options")
 ];
 


### PR DESCRIPTION
## Description

Fixes a bug where if a default time is set that is between intervals the input remains blank as well as some visual bugs: wrong background when hovering the selected option, and rounded corners on the top selection. 

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
