### PR TITLE
feat: Add secondary colours

### DIFF
--- a/packages/components/src/theme.ts
+++ b/packages/components/src/theme.ts
@@ -19,12 +19,12 @@ const Theme: ThemeType = {
     lightGreen: tokens.color_base_light_green,
     red: tokens.color_base_red,
     lightRed: tokens.color_base_light_red,
-    categorical1: tokens.color_base_light_aqua,
-    categorical2: tokens.color_base_light_purple,
-    categorical3: tokens.color_base_light_pink,
-    categorical4: tokens.color_base_light_turquoise,
-    categorical5: tokens.color_base_light_orange,
-    categorical6: tokens.color_base_light_avocado
+    categorical1: tokens.color_base_aqua,
+    categorical2: tokens.color_base_purple,
+    categorical3: tokens.color_base_pink,
+    categorical4: tokens.color_base_turquoise,
+    categorical5: tokens.color_base_orange,
+    categorical6: tokens.color_base_avocado
   },
   fontSizes: {
     smaller: tokens.size_font_smaller,

--- a/packages/components/src/theme.ts
+++ b/packages/components/src/theme.ts
@@ -18,7 +18,13 @@ const Theme: ThemeType = {
     green: tokens.color_base_green,
     lightGreen: tokens.color_base_light_green,
     red: tokens.color_base_red,
-    lightRed: tokens.color_base_light_red
+    lightRed: tokens.color_base_light_red,
+    categorical1: tokens.color_base_light_aqua,
+    categorical2: tokens.color_base_light_purple,
+    categorical3: tokens.color_base_light_pink,
+    categorical4: tokens.color_base_light_turquoise,
+    categorical5: tokens.color_base_light_orange,
+    categorical6: tokens.color_base_light_avocado
   },
   fontSizes: {
     smaller: tokens.size_font_smaller,

--- a/packages/components/src/theme.type.ts
+++ b/packages/components/src/theme.type.ts
@@ -15,6 +15,12 @@ type Colors = {
   lightGreen: string;
   red: string;
   lightRed: string;
+  categorical1: string;
+  categorical2: string;
+  categorical3: string;
+  categorical4: string;
+  categorical5: string;
+  categorical6: string;
 };
 type ColorsOptions = keyof Colors;
 

--- a/packages/tokens/src/color/base.json
+++ b/packages/tokens/src/color/base.json
@@ -16,7 +16,13 @@
       "red": { "value": "#CC1439" },
       "lightRed": { "value": "#FAE6EA" },
       "yellow": { "value": "#FFBB00" },
-      "lightYellow": { "value": "FCF5E3" }
+      "lightYellow": { "value": "FCF5E3" },
+      "aqua": { "value": "19C4E6" },
+      "purple": { "value": "8033CC" },
+      "pink": { "value": "E372D0" },
+      "turquoise": { "value": "55DDB0" },
+      "orange": { "value": "EE5513" },
+      "avocado": { "value": "D3D322" }
     }
   }
 }


### PR DESCRIPTION
## Description

Adds secondary colours for use in charts and stuff 🌈 

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] If a component was changed, the Chromatic check has run and been approved
- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
