### PR TITLE
fix: hide arrow when no default options are passed in AsyncSelect

### DIFF
--- a/packages/components/src/AsyncSelect/AsyncSelect.js
+++ b/packages/components/src/AsyncSelect/AsyncSelect.js
@@ -1,7 +1,7 @@
 import React, { useContext, forwardRef } from "react";
 import AsyncReactSelect from "react-select/async";
 import { useTranslation } from "react-i18next";
-import { ThemeContext } from "styled-components";
+import styled, { ThemeContext } from "styled-components";
 import PropTypes from "prop-types";
 import { Field } from "../Form";
 import { MaybeFieldLabel } from "../FieldLabel";
@@ -27,6 +27,12 @@ const extractValue = (options, isMulti) => {
     return options.value;
   }
 };
+
+const StyledAsyncReactSelect = styled(AsyncReactSelect)(({ showArrow }) => ({
+  "[class*='indicatorContainer'] svg": {
+    display: showArrow ? "block" : "none"
+  }
+}));
 
 const AsyncSelect = forwardRef(
   (
@@ -71,7 +77,7 @@ const AsyncSelect = forwardRef(
     return (
       <Field>
         <MaybeFieldLabel labelText={labelText} requirementText={requirementText} helpText={helpText}>
-          <AsyncReactSelect
+          <StyledAsyncReactSelect
             className={className}
             classNamePrefix={classNamePrefix}
             noOptionsMessage={noOptionsMessage}
@@ -108,6 +114,7 @@ const AsyncSelect = forwardRef(
               Input: SelectInput,
               ...components
             }}
+            showArrow={defaultOptions}
             aria-label={ariaLabel}
             cacheOptions={cacheOptions}
             defaultOptions={defaultOptions}


### PR DESCRIPTION
## Description

hide arrow when no default options are passed in AsyncSelect

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
