### PR TITLE
fix: TruncatedText component should accept spaceProps

### DIFF
--- a/packages/components/src/TruncatedText/TruncatedText.js
+++ b/packages/components/src/TruncatedText/TruncatedText.js
@@ -23,14 +23,14 @@ MaybeTooltip.defaultProps = {
   showTooltip: true
 };
 
-const TruncatedText = ({ children, element, indicator, maxCharacters, showTooltip, tooltipProps }) => {
+const TruncatedText = ({ children, element, indicator, maxCharacters, showTooltip, tooltipProps, ...props }) => {
   const innerText = children;
   const requiresTruncation = innerText.length > maxCharacters;
   const truncatedText = requiresTruncation ? innerText.slice(0, maxCharacters) + indicator : children;
   const hasTooltip = showTooltip && requiresTruncation;
   return (
     <MaybeTooltip showTooltip={hasTooltip} tooltip={innerText} {...tooltipProps}>
-      <StyledWrapper as={element.type} hoverable={hasTooltip} {...element.props}>
+      <StyledWrapper as={element.type} hoverable={hasTooltip} {...element.props} {...props}>
         {truncatedText}
       </StyledWrapper>
     </MaybeTooltip>


### PR DESCRIPTION
## Description

**Include what change you're making, why, and link to any relevant JIRA issues**

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] If a component was changed, the Chromatic check has run and been approved
- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
