### PR TITLE
fix: adds button type to Tab component

### DIFF
--- a/packages/components/src/Tabs/Tab.js
+++ b/packages/components/src/Tabs/Tab.js
@@ -73,7 +73,7 @@ const TabButton = styled.button(({ selected, disabled, fullWidth, theme }) => ({
 }));
 
 const Tab = React.forwardRef(({ label, ...props }, ref) => (
-  <TabButton role="tab" ref={ref} {...props}>
+  <TabButton role="tab" type="button" ref={ref} {...props}>
     {label}
   </TabButton>
 ));

--- a/packages/components/src/Tabs/__snapshots__/Tabs.story.storyshot
+++ b/packages/components/src/Tabs/__snapshots__/Tabs.story.storyshot
@@ -21,6 +21,7 @@ exports[`Storyshots Tabs Tabs 1`] = `
         class="Tab__TabButton-sc-69abpu-0 gcfVpD Tab1"
         role="tab"
         tabindex="0"
+        type="button"
       >
         Tab 1
       </button>
@@ -29,6 +30,7 @@ exports[`Storyshots Tabs Tabs 1`] = `
         class="Tab__TabButton-sc-69abpu-0 gcfVpD Tab2"
         role="tab"
         tabindex="-1"
+        type="button"
       >
         Tab 2
       </button>
@@ -37,6 +39,7 @@ exports[`Storyshots Tabs Tabs 1`] = `
         class="Tab__TabButton-sc-69abpu-0 gcfVpD Tab3"
         role="tab"
         tabindex="-1"
+        type="button"
       >
         Tab 3
       </button>
@@ -45,6 +48,7 @@ exports[`Storyshots Tabs Tabs 1`] = `
         class="Tab__TabButton-sc-69abpu-0 gcfVpD Tab4"
         role="tab"
         tabindex="-1"
+        type="button"
       >
         Tab 4
       </button>
@@ -98,6 +102,7 @@ exports[`Storyshots Tabs controlled 1`] = `
         class="Tab__TabButton-sc-69abpu-0 gcfVpD Tab1"
         role="tab"
         tabindex="0"
+        type="button"
       >
         Tab 1
       </button>
@@ -106,6 +111,7 @@ exports[`Storyshots Tabs controlled 1`] = `
         class="Tab__TabButton-sc-69abpu-0 gcfVpD Tab2"
         role="tab"
         tabindex="-1"
+        type="button"
       >
         Tab 2
       </button>
@@ -114,6 +120,7 @@ exports[`Storyshots Tabs controlled 1`] = `
         class="Tab__TabButton-sc-69abpu-0 gcfVpD Tab3"
         role="tab"
         tabindex="-1"
+        type="button"
       >
         Tab 3
       </button>
@@ -122,6 +129,7 @@ exports[`Storyshots Tabs controlled 1`] = `
         class="Tab__TabButton-sc-69abpu-0 gcfVpD Tab4"
         role="tab"
         tabindex="-1"
+        type="button"
       >
         Tab 4
       </button>
@@ -180,6 +188,7 @@ exports[`Storyshots Tabs set to fitted 1`] = `
         class="Tab__TabButton-sc-69abpu-0 bJxQOQ"
         role="tab"
         tabindex="0"
+        type="button"
       >
         Tab 1
       </button>
@@ -188,6 +197,7 @@ exports[`Storyshots Tabs set to fitted 1`] = `
         class="Tab__TabButton-sc-69abpu-0 bJxQOQ"
         role="tab"
         tabindex="-1"
+        type="button"
       >
         Tab 2
       </button>
@@ -196,6 +206,7 @@ exports[`Storyshots Tabs set to fitted 1`] = `
         class="Tab__TabButton-sc-69abpu-0 bJxQOQ"
         role="tab"
         tabindex="-1"
+        type="button"
       >
         Tab 3
       </button>
@@ -204,6 +215,7 @@ exports[`Storyshots Tabs set to fitted 1`] = `
         class="Tab__TabButton-sc-69abpu-0 bJxQOQ"
         role="tab"
         tabindex="-1"
+        type="button"
       >
         Tab 4
       </button>
