### PR TITLE
feat: allow one of the select options to have a value of null

### DIFF
--- a/packages/components/src/Select/Select.story.js
+++ b/packages/components/src/Select/Select.story.js
@@ -546,3 +546,23 @@ export const UsingRefToControlFocus = () => {
 UsingRefToControlFocus.story = {
   name: "using ref to control focus"
 };
+
+
+export const WithANullValue = () => {
+  const optionsWithBlank = [{ value: null, label: "Nullable" }, { value: null, label: "Other null" }, ...options];
+  return (
+    <Select
+      defaultValue={null}
+      placeholder="Please select inventory status"
+      onChange={action("selection changed")}
+      onBlur={action("blurred")}
+      options={optionsWithBlank}
+      labelText="Inventory status"
+      onInputChange={action("typed input value changed")}
+    />
+  );
+};
+
+WithANullValue.story = {
+  name: "with a null value"
+};


### PR DESCRIPTION
Allows a null value for a select option.
Modifies our previous checks that did not allow one the options to be null in the Select component and adds a dev warning for values that are not unique.

## Description

**Include what change you're making, why, and link to any relevant JIRA issues**

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] If a component was changed, the Chromatic check has run and been approved
- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
