### PR TITLE
feat: Expose react-select prop closeMenuOnSelect for multiselect input

### DIFF
--- a/packages/components/src/DateRange/__snapshots__/DateRange.story.storyshot
+++ b/packages/components/src/DateRange/__snapshots__/DateRange.story.storyshot
@@ -965,7 +965,7 @@ exports[`Storyshots DateRange with default start and end times 1`] = `
         </div>
         <ul
           aria-expanded="false"
-          class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 kAvmAT"
+          class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 dcgWGm"
           data-testid="select-dropdown"
           role="listbox"
         >
@@ -1889,7 +1889,7 @@ exports[`Storyshots DateRange with default start and end times 1`] = `
         </div>
         <ul
           aria-expanded="false"
-          class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 kAvmAT"
+          class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 dcgWGm"
           data-testid="select-dropdown"
           role="listbox"
         >
@@ -2922,7 +2922,7 @@ exports[`Storyshots DateRange with time error 1`] = `
         </div>
         <ul
           aria-expanded="false"
-          class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 kAvmAT"
+          class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 dcgWGm"
           data-testid="select-dropdown"
           role="listbox"
         >
@@ -3846,7 +3846,7 @@ exports[`Storyshots DateRange with time error 1`] = `
         </div>
         <ul
           aria-expanded="false"
-          class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 kAvmAT"
+          class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 dcgWGm"
           data-testid="select-dropdown"
           role="listbox"
         >
@@ -4878,7 +4878,7 @@ exports[`Storyshots DateRange with times 1`] = `
         </div>
         <ul
           aria-expanded="false"
-          class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 kAvmAT"
+          class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 dcgWGm"
           data-testid="select-dropdown"
           role="listbox"
         >
@@ -5801,7 +5801,7 @@ exports[`Storyshots DateRange with times 1`] = `
         </div>
         <ul
           aria-expanded="false"
-          class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 kAvmAT"
+          class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 dcgWGm"
           data-testid="select-dropdown"
           role="listbox"
         >

--- a/packages/components/src/Select/Select.js
+++ b/packages/components/src/Select/Select.js
@@ -74,7 +74,8 @@ const ReactSelect = ({
   components,
   "aria-label": ariaLabel,
   windowThreshold,
-  filterOption
+  filterOption,
+  closeMenuOnSelect
 }) => {
   const { t } = useTranslation();
   const themeContext = useContext(ThemeContext);
@@ -120,6 +121,7 @@ const ReactSelect = ({
           }}
           aria-label={ariaLabel}
           filterOption={filterOption}
+          closeMenuOnSelect={closeMenuOnSelect}
         />
         <InlineValidation mt="x1" errorMessage={errorMessage} errorList={errorList} />
       </MaybeFieldLabel>

--- a/packages/components/src/Select/Select.story.js
+++ b/packages/components/src/Select/Select.story.js
@@ -309,6 +309,26 @@ storiesOf("Select", module)
       />
     );
   })
+  .add("with multiselect, and closeMenuOnSelect turned off", () => {
+    const PCNList = [
+      { value: "2", label: "PCN2" },
+      { value: "4", label: "PCN4" },
+      { value: "1", label: "PCN1" },
+      { value: "9", label: "PCN9" }
+    ];
+    return (
+      <Select
+        defaultValue={[partnerCompanyName[0].value, partnerCompanyName[2].value]}
+        noOptionsMessage={() => "No options"}
+        placeholder="Please select inventory status"
+        options={PCNList}
+        labelText="Select PCN"
+        className="Select"
+        multiselect
+        closeMenuOnSelect={false}
+      />
+    );
+  })
   .add("test multiselect overflow", () => (
     <>
       <Select

--- a/packages/components/src/Select/Select.story.js
+++ b/packages/components/src/Select/Select.story.js
@@ -309,7 +309,7 @@ storiesOf("Select", module)
       />
     );
   })
