### PR TITLE
fix: replace universal selector with button, a tag rule in BrandedNavBar

### DIFF
--- a/packages/components/src/BrandedNavBar/DesktopMenu.js
+++ b/packages/components/src/BrandedNavBar/DesktopMenu.js
@@ -19,7 +19,7 @@ const getSharedStyles = (color, theme) => {
 };
 
 const ApplyMenuLinkStyles = styled.div(({ color, hoverColor, hoverBackground, theme }) => ({
-  "*": {
+  "button, a": {
     ...getSharedStyles(color, theme),
     transition: ".2s",
     "&:hover, &:focus": {

--- a/packages/components/src/BrandedNavBar/MobileMenu.js
+++ b/packages/components/src/BrandedNavBar/MobileMenu.js
@@ -42,7 +42,7 @@ const getSharedStyles = ({ color, layer, theme }) => ({
 
 const ApplyMenuLinkStyles = styled.li(({ color, hoverColor, hoverBackground, layer, theme }) => ({
   display: "block",
-  "*": {
+  "button, a": {
     ...getSharedStyles({ color, layer, theme }),
     textDecoration: "none",
     "&:hover, &:focus": {


### PR DESCRIPTION
## Description

A fix to restrict the styles added in the BrandedNavBar to buttons and links, previously targeted all children which causes issues when rendering a Select component in the NavBar.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] Updated and reviewed changes to storyshots
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
