### PR TITLE
feat: add ability to have a sticky header to table

### DIFF
--- a/packages/components/src/Table/BaseTable.js
+++ b/packages/components/src/Table/BaseTable.js
@@ -25,10 +25,10 @@ const BaseTable = ({
   rowHovers,
   compact,
   className,
-  sticky
+  stickyHeader
 }) => (
   <StyledTable id={id} className={className}>
-    <TableHead columns={columns} compact={compact} sticky={sticky} />
+    <TableHead columns={columns} compact={compact} sticky={stickyHeader} />
     <TableBody
       columns={columns}
       rows={rows}
@@ -65,7 +65,7 @@ BaseTable.defaultProps = {
   rowHovers: true,
   compact: false,
   className: undefined,
-  sticky: false
+  stickyHeader: false
 };
 
 export default BaseTable;

--- a/packages/components/src/Table/BaseTable.js
+++ b/packages/components/src/Table/BaseTable.js
@@ -10,7 +10,8 @@ import { columnsPropType, rowsPropType } from "./Table.types";
 const StyledTable = styled.table({
   borderCollapse: "collapse",
   width: "100%",
-  background: "white"
+  background: "white",
+  position: "relative"
 });
 
 const BaseTable = ({
@@ -23,10 +24,11 @@ const BaseTable = ({
   footerRows,
   rowHovers,
   compact,
-  className
+  className,
+  sticky
 }) => (
   <StyledTable id={id} className={className}>
-    <TableHead columns={columns} compact={compact} />
+    <TableHead columns={columns} compact={compact} sticky={sticky} />
     <TableBody
       columns={columns}
       rows={rows}
@@ -50,7 +52,8 @@ BaseTable.propTypes = {
   footerRows: rowsPropType,
   rowHovers: PropTypes.bool,
   compact: PropTypes.bool,
-  className: PropTypes.string
+  className: PropTypes.string,
+  sticky: PropTypes.bool
 };
 
 BaseTable.defaultProps = {
@@ -61,7 +64,8 @@ BaseTable.defaultProps = {
   footerRows: [],
   rowHovers: true,
   compact: false,
-  className: undefined
+  className: undefined,
+  sticky: false
 };
 
 export default BaseTable;

--- a/packages/components/src/Table/BaseTable.story.js
+++ b/packages/components/src/Table/BaseTable.story.js
@@ -134,6 +134,19 @@ storiesOf("Table", module)
       loading={boolean("Show loading state", false)}
     />
   ))
+  .add("with sticky header", () => (
+    <Box mt="x4">
+      <Table
+        columns={columns}
+        rows={rowData}
+        rowHovers={boolean("Show row hovers", true)}
+        compact={boolean("Show with compact styling", false)}
+        loading={boolean("Show loading state", false)}
+        className="Table"
+        sticky
+      />
+    </Box>
+  ))
   .add("with lots of rows and columns", () => (
     <Table
       columns={mockColumns}

--- a/packages/components/src/Table/StyledTh.js
+++ b/packages/components/src/Table/StyledTh.js
@@ -1,6 +1,14 @@
 import styled from "styled-components";
 
-const StyledTh = styled.th(({ width, compact, theme }) => {
+const stickyStyles = theme => ({
+  position: "sticky",
+  top: 0,
+  background: "white",
+  boxShadow: "0px 1px 0px rgba(0,0,0,.1)",
+  zIndex: theme.zIndex.content
+});
+
+const StyledTh = styled.th(({ width, compact, theme, sticky }) => {
   const padding = compact ? theme.space.x1 : theme.space.x2;
   return {
     fontWeight: "normal",
@@ -8,6 +16,7 @@ const StyledTh = styled.th(({ width, compact, theme }) => {
     padding: `${padding} 0`,
     paddingRight: padding,
     color: theme.colors.darkGrey,
+    ...(sticky && stickyStyles(theme)),
     "&:first-child": {
       paddingLeft: padding
     },

--- a/packages/components/src/Table/TableHead.js
+++ b/packages/components/src/Table/TableHead.js
@@ -12,10 +12,17 @@ const defaultheaderFormatter = ({ label }) => label;
 
 const renderHeaderCellContent = ({ headerFormatter = defaultheaderFormatter, ...column }) => headerFormatter(column);
 
-const TableHead = ({ columns, compact }) => {
+const TableHead = ({ columns, compact, sticky }) => {
   const renderColumns = allColumns =>
     allColumns.map(column => (
-      <StyledTh scope="col" key={column.dataKey} width={column.width} compact={compact} data-testid="table-head">
+      <StyledTh
+        scope="col"
+        key={column.dataKey}
+        width={column.width}
+        compact={compact}
+        data-testid="table-head"
+        sticky={sticky}
+      >
         {renderHeaderCellContent(column)}
       </StyledTh>
     ));
@@ -37,7 +44,12 @@ TableHead.propTypes = {
       headerFormatter: PropTypes.func
     })
   ).isRequired,
-  compact: PropTypes.bool.isRequired
+  compact: PropTypes.bool.isRequired,
+  sticky: PropTypes.bool
+};
+
+TableHead.defaultProps = {
+  sticky: false
 };
 
 export default TableHead;

--- a/packages/components/src/Table/__snapshots__/BaseTable.story.storyshot
+++ b/packages/components/src/Table/__snapshots__/BaseTable.story.storyshot
@@ -8892,21 +8892,21 @@ exports[`Storyshots Table with sticky header 1`] = `
             class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
           >
             <th
-              class="StyledTh-sc-10nzyk9-0 dMKfDV"
+              class="StyledTh-sc-10nzyk9-0 sBlyT"
               data-testid="table-head"
               scope="col"
             >
               Date
             </th>
             <th
-              class="StyledTh-sc-10nzyk9-0 dMKfDV"
+              class="StyledTh-sc-10nzyk9-0 sBlyT"
               data-testid="table-head"
               scope="col"
             >
               Expected Quantity
             </th>
             <th
-              class="StyledTh-sc-10nzyk9-0 dMKfDV"
+              class="StyledTh-sc-10nzyk9-0 sBlyT"
               data-testid="table-head"
               scope="col"
             >

--- a/packages/components/src/Table/__snapshots__/BaseTable.story.storyshot
+++ b/packages/components/src/Table/__snapshots__/BaseTable.story.storyshot
@@ -8881,202 +8881,206 @@ exports[`Storyshots Table with sticky header 1`] = `
   <div
     class="NDSProvider__GlobalStyles-f28eoq-0 gXOmnU"
   >
-    <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 kfnyiE Table"
+    <div
+      class="Box-xda4ls-0 imTYhY"
     >
-      <thead>
-        <tr
-          class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
-        >
-          <th
-            class="StyledTh-sc-10nzyk9-0 dMKfDV"
-            data-testid="table-head"
-            scope="col"
-          >
-            Date
-          </th>
-          <th
-            class="StyledTh-sc-10nzyk9-0 dMKfDV"
-            data-testid="table-head"
-            scope="col"
-          >
-            Expected Quantity
-          </th>
-          <th
-            class="StyledTh-sc-10nzyk9-0 dMKfDV"
-            data-testid="table-head"
-            scope="col"
-          >
-            Actual Quantity
-          </th>
-        </tr>
-      </thead>
-      <tbody
-        data-testid="table-body"
+      <table
+        class="BaseTable__StyledTable-sc-10lnp9m-0 kfnyiE Table"
       >
-        <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
-          data-testid="table-row"
+        <thead>
+          <tr
+            class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
+          >
+            <th
+              class="StyledTh-sc-10nzyk9-0 dMKfDV"
+              data-testid="table-head"
+              scope="col"
+            >
+              Date
+            </th>
+            <th
+              class="StyledTh-sc-10nzyk9-0 dMKfDV"
+              data-testid="table-head"
+              scope="col"
+            >
+              Expected Quantity
+            </th>
+            <th
+              class="StyledTh-sc-10nzyk9-0 dMKfDV"
+              data-testid="table-head"
+              scope="col"
+            >
+              Actual Quantity
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          data-testid="table-body"
         >
-          <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          <tr
+            class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+            data-testid="table-row"
           >
-            2019-10-01
-          </td>
-          <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            <td
+              class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            >
+              2019-10-01
+            </td>
+            <td
+              class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            >
+              2,025 eaches
+            </td>
+            <td
+              class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            >
+              1,800 eaches
+            </td>
+          </tr>
+          <tr
+            class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+            data-testid="table-row"
           >
-            2,025 eaches
-          </td>
-          <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            <td
+              class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            >
+              2019-10-02
+            </td>
+            <td
+              class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            >
+              2,475 eaches
+            </td>
+            <td
+              class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            >
+              2,250 eaches
+            </td>
+          </tr>
+          <tr
+            class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+            data-testid="table-row"
           >
-            1,800 eaches
-          </td>
-        </tr>
-        <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
-          data-testid="table-row"
-        >
-          <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            <td
+              class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            >
+              2019-10-03
+            </td>
+            <td
+              class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            >
+              2,475 eaches
+            </td>
+            <td
+              class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            >
+              1,425 eaches
+            </td>
+          </tr>
+          <tr
+            class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+            data-testid="table-row"
           >
-            2019-10-02
-          </td>
-          <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            <td
+              class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            >
+              2019-10-04
+            </td>
+            <td
+              class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            >
+              2,475 eaches
+            </td>
+            <td
+              class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            >
+              675 eaches
+            </td>
+          </tr>
+          <tr
+            class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+            data-testid="table-row"
           >
-            2,475 eaches
-          </td>
-          <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            <td
+              class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            >
+              2019-10-07
+            </td>
+            <td
+              class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            >
+              2,475 eaches
+            </td>
+            <td
+              class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            >
+              1,575 eaches
+            </td>
+          </tr>
+          <tr
+            class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+            data-testid="table-row"
           >
-            2,250 eaches
-          </td>
-        </tr>
-        <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
-          data-testid="table-row"
-        >
-          <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            <td
+              class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            >
+              2019-10-22
+            </td>
+            <td
+              class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            >
+              1,725 eaches
+            </td>
+            <td
+              class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            >
+              -
+            </td>
+          </tr>
+          <tr
+            class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+            data-testid="table-row"
           >
-            2019-10-03
-          </td>
-          <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            <td
+              class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            >
+              2019-10-23
+            </td>
+            <td
+              class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            >
+              2,475 eaches
+            </td>
+            <td
+              class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            >
+              -
+            </td>
+          </tr>
+          <tr
+            class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+            data-testid="table-row"
           >
-            2,475 eaches
-          </td>
-          <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          >
-            1,425 eaches
-          </td>
-        </tr>
-        <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
-          data-testid="table-row"
-        >
-          <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          >
-            2019-10-04
-          </td>
-          <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          >
-            2,475 eaches
-          </td>
-          <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          >
-            675 eaches
-          </td>
-        </tr>
-        <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
-          data-testid="table-row"
-        >
-          <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          >
-            2019-10-07
-          </td>
-          <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          >
-            2,475 eaches
-          </td>
-          <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          >
-            1,575 eaches
-          </td>
-        </tr>
-        <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
-          data-testid="table-row"
-        >
-          <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          >
-            2019-10-22
-          </td>
-          <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          >
-            1,725 eaches
-          </td>
-          <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          >
-            -
-          </td>
-        </tr>
-        <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
-          data-testid="table-row"
-        >
-          <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          >
-            2019-10-23
-          </td>
-          <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          >
-            2,475 eaches
-          </td>
-          <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          >
-            -
-          </td>
-        </tr>
-        <tr
-          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
-          data-testid="table-row"
-        >
-          <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          >
-            2019-10-24
-          </td>
-          <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          >
-            2,475 eaches
-          </td>
-          <td
-            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
-          >
-            -
-          </td>
-        </tr>
-      </tbody>
-      <tfoot />
-    </table>
+            <td
+              class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            >
+              2019-10-24
+            </td>
+            <td
+              class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            >
+              2,475 eaches
+            </td>
+            <td
+              class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+            >
+              -
+            </td>
+          </tr>
+        </tbody>
+        <tfoot />
+      </table>
+    </div>
   </div>
 </div>
 `;

--- a/packages/components/src/Table/__snapshots__/BaseTable.story.storyshot
+++ b/packages/components/src/Table/__snapshots__/BaseTable.story.storyshot
@@ -8,7 +8,7 @@ exports[`Storyshots Table  with data 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 gXOmnU"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub Table"
+      class="BaseTable__StyledTable-sc-10lnp9m-0 kfnyiE Table"
     >
       <thead>
         <tr
@@ -215,7 +215,7 @@ exports[`Storyshots Table with a cell formatter 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 gXOmnU"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+      class="BaseTable__StyledTable-sc-10lnp9m-0 kfnyiE"
     >
       <thead>
         <tr
@@ -422,7 +422,7 @@ exports[`Storyshots Table with a custom cell component 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 gXOmnU"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+      class="BaseTable__StyledTable-sc-10lnp9m-0 kfnyiE"
     >
       <thead>
         <tr
@@ -827,7 +827,7 @@ exports[`Storyshots Table with a custom column label component 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 gXOmnU"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+      class="BaseTable__StyledTable-sc-10lnp9m-0 kfnyiE"
     >
       <thead>
         <tr
@@ -1069,7 +1069,7 @@ exports[`Storyshots Table with a footer 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 gXOmnU"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+      class="BaseTable__StyledTable-sc-10lnp9m-0 kfnyiE"
     >
       <thead>
         <tr
@@ -1317,7 +1317,7 @@ exports[`Storyshots Table with cell alignment 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 gXOmnU"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+      class="BaseTable__StyledTable-sc-10lnp9m-0 kfnyiE"
     >
       <thead>
         <tr
@@ -1524,7 +1524,7 @@ exports[`Storyshots Table with custom column widths 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 gXOmnU"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+      class="BaseTable__StyledTable-sc-10lnp9m-0 kfnyiE"
     >
       <thead>
         <tr
@@ -1765,7 +1765,7 @@ exports[`Storyshots Table with full width section 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 gXOmnU"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+      class="BaseTable__StyledTable-sc-10lnp9m-0 kfnyiE"
     >
       <thead>
         <tr
@@ -1973,7 +1973,7 @@ exports[`Storyshots Table with lots of rows and columns 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 gXOmnU"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+      class="BaseTable__StyledTable-sc-10lnp9m-0 kfnyiE"
     >
       <thead>
         <tr
@@ -8822,7 +8822,7 @@ exports[`Storyshots Table with no data 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 gXOmnU"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+      class="BaseTable__StyledTable-sc-10lnp9m-0 kfnyiE"
     >
       <thead>
         <tr
@@ -8865,6 +8865,213 @@ exports[`Storyshots Table with no data 1`] = `
             >
               No records have been created for this table.
             </div>
+          </td>
+        </tr>
+      </tbody>
+      <tfoot />
+    </table>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Table with sticky header 1`] = `
+<div
+  style="padding:24px"
+>
+  <div
+    class="NDSProvider__GlobalStyles-f28eoq-0 gXOmnU"
+  >
+    <table
+      class="BaseTable__StyledTable-sc-10lnp9m-0 kfnyiE Table"
+    >
+      <thead>
+        <tr
+          class="TableHead__StyledHeaderRow-msr3t5-0 eqrvph"
+        >
+          <th
+            class="StyledTh-sc-10nzyk9-0 dMKfDV"
+            data-testid="table-head"
+            scope="col"
+          >
+            Date
+          </th>
+          <th
+            class="StyledTh-sc-10nzyk9-0 dMKfDV"
+            data-testid="table-head"
+            scope="col"
+          >
+            Expected Quantity
+          </th>
+          <th
+            class="StyledTh-sc-10nzyk9-0 dMKfDV"
+            data-testid="table-head"
+            scope="col"
+          >
+            Actual Quantity
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        data-testid="table-body"
+      >
+        <tr
+          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
+        >
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            2019-10-01
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            2,025 eaches
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            1,800 eaches
+          </td>
+        </tr>
+        <tr
+          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
+        >
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            2019-10-02
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            2,475 eaches
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            2,250 eaches
+          </td>
+        </tr>
+        <tr
+          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
+        >
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            2019-10-03
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            2,475 eaches
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            1,425 eaches
+          </td>
+        </tr>
+        <tr
+          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
+        >
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            2019-10-04
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            2,475 eaches
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            675 eaches
+          </td>
+        </tr>
+        <tr
+          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
+        >
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            2019-10-07
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            2,475 eaches
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            1,575 eaches
+          </td>
+        </tr>
+        <tr
+          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
+        >
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            2019-10-22
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            1,725 eaches
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            -
+          </td>
+        </tr>
+        <tr
+          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
+        >
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            2019-10-23
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            2,475 eaches
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            -
+          </td>
+        </tr>
+        <tr
+          class="TableBody__StyledTr-sc-1amzhx8-1 jsrSxq"
+          data-testid="table-row"
+        >
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            2019-10-24
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            2,475 eaches
+          </td>
+          <td
+            class="TableCell__StyledTableCell-sc-1t826om-0 cMUUMq"
+          >
+            -
           </td>
         </tr>
       </tbody>

--- a/packages/components/src/Table/__snapshots__/Table.story.storyshot
+++ b/packages/components/src/Table/__snapshots__/Table.story.storyshot
@@ -8,7 +8,7 @@ exports[`Storyshots Table with everything 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 gXOmnU"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub Table"
+      class="BaseTable__StyledTable-sc-10lnp9m-0 kfnyiE Table"
     >
       <thead>
         <tr
@@ -589,7 +589,7 @@ exports[`Storyshots Table with pagination 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 gXOmnU"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub Table"
+      class="BaseTable__StyledTable-sc-10lnp9m-0 kfnyiE Table"
     >
       <thead>
         <tr

--- a/packages/components/src/Table/__snapshots__/TableWithExpandableRows.story.storyshot
+++ b/packages/components/src/Table/__snapshots__/TableWithExpandableRows.story.storyshot
@@ -8,7 +8,7 @@ exports[`Storyshots Table/with expandable rows with expandable rows 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 gXOmnU"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+      class="BaseTable__StyledTable-sc-10lnp9m-0 kfnyiE"
     >
       <thead>
         <tr
@@ -311,7 +311,7 @@ exports[`Storyshots Table/with expandable rows with rows expanded by default 1`]
     class="NDSProvider__GlobalStyles-f28eoq-0 gXOmnU"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+      class="BaseTable__StyledTable-sc-10lnp9m-0 kfnyiE"
     >
       <thead>
         <tr

--- a/packages/components/src/Table/__snapshots__/TableWithSelectableRows.story.storyshot
+++ b/packages/components/src/Table/__snapshots__/TableWithSelectableRows.story.storyshot
@@ -8,7 +8,7 @@ exports[`Storyshots Table/with selectable rows with preselected rows 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 gXOmnU"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+      class="BaseTable__StyledTable-sc-10lnp9m-0 kfnyiE"
     >
       <thead>
         <tr
@@ -427,7 +427,7 @@ exports[`Storyshots Table/with selectable rows with selectable rows 1`] = `
     class="NDSProvider__GlobalStyles-f28eoq-0 gXOmnU"
   >
     <table
-      class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+      class="BaseTable__StyledTable-sc-10lnp9m-0 kfnyiE"
     >
       <thead>
         <tr

--- a/packages/components/src/pages/__snapshots__/Details.story.storyshot
+++ b/packages/components/src/pages/__snapshots__/Details.story.storyshot
@@ -355,7 +355,7 @@ exports[`Storyshots Pages/Details page Default 1`] = `
                 Milestone Performance
               </h2>
               <table
-                class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+                class="BaseTable__StyledTable-sc-10lnp9m-0 kfnyiE"
               >
                 <thead>
                   <tr
@@ -610,7 +610,7 @@ exports[`Storyshots Pages/Details page Default 1`] = `
                 Production Records
               </h2>
               <table
-                class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+                class="BaseTable__StyledTable-sc-10lnp9m-0 kfnyiE"
               >
                 <thead>
                   <tr
@@ -1205,7 +1205,7 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                 Milestone Performance
               </h2>
               <table
-                class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+                class="BaseTable__StyledTable-sc-10lnp9m-0 kfnyiE"
               >
                 <thead>
                   <tr
@@ -1460,7 +1460,7 @@ exports[`Storyshots Pages/Details page With breadcrumbs and actions 1`] = `
                 Production Records
               </h2>
               <table
-                class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+                class="BaseTable__StyledTable-sc-10lnp9m-0 kfnyiE"
               >
                 <thead>
                   <tr
@@ -2022,7 +2022,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 Milestone Performance
               </h2>
               <table
-                class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+                class="BaseTable__StyledTable-sc-10lnp9m-0 kfnyiE"
               >
                 <thead>
                   <tr
@@ -2277,7 +2277,7 @@ exports[`Storyshots Pages/Details page With sidebar 1`] = `
                 Production Records
               </h2>
               <table
-                class="BaseTable__StyledTable-sc-10lnp9m-0 cHvXub"
+                class="BaseTable__StyledTable-sc-10lnp9m-0 kfnyiE"
               >
                 <thead>
                   <tr

--- a/src/pages/components/table.js
+++ b/src/pages/components/table.js
@@ -179,7 +179,7 @@ const propsRows = [
     type: "boolean",
     defaultValue: "false",
     description:
-      "Sets the table header to sticky. NOTE: the vertical position of the sticky header is aligned to the top of the Table, if you have padding on an element wrapping the Table you will see that the header is offset according to the top padding."
+      "Sets the table header to sticky. NOTE: the vertical position of the sticky header is aligned to the top of the Table. If there is padding on an element wrapping the Table you will see that the header is offset according to the top padding."
   },
   {
     name: "hasSelectableRows",

--- a/src/pages/components/table.js
+++ b/src/pages/components/table.js
@@ -175,10 +175,11 @@ const propsRows = [
       "The name of the key to use as a unique identifier for individual rows"
   },
   {
-    name: "sticky",
+    name: "stickyHeader",
     type: "boolean",
     defaultValue: "false",
-    description: "sets the table header to sticky"
+    description:
+      "Sets the table header to sticky. NOTE: the vertical position of the sticky header is aligned to the top of the Table, if you have padding on an element wrapping the Table you will see that the header is offset according to the top padding."
   },
   {
     name: "hasSelectableRows",
@@ -603,6 +604,18 @@ const columnsWithCustomCells = [
       <Table columns={columns} rows={rows} compact />
       <Highlight className="js">
         {`<Table columns={columns} rows={rows} compact />`}
+      </Highlight>
+    </DocSection>
+
+    <DocSection>
+      <SectionTitle>Sticky Header</SectionTitle>
+      <Text>
+        The table header can remain fixed to the top of the table when scrolling
+        by setting the prop stickyHeader to true.
+      </Text>
+      <Table columns={columns} rows={rows} stickyHeader />
+      <Highlight className="js">
+        {`<Table columns={columns} rows={rows} stickyHeader />`}
       </Highlight>
     </DocSection>
 

--- a/src/pages/components/table.js
+++ b/src/pages/components/table.js
@@ -175,6 +175,12 @@ const propsRows = [
       "The name of the key to use as a unique identifier for individual rows"
   },
   {
+    name: "sticky",
+    type: "boolean",
+    defaultValue: "false",
+    description: "sets the table header to sticky"
+  },
+  {
     name: "hasSelectableRows",
     type: "boolean",
     defaultValue: "false",


### PR DESCRIPTION
## Description
Add sticky header styles when sticky is set on the <Table />

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [x] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
