### PR TITLE
feat: Add features uncovered from eco capacity management work 

### DIFF
--- a/cypress/integration/components/TruncatedText.spec.js
+++ b/cypress/integration/components/TruncatedText.spec.js
@@ -73,4 +73,18 @@ describe("TruncatedText", () => {
       assertText("Special instructions...", "h1");
     });
   });
+  describe("with fillWidth setting", () => {
+    beforeEach(() => {
+      cy.renderFromStorybook("truncatedtext--fill-width");
+    });
+    it("shows the tooltip when there is overflow", () => {
+      cy.get("[data-testid='truncated-text']").first().trigger('mouseover');
+      cy.get('[role="tooltip"]').contains("Special instructions are truncated because there is not enough space to show them.");
+    });
+    it("doesn't show a tooltip when there's no overflow", () => {
+      cy.get("[data-testid='truncated-text']").eq(1).trigger('mouseover');
+      cy.get('[role="tooltip"]').should("not.exist");
+      cy.get("[data-testid='truncated-text']").contains("Instructions fit here.");
+    });
+  });
 });

--- a/cypress/integration/components/TruncatedText.spec.js
+++ b/cypress/integration/components/TruncatedText.spec.js
@@ -84,7 +84,7 @@ describe("TruncatedText", () => {
     it("doesn't show a tooltip when there's no overflow", () => {
       cy.get("[data-testid='truncated-text']").eq(1).trigger('mouseover');
       cy.get('[role="tooltip"]').should("not.exist");
-      cy.get("[data-testid='truncated-text']").contains("Instructions fit here.");
+      cy.get("[data-testid='truncated-text']").eq(1).contains("Instructions fit here.");
     });
   });
 });

