### PR TITLE
fix: replace div in TruncatedText with Text component

### DIFF
--- a/src/TruncatedText/TruncatedText.js
+++ b/src/TruncatedText/TruncatedText.js
@@ -4,9 +4,9 @@ import styled from "styled-components";
 import { Tooltip } from "../Tooltip";
 import { Text } from "../Type";
 
-const StyledWrapper = styled("div")(({ hoverable }) => ({
+const StyledWrapper = styled(Text)(({ hoverable }) => ({
   width: "fit-content",
-  cursor: hoverable ? "pointer" : "default"
+  cursor: hoverable ? "pointer" : "default",
 }));
 
 const MaybeTooltip = ({ children, showTooltip, ...props }) => {
@@ -15,22 +15,41 @@ const MaybeTooltip = ({ children, showTooltip, ...props }) => {
 
 MaybeTooltip.propTypes = {
   children: PropTypes.node,
-  showTooltip: PropTypes.bool
+  showTooltip: PropTypes.bool,
 };
 
 MaybeTooltip.defaultProps = {
   children: undefined,
-  showTooltip: true
+  showTooltip: true,
 };
 
-const TruncatedText = ({ children, element, indicator, maxCharacters, showTooltip, tooltipProps, ...props }) => {
+const TruncatedText = ({
+  children,
+  element,
+  indicator,
+  maxCharacters,
+  showTooltip,
+  tooltipProps,
+  ...props
+}) => {
   const innerText = children;
   const requiresTruncation = innerText.length > maxCharacters;
-  const truncatedText = requiresTruncation ? innerText.slice(0, maxCharacters) + indicator : children;
+  const truncatedText = requiresTruncation
+    ? innerText.slice(0, maxCharacters) + indicator
+    : children;
   const hasTooltip = showTooltip && requiresTruncation;
   return (
-    <MaybeTooltip showTooltip={hasTooltip} tooltip={innerText} {...tooltipProps}>
-      <StyledWrapper as={element.type} hoverable={hasTooltip} {...element.props} {...props}>
+    <MaybeTooltip
+      showTooltip={hasTooltip}
+      tooltip={innerText}
+      {...tooltipProps}
+    >
+      <StyledWrapper
+        as={element.type}
+        hoverable={hasTooltip}
+        {...element.props}
+        {...props}
+      >
         {truncatedText}
       </StyledWrapper>
     </MaybeTooltip>
@@ -43,7 +62,7 @@ TruncatedText.propTypes = {
   element: PropTypes.node,
   maxCharacters: PropTypes.number,
   showTooltip: PropTypes.bool,
-  tooltipProps: PropTypes.shape({})
+  tooltipProps: PropTypes.shape({}),
 };
 
 TruncatedText.defaultProps = {
@@ -52,7 +71,7 @@ TruncatedText.defaultProps = {
   element: <Text />,
   maxCharacters: 20,
   showTooltip: true,
-  tooltipProps: undefined
+  tooltipProps: undefined,
 };
 
 export default TruncatedText;


### PR DESCRIPTION
## Description

This fixed the extra div that was being added to around. the truncated text component which may have unexpected layout problems and is not semantically correct.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] If a component was changed, the Chromatic check has run and been approved
- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
