### PR TITLE
fix: TimePicker rerender issue

### DIFF
--- a/packages/components/src/TimePicker/TimePicker.story.js
+++ b/packages/components/src/TimePicker/TimePicker.story.js
@@ -98,10 +98,12 @@ WithCustomDefault.story = {
   name: "with custom default"
 };
 
-export const WithValue = () => {
+const ControlledTimePicker = () => {
   const [value, setValue] = useState("13:43");
   return <TimePicker onChange={setValue} onInputChange={setValue} labelText="End Time" value={value} />;
-};
+}
+
+export const WithValue = () => <ControlledTimePicker />;
 
 WithValue.story = {
   name: "with value"


### PR DESCRIPTION
## Description

The controlled timepicker loses focus when its value is changed because the entire component is rebuilt, this started happening when we added the addon, see related issue here: https://stackoverflow.com/questions/39120494/react-higher-order-component-forces-re-render-of-wrapped-component

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] If a component was changed, the Chromatic check has run and been approved
- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
