### PR TITLE
fix: missing styled props on breadcrumbs component

### DIFF
--- a/packages/components/src/Breadcrumbs/Breadcrumbs.js
+++ b/packages/components/src/Breadcrumbs/Breadcrumbs.js
@@ -41,7 +41,7 @@ const StyledOl = styled.ol(() => ({
   display: "flex"
 }));
 
-const Breadcrumbs = ({ children, as }) => {
+const Breadcrumbs = ({ children, as, ...props }) => {
   const childrenArr = Array.isArray(children) ? children : [children];
   const allItems = [...childrenArr].map((child, index) => {
     return (
@@ -55,7 +55,7 @@ const Breadcrumbs = ({ children, as }) => {
   });
 
   return (
-    <Flex as={as}>
+    <Flex as={as} {...props}>
       <StyledOl>{insertSeparators(allItems, "seperator")}</StyledOl>
     </Flex>
   );


### PR DESCRIPTION
## Description

Previous p= and other styled component props couldn't be used because they weren't passed down to the Flex container within the component

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