@@ -258,6 +270,7 @@ exports[`Storyshots Tabs with a defaultSelectedIndex 1`] = `
         role="tab"
         selected=""
         tabindex="0"
+        type="button"
       >
         Tab 1
       </button>
@@ -266,6 +279,7 @@ exports[`Storyshots Tabs with a defaultSelectedIndex 1`] = `
         class="Tab__TabButton-sc-69abpu-0 gcfVpD"
         role="tab"
         tabindex="-1"
+        type="button"
       >
         Tab 2
       </button>
@@ -274,6 +288,7 @@ exports[`Storyshots Tabs with a defaultSelectedIndex 1`] = `
         class="Tab__TabButton-sc-69abpu-0 gcfVpD"
         role="tab"
         tabindex="-1"
+        type="button"
       >
         Tab 3
       </button>
@@ -282,6 +297,7 @@ exports[`Storyshots Tabs with a defaultSelectedIndex 1`] = `
         class="Tab__TabButton-sc-69abpu-0 gcfVpD"
         role="tab"
         tabindex="-1"
+        type="button"
       >
         Tab 4
       </button>
@@ -325,6 +341,7 @@ exports[`Storyshots Tabs with all tab states 1`] = `
       <button
         class="Tab__TabButton-sc-69abpu-0 gcfVpD"
         role="tab"
+        type="button"
       >
         Tab
       </button>
@@ -332,6 +349,7 @@ exports[`Storyshots Tabs with all tab states 1`] = `
         class="Tab__TabButton-sc-69abpu-0 kfQsHL"
         role="tab"
         selected=""
+        type="button"
       >
         Tab
       </button>
@@ -339,6 +357,7 @@ exports[`Storyshots Tabs with all tab states 1`] = `
         class="Tab__TabButton-sc-69abpu-0 iQOraC"
         disabled=""
         role="tab"
+        type="button"
       >
         Tab
       </button>
@@ -347,6 +366,7 @@ exports[`Storyshots Tabs with all tab states 1`] = `
         disabled=""
         role="tab"
         selected=""
+        type="button"
       >
         Tab
       </button>
@@ -376,6 +396,7 @@ exports[`Storyshots Tabs with content loaded on selection 1`] = `
         class="Tab__TabButton-sc-69abpu-0 gcfVpD Tab1"
         role="tab"
         tabindex="0"
+        type="button"
       >
         Tab 1
       </button>
@@ -384,6 +405,7 @@ exports[`Storyshots Tabs with content loaded on selection 1`] = `
         class="Tab__TabButton-sc-69abpu-0 gcfVpD Tab2"
         role="tab"
         tabindex="-1"
+        type="button"
       >
         Tab 2
       </button>
@@ -413,6 +435,7 @@ exports[`Storyshots Tabs with inputs 1`] = `
         class="Tab__TabButton-sc-69abpu-0 gcfVpD Tab1"
         role="tab"
         tabindex="0"
+        type="button"
       >
         Tab 1
       </button>
@@ -421,6 +444,7 @@ exports[`Storyshots Tabs with inputs 1`] = `
         class="Tab__TabButton-sc-69abpu-0 gcfVpD Tab2"
         role="tab"
         tabindex="-1"
+        type="button"
       >
         Tab 2
       </button>
@@ -466,6 +490,7 @@ exports[`Storyshots Tabs with scrolling tabs 1`] = `
         class="Tab__TabButton-sc-69abpu-0 gcfVpD"
         role="tab"
         tabindex="0"
+        type="button"
       >
         Tab 1
       </button>
@@ -474,6 +499,7 @@ exports[`Storyshots Tabs with scrolling tabs 1`] = `
         class="Tab__TabButton-sc-69abpu-0 gcfVpD"
         role="tab"
         tabindex="-1"
+        type="button"
       >
         Tab 2
       </button>
@@ -482,6 +508,7 @@ exports[`Storyshots Tabs with scrolling tabs 1`] = `
         class="Tab__TabButton-sc-69abpu-0 gcfVpD"
         role="tab"
         tabindex="-1"
+        type="button"
       >
         Tab 3
       </button>
@@ -490,6 +517,7 @@ exports[`Storyshots Tabs with scrolling tabs 1`] = `
         class="Tab__TabButton-sc-69abpu-0 gcfVpD"
         role="tab"
         tabindex="-1"
+        type="button"
       >
         Tab 4
       </button>
