### PR TITLE
fix: Align dropdown menus to vertically center

### DIFF
--- a/src/BrandedNavBar/DesktopMenu.js
+++ b/src/BrandedNavBar/DesktopMenu.js
@@ -14,39 +14,41 @@ const getSharedStyles = (color, theme) => {
     lineHeight: theme.lineHeights.base,
     fontSize: `${theme.fontSizes.medium}`,
     padding: `${theme.space.x1} ${theme.space.x2}`,
-    borderRadius: theme.radii.medium
+    borderRadius: theme.radii.medium,
   };
 };
 
-const ApplyMenuLinkStyles = styled.div(({ color, hoverColor, hoverBackground, theme }) => ({
-  "button, a": {
-    ...getSharedStyles(color, theme),
-    transition: ".2s",
-    "&:hover, &:focus": {
-      outline: "none",
-      color: theme.colors.hoverColor || hoverColor,
-      backgroundColor: theme.colors.hoverBackground || hoverBackground,
-      cursor: "pointer"
+const ApplyMenuLinkStyles = styled.div(
+  ({ color, hoverColor, hoverBackground, theme }) => ({
+    "button, a": {
+      ...getSharedStyles(color, theme),
+      transition: ".2s",
+      "&:hover, &:focus": {
+        outline: "none",
+        color: theme.colors.hoverColor || hoverColor,
+        backgroundColor: theme.colors.hoverBackground || hoverBackground,
+        cursor: "pointer",
+      },
+      "&:disabled": {
+        opacity: ".5",
+      },
+      "&:focus": {
+        boxShadow: theme.shadows.focus,
+      },
     },
-    "&:disabled": {
-      opacity: ".5"
-    },
-    "&:focus": {
-      boxShadow: theme.shadows.focus
-    }
-  }
-}));
+  })
+);
 
 ApplyMenuLinkStyles.propTypes = {
   color: PropTypes.string,
   hoverColor: PropTypes.string,
-  hoverBackground: PropTypes.string
+  hoverBackground: PropTypes.string,
 };
 
 ApplyMenuLinkStyles.defaultProps = {
   color: "white",
   hoverColor: "lightBlue",
-  hoverBackground: "black"
+  hoverBackground: "black",
 };
 
 const MenuLink = styled.a(({ color, hoverColor, hoverBackground, theme }) => ({
@@ -57,28 +59,34 @@ const MenuLink = styled.a(({ color, hoverColor, hoverBackground, theme }) => ({
     outline: "none",
     color: theme.colors[hoverColor] || hoverColor,
     backgroundColor: theme.colors[hoverBackground] || hoverBackground,
-    cursor: "pointer"
+    cursor: "pointer",
   },
   "&:disabled": {
-    opacity: ".5"
+    opacity: ".5",
   },
   "&:focus": {
-    boxShadow: theme.shadows.focus
-  }
+    boxShadow: theme.shadows.focus,
+  },
 }));
 
 const MenuText = styled.div(({ textColor, theme }) => ({
   ...getSharedStyles(textColor, theme),
-  fontWeight: theme.fontWeights.medium
+  fontWeight: theme.fontWeights.medium,
 }));
 
 const Nav = styled.nav({
-  display: "flex"
+  display: "flex",
+  alignItems: "center",
 });
 
 const renderMenuTrigger = (menuItem, themeColorObject) => (
   <div key={menuItem.name}>
-    <MenuTrigger name={menuItem.name} aria-label={menuItem.ariaLabel} menuData={menuItem.items} {...themeColorObject} />
+    <MenuTrigger
+      name={menuItem.name}
+      aria-label={menuItem.ariaLabel}
+      menuData={menuItem.items}
+      {...themeColorObject}
+    />
   </div>
 );
 
@@ -102,7 +110,7 @@ const renderText = (menuItem, themeColorObject) => (
   </MenuText>
 );
 
-const getRenderFunction = menuItem => {
+const getRenderFunction = (menuItem) => {
   if (menuItem.items) {
     return renderMenuTrigger;
   } else if (menuItem.href) {
@@ -114,28 +122,31 @@ const getRenderFunction = menuItem => {
   }
 };
 
-const renderMenuItem = (menuItem, themeColorObject) => getRenderFunction(menuItem)(menuItem, themeColorObject);
+const renderMenuItem = (menuItem, themeColorObject) =>
+  getRenderFunction(menuItem)(menuItem, themeColorObject);
 
 const BaseDesktopMenu = ({ menuData, themeColorObject, ...props }) => (
-  <Nav {...props}>{menuData.map(menuItem => renderMenuItem(menuItem, themeColorObject))}</Nav>
+  <Nav {...props}>
+    {menuData.map((menuItem) => renderMenuItem(menuItem, themeColorObject))}
+  </Nav>
 );
 
 BaseDesktopMenu.propTypes = {
   menuData: PropTypes.arrayOf(PropTypes.shape({})),
-  themeColorObject: PropTypes.shape({})
+  themeColorObject: PropTypes.shape({}),
 };
 
 BaseDesktopMenu.defaultProps = {
   menuData: null,
-  themeColorObject: null
+  themeColorObject: null,
 };
 
 const DesktopMenu = styled(BaseDesktopMenu)({
   div: {
     ":not(:last-of-type)": {
-      marginRight: "8px"
-    }
-  }
+      marginRight: "8px",
+    },
+  },
 });
 
 export default DesktopMenu;

--- a/src/BrandedNavBar/MenuTrigger.js
+++ b/src/BrandedNavBar/MenuTrigger.js
@@ -7,76 +7,99 @@ import NavBarDropdownMenu from "./NavBarDropdownMenu";
 import SubMenuTrigger from "./SubMenuTrigger";
 import renderSubMenuItems from "./renderSubMenuItems";
 
-const StyledButton = styled.button(({ color, hoverColor, hoverBackground, theme }) => ({
-  display: "flex",
-  alignItems: "center",
-  position: "relative",
-  fontWeight: theme.fontWeights.medium,
-  color: theme.colors[color] || color,
-  border: "none",
-  backgroundColor: "transparent",
-  textDecoration: "none",
-  lineHeight: theme.lineHeights.base,
-  transition: "background-color .2s",
-  fontSize: `${theme.fontSizes.medium}`,
-  padding: `${theme.space.x1} 28px ${theme.space.x1} ${theme.space.x2}`,
-  borderRadius: theme.radii.medium,
-  "&:hover, &:focus": {
-    outline: "none",
-    color: theme.colors[hoverColor] || hoverColor,
-    backgroundColor: theme.colors[hoverBackground] || hoverBackground,
-    cursor: "pointer"
-  },
-  "&:focus": {
-    boxShadow: theme.shadows.focus
-  },
-  "&:disabled": {
-    opacity: ".5"
-  }
-}));
+const StyledButton = styled.button(
+  ({ color, hoverColor, hoverBackground, theme }) => ({
+    display: "flex",
+    alignItems: "center",
+    position: "relative",
+    fontWeight: theme.fontWeights.medium,
+    color: theme.colors[color] || color,
+    border: "none",
+    backgroundColor: "transparent",
+    textDecoration: "none",
+    lineHeight: theme.lineHeights.base,
+    transition: "background-color .2s",
+    fontSize: `${theme.fontSizes.medium}`,
+    padding: `${theme.space.x1} 28px ${theme.space.x1} ${theme.space.x2}`,
+    borderRadius: theme.radii.medium,
+    "&:hover, &:focus": {
+      outline: "none",
+      color: theme.colors[hoverColor] || hoverColor,
+      backgroundColor: theme.colors[hoverBackground] || hoverBackground,
+      cursor: "pointer",
+    },
+    "&:focus": {
+      boxShadow: theme.shadows.focus,
+    },
+    "&:disabled": {
+      opacity: ".5",
+    },
+  })
+);
 
 StyledButton.propTypes = {
   color: PropTypes.string,
   hoverColor: PropTypes.string,
-  hoverBackground: PropTypes.string
+  hoverBackground: PropTypes.string,
 };
 
 StyledButton.defaultProps = {
   color: "white",
   hoverColor: "lightBlue",
-  hoverBackground: "black"
+  hoverBackground: "black",
 };
 
-const MenuTriggerButton = React.forwardRef(({ name, color, hoverColor, hoverBackground, ...props }, ref) => (
-  <StyledButton color={color} hoverColor={hoverColor} hoverBackground={hoverBackground} ref={ref} {...props}>
-    {name}
-    <Icon
-      style={{ position: "absolute", top: "11px", right: "8px" }}
-      icon="downArrow"
-      color={themeGet(`colors.${color}`, color)(color)}
-      size="20px"
-      p="2px"
-    />
-  </StyledButton>
-));
+const MenuTriggerButton = React.forwardRef(
+  ({ name, color, hoverColor, hoverBackground, ...props }, ref) => (
+    <StyledButton
+      color={color}
+      hoverColor={hoverColor}
+      hoverBackground={hoverBackground}
+      ref={ref}
+      {...props}
+    >
+      {name}
+      <Icon
+        style={{
+          position: "absolute",
+          top: "50%",
+          transform: "translateY(-50%)",
+          right: "8px",
+        }}
+        icon="downArrow"
+        color={themeGet(`colors.${color}`, color)(color)}
+        size="20px"
+        p="2px"
+      />
+    </StyledButton>
+  )
+);
 
 MenuTriggerButton.propTypes = {
   name: PropTypes.node.isRequired,
   color: PropTypes.string,
   hoverColor: PropTypes.string,
-  hoverBackground: PropTypes.string
+  hoverBackground: PropTypes.string,
 };
 
 MenuTriggerButton.defaultProps = {
   color: "white",
   hoverColor: "lightBlue",
-  hoverBackground: "black"
+  hoverBackground: "black",
 };
 
-const MenuTrigger = props => {
-  const { menuData, name, color, hoverColor, hoverBackground, "aria-label": ariaLabel, ...otherProps } = props;
+const MenuTrigger = (props) => {
+  const {
+    menuData,
+    name,
+    color,
+    hoverColor,
+    hoverBackground,
+    "aria-label": ariaLabel,
+    ...otherProps
+  } = props;
   let dropdownMinWidth = "auto";
-  const setDropdownMinWidth = popperData => {
+  const setDropdownMinWidth = (popperData) => {
     // Popper.js throws an error if popperData is not returned from this fn
     dropdownMinWidth = `${popperData.instance.reference.clientWidth}px`;
     return popperData;
@@ -89,9 +112,13 @@ const MenuTrigger = props => {
         flip: { behavior: ["bottom"] },
         setPopperWidth: {
           enabled: true,
-          fn: setDropdownMinWidth
+          fn: setDropdownMinWidth,
         },
-        preventOverflow: { enabled: true, padding: 8, boundariesElement: "viewport" }
+        preventOverflow: {
+          enabled: true,
+          padding: 8,
+          boundariesElement: "viewport",
+        },
       }}
       trigger={() => (
         <MenuTriggerButton
@@ -104,10 +131,17 @@ const MenuTrigger = props => {
       )}
     >
       {({ closeMenu }) => (
-        <ul style={{ listStyle: "none", margin: "0", padding: "0", minWidth: dropdownMinWidth }}>
+        <ul
+          style={{
+            listStyle: "none",
+            margin: "0",
+            padding: "0",
+            minWidth: dropdownMinWidth,
+          }}
+        >
           {renderSubMenuItems(
             menuData,
-            e => {
+            (e) => {
               closeMenu(e);
               e.stopPropagation();
             },
@@ -125,7 +159,7 @@ MenuTrigger.propTypes = {
   menuData: PropTypes.arrayOf(PropTypes.shape({})),
   color: PropTypes.string,
   hoverColor: PropTypes.string,
-  hoverBackground: PropTypes.string
+  hoverBackground: PropTypes.string,
 };
 
 MenuTrigger.defaultProps = {
@@ -133,7 +167,7 @@ MenuTrigger.defaultProps = {
   "aria-label": undefined,
   color: "white",
   hoverColor: "lightBlue",
-  hoverBackground: "black"
+  hoverBackground: "black",
 };
 
 export default MenuTrigger;

--- a/src/BrandedNavBar/MenuTrigger.js
+++ b/src/BrandedNavBar/MenuTrigger.js
@@ -62,7 +62,7 @@ const MenuTriggerButton = React.forwardRef(
       <Icon
         style={{
           position: "absolute",
-          top: "50%",
+          top: "52%",
           transform: "translateY(-50%)",
           right: "8px",
         }}

--- a/src/BrandedNavBar/NavBar.story.js
+++ b/src/BrandedNavBar/NavBar.story.js
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import { select } from "@storybook/addon-knobs";
 import { BrandedNavBar as NDSBrandedNavBar } from "./index";
 import { Heading1 } from "../Type";
+import { Icon } from "../Icon";
 
 const sampleLogo = "http://pigment.github.io/fake-logos/logos/vector/color/auto-speed.svg";
 
@@ -87,6 +88,19 @@ const secondaryMenu = [
   }
 ];
 
+
+const secondaryMenuWithIcon = [
+  {
+    name: "Account Information: User@Nulogy.com",
+    items: [{ name: "Profile", href: "/" }, { name: "Preferences", href: "/" }, { name: "Logout", href: "/" }]
+  },
+  {
+    name: <Icon icon="settings" />,
+    ariaLabel: "Settings",
+    items: [{ name: "Permissions", href: "/" }, { name: "Manage account", href: "/" }]
+  }
+];
+
 export default {
   title: "Components/BrandedNavBar"
 };
@@ -128,4 +142,17 @@ export const WithEnvironmentBanner = () => (
 
 WithEnvironmentBanner.story = {
   name: "with environment banner"
+};
+
+export const WithIcon = () => (
+  <BrandedNavBar
+    menuData={{
+      primaryMenu: primaryMenu,
+      secondaryMenu: secondaryMenuWithIcon,
+    }}
+  />
+);
+
+WithIcon.story = {
+  name: "With icon",
 };


### PR DESCRIPTION
## Description

Make dropdown items vertically center even when there is more than one line of text.
Fixed: 
<img width="1042" alt="Screen Shot 2020-11-17 at 4 32 20 PM" src="https://user-images.githubusercontent.com/8175052/99453135-7f6d5380-28f2-11eb-8c83-ff374b66ca60.png">


## Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Documentation only

## Checklist

**Please check all that apply.**

- [ ] Storybook updated with examples of new functionality
- [ ] Storybook uses variable and realistic data (ex: short and long text)
- [ ] Docs updated with correct props and examples
- [ ] e2e tests added for component iterations
- [ ] jest tests added for component API that may not be captured with storyshots (change handlers, renderers etc)
- [ ] Accessibility (includes relevant tags, keyboard functionality, colour contrast)

## Before Merging

- [ ] If a component was changed, the Chromatic check has run and been approved
- [ ] Tested storybook deployment preview
- [ ] Tested docs deployment preview
