### PR TITLE
fix(AsyncSelect): show clear button when items are selected

### DIFF
--- a/src/AsyncSelect/AsyncSelect.tsx
+++ b/src/AsyncSelect/AsyncSelect.tsx
@@ -28,8 +28,8 @@ const extractValue = (options, isMulti) => {
   }
 };
 const StyledAsyncReactSelect = styled(AsyncReactSelect)(({ showArrow }) => ({
-  "[class*='indicatorContainer'] svg": {
-    display: showArrow ? "block" : "none",
+  "[class*='dropdown-indicator'], [class*='indicator-separator']": {
+    display: showArrow ? "flex" : "none",
   },
 }));
 type AsyncSelectProps = any;


### PR DESCRIPTION
## Description

The css rule to hide the arrow in the AsyncSelect was too general and unintentionally hid the x icon in the multiselect. This pr hides only the dropdown and the seperator, but shows the clear button once atleast one item is selected. 

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
