### PR TITLE
fix: unknown property warning in Table

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -4,6 +4,7 @@ import { select } from "@storybook/addon-knobs";
 import "cypress-storybook/react";
 import NDSProvider from "../src/NDSProvider/NDSProvider";
 import { ALL_NDS_LOCALES } from "../src/locales.const";
+import { theme } from "../src";
 import withNDSTheme from "./nds-theme";
 
 const localeKnobOptions = ALL_NDS_LOCALES.reduce(
@@ -18,35 +19,35 @@ const newViewports = {
   extraSmall: {
     name: "Extra small",
     styles: {
-      width: "320px",
+      width: theme.breakpoints.extraSmall,
       height: "100%",
     },
   },
   small: {
     name: "Small",
     styles: {
-      width: "768px",
+      width: theme.breakpoints.small,
       height: "100%",
     },
   },
   medium: {
     name: "Medium",
     styles: {
-      width: "1024px",
+      width: theme.breakpoints.medium,
       height: "100%",
     },
   },
   large: {
     name: "Large",
     styles: {
-      width: "1360px",
+      width: theme.breakpoints.large,
       height: "100%",
     },
   },
   extraLarge: {
-    name: "Extra large",
+    name: "Extra Large",
     styles: {
-      width: "1920px",
+      width: theme.breakpoints.extraLarge,
       height: "100%",
     },
   },

--- a/src/Table/BaseTable.tsx
+++ b/src/Table/BaseTable.tsx
@@ -3,6 +3,9 @@ import styled from "styled-components";
 import TableHead from "./TableHead";
 import TableBody from "./TableBody";
 import TableFoot from "./TableFoot";
+import PropTypes from 'prop-types';
+import { columnsPropType, rowsPropType } from './Table.types';
+
 const StyledTable = styled.table<any>({
   borderCollapse: "collapse",
   width: "100%",
@@ -55,7 +58,24 @@ const BaseTable: React.SFC<BaseTableProps> = ({
     />
     {footerRows && <TableFoot columns={columns} rows={footerRows} keyField={keyField} loading={loading} />}
   </StyledTable>
-);
+  );
+
+BaseTable.propTypes = {
+  columns: columnsPropType,
+  rows: rowsPropType,
+  noRowsContent: PropTypes.string,
+  keyField: PropTypes.string,
+  id: PropTypes.string,
+  loading: PropTypes.bool,
+  footerRows: rowsPropType,
+  rowHovers: PropTypes.bool,
+  compact: PropTypes.bool,
+  className: PropTypes.string,
+  stickyHeader: PropTypes.bool,
+  onRowMouseEnter: PropTypes.func,
+  onRowMouseLeave: PropTypes.func
+};
+
 BaseTable.defaultProps = {
   noRowsContent: "No records have been created for this table.",
   keyField: "id",

--- a/src/Table/StatefulTable.js
+++ b/src/Table/StatefulTable.js
@@ -1,15 +1,20 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import BaseTable from "./BaseTable";
 import { Pagination } from "../Pagination";
+import { getSubset } from "../utils/subset";
+import BaseTable from "./BaseTable";
 import { addExpandableControl } from "./addExpandableControl";
 import { addSelectableControl } from "./addSelectableControl";
 
-const getAllRowKeys = (rows = [], keyField) => rows.map(row => row[keyField]);
+const getAllRowKeys = (rows = [], keyField) => rows.map((row) => row[keyField]);
 
 const paginateRows = (rows, rowsPerPage) =>
   rowsPerPage
-    ? rows.reduce((acc, item, i) => (i % rowsPerPage ? acc : [...acc, rows.slice(i, i + rowsPerPage)]), [])
+    ? rows.reduce(
+        (acc, item, i) =>
+          i % rowsPerPage ? acc : [...acc, rows.slice(i, i + rowsPerPage)],
+        []
+      )
     : [rows];
 
 class StatefulTable extends Component {
@@ -21,7 +26,7 @@ class StatefulTable extends Component {
       expandedRows: expandedRows || [],
       isHeaderSelected: false,
       currentPage: 1,
-      paginatedRows: paginateRows(rows, rowsPerPage)
+      paginatedRows: paginateRows(rows, rowsPerPage),
     };
   }
 
@@ -32,7 +37,10 @@ class StatefulTable extends Component {
     // when the rows prop changes paginate the new rows and reset the current page
     return {
       paginatedRows,
-      currentPage: paginatedRows.length < currentPage ? paginatedRows.length || 1 : currentPage
+      currentPage:
+        paginatedRows.length < currentPage
+          ? paginatedRows.length || 1
+          : currentPage,
     };
   }
 
@@ -40,11 +48,13 @@ class StatefulTable extends Component {
     const { onRowExpansionChange } = this.props;
     const { expandedRows, currentPage } = this.state;
     if (onRowExpansionChange) {
-      onRowExpansionChange(this.currentRowsByPageSelector(expandedRows, currentPage));
+      onRowExpansionChange(
+        this.currentRowsByPageSelector(expandedRows, currentPage)
+      );
     }
   };
 
-  onExpandRow = row => {
+  onExpandRow = (row) => {
     const { keyField, onRowExpansionChange } = this.props;
     const currentRowKey = row[keyField];
     const newExpandedRows = !row.expanded
@@ -52,18 +62,18 @@ class StatefulTable extends Component {
       : this.removeRowFromExpandedRows(currentRowKey);
     this.setState(
       {
-        expandedRows: newExpandedRows
+        expandedRows: newExpandedRows,
       },
       onRowExpansionChange(newExpandedRows)
     );
   };
 
-  removeRowFromExpandedRows = rowKeyToRemove => {
+  removeRowFromExpandedRows = (rowKeyToRemove) => {
     const { expandedRows } = this.state;
-    return expandedRows.filter(rowKey => rowKey !== rowKeyToRemove);
+    return expandedRows.filter((rowKey) => rowKey !== rowKeyToRemove);
   };
 
-  addRowToExpandedRows = rowKeyToAdd => {
+  addRowToExpandedRows = (rowKeyToAdd) => {
     const { expandedRows } = this.state;
     return [...expandedRows, rowKeyToAdd];
   };
@@ -72,11 +82,13 @@ class StatefulTable extends Component {
     const { onRowSelectionChange } = this.props;
     const { selectedRows, currentPage } = this.state;
     if (onRowSelectionChange) {
-      onRowSelectionChange(this.currentRowsByPageSelector(selectedRows, currentPage));
+      onRowSelectionChange(
+        this.currentRowsByPageSelector(selectedRows, currentPage)
+      );
     }
   };
 
-  onSelectRow = row => {
+  onSelectRow = (row) => {
     const { currentPage } = this.state;
     const { keyField } = this.props;
     const currentRowKey = row[keyField];
@@ -86,7 +98,10 @@ class StatefulTable extends Component {
     this.setState(
       {
         selectedRows: newRowSelections,
-        isHeaderSelected: this.areAllRowsSelectedOnPage(newRowSelections, currentPage)
+        isHeaderSelected: this.areAllRowsSelectedOnPage(
+          newRowSelections,
+          currentPage
+        ),
       },
       this.onRowSelectionChangeHandler
     );
@@ -95,52 +110,58 @@ class StatefulTable extends Component {
   onSelectHeader = () => {
     const { isHeaderSelected, currentPage } = this.state;
     const { keyField } = this.props;
-    const currentRowKeys = getAllRowKeys(this.rowsByPageSelector(currentPage), keyField);
+    const currentRowKeys = getAllRowKeys(
+      this.rowsByPageSelector(currentPage),
+      keyField
+    );
     this.setState(
       {
         isHeaderSelected: !isHeaderSelected,
         selectedRows: isHeaderSelected
           ? this.removeRowsFromSelection(currentRowKeys)
-          : this.addRowsToSelection(currentRowKeys)
+          : this.addRowsToSelection(currentRowKeys),
       },
       this.onRowSelectionChangeHandler
     );
   };
 
-  removeRowFromSelection = rowKeyToRemove => {
+  removeRowFromSelection = (rowKeyToRemove) => {
     const { selectedRows } = this.state;
-    return selectedRows.filter(rowKey => rowKey !== rowKeyToRemove);
+    return selectedRows.filter((rowKey) => rowKey !== rowKeyToRemove);
   };
 
-  addRowToSelection = rowKeyToAdd => {
+  addRowToSelection = (rowKeyToAdd) => {
     const { selectedRows } = this.state;
     return [...selectedRows, rowKeyToAdd];
   };
 
-  addRowsToSelection = rowsKeysToAdd => {
+  addRowsToSelection = (rowsKeysToAdd) => {
     const { selectedRows } = this.state;
     return [...selectedRows, ...rowsKeysToAdd];
   };
 
-  removeRowsFromSelection = rowKeysToRemove => {
+  removeRowsFromSelection = (rowKeysToRemove) => {
     const { selectedRows } = this.state;
-    return selectedRows.filter(row => !rowKeysToRemove.includes(row));
+    return selectedRows.filter((row) => !rowKeysToRemove.includes(row));
   };
 
-  rowsByPageSelector = pageNumber => {
+  rowsByPageSelector = (pageNumber) => {
     const { paginatedRows } = this.state;
     return paginatedRows[pageNumber - 1];
   };
 
-  goToPage = pageNumber => {
+  goToPage = (pageNumber) => {
     const { selectedRows } = this.state;
     const { hasSelectableRows } = this.props;
     this.setState(
       {
         currentPage: pageNumber,
         ...(hasSelectableRows && {
-          isHeaderSelected: this.areAllRowsSelectedOnPage(selectedRows, pageNumber)
-        })
+          isHeaderSelected: this.areAllRowsSelectedOnPage(
+            selectedRows,
+            pageNumber
+          ),
+        }),
       },
       this.onPageSelectionChangeHandler
     );
@@ -150,14 +171,17 @@ class StatefulTable extends Component {
     const currentRows = this.rowsByPageSelector(pageNumber);
     const { keyField } = this.props;
     const allRowKeysOnPage = getAllRowKeys(currentRows, keyField);
-    return allRowKeysOnPage.filter(rowKey => rows.includes(rowKey));
+    return allRowKeysOnPage.filter((rowKey) => rows.includes(rowKey));
   };
 
   areAllRowsSelectedOnPage = (selectedRows, pageNumber) => {
     const { keyField } = this.props;
     const currentRows = this.rowsByPageSelector(pageNumber);
     const allRowKeysOnPage = getAllRowKeys(currentRows, keyField);
-    return allRowKeysOnPage.length === this.currentRowsByPageSelector(selectedRows, pageNumber).length;
+    return (
+      allRowKeysOnPage.length ===
+      this.currentRowsByPageSelector(selectedRows, pageNumber).length
+    );
   };
 
   goToPrevPage = () => {
@@ -179,27 +203,33 @@ class StatefulTable extends Component {
   };
 
   getControlProps = () => {
-    const { selectedRows, isHeaderSelected, currentPage, expandedRows } = this.state;
+    const {
+      selectedRows,
+      isHeaderSelected,
+      currentPage,
+      expandedRows,
+    } = this.state;
     const { hasSelectableRows, hasExpandableRows } = this.props;
     const selectionConfig = {
       onSelectRow: this.onSelectRow,
       onSelectHeader: this.onSelectHeader,
       selectedRows: this.currentRowsByPageSelector(selectedRows, currentPage),
-      isHeaderSelected
+      isHeaderSelected,
     };
     const expandableConfig = {
       onRowExpansionChange: this.onExpandRow,
-      expandedRows
+      expandedRows,
     };
     const props = {
       ...this.props,
       rows: this.rowsByPageSelector(currentPage) || [],
       ...(hasSelectableRows && selectionConfig),
-      ...(hasExpandableRows && expandableConfig)
+      ...(hasExpandableRows && expandableConfig),
     };
     const selectableProps = { ...props, ...addSelectableControl(props) };
     const expandableProps = { ...props, ...addExpandableControl(props) };
-    if (hasSelectableRows && hasExpandableRows) return { ...props, ...addExpandableControl(selectableProps) };
+    if (hasSelectableRows && hasExpandableRows)
+      return { ...props, ...addExpandableControl(selectableProps) };
     if (hasSelectableRows) return selectableProps;
     if (hasExpandableRows) return expandableProps;
     return props;
@@ -208,9 +238,13 @@ class StatefulTable extends Component {
   render() {
     const { paginatedRows, currentPage } = this.state;
     const { rowsPerPage, paginationProps, paginationCss } = this.props;
+    const baseTableProps = getSubset(
+      this.getControlProps(),
+      BaseTable.propTypes
+    );
     return (
       <>
-        <BaseTable {...this.getControlProps()} />
+        <BaseTable {...baseTableProps} />
 
         {rowsPerPage && (
           <Pagination
@@ -241,7 +275,7 @@ StatefulTable.propTypes = {
   deselectAllAriaLabel: PropTypes.string,
   /* PM support only */
   paginationCss: PropTypes.shape({}),
-  paginationProps: PropTypes.shape({})
+  paginationProps: PropTypes.shape({}),
 };
 
 StatefulTable.defaultProps = {
@@ -254,7 +288,7 @@ StatefulTable.defaultProps = {
   deselectAllAriaLabel: undefined,
   /* PM support only */
   paginationCss: undefined,
-  paginationProps: {}
+  paginationProps: {},
 };
 
 export default StatefulTable;

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -4,26 +4,49 @@ import StatefulTable from "./StatefulTable";
 import BaseTable from "./BaseTable";
 import SortingColumnHeader from "./SortingColumnHeader";
 
-const Table = props => {
-  const { hasSelectableRows, rowsPerPage, hasExpandableRows } = props;
-
-  return hasSelectableRows || rowsPerPage || hasExpandableRows ? (
-    <StatefulTable {...props} />
+const Table = ({
+  hasSelectableRows,
+  rowsPerPage,
+  hasExpandableRows,
+  selectedRows,
+  onRowSelectionChange,
+  onRowExpansionChange,
+  onPageChange,
+  selectAllAriaLabel,
+  deselectAllAriaLabel,
+  paginationCss,
+  paginationProps,
+  ...props
+}) =>
+  hasSelectableRows || rowsPerPage || hasExpandableRows ? (
+    <StatefulTable
+      hasExpandableRows={hasExpandableRows}
+      hasSelectableRows={hasSelectableRows}
+      onRowExpansionChange={onRowExpansionChange}
+      onRowSelectionChange={onRowSelectionChange}
+      selectedRows={selectedRows}
+      rowsPerPage={rowsPerPage}
+      onPageChange={onPageChange}
+      selectAllAriaLabel={selectAllAriaLabel}
+      deselectAllAriaLabel={deselectAllAriaLabel}
+      paginationCss={paginationCss}
+      paginationProps={paginationProps}
+      {...props}
+    />
   ) : (
     <BaseTable {...props} />
   );
-};
 
 Table.SortingHeader = SortingColumnHeader;
 
 Table.propTypes = {
   ...BaseTable.propTypes,
-  ...StatefulTable.propTypes
+  ...StatefulTable.propTypes,
 };
 
 Table.defaultProps = {
   ...BaseTable.defaultProps,
-  ...StatefulTable.defaultProps
+  ...StatefulTable.defaultProps,
 };
 
 export default Table;

--- a/src/TruncatedText/TruncatedText.js
+++ b/src/TruncatedText/TruncatedText.js
@@ -104,7 +104,7 @@ const TruncatedText = ({ fullWidth, children, ...props }) =>
   );
 
 TruncatedText.propTypes = {
-  children: PropTypes.string,
+  children: PropTypes.node,
   indicator: PropTypes.string,
   element: PropTypes.node,
   maxCharacters: PropTypes.number,


### PR DESCRIPTION
## Description

Fixes prop type warnings  caused by statefulTable props (ex. onExpanpasionChange) being spread down to BaseTable.

## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] If a component was changed, the Chromatic check has run and been approved
- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
