### PR TITLE
fix: toggle should switch when clicked when toggled prop is not passed

### DIFF
--- a/packages/components/src/Toggle/Toggle.js
+++ b/packages/components/src/Toggle/Toggle.js
@@ -64,6 +64,7 @@ class BaseToggle extends React.Component {
       requirementText,
       helpText,
       toggled,
+      onClick,
       ...props
     } = this.props;
     return (
@@ -74,13 +75,7 @@ class BaseToggle extends React.Component {
           requirementText={requirementText}
           helpText={helpText}
         >
-          <ClickInputLabel
-            as="div"
-            onClick={() => {
-              this.props.innerRef.current.click();
-            }}
-            disabled={disabled}
-          >
+          <ClickInputLabel as="div" onClick={onClick} disabled={disabled}>
             <ToggleButton
               id={id}
               checked={toggled}


### PR DESCRIPTION
## Description

Fix issue with ref that stopped the prop from switching

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