@@ -498,6 +526,7 @@ exports[`Storyshots Tabs with scrolling tabs 1`] = `
         class="Tab__TabButton-sc-69abpu-0 gcfVpD"
         role="tab"
         tabindex="-1"
+        type="button"
       >
         Tab 5
       </button>
@@ -506,6 +535,7 @@ exports[`Storyshots Tabs with scrolling tabs 1`] = `
         class="Tab__TabButton-sc-69abpu-0 gcfVpD"
         role="tab"
         tabindex="-1"
+        type="button"
       >
         Tab 6
       </button>
@@ -514,6 +544,7 @@ exports[`Storyshots Tabs with scrolling tabs 1`] = `
         class="Tab__TabButton-sc-69abpu-0 gcfVpD"
         role="tab"
         tabindex="-1"
+        type="button"
       >
         Tab 7
       </button>
@@ -522,6 +553,7 @@ exports[`Storyshots Tabs with scrolling tabs 1`] = `
         class="Tab__TabButton-sc-69abpu-0 gcfVpD"
         role="tab"
         tabindex="-1"
+        type="button"
       >
         Tab 8
       </button>
@@ -530,6 +562,7 @@ exports[`Storyshots Tabs with scrolling tabs 1`] = `
         class="Tab__TabButton-sc-69abpu-0 gcfVpD"
         role="tab"
         tabindex="-1"
+        type="button"
       >
         Tab 9
       </button>
@@ -538,6 +571,7 @@ exports[`Storyshots Tabs with scrolling tabs 1`] = `
         class="Tab__TabButton-sc-69abpu-0 gcfVpD"
         role="tab"
         tabindex="-1"
+        type="button"
       >
         Tab 10
       </button>
@@ -546,6 +580,7 @@ exports[`Storyshots Tabs with scrolling tabs 1`] = `
         class="Tab__TabButton-sc-69abpu-0 gcfVpD"
         role="tab"
         tabindex="-1"
+        type="button"
       >
         Tab 11
       </button>
@@ -554,6 +589,7 @@ exports[`Storyshots Tabs with scrolling tabs 1`] = `
         class="Tab__TabButton-sc-69abpu-0 gcfVpD"
         role="tab"
         tabindex="-1"
+        type="button"
       >
         Tab 12
       </button>

--- a/packages/components/src/pages/__snapshots__/Details.story.storyshot
+++ b/packages/components/src/pages/__snapshots__/Details.story.storyshot
@@ -180,6 +180,7 @@ exports[`Storyshots Pages/Details page Default 1`] = `
               role="tab"
               selected=""
               tabindex="0"
+              type="button"
             >
               Details
             </button>
@@ -188,6 +189,7 @@ exports[`Storyshots Pages/Details page Default 1`] = `
               class="Tab__TabButton-sc-69abpu-0 gcfVpD"
               role="tab"
               tabindex="-1"
+              type="button"
             >
               Milestones
             </button>
@@ -196,6 +198,7 @@ exports[`Storyshots Pages/Details page Default 1`] = `
               class="Tab__TabButton-sc-69abpu-0 gcfVpD"
               role="tab"
               tabindex="-1"
+              type="button"
             >
               Production Records
             </button>
@@ -1030,6 +1033,7 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
               role="tab"
               selected=""
               tabindex="0"
+              type="button"
             >
               Details
             </button>
@@ -1038,6 +1042,7 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
               class="Tab__TabButton-sc-69abpu-0 gcfVpD"
               role="tab"
               tabindex="-1"
+              type="button"
             >
               Milestones
             </button>
@@ -1046,6 +1051,7 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
               class="Tab__TabButton-sc-69abpu-0 gcfVpD"
               role="tab"
               tabindex="-1"
+              type="button"
             >
               Production Records
             </button>
@@ -1847,6 +1853,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
               role="tab"
               selected=""
               tabindex="0"
+              type="button"
             >
               Details
             </button>
@@ -1855,6 +1862,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
               class="Tab__TabButton-sc-69abpu-0 gcfVpD"
               role="tab"
               tabindex="-1"
+              type="button"
             >
               Milestones
             </button>
@@ -1863,6 +1871,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
               class="Tab__TabButton-sc-69abpu-0 gcfVpD"
               role="tab"
               tabindex="-1"
+              type="button"
             >
               Production Records
             </button>


### PR DESCRIPTION
## Description

The `Tab` components are buttons which do not specify a `type`. This can cause them to act as `submit` buttons, which they really shouldn't do.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [x] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
