### PR TITLE
fix: removes node engine version requirement from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "component library"
   ],
   "engines": {
-    "node": "^12.16.3",
     "yarn": "^1.17.3"
   },
   "main": "dist/main.js",


### PR DESCRIPTION
## Description

**Include what change you're making, why, and link to any relevant JIRA issues**
Removing the node engine version requirement from `package.json`. NDS libraries are not dependent on the node version and this removes the need for consumers of NDS to be forced to upgrade their local node versions.

## Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] If a component was changed, the Chromatic check has run and been approved
- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
