### PR TITLE
fix: cursor shown after placeholder text in Select

### DIFF
--- a/components/src/BrandedNavBar/NavBar.js
+++ b/components/src/BrandedNavBar/NavBar.js
@@ -288,12 +288,11 @@ const SelectNavBarBasedOnWidth = ({ width, defaultOpen, breakpointUpper, ...prop
   }
 };
 
-const BaseNavBar = props => {
-  const { showTraining, environment, ...rest } = props;
+const BaseNavBar = ({ showTraining, environment, ...props }) => {
   const environmentValue = showTraining ? "training" : environment;
   return (
     <ReactResizeDetector handleWidth>
-      <SelectNavBarBasedOnWidth {...rest} environment={environmentValue} />
+      <SelectNavBarBasedOnWidth {...props} environment={environmentValue} />
     </ReactResizeDetector>
   );
 };
@@ -312,7 +311,7 @@ BaseNavBar.defaultProps = {
   className: undefined,
   breakpointUpper: NDSTheme.breakpoints.medium,
   environment: undefined,
-  showTraining: false,
+  showTraining: undefined,
   logoSrc: undefined
 };
 

--- a/components/src/DateRange/__snapshots__/DateRange.story.storyshot
+++ b/components/src/DateRange/__snapshots__/DateRange.story.storyshot
@@ -1543,7 +1543,7 @@ exports[`Storyshots DateRange with times 1`] = `
                   class=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    class=" css-1n91s4n-placeholder"
                   >
                     HH:MM
                   </div>
@@ -1639,7 +1639,7 @@ exports[`Storyshots DateRange with times 1`] = `
                   class=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    class=" css-1n91s4n-placeholder"
                   >
                     HH:MM
                   </div>

--- a/components/src/Form/__snapshots__/Form.story.storyshot
+++ b/components/src/Form/__snapshots__/Form.story.storyshot
@@ -213,7 +213,7 @@ exports[`Storyshots Form Demo form 1`] = `
                       class=" css-7zc8my"
                     >
                       <div
-                        class=" css-1yhx6vz-Placeholder"
+                        class=" css-1n91s4n-placeholder"
                       >
                         Select...
                       </div>

--- a/components/src/Select/__snapshots__/Select.story.storyshot
+++ b/components/src/Select/__snapshots__/Select.story.storyshot
@@ -41,7 +41,7 @@ exports[`Storyshots Select Select 1`] = `
                   class="SelectTest__value-container css-7zc8my"
                 >
                   <div
-                    class="SelectTest__placeholder css-1yhx6vz-Placeholder"
+                    class="SelectTest__placeholder css-1n91s4n-placeholder"
                   >
                     Please select inventory status
                   </div>
@@ -149,7 +149,7 @@ exports[`Storyshots Select With wrapping text 1`] = `
                   class=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    class=" css-1n91s4n-placeholder"
                   >
                     Please select inventory status
                   </div>
@@ -301,7 +301,7 @@ exports[`Storyshots Select set to disabled 1`] = `
                   class=" css-7zc8my"
                 >
                   <div
-                    class=" css-b1k6bm-Placeholder"
+                    class=" css-1uswkev-placeholder"
                   >
                     Please select inventory status
                   </div>
@@ -437,7 +437,7 @@ exports[`Storyshots Select set to required 1`] = `
                     class=" css-7zc8my"
                   >
                     <div
-                      class=" css-1yhx6vz-Placeholder"
+                      class=" css-1n91s4n-placeholder"
                     >
                       Please select inventory status
                     </div>
@@ -1376,7 +1376,7 @@ exports[`Storyshots Select with a blank value 1`] = `
                   class=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    class=" css-1n91s4n-placeholder"
                   >
                     Please select inventory status
                   </div>
@@ -1929,7 +1929,7 @@ exports[`Storyshots Select with custom id 1`] = `
                   class=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    class=" css-1n91s4n-placeholder"
                   >
                     Please select inventory status
                   </div>
@@ -2037,7 +2037,7 @@ exports[`Storyshots Select with error list 1`] = `
                   class=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    class=" css-1n91s4n-placeholder"
                   >
                     Please select inventory status
                   </div>
@@ -2169,7 +2169,7 @@ exports[`Storyshots Select with error list 1`] = `
                 class=" css-7zc8my"
               >
                 <div
-                  class=" css-1yhx6vz-Placeholder"
+                  class=" css-1n91s4n-placeholder"
                 >
                   Please select inventory status
                 </div>
@@ -2449,7 +2449,7 @@ exports[`Storyshots Select with error message 1`] = `
                   class=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    class=" css-1n91s4n-placeholder"
                   >
                     Please select inventory status
                   </div>
@@ -2564,7 +2564,7 @@ exports[`Storyshots Select with error message 1`] = `
                 class=" css-7zc8my"
               >
                 <div
-                  class=" css-1yhx6vz-Placeholder"
+                  class=" css-1n91s4n-placeholder"
                 >
                   Please select inventory status
                 </div>
@@ -2947,7 +2947,7 @@ exports[`Storyshots Select with helpText 1`] = `
                   class=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    class=" css-1n91s4n-placeholder"
                   >
                     Please select inventory status
                   </div>
@@ -3469,7 +3469,7 @@ exports[`Storyshots Select with state 1`] = `
                   class="SelectTest__value-container css-7zc8my"
                 >
                   <div
-                    class="SelectTest__placeholder css-1yhx6vz-Placeholder"
+                    class="SelectTest__placeholder css-1n91s4n-placeholder"
                   >
                     Please select inventory status
                   </div>

--- a/components/src/Select/customReactSelectStyles.js
+++ b/components/src/Select/customReactSelectStyles.js
@@ -145,6 +145,7 @@ const customStyles = ({ theme, error, maxHeight, windowed }) => {
       borderLeft: `1px solid ${theme.colors.grey}`
     }),
     placeholder: (provided, state) => ({
+      ...provided,
       color: state.isDisabled ? transparentize(0.6667, theme.colors.black) : "hsl(0,0%,50%)"
     })
   };

--- a/components/src/TimePicker/__snapshots__/TimePicker.story.storyshot
+++ b/components/src/TimePicker/__snapshots__/TimePicker.story.storyshot
@@ -41,7 +41,7 @@ exports[`Storyshots TimePicker default 1`] = `
                   class=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    class=" css-1n91s4n-placeholder"
                   >
                     HH:MM
                   </div>
@@ -153,7 +153,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
                   class=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    class=" css-1n91s4n-placeholder"
                   >
                     --:--
                   </div>
@@ -489,7 +489,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
                   class=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    class=" css-1n91s4n-placeholder"
                   >
                     HH:MM
                   </div>
@@ -633,7 +633,7 @@ exports[`Storyshots TimePicker with min and max time 1`] = `
                   class=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    class=" css-1n91s4n-placeholder"
                   >
                     HH:MM
                   </div>

--- a/components/src/TimeRange/__snapshots__/TimeRange.story.storyshot
+++ b/components/src/TimeRange/__snapshots__/TimeRange.story.storyshot
@@ -46,7 +46,7 @@ exports[`Storyshots TimeRange default 1`] = `
                   class=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    class=" css-1n91s4n-placeholder"
                   >
                     HH:MM
                   </div>
@@ -142,7 +142,7 @@ exports[`Storyshots TimeRange default 1`] = `
                   class=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    class=" css-1n91s4n-placeholder"
                   >
                     HH:MM
                   </div>
@@ -472,7 +472,7 @@ exports[`Storyshots TimeRange with min and max time range 1`] = `
                   class=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    class=" css-1n91s4n-placeholder"
                   >
                     HH:MM
                   </div>
@@ -568,7 +568,7 @@ exports[`Storyshots TimeRange with min and max time range 1`] = `
                   class=" css-7zc8my"
                 >
                   <div
-                    class=" css-1yhx6vz-Placeholder"
+                    class=" css-1n91s4n-placeholder"
                   >
                     HH:MM
                   </div>

--- a/components/src/pages/__snapshots__/Details.story.storyshot
+++ b/components/src/pages/__snapshots__/Details.story.storyshot
@@ -2602,7 +2602,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                             class=" css-7zc8my"
                           >
                             <div
-                              class=" css-1yhx6vz-Placeholder"
+                              class=" css-1n91s4n-placeholder"
                             >
                               Select...
                             </div>


### PR DESCRIPTION
## Description

- Fixes text cursor shown after placehlder text due to missing default styles from react-select
- Fixes deprecates showTraining Prop warning coming from setting a default value in BaseNavBar

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
