### PR TITLE
feat: disable flipping in datepicker

### DIFF
--- a/components/src/DatePicker/DatePicker.js
+++ b/components/src/DatePicker/DatePicker.js
@@ -81,7 +81,17 @@ class DatePicker extends Component {
   };
 
   render() {
-    const { dateFormat, errorMessage, errorList, inputProps, minDate, maxDate, highlightDates, className } = this.props;
+    const {
+      dateFormat,
+      errorMessage,
+      errorList,
+      inputProps,
+      minDate,
+      maxDate,
+      highlightDates,
+      disableFlipping,
+      className
+    } = this.props;
     const { selectedDate } = this.state;
     const customInputProps = {
       ...inputProps,
@@ -121,6 +131,9 @@ class DatePicker extends Component {
               ref={r => {
                 this.datepickerRef = r;
               }}
+              popperModifiers={{
+                flip: { enabled: !disableFlipping }
+              }}
             />
           )}
         </LocaleContext.Consumer>
@@ -141,6 +154,7 @@ DatePicker.propTypes = {
   minDate: PropTypes.instanceOf(Date),
   maxDate: PropTypes.instanceOf(Date),
   highlightDates: PropTypes.arrayOf(PropTypes.shape({})),
+  disableFlipping: PropTypes.bool,
   className: PropTypes.string
 };
 
@@ -155,6 +169,7 @@ DatePicker.defaultProps = {
   minDate: undefined,
   maxDate: undefined,
   highlightDates: undefined,
+  disableFlipping: false,
   className: ""
 };
 

--- a/components/src/DatePicker/DatePicker.story.js
+++ b/components/src/DatePicker/DatePicker.story.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
-import { withKnobs, select } from "@storybook/addon-knobs";
+import { withKnobs, select, boolean } from "@storybook/addon-knobs";
 
 import { DatePicker } from ".";
 
@@ -63,5 +63,14 @@ storiesOf("DatePicker", module)
       onChange={action("date changed")}
       onInputChange={action("input changed")}
       inputProps={{ labelText: "Expiry Date" }}
+    />
+  ))
+  .add("disable flipping", () => (
+    <DatePicker
+      selected={select("selected", selectedDateExamples, selectedDateExamples[0], "selected")}
+      onChange={action("date changed")}
+      onInputChange={action("input changed")}
+      inputProps={{ labelText: "Expiry Date" }}
+      disableFlipping={boolean("disableFlipping", true)}
     />
   ));

--- a/components/src/DatePicker/__snapshots__/DatePicker.story.storyshot
+++ b/components/src/DatePicker/__snapshots__/DatePicker.story.storyshot
@@ -71,6 +71,77 @@ exports[`Storyshots DatePicker default 1`] = `
 </div>
 `;
 