-  .add("with multiselect, and closeMenuOnSelect turned off", () => {
+  .add("with closeMenuOnSelect turned off", () => {
     const PCNList = [
       { value: "2", label: "PCN2" },
       { value: "4", label: "PCN4" },

--- a/packages/components/src/Select/__snapshots__/Select.story.storyshot
+++ b/packages/components/src/Select/__snapshots__/Select.story.storyshot
@@ -624,7 +624,7 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
                           autocapitalize="none"
                           autocomplete="off"
                           autocorrect="off"
-                          id="react-select-20-input"
+                          id="react-select-21-input"
                           spellcheck="false"
                           style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
                           tabindex="0"
@@ -944,7 +944,7 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
                             autocapitalize="none"
                             autocomplete="off"
                             autocorrect="off"
-                            id="react-select-21-input"
+                            id="react-select-22-input"
                             spellcheck="false"
                             style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
                             tabindex="0"
@@ -1265,7 +1265,7 @@ exports[`Storyshots Select test multiselect overflow 1`] = `
                             autocapitalize="none"
                             autocomplete="off"
                             autocorrect="off"
-                            id="react-select-22-input"
+                            id="react-select-23-input"
                             spellcheck="false"
                             style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
                             tabindex="0"
@@ -2086,7 +2086,7 @@ exports[`Storyshots Select with custom option component 1`] = `
                             autocapitalize="none"
                             autocomplete="off"
                             autocorrect="off"
-                            id="react-select-24-input"
+                            id="react-select-25-input"
                             spellcheck="false"
                             style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
                             tabindex="0"
@@ -3010,7 +3010,7 @@ exports[`Storyshots Select with fixed positioning 1`] = `
                             autocapitalize="none"
                             autocomplete="off"
                             autocorrect="off"
-                            id="react-select-23-input"
+                            id="react-select-24-input"
                             spellcheck="false"
                             style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
                             tabindex="0"
@@ -3288,6 +3288,188 @@ exports[`Storyshots Select with multiselect 1`] = `
                           autocomplete="off"
                           autocorrect="off"
                           id="react-select-19-input"
+                          spellcheck="false"
+                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
+                          tabindex="0"
+                          type="text"
+                          value=""
+                        />
+                        <div
+                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class=" css-173cxbq-IndicatorsContainer"
+                >
+                  <div
+                    data-testid="select-clear"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class=" css-kaqmzc-indicatorContainer"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="css-6q0nyr-Svg"
+                        focusable="false"
+                        height="20"
+                        viewBox="0 0 20 20"
+                        width="20"
+                      >
+                        <path
+                          d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <span
+                    class=" css-uv1fd5-indicatorSeparator"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class=" css-19phze7-indicatorContainer"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="css-6q0nyr-Svg"
+                      focusable="false"
+                      height="20"
+                      viewBox="0 0 20 20"
+                      width="20"
+                    >
+                      <path
+                        d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </label>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Select with multiselect, and closeMenuOnSelect turned off 1`] = `
+<div
+  style="padding:24px"
+>
+  <div
+    class="NDSProvider__GlobalStyles-f28eoq-0 gXOmnU"
+  >
+    <div
+      class="Box-xda4ls-0 Field-sc-1lebjra-0 erVIOB"
+    >
+      <label
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        color="black"
+        style="display:block"
+      >
+        <div
+          class="Box-xda4ls-0 biCpIl"
+          data-testid="field-label"
+        >
+          <span
+            class="FieldLabel__LabelText-sc-1t1cp4f-1 idDszt"
+          >
+            Select PCN
+          </span>
+        </div>
+        <div
+          data-testid="select-container"
+        >
+          <div
+            class="Select css-2b097c-container"
+          >
+            <div
+              data-testid="select-control"
+            >
+              <div
+                class=" css-16f1mi0-Control"
+              >
+                <div
+                  class=" css-7zc8my"
+                >
+                  <div
+                    data-testid="select-multivalue"
+                  >
+                    <div
+                      class="css-gxde6l-multiValue"
+                    >
+                      <div
+                        class="css-1ekzmfk"
+                      >
+                        PCN2
+                      </div>
+                      <div
+                        class="css-kurm45"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="css-6q0nyr-Svg"
+                          focusable="false"
+                          height="14"
+                          viewBox="0 0 20 20"
+                          width="14"
+                        >
+                          <path
+                            d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    data-testid="select-multivalue"
+                  >
+                    <div
+                      class="css-gxde6l-multiValue"
+                    >
+                      <div
+                        class="css-1ekzmfk"
+                      >
+                        PCN1
+                      </div>
+                      <div
+                        class="css-kurm45"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="css-6q0nyr-Svg"
+                          focusable="false"
+                          height="14"
+                          viewBox="0 0 20 20"
+                          width="14"
+                        >
+                          <path
+                            d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    data-testid="select-input"
+                  >
+                    <div
+                      class="css-17yls17-Input"
+                    >
+                      <div
+                        class=""
+                        style="display:inline-block"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          autocapitalize="none"
+                          autocomplete="off"
+                          autocorrect="off"
+                          id="react-select-20-input"
                           spellcheck="false"
                           style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
                           tabindex="0"

--- a/packages/components/src/Select/__snapshots__/Select.story.storyshot
+++ b/packages/components/src/Select/__snapshots__/Select.story.storyshot
@@ -1881,6 +1881,188 @@ exports[`Storyshots Select with an option selected 1`] = `
 </div>
 `;
 
+exports[`Storyshots Select with closeMenuOnSelect turned off 1`] = `
+<div
+  style="padding:24px"
+>
+  <div
+    class="NDSProvider__GlobalStyles-f28eoq-0 gXOmnU"
+  >
+    <div
+      class="Box-xda4ls-0 Field-sc-1lebjra-0 erVIOB"
+    >
+      <label
+        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
+        color="black"
+        style="display:block"
+      >
+        <div
+          class="Box-xda4ls-0 biCpIl"
+          data-testid="field-label"
+        >
+          <span
+            class="FieldLabel__LabelText-sc-1t1cp4f-1 idDszt"
+          >
+            Select PCN
+          </span>
+        </div>
+        <div
+          data-testid="select-container"
+        >
+          <div
+            class="Select css-2b097c-container"
+          >
+            <div
+              data-testid="select-control"
+            >
+              <div
+                class=" css-16f1mi0-Control"
+              >
+                <div
+                  class=" css-7zc8my"
+                >
+                  <div
+                    data-testid="select-multivalue"
+                  >
+                    <div
+                      class="css-gxde6l-multiValue"
+                    >
+                      <div
+                        class="css-1ekzmfk"
+                      >
+                        PCN2
+                      </div>
+                      <div
+                        class="css-kurm45"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="css-6q0nyr-Svg"
+                          focusable="false"
+                          height="14"
+                          viewBox="0 0 20 20"
+                          width="14"
+                        >
+                          <path
+                            d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    data-testid="select-multivalue"
+                  >
+                    <div
+                      class="css-gxde6l-multiValue"
+                    >
+                      <div
+                        class="css-1ekzmfk"
+                      >
+                        PCN1
+                      </div>
+                      <div
+                        class="css-kurm45"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="css-6q0nyr-Svg"
+                          focusable="false"
+                          height="14"
+                          viewBox="0 0 20 20"
+                          width="14"
+                        >
+                          <path
+                            d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    data-testid="select-input"
+                  >
+                    <div
+                      class="css-17yls17-Input"
+                    >
+                      <div
+                        class=""
+                        style="display:inline-block"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          autocapitalize="none"
+                          autocomplete="off"
+                          autocorrect="off"
+                          id="react-select-20-input"
+                          spellcheck="false"
+                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
+                          tabindex="0"
+                          type="text"
+                          value=""
+                        />
+                        <div
+                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class=" css-173cxbq-IndicatorsContainer"
+                >
+                  <div
+                    data-testid="select-clear"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class=" css-kaqmzc-indicatorContainer"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="css-6q0nyr-Svg"
+                        focusable="false"
+                        height="20"
+                        viewBox="0 0 20 20"
+                        width="20"
+                      >
+                        <path
+                          d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <span
+                    class=" css-uv1fd5-indicatorSeparator"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class=" css-19phze7-indicatorContainer"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="css-6q0nyr-Svg"
+                      focusable="false"
+                      height="20"
+                      viewBox="0 0 20 20"
+                      width="20"
+                    >
+                      <path
+                        d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </label>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Select with custom id 1`] = `
 <div
   style="padding:24px"
@@ -3288,188 +3470,6 @@ exports[`Storyshots Select with multiselect 1`] = `
                           autocomplete="off"
                           autocorrect="off"
                           id="react-select-19-input"
-                          spellcheck="false"
-                          style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
-                          tabindex="0"
-                          type="text"
-                          value=""
-                        />
-                        <div
-                          style="position:absolute;top:0;left:0;visibility:hidden;height:0;overflow:scroll;white-space:pre"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class=" css-173cxbq-IndicatorsContainer"
-                >
-                  <div
-                    data-testid="select-clear"
-                  >
-                    <div
-                      aria-hidden="true"
-                      class=" css-kaqmzc-indicatorContainer"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="css-6q0nyr-Svg"
-                        focusable="false"
-                        height="20"
-                        viewBox="0 0 20 20"
-                        width="20"
-                      >
-                        <path
-                          d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                  <span
-                    class=" css-uv1fd5-indicatorSeparator"
-                  />
-                  <div
-                    aria-hidden="true"
-                    class=" css-19phze7-indicatorContainer"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="css-6q0nyr-Svg"
-                      focusable="false"
-                      height="20"
-                      viewBox="0 0 20 20"
-                      width="20"
-                    >
-                      <path
-                        d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
-                      />
-                    </svg>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </label>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Select with multiselect, and closeMenuOnSelect turned off 1`] = `
-<div
-  style="padding:24px"
->
-  <div
-    class="NDSProvider__GlobalStyles-f28eoq-0 gXOmnU"
-  >
-    <div
-      class="Box-xda4ls-0 Field-sc-1lebjra-0 erVIOB"
-    >
-      <label
-        class="FieldLabel__Label-sc-1t1cp4f-0 dDzyZF FieldLabel-sc-1t1cp4f-2 dClnot"
-        color="black"
-        style="display:block"
-      >
-        <div
-          class="Box-xda4ls-0 biCpIl"
-          data-testid="field-label"
-        >
-          <span
-            class="FieldLabel__LabelText-sc-1t1cp4f-1 idDszt"
-          >
-            Select PCN
-          </span>
-        </div>
-        <div
-          data-testid="select-container"
-        >
-          <div
-            class="Select css-2b097c-container"
-          >
-            <div
-              data-testid="select-control"
-            >
-              <div
-                class=" css-16f1mi0-Control"
-              >
-                <div
-                  class=" css-7zc8my"
-                >
-                  <div
-                    data-testid="select-multivalue"
-                  >
-                    <div
-                      class="css-gxde6l-multiValue"
-                    >
-                      <div
-                        class="css-1ekzmfk"
-                      >
-                        PCN2
-                      </div>
-                      <div
-                        class="css-kurm45"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="css-6q0nyr-Svg"
-                          focusable="false"
-                          height="14"
-                          viewBox="0 0 20 20"
-                          width="14"
-                        >
-                          <path
-                            d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    data-testid="select-multivalue"
-                  >
-                    <div
-                      class="css-gxde6l-multiValue"
-                    >
-                      <div
-                        class="css-1ekzmfk"
-                      >
-                        PCN1
-                      </div>
-                      <div
-                        class="css-kurm45"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="css-6q0nyr-Svg"
-                          focusable="false"
-                          height="14"
-                          viewBox="0 0 20 20"
-                          width="14"
-                        >
-                          <path
-                            d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    data-testid="select-input"
-                  >
-                    <div
-                      class="css-17yls17-Input"
-                    >
-                      <div
-                        class=""
-                        style="display:inline-block"
-                      >
-                        <input
-                          aria-autocomplete="list"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          autocorrect="off"
-                          id="react-select-20-input"
                           spellcheck="false"
                           style="box-sizing:content-box;width:1px;label:input;background:0;border:0;font-size:inherit;opacity:1;outline:0;padding:0;color:inherit"
                           tabindex="0"

--- a/packages/components/src/TimePicker/TimePicker.js
+++ b/packages/components/src/TimePicker/TimePicker.js
@@ -95,7 +95,8 @@ const TimePickerDropdown = styled.ul(({ theme, isOpen }) => {
     borderColor: theme.colors.blue,
     borderBottomLeftRadius: theme.radii.medium,
     borderBottomRightRadius: theme.radii.medium,
-    display: isOpen ? "block" : "none"
+    display: isOpen ? "block" : "none",
+    zIndex: theme.zIndex.content
   };
 });
 

--- a/packages/components/src/TimePicker/__snapshots__/TimePicker.story.storyshot
+++ b/packages/components/src/TimePicker/__snapshots__/TimePicker.story.storyshot
@@ -65,7 +65,7 @@ exports[`Storyshots TimePicker default 1`] = `
       </label>
       <ul
         aria-expanded="false"
-        class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 kAvmAT"
+        class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 dcgWGm"
         data-testid="select-dropdown"
         role="listbox"
       >
@@ -1004,7 +1004,7 @@ exports[`Storyshots TimePicker with custom default 1`] = `
       </label>
       <ul
         aria-expanded="false"
-        class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 kAvmAT"
+        class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 dcgWGm"
         data-testid="select-dropdown"
         role="listbox"
       >
@@ -1943,7 +1943,7 @@ exports[`Storyshots TimePicker with custom placeholder 1`] = `
       </label>
       <ul
         aria-expanded="false"
-        class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 kAvmAT"
+        class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 dcgWGm"
         data-testid="select-dropdown"
         role="listbox"
       >
@@ -2882,7 +2882,7 @@ exports[`Storyshots TimePicker with custom time format 1`] = `
       </label>
       <ul
         aria-expanded="false"
-        class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 kAvmAT"
+        class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 dcgWGm"
         data-testid="select-dropdown"
         role="listbox"
       >
@@ -3821,7 +3821,7 @@ exports[`Storyshots TimePicker with custom time interval 1`] = `
       </label>
       <ul
         aria-expanded="false"
-        class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 kAvmAT"
+        class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 dcgWGm"
         data-testid="select-dropdown"
         role="listbox"
       >
@@ -4328,7 +4328,7 @@ exports[`Storyshots TimePicker with error state 1`] = `
       </label>
       <ul
         aria-expanded="false"
-        class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 kAvmAT"
+        class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 dcgWGm"
         data-testid="select-dropdown"
         role="listbox"
       >
@@ -5299,7 +5299,7 @@ exports[`Storyshots TimePicker with min and max time 1`] = `
       </label>
       <ul
         aria-expanded="false"
-        class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 kAvmAT"
+        class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 dcgWGm"
         data-testid="select-dropdown"
         role="listbox"
       >

--- a/packages/components/src/TimeRange/__snapshots__/TimeRange.story.storyshot
+++ b/packages/components/src/TimeRange/__snapshots__/TimeRange.story.storyshot
@@ -69,7 +69,7 @@ exports[`Storyshots TimeRange default 1`] = `
         </div>
         <ul
           aria-expanded="false"
-          class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 kAvmAT"
+          class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 dcgWGm"
           data-testid="select-dropdown"
           role="listbox"
         >
@@ -992,7 +992,7 @@ exports[`Storyshots TimeRange default 1`] = `
         </div>
         <ul
           aria-expanded="false"
-          class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 kAvmAT"
+          class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 dcgWGm"
           data-testid="select-dropdown"
           role="listbox"
         >
@@ -1936,7 +1936,7 @@ exports[`Storyshots TimeRange default selections 1`] = `
         </div>
         <ul
           aria-expanded="false"
-          class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 kAvmAT"
+          class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 dcgWGm"
           data-testid="select-dropdown"
           role="listbox"
         >
@@ -2859,7 +2859,7 @@ exports[`Storyshots TimeRange default selections 1`] = `
         </div>
         <ul
           aria-expanded="false"
-          class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 kAvmAT"
+          class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 dcgWGm"
           data-testid="select-dropdown"
           role="listbox"
         >
@@ -3803,7 +3803,7 @@ exports[`Storyshots TimeRange with min and max time range 1`] = `
         </div>
         <ul
           aria-expanded="false"
-          class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 kAvmAT"
+          class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 dcgWGm"
           data-testid="select-dropdown"
           role="listbox"
         >
@@ -4213,7 +4213,7 @@ exports[`Storyshots TimeRange with min and max time range 1`] = `
         </div>
         <ul
           aria-expanded="false"
-          class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 kAvmAT"
+          class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 dcgWGm"
           data-testid="select-dropdown"
           role="listbox"
         >
@@ -4644,7 +4644,7 @@ exports[`Storyshots TimeRange with range validation 1`] = `
         </div>
         <ul
           aria-expanded="false"
-          class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 kAvmAT"
+          class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 dcgWGm"
           data-testid="select-dropdown"
           role="listbox"
         >
@@ -5567,7 +5567,7 @@ exports[`Storyshots TimeRange with range validation 1`] = `
         </div>
         <ul
           aria-expanded="false"
-          class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 kAvmAT"
+          class="TimePicker__TimePickerDropdown-sc-1r3kwxy-1 dcgWGm"
           data-testid="select-dropdown"
           role="listbox"
         >

--- a/src/shared/selectProps.js
+++ b/src/shared/selectProps.js
@@ -76,6 +76,12 @@ const selectProps = [
     description:
       "Pass in an object with the keys of the component you would like to replace"
   },
+  {
+    name: "closeMenuOnSelect",
+    type: "Boolean",
+    defaultValue: "true",
+    description: "Close the select menu when the user selects an option"
+  },
   ...inputProps.map(prop => {
     if (prop.name === "required") {
       return {


### PR DESCRIPTION
## Description

- Added a new prop `closeMenuOnSelect` to the Select component, so that users can keep the menu open when selecting multiple values
- Fixed a z-index bug in the `TimePicker` and `TimeRange` components
  - If a `Checkbox` was rendered underneath a `TimePicker`, then the dropdown would appear underneath the checkboxes

## Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [X] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [X] Docs updated with correct props and examples
- [X] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [X] Tested storybook deployment preview
- [X] Tested docs deployment preview
