### PR TITLE
fix: Add disabled prop to group components

### DIFF
--- a/packages/components/.storybook/nds-theme/index.js
+++ b/packages/components/.storybook/nds-theme/index.js
@@ -21,7 +21,7 @@ export default Component =>
 
       useEffect(() => {
         setLoading(false);
-      });
+      }, [setLoading]);
 
       useEffect(() => {
         channel.on("theme-update", data => {

--- a/packages/components/src/Checkbox/CheckboxGroup.tsx
+++ b/packages/components/src/Checkbox/CheckboxGroup.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled, { CSSObject } from "styled-components";
+import styled from "styled-components";
 import Checkbox from "./Checkbox";
 import { HelpText, RequirementText } from "../FieldLabel";
 import { InlineValidation } from "../Validation";
@@ -31,7 +31,7 @@ const LabelText = styled.span<any>(({ theme }) => ({
 const Legend = styled.legend(({ theme }) => ({
   marginBottom: theme.space.x1
 }));
-type BaseCheckboxGroupProps = {
+interface BaseCheckboxGroupProps {
   errorMessage?: string;
   errorList?: string[];
   labelText: string;
@@ -43,6 +43,7 @@ type BaseCheckboxGroupProps = {
   id?: string;
   helpText?: React.ReactNode;
   requirementText?: string;
+  disabled?: boolean;
 };
 const BaseCheckboxGroup: React.SFC<BaseCheckboxGroupProps> = ({
   className,
@@ -76,7 +77,8 @@ BaseCheckboxGroup.defaultProps = {
   className: undefined,
   id: undefined,
   helpText: undefined,
-  requirementText: undefined
+  requirementText: undefined,
+  disabled: false
 };
 const CheckboxGroup = styled(BaseCheckboxGroup)({});
 export default CheckboxGroup;

--- a/packages/components/src/Radio/RadioGroup.tsx
+++ b/packages/components/src/Radio/RadioGroup.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react";
-import PropTypes from "prop-types";
 import styled, { CSSObject, ThemeContext } from "styled-components";
 
 import Radio from "./Radio";
@@ -34,7 +33,7 @@ const getRadioButtons = (props: any) => {
   return radioButtons;
 };
 
-type BaseRadioGroupProps = {
+interface BaseRadioGroupProps {
   className?: string;
   id?: string;
   errorMessage?: string;
@@ -44,7 +43,8 @@ type BaseRadioGroupProps = {
   requirementText?: string;
   children?: any;
   name?: string;
-};
+  disabled?: boolean;
+}
 
 const BaseRadioGroup = ({
   className,
@@ -81,7 +81,8 @@ BaseRadioGroup.defaultProps = {
   className: undefined,
   id: undefined,
   helpText: null,
-  requirementText: null
+  requirementText: null,
+  default: false
 };
 
 const RadioGroup = styled(BaseRadioGroup)({});


### PR DESCRIPTION
## Description

The disabled prop is used for both the `<CheckboxGroup>` and `<RadioGroup>` components, but was not available in the props interfaces. This was thus causing incorrect TSC issues. This PR corrects that.

NOTE: Related PR for documentation: https://github.com/nulogy/nulogy.design/pull/6

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [x] Docs updated with correct props and examples
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] If a component was changed, the Chromatic check has run and been approved
- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
