### PR TITLE
feat: add onRowMouseLeave onRowMouseEnter events to Table component

### DIFF
--- a/cypress/integration/components/Table.spec.js
+++ b/cypress/integration/components/Table.spec.js
@@ -5,6 +5,8 @@ describe("Table", () => {
   const rowCheckboxInputSelector = "[data-testid='table-body'] [type='checkbox']";
   const rowExpandButtonSelector = "[data-testid='table-body'] [aria-label='Expand row']";
   const rowCollapseButtonSelector = "[data-testid='table-body'] [aria-label='Collapse row']";
+  const tableRowSelector = "[data-testid='table-row']";
+  const dropdownButtonSelector = "[type='button']";
   const getNextPageButton = () => cy.get("[aria-label='Go to next results']");
   const getPreviousPageButton = () => cy.get("[aria-label='Go to previous results']");
   const selectAll = () => cy.get(headerCheckboxSelector);
@@ -14,6 +16,8 @@ describe("Table", () => {
   const paginationButtons = pageNumber => cy.get(`[aria-label='Go to page ${pageNumber}']`);
   const expandButtons = () => cy.get(rowExpandButtonSelector);
   const collapseButtons = () => cy.get(rowCollapseButtonSelector);
+  const dropdownButtons = () => cy.get(dropdownButtonSelector);
+  const tableRows = () => cy.get(tableRowSelector);
 
   const selectableRowsTests = storyName => {
     beforeEach(() => {
@@ -193,6 +197,24 @@ describe("Table", () => {
         .should("be.disabled");
       paginationButtons(2).should("exist");
       paginationButtons(3).should("not.exist");
+    });
+  });
+  describe("hover actions", () => {
+    beforeEach(() => {
+      cy.renderFromStorybook("table--with-on-hover-actions");
+    });
+    it("shows the dropdown on hover", () => {
+      dropdownButtons().should("not.exist");
+      tableRows().first().should("not.have.descendants", dropdownButtonSelector);
+      tableRows().first().trigger('mouseover');
+      dropdownButtons().should("exist");
+    });
+    it("dropdown is shown on row that is hovered", () => {
+      tableRows().first().trigger('mouseover');
+      tableRows().first().find(dropdownButtonSelector).should("exist");
+      tableRows().eq(3).trigger('mouseover');
+      tableRows().first().find(dropdownButtonSelector).should("not.exist");
+      tableRows().eq(3).find(dropdownButtonSelector).should("exist");
     });
   });
 });

--- a/src/Table/BaseTable.tsx
+++ b/src/Table/BaseTable.tsx
@@ -3,13 +3,13 @@ import styled from "styled-components";
 import TableHead from "./TableHead";
 import TableBody from "./TableBody";
 import TableFoot from "./TableFoot";
-const StyledTable = styled.table({
+const StyledTable = styled.table<any>({
   borderCollapse: "collapse",
   width: "100%",
   background: "white",
   position: "relative"
 });
-type BaseTableProps = {
+type BaseTableProps = React.ComponentProps<"table"> & {
   columns: any;
   rows: any;
   noRowsContent?: string;
@@ -21,6 +21,8 @@ type BaseTableProps = {
   compact?: boolean;
   className?: string;
   stickyHeader?: boolean;
+  onRowMouseEnter?: an
+  onRowMouseLeave?: any;
 };
 const BaseTable: React.SFC<BaseTableProps> = ({
   columns,
@@ -33,9 +35,12 @@ const BaseTable: React.SFC<BaseTableProps> = ({
   rowHovers,
   compact,
   className,
-  stickyHeader
+  stickyHeader,
+  onRowMouseEnter,
+  onRowMouseLeave,
+  ...props
 }) => (
-  <StyledTable id={id} className={className}>
+  <StyledTable id={id} className={className} {...props}>
     <TableHead columns={columns} compact={compact} sticky={stickyHeader} />
     <TableBody
       columns={columns}
@@ -45,6 +50,8 @@ const BaseTable: React.SFC<BaseTableProps> = ({
       loading={loading}
       rowHovers={rowHovers}
       compact={compact}
+      onRowMouseLeave={onRowMouseLeave}
+      onRowMouseEnter={onRowMouseEnter}
     />
     {footerRows && <TableFoot columns={columns} rows={footerRows} keyField={keyField} loading={loading} />}
   </StyledTable>
@@ -58,6 +65,8 @@ BaseTable.defaultProps = {
   rowHovers: true,
   compact: false,
   className: undefined,
-  stickyHeader: false
+  stickyHeader: false,
+  onRowMouseEnter: () => { },
+  onRowMouseLeave: () => { },
 };
 export default BaseTable;

--- a/src/Table/BaseTable.tsx
+++ b/src/Table/BaseTable.tsx
@@ -21,7 +21,7 @@ type BaseTableProps = React.ComponentProps<"table"> & {
   compact?: boolean;
   className?: string;
   stickyHeader?: boolean;
-  onRowMouseEnter?: an
+  onRowMouseEnter?: any;
   onRowMouseLeave?: any;
 };
 const BaseTable: React.SFC<BaseTableProps> = ({

--- a/src/Table/Table.spec.js
+++ b/src/Table/Table.spec.js
@@ -2,10 +2,10 @@ import React from "react";
 import { fireEvent } from "@testing-library/react";
 
 import { Pagination } from "../Pagination";
-import { Table } from ".";
-import { mockColumns, getMockRows, getMockColumns } from "./Table.mock-utils";
 import { renderWithNDSProvider } from "../NDSProvider/renderWithNDSProvider.spec-utils";
 import { mountWithNDSProvider } from "../NDSProvider/mountWithNDSProvider.spec-utils";
+import { mockColumns, getMockRows, getMockColumns } from "./Table.mock-utils";
+import { Table } from ".";
 
 describe("Table", () => {
   describe("row selections", () => {
@@ -16,7 +16,13 @@ describe("Table", () => {
         const callback = jest.fn();
 
         const { container } = renderWithNDSProvider(
-          <Table columns={columns} rows={rowData} hasSelectableRows keyField="c1" onRowSelectionChange={callback} />
+          <Table
+            columns={columns}
+            rows={rowData}
+            hasSelectableRows
+            keyField="c1"
+            onRowSelectionChange={callback}
+          />
         );
 
         fireEvent.click(container.querySelectorAll("input")[1]);
@@ -29,7 +35,13 @@ describe("Table", () => {
         const callback = jest.fn();
 
         const { container } = renderWithNDSProvider(
-          <Table columns={columns} rows={rowData} hasSelectableRows keyField="c1" onRowSelectionChange={callback} />
+          <Table
+            columns={columns}
+            rows={rowData}
+            hasSelectableRows
+            keyField="c1"
+            onRowSelectionChange={callback}
+          />
         );
 
         fireEvent.click(container.querySelectorAll("input")[0]);
@@ -49,17 +61,28 @@ describe("Table", () => {
             c2: "r1c2",
             c3: "2019-09-21",
             id: "2",
-            expandedContent
+            expandedContent,
           },
           { c1: "r2c1", c2: "r2c2", c3: "2019-09-22", id: "3" },
           { c1: "r3c1", c2: "r2c2", c3: "2019-09-22", id: "4" },
-          { c1: "r4c1", c2: "r2c2", c3: "2019-09-22", id: "6", expandedContent },
-          { c1: "r5c1", c2: "r2c2", c3: "2019-09-22", id: "7" }
+          {
+            c1: "r4c1",
+            c2: "r2c2",
+            c3: "2019-09-22",
+            id: "6",
+            expandedContent,
+          },
+          { c1: "r5c1", c2: "r2c2", c3: "2019-09-22", id: "7" },
         ];
         const callback = jest.fn();
 
         const { container } = renderWithNDSProvider(
-          <Table columns={getMockColumns(3)} rows={rowData} hasExpandableRows onRowExpansionChange={callback} />
+          <Table
+            columns={getMockColumns(3)}
+            rows={rowData}
+            hasExpandableRows
+            onRowExpansionChange={callback}
+          />
         );
 
         fireEvent.click(container.querySelectorAll("button")[0]);
@@ -74,17 +97,28 @@ describe("Table", () => {
             c2: "r1c2",
             c3: "2019-09-21",
             id: "2",
-            expandedContent
+            expandedContent,
           },
           { c1: "r2c1", c2: "r2c2", c3: "2019-09-22", id: "3" },
           { c1: "r3c1", c2: "r2c2", c3: "2019-09-22", id: "4" },
-          { c1: "r4c1", c2: "r2c2", c3: "2019-09-22", id: "6", expandedContent },
-          { c1: "r5c1", c2: "r2c2", c3: "2019-09-22", id: "7" }
+          {
+            c1: "r4c1",
+            c2: "r2c2",
+            c3: "2019-09-22",
+            id: "6",
+            expandedContent,
+          },
+          { c1: "r5c1", c2: "r2c2", c3: "2019-09-22", id: "7" },
         ];
         const callback = jest.fn();
 
         const { container } = renderWithNDSProvider(
-          <Table columns={getMockColumns(3)} rows={rowData} hasExpandableRows onRowExpansionChange={callback} />
+          <Table
+            columns={getMockColumns(3)}
+            rows={rowData}
+            hasExpandableRows
+            onRowExpansionChange={callback}
+          />
         );
 
         fireEvent.click(container.querySelectorAll("button")[1]);
@@ -111,11 +145,8 @@ describe("Table", () => {
             onPageChange={pageChangeCallback}
           />
         );
-        const onClickPage = pageNum => {
-          wrapper
-            .find("button")
-            .at(pageNum)
-            .simulate("click");
+        const onClickPage = (pageNum) => {
+          wrapper.find("button").at(pageNum).simulate("click");
         };
         expect(pageChangeCallback).not.toHaveBeenCalled();
         onClickPage(3);
@@ -159,7 +190,13 @@ describe("Table", () => {
       });
       it("renders the inner Pagination with correct props", () => {
         const wrapper = mountWithNDSProvider(
-          <Table columns={mockColumns} rows={getMockRows(20)} hasSelectableRows keyField="c1" rowsPerPage={6} />
+          <Table
+            columns={mockColumns}
+            rows={getMockRows(20)}
+            hasSelectableRows
+            keyField="c1"
+            rowsPerPage={6}
+          />
         );
         const pagination = wrapper.find(Pagination);
         expect(pagination.length).toEqual(1);
@@ -168,7 +205,12 @@ describe("Table", () => {
       });
       it("does not display pagination when rowsPerPage is falsy", () => {
         const wrapper = mountWithNDSProvider(
-          <Table columns={mockColumns} rows={getMockRows(20)} hasSelectableRows keyField="c1" />
+          <Table
+            columns={mockColumns}
+            rows={getMockRows(20)}
+            hasSelectableRows
+            keyField="c1"
+          />
         );
         const pagination = wrapper.find(Pagination);
         const rows = wrapper.find("tbody tr");
@@ -180,7 +222,12 @@ describe("Table", () => {
   describe("loading", () => {
     it("shows only loading text when loading", () => {
       const wrapper = mountWithNDSProvider(
-        <Table columns={mockColumns} rows={getMockRows(20)} hasSelectableRows loading />
+        <Table
+          columns={mockColumns}
+          rows={getMockRows(20)}
+          hasSelectableRows
+          loading
+        />
       );
       const rows = wrapper.find("tbody tr");
       const loadingCell = wrapper.find("tbody tr td");
@@ -190,12 +237,61 @@ describe("Table", () => {
     it("shows rows when not loading", () => {
       const rowData = getMockRows(20);
       const wrapper = mountWithNDSProvider(
-        <Table columns={mockColumns} rows={rowData} hasSelectableRows loading={false} />
+        <Table
+          columns={mockColumns}
+          rows={rowData}
+          hasSelectableRows
+          loading={false}
+        />
       );
       const rows = wrapper.find("tbody tr");
       const cell = wrapper.find("tbody tr td");
       expect(cell.at(0).text()).not.toEqual("Loading...");
       expect(rows.length).toEqual(20);
+    });
+  });
+  describe("row hovers", () => {
+    describe("onRowMouseEnter", () => {
+      it("is called with the row when mouse enters a row", () => {
+        const columns = [{ label: "Column 1", dataKey: "c1" }];
+        const rowData = [{ c1: "r1c1" }, { c1: "r2c1" }];
+        const callback = jest.fn();
+
+        const { getAllByTestId } = renderWithNDSProvider(
+          <Table
+            columns={columns}
+            rows={rowData}
+            keyField="c1"
+            onRowMouseEnter={callback}
+          />
+        );
+
+
+        fireEvent.mouseEnter(getAllByTestId("table-row")[1]);
+
+        expect(callback).toHaveBeenCalled();
+      });
+    });
+  });
+  describe("row hovers", () => {
+    describe("onRowMouseLeave", () => {
+      it("is called with the row when mouse leaves a row", () => {
+        const columns = [{ label: "Column 1", dataKey: "c1" }];
+        const rowData = [{ c1: "r1c1" }, { c1: "r2c1" }];
+        const callback = jest.fn();
+
+        const { getAllByTestId } = renderWithNDSProvider(
+          <Table
+            columns={columns}
+            rows={rowData}
+            keyField="c1"
+            onRowMouseLeave={callback}
+          />
+        );
+
+        fireEvent.mouseLeave(getAllByTestId("table-row")[1]);
+        expect(callback).toHaveBeenCalled();
+      });
     });
   });
 });

--- a/src/Table/Table.story.js
+++ b/src/Table/Table.story.js
@@ -2,15 +2,12 @@
 import React from "react";
 import { action } from "@storybook/addon-actions";
 import { withKnobs, boolean, number } from "@storybook/addon-knobs";
-import { Table } from ".";
+import { useState } from "react";
 import { Box, DropdownButton, DropdownMenu, Text } from "..";
+import { Table } from ".";
 
 const dateToString = ({ cellData }) => {
-  return new Date(cellData)
-    .toUTCString()
-    .split(" ")
-    .splice(0, 4)
-    .join(" ");
+  return new Date(cellData).toUTCString().split(" ").splice(0, 4).join(" ");
 };
 
 const sectionRow = ({ cellData }) => (
@@ -29,19 +26,21 @@ const expandedContent = () => (
   </Box>
 );
 
-const dropdownCellRenderer = ({ cellData }) => (
-  <Box textAlign="right" pr="x3">
-    <DropdownMenu>
-      <DropdownButton onClick={action(cellData)}>Edit</DropdownButton>
-      <DropdownButton onClick={action(cellData)}>Delete</DropdownButton>
-    </DropdownMenu>
-  </Box>
-);
+const dropdownCellRenderer = ({ cellData }) => {
+  return (
+    <Box textAlign="right" pr="x3">
+      <DropdownMenu>
+        <DropdownButton onClick={action(cellData)}>Edit</DropdownButton>
+        <DropdownButton onClick={action(cellData)}>Delete</DropdownButton>
+      </DropdownMenu>
+    </Box>
+  );
+};
 
 const columns = [
   { label: "Date", dataKey: "date" },
   { label: "Expected Quantity", dataKey: "expectedQuantity" },
-  { label: "Actual Quantity", dataKey: "actualQuantity" }
+  { label: "Actual Quantity", dataKey: "actualQuantity" },
 ];
 
 const columnsWithEverything = [
@@ -49,7 +48,12 @@ const columnsWithEverything = [
   { label: "Expected Quantity", dataKey: "expectedQuantity", width: "20%" },
   { label: "Actual Quantity", dataKey: "actualQuantity", width: "20%" },
   { label: "Note", dataKey: "note", width: "45%" },
-  { label: "", dataKey: "actions", width: "5%", cellRenderer: dropdownCellRenderer }
+  {
+    label: "",
+    dataKey: "actions",
+    width: "5%",
+    cellRenderer: dropdownCellRenderer,
+  },
 ];
 
 const rowData = [
@@ -57,37 +61,57 @@ const rowData = [
     date: "2019-10-01",
     expectedQuantity: "2,025 eaches",
     actualQuantity: "1,800 eaches",
-    id: "r1"
+    id: "r1",
   },
   {
     date: "2019-10-02",
     expectedQuantity: "2,475 eaches",
     actualQuantity: "2,250 eaches",
-    id: "r2"
+    id: "r2",
   },
   {
     date: "2019-10-03",
     expectedQuantity: "2,475 eaches",
     actualQuantity: "1,425 eaches",
-    id: "r3"
+    id: "r3",
   },
-  { date: "2019-10-04", expectedQuantity: "2,475 eaches", actualQuantity: "675 eaches", id: "r4" },
+  {
+    date: "2019-10-04",
+    expectedQuantity: "2,475 eaches",
+    actualQuantity: "675 eaches",
+    id: "r4",
+  },
   {
     date: "2019-10-07",
     expectedQuantity: "2,475 eaches",
     actualQuantity: "1,575 eaches",
-    id: "r5"
+    id: "r5",
   },
-  { date: "2019-10-22", expectedQuantity: "1,725 eaches", actualQuantity: "-", id: "r7" },
-  { date: "2019-10-23", expectedQuantity: "2,475 eaches", actualQuantity: "-", id: "r8" },
-  { date: "2019-10-24", expectedQuantity: "2,475 eaches", actualQuantity: "-", id: "r9" }
+  {
+    date: "2019-10-22",
+    expectedQuantity: "1,725 eaches",
+    actualQuantity: "-",
+    id: "r7",
+  },
+  {
+    date: "2019-10-23",
+    expectedQuantity: "2,475 eaches",
+    actualQuantity: "-",
+    id: "r8",
+  },
+  {
+    date: "2019-10-24",
+    expectedQuantity: "2,475 eaches",
+    actualQuantity: "-",
+    id: "r9",
+  },
 ];
 
 const rowDataWithEverything = [
   {
     heading: "ABC & XYZ Company",
     cellRenderer: sectionRow,
-    id: "r1"
+    id: "r1",
   },
   {
     date: "2019-10-01",
@@ -96,53 +120,77 @@ const rowDataWithEverything = [
     id: "r2",
     expandedContent,
     selectAriaLabel: "select item 12",
-    deselectAriaLabel: "deselect item 12"
+    deselectAriaLabel: "deselect item 12",
   },
   {
     date: "2019-10-02",
     expectedQuantity: "2,475 eaches",
     actualQuantity: "2,250 eaches",
-    id: "r3"
+    id: "r3",
   },
   {
     date: "2019-10-03",
     expectedQuantity: "2,475 eaches",
     actualQuantity: "1,425 eaches",
-    id: "r4"
+    id: "r4",
   },
   {
     date: "2019-10-04",
     expectedQuantity: "2,475 eaches",
     actualQuantity: "675 eaches",
     note: "1c Other Plant-related issue, equipment issues",
-    id: "r5"
+    id: "r5",
   },
   {
     date: "2019-10-07",
     expectedQuantity: "2,475 eaches",
     actualQuantity: "1,575 eaches",
-    id: "r6"
+    id: "r6",
   },
-  { date: "2019-10-22", expectedQuantity: "1,725 eaches", actualQuantity: "-", id: "r7" },
+  {
+    date: "2019-10-22",
+    expectedQuantity: "1,725 eaches",
+    actualQuantity: "-",
+    id: "r7",
+  },
   { heading: "And Another Company", cellRenderer: sectionRow, id: "r8" },
   {
     date: "2019-10-23",
     expectedQuantity: "2,475 eaches",
     actualQuantity: "-",
     id: "r9",
-    expandedContent
+    expandedContent,
   },
-  { date: "2019-10-24", expectedQuantity: "2,475 eaches", actualQuantity: "-", id: "r10" },
-  { date: "2020-01-24", expectedQuantity: { value: 2475, unit: "eaches" }, id: "r11" }
+  {
+    date: "2019-10-24",
+    expectedQuantity: "2,475 eaches",
+    actualQuantity: "-",
+    id: "r10",
+  },
+  {
+    date: "2020-01-24",
+    expectedQuantity: { value: 2475, unit: "eaches" },
+    id: "r11",
+  },
 ];
 
 const footerRowData = [
-  { date: "Total", expectedQuantity: "18,000 eaches", actualQuantity: "7,725 eaches", id: "f1" },
-  { date: "Attainment", expectedQuantity: "", actualQuantity: "41.5%", id: "f2" }
+  {
+    date: "Total",
+    expectedQuantity: "18,000 eaches",
+    actualQuantity: "7,725 eaches",
+    id: "f1",
+  },
+  {
+    date: "Attainment",
+    expectedQuantity: "",
+    actualQuantity: "41.5%",
+    id: "f2",
+  },
 ];
 
 export default {
-  title: "Components/Table"
+  title: "Components/Table",
 };
 
 export const WithPagination = () => (
@@ -156,7 +204,7 @@ export const WithPagination = () => (
 );
 
 WithPagination.story = {
-  name: "with pagination"
+  name: "with pagination",
 };
 
 export const WithEverything = () => (
@@ -171,9 +219,160 @@ export const WithEverything = () => (
     onRowSelectionChange={action("row selection changed")}
     onPageChange={action("page changed")}
     className="Table"
+    onRowMouseEnter={action("row mouse enter")}
+    onRowMouseLeave={action("row mouse leave")}
   />
 );
 
 WithEverything.story = {
-  name: "with everything"
+  name: "with everything",
+};
+
+export const WithOnHoverActions = () => {
+  const rowDataWithHovers = [
+    {
+      date: "2019-10-01",
+      expectedQuantity: "2,025 eaches",
+      actualQuantity: "1,800 eaches",
+      id: "r1",
+    },
+    {
+      date: "2019-10-01",
+      expectedQuantity: "2,025 eaches",
+      actualQuantity: "1,800 eaches",
+      id: "r2",
+    },
+    {
+      date: "2019-10-02",
+      expectedQuantity: "2,475 eaches",
+      actualQuantity: "2,250 eaches",
+      id: "r3"
+    },
+    {
+      date: "2019-10-03",
+      expectedQuantity: "2,475 eaches",
+      actualQuantity: "1,425 eaches",
+      id: "r4"
+    },
+    {
+      date: "2019-10-04",
+      expectedQuantity: "2,475 eaches",
+      actualQuantity: "675 eaches",
+      note: "1c Other Plant-related issue, equipment issues",
+      id: "r5",
+    },
+    {
+      date: "2019-10-07",
+      expectedQuantity: "2,475 eaches",
+      actualQuantity: "1,575 eaches",
+      id: "r6",
+    },
+    {
+      date: "2019-10-22",
+      expectedQuantity: "1,725 eaches",
+      actualQuantity: "-",
+      id: "r7",
+    },
+    {
+      date: "2019-10-23",
+      expectedQuantity: "2,475 eaches",
+      actualQuantity: "-",
+      id: "r8",
+    },
+    {
+      date: "2019-10-23",
+      expectedQuantity: "2,475 eaches",
+      actualQuantity: "-",
+      id: "r9",
+    },
+    {
+      date: "2019-10-24",
+      expectedQuantity: "2,475 eaches",
+      actualQuantity: "-",
+      id: "r10",
+    },
+    {
+      date: "2019-10-23",
+      expectedQuantity: "2,475 eaches",
+      actualQuantity: "-",
+      id: "r11",
+    },
+    {
+      date: "2019-10-23",
+      expectedQuantity: "2,475 eaches",
+      actualQuantity: "-",
+      id: "r12",
+    },
+    {
+      date: "2019-10-24",
+      expectedQuantity: "2,475 eaches",
+      actualQuantity: "-",
+      id: "r13",
+    },
+    {
+      date: "2019-10-24",
+      expectedQuantity: "2,475 eaches",
+      actualQuantity: "-",
+      id: "r14",
+    },
+    {
+      date: "2019-10-24",
+      expectedQuantity: "2,475 eaches",
+      actualQuantity: "-",
+      id: "r15",
+    },
+  ];
+  const dropdownCellRendererWithHover = ({ cellData, row }) => {
+    return (
+      <Box textAlign="right" pr="x3" width="40px">
+        {row.id === hoveredRow && (
+          <DropdownMenu>
+            <DropdownButton onClick={action(cellData)}>Edit</DropdownButton>
+            <DropdownButton onClick={action(cellData)}>Delete</DropdownButton>
+          </DropdownMenu>
+        )}
+      </Box>
+    );
+  };
+  const columnsWithHovers = [
+    {
+      label: "Date",
+      dataKey: "date",
+      cellFormatter: dateToString,
+      width: "15%",
+    },
+    { label: "Expected Quantity", dataKey: "expectedQuantity", width: "20%" },
+    { label: "Actual Quantity", dataKey: "actualQuantity", width: "20%" },
+    { label: "Note", dataKey: "note", width: "45%" },
+    {
+      label: "",
+      dataKey: "actions",
+      width: "100px",
+      cellRenderer: dropdownCellRendererWithHover,
+    },
+  ];
+  const [hoveredRow, setHoveredRow] = useState(null);
+  const onMouseEnter = ({ row }) => {
+    setHoveredRow(row.id);
+  };
+  const onMouseLeave = () => {
+    setHoveredRow(null);
+  };
+  return (
+    <Table
+      columns={columnsWithHovers}
+      rows={rowDataWithHovers}
+      footerRows={footerRowData}
+      hasSelectableRows={boolean("Selectable", true)}
+      onRowSelectionChange={action("row selection changed")}
+      className="Table"
+      onRowMouseEnter={onMouseEnter}
+      onRowMouseLeave={onMouseLeave}
+      onMouseLeave={onMouseLeave}
+    />
+  );
+};
+
+WithOnHoverActions.story = {
+  name: "with hover actions",
 };

--- a/src/Table/TableBody.tsx
+++ b/src/Table/TableBody.tsx
@@ -12,7 +12,7 @@ const StyledMessageContainer = styled(Box)(({ theme }) => ({
   color: theme.colors.darkGrey
 }));
 
-type StyledTrProps = {
+type StyledTrProps = React.ComponentProps<"tr"> & {
   rowHovers?: boolean;
   theme?: ThemeType;
   className?: string;
@@ -24,7 +24,7 @@ const StyledTr: React.SFC<StyledTrProps> = styled.tr(({ rowHovers, theme }: Styl
   }
 }));
 
-const renderRows = (rows, columns, keyField, noRowsContent, rowHovers, compact) =>
+const renderRows = (rows, columns, keyField, noRowsContent, rowHovers, compact, onRowMouseLeave, onRowMouseEnter) =>
   rows.length > 0 ? (
     rows.map(row => (
       <TableBodyRow
@@ -35,6 +35,8 @@ const renderRows = (rows, columns, keyField, noRowsContent, rowHovers, compact) 
         rowHovers={rowHovers}
         compact={compact}
         rowClassName={row.rowClassName}
+        onMouseEnter={(e) => onRowMouseEnter({ row, e })}
+        onMouseLeave={(e) => onRowMouseLeave({row, e})}
       />
     ))
   ) : (
@@ -48,16 +50,18 @@ type TableBodyRowProps = {
   compact?: boolean;
   rowClassName?: string;
   keyField?: string;
+  onMouseEnter?: any;
+  onMouseLeave?: any;
 };
 
-const TableBodyRow = ({ row, columns, rowHovers, compact, rowClassName }: TableBodyRowProps) => {
+const TableBodyRow = ({ row, columns, rowHovers, compact, rowClassName, onMouseLeave, onMouseEnter }: TableBodyRowProps) => {
   const renderAllCells = () =>
     columns.map(column => (
       <TableCell key={column.dataKey} row={row} column={column} cellData={row[column.dataKey]} compact={compact} />
     ));
   return (
     <>
-      <StyledTr rowHovers={rowHovers} data-testid="table-row" className={rowClassName}>
+      <StyledTr rowHovers={rowHovers} data-testid="table-row" className={rowClassName} onMouseLeave={onMouseLeave} onMouseEnter={onMouseEnter}>
         {row.heading ? (
           <TableCell row={row} colSpan={columns.length} cellData={row.heading} compact={compact} />
         ) : (
@@ -112,12 +116,14 @@ type TableBodyProps = {
   loading?: boolean;
   rowHovers?: boolean;
   compact?: boolean;
+  onRowMouseLeave?: any;
+  onRowMouseEnter?: any;
 };
 
-const TableBody = ({ rows, columns, keyField, noRowsContent, loading, rowHovers, compact }: TableBodyProps) => (
+const TableBody = ({ rows, columns, keyField, noRowsContent, loading, rowHovers, compact, onRowMouseLeave, onRowMouseEnter }: TableBodyProps) => (
   <tbody data-testid="table-body">
     {!loading ? (
-      renderRows(rows, columns, keyField, noRowsContent, rowHovers, compact)
+      renderRows(rows, columns, keyField, noRowsContent, rowHovers, compact, onRowMouseLeave, onRowMouseEnter)
     ) : (
       <LoadingContent colSpan={columns.length} />
     )}


### PR DESCRIPTION
## Description

Adds onRowMouseLeave and Enter events to capture hover actions and,  for example, show additional buttons.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [x] Storybook updated with examples of new functionality
- [x] Storybook uses variable and realistic data (ex: short and long text)
- [] Docs updated with correct props and examples
- [x] e2e tests added for component iterations
- [x] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] If a component was changed, the Chromatic check has run and been approved
- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