+exports[`Storyshots DatePicker disable flipping 1`] = `
+<div
+  style="padding:24px"
+>
+  <div
+    class="NDSProvider__GlobalStyles-f28eoq-0 gXOmnU"
+  >
+    <div
+      class="Box-sc-1qu1edy-0 Field-sc-1lebjra-0 erVIOB  nds-date-picker"
+    >
+      <div
+        class="react-datepicker-wrapper"
+      >
+        <div
+          class="react-datepicker__input-container"
+        >
+          <label
+            class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+            color="black"
+            style="display:block"
+          >
+            <div
+              class="Box-sc-1qu1edy-0 ilQgHG"
+              data-testid="field-label"
+            >
+              <span
+                class="FieldLabel__LabelText-sc-1t1cp4f-1 idDszt"
+              >
+                Expiry Date
+              </span>
+            </div>
+            <div
+              class="Box-sc-1qu1edy-0 Flex-hrfu3s-0 fbOeeQ"
+            >
+              <div
+                class="Box-sc-1qu1edy-0 hxUhcg"
+                display="flex"
+              >
+                <input
+                  aria-invalid="false"
+                  aria-label="select a date"
+                  aria-required="false"
+                  class="InputField__StyledInput-sc-6cu4mg-0 lawkjo"
+                  placeholder="DD Mon YYYY"
+                  value="01 Jan 2019"
+                />
+                <svg
+                  aria-hidden="true"
+                  class="Icon-fc7twp-0 InputField__StyledInputIcon-sc-6cu4mg-1 gnzknl"
+                  color="currentColor"
+                  fill="currentColor"
+                  focusable="false"
+                  height="16px"
+                  icon="calendarToday"
+                  viewBox="0 0 24 24"
+                  width="16px"
+                >
+                  <path
+                    d="M22 3h-3V1h-2v2H7V1H5v2H2v20h20V3zm-2 18H4V8h16v13z"
+                  />
+                </svg>
+              </div>
+            </div>
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots DatePicker with custom date format 1`] = `
 <div
   style="padding:24px"

--- a/components/src/DateRange/DateRange.js
+++ b/components/src/DateRange/DateRange.js
@@ -47,6 +47,7 @@ const DateRange = ({
   onEndTimeChange,
   timeFormat,
   interval,
+  disableFlipping,
   locale
 }) => {
   const [startDate, setStartDate] = useState(defaultStartDate);
@@ -120,6 +121,7 @@ const DateRange = ({
         maxDate={maxDate}
         highlightDates={highlightDates(startDate, endDate)}
         locale={locale}
+        disableFlipping={disableFlipping}
       />
       {showTimes && (
         <StyledStartTime
@@ -165,6 +167,7 @@ const DateRange = ({
         maxDate={maxDate}
         highlightDates={highlightDates(startDate, endDate)}
         locale={locale}
+        disableFlipping={disableFlipping}
       />
     </>
   );
@@ -214,7 +217,8 @@ DateRange.propTypes = {
   onEndTimeChange: PropTypes.func,
   timeFormat: PropTypes.string,
   interval: PropTypes.number,
-  locale: PropTypes.string
+  locale: PropTypes.string,
+  disableFlipping: PropTypes.bool
 };
 
 DateRange.defaultProps = {
@@ -245,7 +249,8 @@ DateRange.defaultProps = {
   onEndTimeChange: null,
   timeFormat: undefined,
   interval: undefined,
-  locale: undefined
+  locale: undefined,
+  disableFlipping: false
 };
 
 export default DateRange;

--- a/docs/src/pages/components/date-picker.js
+++ b/docs/src/pages/components/date-picker.js
@@ -70,6 +70,13 @@ const propsRows = [
     description: "The latest date that can be selected"
   },
   {
+    name: "disableFlipping",
+    type: "boolean",
+    defaultValue: "false",
+    description:
+      "Disables the calendar from opening in a direction other than bottom when there isn't space"
+  },
+  {
     name: "className",
     type: "string",
     defaultValue: "undefined"

--- a/docs/src/pages/components/date-picker.js
+++ b/docs/src/pages/components/date-picker.js
@@ -74,7 +74,7 @@ const propsRows = [
     type: "boolean",
     defaultValue: "false",
     description:
-      "Disables the calendar from opening in a direction other than bottom when there isn't space"
+      "If true, always opens the calendar below the input rather than automatically flipping upward if there is not enough space below the input"
   },
   {
     name: "className",

--- a/docs/src/pages/components/date-range.js
+++ b/docs/src/pages/components/date-range.js
@@ -150,7 +150,7 @@ const propsRows = [
     type: "boolean",
     defaultValue: "false",
     description:
-      "Disables the calendar from opening in a direction other than bottom when there isn't space"
+      "If true, always opens the calendar below the input rather than automatically flipping upward if there is not enough space below the input"
   }
 ];
 

--- a/docs/src/pages/components/date-range.js
+++ b/docs/src/pages/components/date-range.js
@@ -144,6 +144,13 @@ const propsRows = [
     type: "Number",
     defaultValue: "15",
     description: "The time difference in minutes between the time options"
+  },
+  {
+    name: "disableFlipping",
+    type: "boolean",
+    defaultValue: "false",
+    description:
+      "Disables the calendar from opening in a direction other than bottom when there isn't space"
   }
 ];
 


### PR DESCRIPTION
## Description

Datepicker automatically flips position if there isn't space to show it. In some cases, this adds an option to disable the automatic flipping and the datepicker will open to the bottom always. 

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
