### PR TITLE
fix: @nulogy/icons upgraded to fix error "Can't resolve './assets/ico…

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.9.6",
-    "@nulogy/icons": "^4.1.3",
+    "@nulogy/icons": "^4.10.5",
     "@nulogy/tokens": "^4.9.1",
     "@styled-system/prop-types": "^5.1.4",
     "@styled-system/theme-get": "^5.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1758,10 +1758,10 @@
     eslint-plugin-react-hooks "^4.0.4"
     prettier "^2.0.5"
 
-"@nulogy/icons@^4.1.3":
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/@nulogy/icons/-/icons-4.1.3.tgz#67c3780d11fa99ca6c7f41152f18b803cef016a1"
-  integrity sha512-eD5u2aGETC661ScBbJt5sROKLWbkeY/ZX+3U6lFaN8J4pkkkBCeiaXtzWcmZEiqF2BSQmNFqsh3tCBYfJ8W30Q==
+"@nulogy/icons@^4.10.5":
+  version "4.10.5"
+  resolved "https://registry.yarnpkg.com/@nulogy/icons/-/icons-4.10.5.tgz#17729a9d76cb619db767e1554d95616f317ef0bb"
+  integrity sha512-UnUHubuAaxE8ZgCeYPFHWCbxWjHfZlvl994OexMV0NwJotoYR3Uh39biK7HbSrtmoluDZFKlSWl5QOHJAuvahQ==
   dependencies:
     fs "^0.0.1-security"
     svgi "^1.1.0"


### PR DESCRIPTION
## Description

@nulogy/icons was upgraded to fix error "Can't resolve './assets/icons.json' in '{PATH}/node_modules/@nulogy/components/dist' which arose after breaking apart the monorepo wherever the components package is imported.

relevant work included bundling nds-icons with babel and rollup which we weren't doing when icons lived in the monorepo: 
https://github.com/nulogy/nds-icons/pull/3

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] If a component was changed, the Chromatic check has run and been approved
- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