--- a/src/Box/Box.story.js
+++ b/src/Box/Box.story.js
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useState } from "react";
+import { Button } from "../Button";
 import { Box } from "../index";
 
 export default {
@@ -138,4 +139,27 @@ export const WithABackgroundImage = () => (
 
 WithABackgroundImage.story = {
   name: "With a background image",
+};
+
+export const WithTransition = () => {
+  const [slideOver, setSlideOver] = useState(false);
+
+  return (
+    <>
+      <Box
+        p="x1"
+        mb="x2"
+        bg="red"
+        transition="transform 0.5s linear"
+        transform={`translateX(${slideOver ? "50" : "0"}%)`}
+      >
+        Gradient
+      </Box>
+      <Button onClick={() => setSlideOver(!slideOver)}>Slide!</Button>
+    </>
+  );
+};
+
+WithTransition.story = {
+  name: "With transition",
 };

--- a/src/Box/Box.story.js
+++ b/src/Box/Box.story.js
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
-import { Button } from "../Button";
+import React from "react";
+import styled from "styled-components";
 import { Box } from "../index";
 
 export default {
@@ -140,26 +140,47 @@ export const WithABackgroundImage = () => (
 WithABackgroundImage.story = {
   name: "With a background image",
 };
+const HoverableBox = styled(Box)({
+  ":hover": {
+    backgroundColor: "blue",
+  },
+});
 
-export const WithTransition = () => {
-  const [slideOver, setSlideOver] = useState(false);
+export const WithHoverTransition = () => (
+  <HoverableBox
+    p="x1"
+    mb="x2"
+    bg="red"
+    marginLeft="50px"
+    mt="50px"
+    color="white"
+    height="40px"
+    width="200px"
+    transition="background-color 0.5s linear"
+  >
+    Transition
+  </HoverableBox>
+);
 
-  return (
-    <>
-      <Box
-        p="x1"
-        mb="x2"
-        bg="red"
-        transition="transform 0.5s linear"
-        transform={`translateX(${slideOver ? "50" : "0"}%)`}
-      >
-        Gradient
-      </Box>
-      <Button onClick={() => setSlideOver(!slideOver)}>Slide!</Button>
-    </>
-  );
+WithHoverTransition.story = {
+  name: "With hover transition",
 };
+export const WithTransform = () => (
+  <Box
+    p="x1"
+    mb="x2"
+    bg="red"
+    marginLeft="50px"
+    mt="50px"
+    color="white"
+    height="40px"
+    width="200px"
+    transform="rotate(90deg)"
+  >
+    Rotated
+  </Box>
+);
 
-WithTransition.story = {
-  name: "With transition",
+WithTransform.story = {
+  name: "with transform",
 };

--- a/src/Box/Box.tsx
+++ b/src/Box/Box.tsx
@@ -21,9 +21,11 @@ import {
   BorderProps,
   FlexboxProps,
   BackgroundProps,
+  system,
 
 } from "styled-system";
-import { HTMLAttributes } from "react";
+import { transition, TransitionProps } from '../StyledProps/transition';
+import { transform, TransformProps } from "../StyledProps/transform";
 
 export type BoxProps = ColorProps &
   SpaceProps &
@@ -36,6 +38,8 @@ export type BoxProps = ColorProps &
   BorderProps &
   FlexboxProps &
   BackgroundProps &
+  TransformProps &
+  TransitionProps &
   React.ComponentPropsWithRef<"div"> & {
     as?: string;
   };
@@ -50,7 +54,9 @@ const Box: React.SFC<BoxProps> = styled.div(
   order,
   flexGrow,
   position,
-  background
+  background,
+  transition,
+  transform,
 );
 
 export default Box;

--- a/src/Box/Box.tsx
+++ b/src/Box/Box.tsx
@@ -26,6 +26,7 @@ import {
 } from "styled-system";
 import { transition, TransitionProps } from '../StyledProps/transition';
 import { transform, TransformProps } from "../StyledProps/transform";
+import { CursorProps, cursor } from '../StyledProps/cursor';
 
 export type BoxProps = ColorProps &
   SpaceProps &
@@ -40,6 +41,7 @@ export type BoxProps = ColorProps &
   BackgroundProps &
   TransformProps &
   TransitionProps &
+  CursorProps &
   React.ComponentPropsWithRef<"div"> & {
     as?: string;
   };
@@ -57,6 +59,7 @@ const Box: React.SFC<BoxProps> = styled.div(
   background,
   transition,
   transform,
+  cursor,
 );
 
 export default Box;

--- a/src/StyledProps/cursor.ts
+++ b/src/StyledProps/cursor.ts
@@ -1,0 +1,9 @@
+import { system } from 'styled-system';
+
+export type CursorProps = {
+  cursor?: "string"
+};
+
+export const cursor = system({
+  cursor: true
+});

--- a/src/StyledProps/textOverflow.ts
+++ b/src/StyledProps/textOverflow.ts
@@ -1,0 +1,11 @@
+import { system } from 'styled-system';
+
+export type TextOverflowProps = {
+  whiteSpace?: "normal" | "nowrap" | "pre" | "pre-line" | "pre-wrap" | "initial" | "inherit",
+  textOverflow?: "clip" | "ellipsis" | "string" | "initial" | "inherit",
+};
+
+export const textOverflow = system({
+  whiteSpace: true,
+  textOverflow: true,
+});

--- a/src/StyledProps/transform.ts
+++ b/src/StyledProps/transform.ts
@@ -1,7 +1,7 @@
 import { system } from "styled-system";
 
 export type TransformProps = {
-  transform: string
+  transform?: string
 }
 
 export const transform = system({

--- a/src/StyledProps/transform.ts
+++ b/src/StyledProps/transform.ts
@@ -1,0 +1,9 @@
+import { system } from "styled-system";
+
+export type TransformProps = {
+  transform: string
+}
+
+export const transform = system({
+  transform: true,
+});

--- a/src/StyledProps/transition.ts
+++ b/src/StyledProps/transition.ts
@@ -1,11 +1,11 @@
 import { system } from "styled-system";
 
 export type TransitionProps = {
-  transition: string,
-  transitionProperty: string;
-  transitonDuration: string;
-  transitionTimingFunction: string;
-  transitionDelay: string;
+  transition?: string,
+  transitionProperty?: string;
+  transitonDuration?: string;
+  transitionTimingFunction?: string;
+  transitionDelay?: string;
 }
 
 export const transition = system({

--- a/src/StyledProps/transition.ts
+++ b/src/StyledProps/transition.ts
@@ -1,0 +1,17 @@
+import { system } from "styled-system";
+
+export type TransitionProps = {
+  transition: string,
+  transitionProperty: string;
+  transitonDuration: string;
+  transitionTimingFunction: string;
+  transitionDelay: string;
+}
+
+export const transition = system({
+  transition: true,
+  transitionProperty: true,
+  transitionDuration: true,
+  transitionTimingFunction: true,
+  transitionDelay: true,
+});

--- a/src/TruncatedText/TruncatedText.js
+++ b/src/TruncatedText/TruncatedText.js
@@ -1,13 +1,7 @@
-import React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
-import styled from "styled-components";
 import { Tooltip } from "../Tooltip";
-import { Text } from "../Type";
-
-const StyledWrapper = styled(Text)(({ hoverable }) => ({
-  width: "fit-content",
-  cursor: hoverable ? "pointer" : "default",
-}));
+import { Text } from "../Type";;
 
 const MaybeTooltip = ({ children, showTooltip, ...props }) => {
   return showTooltip ? <Tooltip {...props}>{children}</Tooltip> : children;
@@ -23,7 +17,46 @@ MaybeTooltip.defaultProps = {
   showTooltip: true,
 };
 
-const TruncatedText = ({
+const TruncatedTextFillWidth = ({
+  element,
+  showTooltip,
+  tooltipProps,
+  children,
+  ...props
+}) => {
+  const [hasOverflowText, setHasOverflowText] = useState(false);
+  const hasTooltip = showTooltip && hasOverflowText;
+  const updateOverflow = (e) => {
+    const { scrollWidth, clientWidth } = e.target;
+    if (!hasOverflowText && scrollWidth > clientWidth) {
+      setHasOverflowText(true);
+    }
+  };
+  return (
+    <MaybeTooltip
+      showTooltip={hasTooltip}
+      tooltip={children}
+      defaultOpen
+      {...tooltipProps}
+    >
+      <Text
+        as={element.type}
+        cursor={hasTooltip ? "pointer" : "default"}
+        onMouseEnter={updateOverflow}
+        width="100%"
+        whiteSpace="nowrap"
+        overflow="hidden"
+        textOverflow="ellipsis"
+        {...element.props}
+        {...props}
+      >
+        {children}
+      </Text>
+    </MaybeTooltip>
+  );
+};
+
+const TruncatedTextMaxCharacters = ({
   children,
   element,
   indicator,
@@ -44,17 +77,27 @@ const TruncatedText = ({
       tooltip={innerText}
       {...tooltipProps}
     >
-      <StyledWrapper
+      <Text
         as={element.type}
-        hoverable={hasTooltip}
+        cursor={hasTooltip ? "pointer" : "default"}
+        width="fit-content"
         {...element.props}
         {...props}
       >
         {truncatedText}
-      </StyledWrapper>
+      </Text>
     </MaybeTooltip>
   );
 };
+
+const TruncatedText = ({ fillWidth, children, ...props }) =>
+  fillWidth ? (
+    <TruncatedTextFillWidth {...props}>{children}</TruncatedTextFillWidth>
+  ) : (
+    <TruncatedTextMaxCharacters {...props}>
+      {children}
+    </TruncatedTextMaxCharacters>
+  );
 
 TruncatedText.propTypes = {
   children: PropTypes.string,
@@ -62,6 +105,7 @@ TruncatedText.propTypes = {
   element: PropTypes.node,
   maxCharacters: PropTypes.number,
   showTooltip: PropTypes.bool,
+  fillWidth: PropTypes.bool,
   tooltipProps: PropTypes.shape({}),
 };
 
@@ -70,6 +114,7 @@ TruncatedText.defaultProps = {
   indicator: "...",
   element: <Text />,
   maxCharacters: 20,
+  fillWidth: false,
   showTooltip: true,
   tooltipProps: undefined,
 };

--- a/src/TruncatedText/TruncatedText.js
+++ b/src/TruncatedText/TruncatedText.js
@@ -22,6 +22,7 @@ const TruncatedTextFillWidth = ({
   showTooltip,
   tooltipProps,
   children,
+  "data-testid": testId,
   ...props
 }) => {
   const [hasOverflowText, setHasOverflowText] = useState(false);
@@ -47,6 +48,7 @@ const TruncatedTextFillWidth = ({
         whiteSpace="nowrap"
         overflow="hidden"
         textOverflow="ellipsis"
+        data-testid={testId}
         {...element.props}
         {...props}
       >
@@ -63,6 +65,7 @@ const TruncatedTextMaxCharacters = ({
   maxCharacters,
   showTooltip,
   tooltipProps,
+  "data-testid": testId,
   ...props
 }) => {
   const innerText = children;
@@ -81,6 +84,7 @@ const TruncatedTextMaxCharacters = ({
         as={element.type}
         cursor={hasTooltip ? "pointer" : "default"}
         width="fit-content"
+        data-testid={testId}
         {...element.props}
         {...props}
       >
@@ -106,6 +110,7 @@ TruncatedText.propTypes = {
   maxCharacters: PropTypes.number,
   showTooltip: PropTypes.bool,
   fillWidth: PropTypes.bool,
+  "data-testid": PropTypes.string,
   tooltipProps: PropTypes.shape({}),
 };
 
@@ -116,6 +121,7 @@ TruncatedText.defaultProps = {
   maxCharacters: 20,
   fillWidth: false,
   showTooltip: true,
+  "data-testid": "truncated-text",
   tooltipProps: undefined,
 };
 

--- a/src/TruncatedText/TruncatedText.story.js
+++ b/src/TruncatedText/TruncatedText.story.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { Heading1 } from "../Type";
+import { Box } from "../Box";
 import { TruncatedText } from ".";
 
 export default {
@@ -46,4 +47,16 @@ export const AsTitle = () => (
 
 AsTitle.story = {
   name: "as title"
+};
+
+export const FillWidth = () => (
+  <Box width="200px">
+    <TruncatedText fillWidth>
+      Special instructions are provided for the shipment
+    </TruncatedText>
+  </Box>
+);
+
+FillWidth.story = {
+  name: "fill width",
 };

--- a/src/TruncatedText/TruncatedText.story.js
+++ b/src/TruncatedText/TruncatedText.story.js
@@ -4,56 +4,72 @@ import { Box } from "../Box";
 import { TruncatedText } from ".";
 
 export default {
-  title: "Components/TruncatedText"
+  title: "Components/TruncatedText",
 };
 
-export const _TruncatedText = () => <TruncatedText>Special instructions are provided for the shipment</TruncatedText>;
+export const _TruncatedText = () => (
+  <TruncatedText>
+    Special instructions are provided for the shipment
+  </TruncatedText>
+);
 
 _TruncatedText.story = {
-  name: "TruncatedText"
+  name: "TruncatedText",
 };
 
 export const WithoutTooltip = () => (
-  <TruncatedText showTooltip={false}>Special instructions are provided for the shipment</TruncatedText>
+  <TruncatedText showTooltip={false}>
+    Special instructions are provided for the shipment
+  </TruncatedText>
 );
 
 WithoutTooltip.story = {
-  name: "without tooltip"
+  name: "without tooltip",
 };
 
-export const UnderMaxCharacters = () => <TruncatedText>Item is available</TruncatedText>;
+export const UnderMaxCharacters = () => (
+  <TruncatedText>Item is available</TruncatedText>
+);
 
 UnderMaxCharacters.story = {
-  name: "under max characters"
+  name: "under max characters",
 };
 
-export const WithMaxCharacters10 = () => <TruncatedText maxCharacters={10}>Item is available</TruncatedText>;
+export const WithMaxCharacters10 = () => (
+  <TruncatedText maxCharacters={10}>Item is available</TruncatedText>
+);
 
 WithMaxCharacters10.story = {
-  name: "with max characters 10"
+  name: "with max characters 10",
 };
 
 export const WithCustomTruncationIndicator = () => (
-  <TruncatedText indicator=" + 2...">Special instructions are provided for the shipment</TruncatedText>
+  <TruncatedText indicator=" + 2...">
+    Special instructions are provided for the shipment
+  </TruncatedText>
 );
 
 WithCustomTruncationIndicator.story = {
-  name: "with custom truncation indicator"
+  name: "with custom truncation indicator",
 };
 
 export const AsTitle = () => (
-  <TruncatedText element={<Heading1 />}>Special instructions are provided for the shipment</TruncatedText>
+  <TruncatedText element={<Heading1 />}>
+    Special instructions are provided for the shipment
+  </TruncatedText>
 );
 
 AsTitle.story = {
-  name: "as title"
+  name: "as title",
 };
 
 export const FillWidth = () => (
   <Box width="200px">
     <TruncatedText fillWidth>
-      Special instructions are provided for the shipment
+      Special instructions are truncated because there is not enough space to
+      show them.
     </TruncatedText>
+    <TruncatedText fillWidth>Instructions fit here.</TruncatedText>
   </Box>
 );
 

--- a/src/Type/Text.tsx
+++ b/src/Type/Text.tsx
@@ -1,32 +1,42 @@
 import styled, { CSSObject } from "styled-components";
-import { color, space, typography, SpaceProps, TypographyProps, ColorProps } from "styled-system";
+import { color, space, typography, SpaceProps, TypographyProps, ColorProps, OverflowProps, overflow, LayoutProps, layout } from 'styled-system';
+import { TextOverflowProps, textOverflow } from '../StyledProps/textOverflow';
+import { CursorProps, cursor } from '../StyledProps/cursor';
 const getAttrs = (inline?: boolean) => (inline ? { as: "span" } : null);
 
 export type TextProps = React.HTMLAttributes<HTMLParagraphElement> & {
   inline?: boolean;
   disabled?: boolean;
   textTransform?:
-    | "none"
-    | "inherit"
-    | "initial"
-    | "-moz-initial"
-    | "revert"
-    | "unset"
-    | "capitalize"
-    | "full-size-kana"
-    | "full-width"
-    | "lowercase"
-    | "uppercase"
-    | undefined;
+  | "none"
+  | "inherit"
+  | "initial"
+  | "-moz-initial"
+  | "revert"
+  | "unset"
+  | "capitalize"
+  | "full-size-kana"
+  | "full-width"
+  | "lowercase"
+  | "uppercase"
+  | undefined;
   fontSize?: string;
 } & SpaceProps &
+  OverflowProps &
+  LayoutProps &
+  TextOverflowProps &
   TypographyProps &
+  CursorProps &
   ColorProps;
 
 const Text = styled.p.attrs<TextProps>((props: TextProps) => getAttrs(props.inline))<TextProps>(
   space,
   typography,
   color,
+  layout,
+  overflow,
+  textOverflow,
+  cursor,
   ({ disabled, textTransform }: TextProps): CSSObject => ({
     textTransform,
     opacity: disabled ? "0.3333" : undefined

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,3 +58,4 @@ export { Toast } from "./Toast";
 
 export { BrandedNavBar } from "./BrandedNavBar";
 export { AsyncSelect } from "./AsyncSelect";
+export { useWindowDimensions }  from "./utils";

--- a/src/utils/convertPxToNumber.js
+++ b/src/utils/convertPxToNumber.js
@@ -1,0 +1,5 @@
+const convertPxToNumber = (px) => {
+  return parseFloat(px);
+};
+
+export default convertPxToNumber;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -8,3 +8,4 @@ export { default as PopperArrow } from "./PopperArrow";
 export { default as ScrollIndicators } from "./ScrollIndicators";
 export { default as withMenuState } from "./withMenuState";
 export { default as PreventBodyElementScrolling } from "./PreventBodyElementScrolling";
+export { default as useWindowDimensions } from "./useWindowDimensions";

--- a/src/utils/useWindowDimension.story.js
+++ b/src/utils/useWindowDimension.story.js
@@ -1,0 +1,35 @@
+import React from "react";
+import { Box } from "../Box";
+import { Flex } from "../Flex";
+import { Heading4, Text } from "../Type";
+import useWindowDimensions from "./useWindowDimensions";
+
+export default {
+  title: "utils/useWindowDimensions",
+};
+
+export const _UseWindowDimensions = () => {
+  const { width, height, widthBreakpoints } = useWindowDimensions();
+  return (
+    <Box width="400px">
+      <Heading4>Current window dimensions:</Heading4>
+      <Flex fontSize="large" justifyContent="space-between" my="half">
+        <Text>width:</Text>
+        <Text>{String(width)}</Text>
+      </Flex>
+      <Flex fontSize="large" justifyContent="space-between" my="half">
+        <Text>height:</Text>
+        <Text>{String(height)}</Text>
+      </Flex>
+      <hr></hr>
+      <Box mt="x1">
+        {Object.keys(widthBreakpoints).map((key) => (
+          <Flex justifyContent="space-between" my="half" key={key}>
+            <Text>{key}:</Text>
+            <Text>{String(widthBreakpoints[key])}</Text>
+          </Flex>
+        ))}
+      </Box>
+    </Box>
+  );
+};

--- a/src/utils/useWindowDimensions.js
+++ b/src/utils/useWindowDimensions.js
@@ -1,0 +1,58 @@
+import { useState, useEffect } from "react";
+import Theme from "../theme";
+import convertPxToNumber from "./convertPxToNumber";
+
+const xlargeBreakpoint = convertPxToNumber(Theme.breakpoints.extraLarge);
+const largeBreakpoint = convertPxToNumber(Theme.breakpoints.large);
+const mediumBreakpoint = convertPxToNumber(Theme.breakpoints.medium);
+const smallBreakpoint = convertPxToNumber(Theme.breakpoints.small);
+const xSmallBreakpoint = convertPxToNumber(Theme.breakpoints.extraSmall);
+
+export const getWindowDimensionInfo = (width, height) => ({
+  width,
+  height,
+  widthBreakpoints: {
+    xlargeBreakpoint,
+    largeBreakpoint,
+    mediumBreakpoint,
+    smallBreakpoint,
+    xSmallBreakpoint,
+    isXlargeScreen: width >= xlargeBreakpoint,
+    isLargeScreen: width >= largeBreakpoint && width < xlargeBreakpoint,
+    isMediumScreen: width >= mediumBreakpoint && width < largeBreakpoint,
+    isSmallScreen: width >= smallBreakpoint && width < mediumBreakpoint,
+    isSmallestScreen: width >= xSmallBreakpoint && width < smallBreakpoint,
+    isGreaterThanLargeScreen: width >= largeBreakpoint,
+    isGreaterThanMediumScreen: width >= mediumBreakpoint,
+    isGreaterThanSmallScreen: width >= smallBreakpoint,
+  },
+});
+
+const useWindowDimensions = () => {
+  const hasWindow = typeof window !== "undefined";
+
+  const getWindowDimensions = () => {
+    const width = hasWindow ? window.innerWidth : null;
+    const height = hasWindow ? window.innerHeight : null;
+    return getWindowDimensionInfo(width, height);
+  };
+
+  const [windowDimensions, setWindowDimensions] = useState(
+    getWindowDimensions()
+  );
+
+  useEffect(() => {
+    if (hasWindow) {
+      const handleResize = () => {
+        setWindowDimensions(getWindowDimensions());
+      };
+
+      window.addEventListener("resize", handleResize);
+      return () => window.removeEventListener("resize", handleResize);
+    }
+  });
+
+  return windowDimensions;
+};
+
+export default useWindowDimensions;

--- a/src/utils/useWindowDimensions.spec.js
+++ b/src/utils/useWindowDimensions.spec.js
@@ -1,0 +1,223 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react";
+import useWindowDimensions, { getWindowDimensionInfo } from "./useWindowDimensions";
+import { act } from "react-dom/test-utils";
+
+// simulate window resize 
+const  fireResize = (width, height) => {
+  act(() => {
+    // Change the viewport to 500px.
+    window.innerWidth = width;
+    window.innerHeight = height;
+  })
+  fireEvent(window, new Event('resize'));
+};
+
+const ComponentUsingDimensions = () => {
+  const dimensions = useWindowDimensions();
+  return <span>{JSON.stringify(dimensions)}</span>;
+};
+
+describe("updates dimensions on resize", () => {
+  it("returns the new dimension info", () => {
+    const { container } = render(<ComponentUsingDimensions />)
+    const span = container.firstChild;
+    const width = 1024;
+    const height = 768;
+    const dimensionsInfo = {
+      width,
+      height,
+      widthBreakpoints: {
+        xlargeBreakpoint: 1920,
+        largeBreakpoint: 1360,
+        mediumBreakpoint: 1024,
+        smallBreakpoint: 768,
+        xSmallBreakpoint: 0,
+        isXlargeScreen: false,
+        isLargeScreen: false,
+        isMediumScreen: true,
+        isSmallScreen: false,
+        isSmallestScreen: false,
+        isGreaterThanLargeScreen: false,
+        isGreaterThanMediumScreen: true,
+        isGreaterThanSmallScreen: true,
+      },
+    };
+    expect(span.textContent).toBe(JSON.stringify(dimensionsInfo));
+    const newWidth = 600;
+    fireResize(newWidth, height);
+    const newDimensionsInfo = {
+      width: newWidth,
+      height,
+      widthBreakpoints: {
+        xlargeBreakpoint: 1920,
+        largeBreakpoint: 1360,
+        mediumBreakpoint: 1024,
+        smallBreakpoint: 768,
+        xSmallBreakpoint: 0,
+        isXlargeScreen: false,
+        isLargeScreen: false,
+        isMediumScreen: false,
+        isSmallScreen: false,
+        isSmallestScreen: true,
+        isGreaterThanLargeScreen: false,
+        isGreaterThanMediumScreen: false,
+        isGreaterThanSmallScreen: false,
+      },
+    };
+    expect(span.textContent).toBe(JSON.stringify(newDimensionsInfo));
+  });
+});
+
+describe("getWindowDimensionInfo", () => {
+  it("returns the correct dimension info when within medium breakpoint", () => {
+    const width = 1300;
+    const height = 900;
+    const actual = getWindowDimensionInfo(width, height);
+    const expected = {
+      width,
+      height,
+      widthBreakpoints: {
+        xlargeBreakpoint: 1920,
+        largeBreakpoint: 1360,
+        mediumBreakpoint: 1024,
+        smallBreakpoint: 768,
+        xSmallBreakpoint: 0,
+        isXlargeScreen: false,
+        isLargeScreen: false,
+        isMediumScreen: true,
+        isSmallScreen: false,
+        isSmallestScreen: false,
+        isGreaterThanLargeScreen: false,
+        isGreaterThanMediumScreen: true,
+        isGreaterThanSmallScreen: true,
+      },
+    };
+    expect(actual).toEqual(expected);
+  });
+  it("returns the correct dimension info when within large breakpoint", () => {
+    const width = 1575;
+    const height = 900;
+    const actual = getWindowDimensionInfo(width, height);
+    const expected = {
+      width,
+      height,
+      widthBreakpoints: {
+        xlargeBreakpoint: 1920,
+        largeBreakpoint: 1360,
+        mediumBreakpoint: 1024,
+        smallBreakpoint: 768,
+        xSmallBreakpoint: 0,
+        isXlargeScreen: false,
+        isLargeScreen: true,
+        isMediumScreen: false,
+        isSmallScreen: false,
+        isSmallestScreen: false,
+        isGreaterThanLargeScreen: true,
+        isGreaterThanMediumScreen: true,
+        isGreaterThanSmallScreen: true,
+      },
+    };
+    expect(actual).toEqual(expected);
+  });
+  it("returns the correct dimension info when within xlarge breakpoint", () => {
+    const width = 2575;
+    const height = 1900;
+    const actual = getWindowDimensionInfo(width, height);
+    const expected = {
+      width,
+      height,
+      widthBreakpoints: {
+        xlargeBreakpoint: 1920,
+        largeBreakpoint: 1360,
+        mediumBreakpoint: 1024,
+        smallBreakpoint: 768,
+        xSmallBreakpoint: 0,
+        isXlargeScreen: true,
+        isLargeScreen: false,
+        isMediumScreen: false,
+        isSmallScreen: false,
+        isSmallestScreen: false,
+        isGreaterThanLargeScreen: true,
+        isGreaterThanMediumScreen: true,
+        isGreaterThanSmallScreen: true,
+      },
+    };
+    expect(actual).toEqual(expected);
+  });
+  it("returns the correct dimension info when within small breakpoint", () => {
+    const width = 900;
+    const height = 800;
+    const actual = getWindowDimensionInfo(width, height);
+    const expected = {
+      width,
+      height,
+      widthBreakpoints: {
+        xlargeBreakpoint: 1920,
+        largeBreakpoint: 1360,
+        mediumBreakpoint: 1024,
+        smallBreakpoint: 768,
+        xSmallBreakpoint: 0,
+        isXlargeScreen: false,
+        isLargeScreen: false,
+        isMediumScreen: false,
+        isSmallScreen: true,
+        isSmallestScreen: false,
+        isGreaterThanLargeScreen: false,
+        isGreaterThanMediumScreen: false,
+        isGreaterThanSmallScreen: true,
+      },
+    };
+    expect(actual).toEqual(expected);
+  });
+  it("returns the correct dimension info when on breakpoint", () => {
+    const width = 768;
+    const height = 800;
+    const actual = getWindowDimensionInfo(width, height);
+    const expected = {
+      width,
+      height,
+      widthBreakpoints: {
+        xlargeBreakpoint: 1920,
+        largeBreakpoint: 1360,
+        mediumBreakpoint: 1024,
+        smallBreakpoint: 768,
+        xSmallBreakpoint: 0,
+        isXlargeScreen: false,
+        isLargeScreen: false,
+        isMediumScreen: false,
+        isSmallScreen: true,
+        isSmallestScreen: false,
+        isGreaterThanLargeScreen: false,
+        isGreaterThanMediumScreen: false,
+        isGreaterThanSmallScreen: true,
+      },
+    };
+    expect(actual).toEqual(expected);
+  });
+  it("returns the correct dimension info when within xsmall breakpoint", () => {
+    const width = 600;
+    const height = 800;
+    const actual = getWindowDimensionInfo(width, height);
+    const expected = {
+      width,
+      height,
+      widthBreakpoints: {
+        xlargeBreakpoint: 1920,
+        largeBreakpoint: 1360,
+        mediumBreakpoint: 1024,
+        smallBreakpoint: 768,
+        xSmallBreakpoint: 0,
+        isXlargeScreen: false,
+        isLargeScreen: false,
+        isMediumScreen: false,
+        isSmallScreen: false,
+        isSmallestScreen: true,
+        isGreaterThanLargeScreen: false,
+        isGreaterThanMediumScreen: false,
+        isGreaterThanSmallScreen: false,
+      },
+    };
+    expect(actual).toEqual(expected);
+  });
+});


### PR DESCRIPTION
## Description
Adding a bunch of options we found to be useful while working on the Capacity Table in Eco
- Add Transition, and Transform, Cursor props to Box component so they can be set using styled props
- Add windowDimensions hook for getting the window dimensions and comparing them to our breakpoints
- Add fillWidth option to TruncatedText and TextOverflow, Cursor props to Text

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [x] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] e2e tests added for component iterations
- [x] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] If a component was changed, the Chromatic check has run and been approved
- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
