### PR TITLE
fix(AsyncSelect)!: AsyncSelect can now be used as a controlled compo…

### DIFF
--- a/src/AsyncSelect/AsyncSelect.spec.js
+++ b/src/AsyncSelect/AsyncSelect.spec.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { selectOption } from "../Select/Select.spec-utils";
 import { renderWithNDSProvider } from "../NDSProvider/renderWithNDSProvider.spec-utils";
-import { AsyncSelect } from "./AsyncSelect";
+import { AsyncSelect } from ".";
 
 describe("select", () => {
   it("returns the selected item on change", () => {

--- a/src/AsyncSelect/AsyncSelect.spec.js
+++ b/src/AsyncSelect/AsyncSelect.spec.js
@@ -1,7 +1,7 @@
 import React from "react";
-import { AsyncSelect } from ".";
 import { selectOption } from "../Select/Select.spec-utils";
 import { renderWithNDSProvider } from "../NDSProvider/renderWithNDSProvider.spec-utils";
+import { AsyncSelect } from "./AsyncSelect";
 
 describe("select", () => {
   it("returns the selected item on change", () => {
@@ -19,6 +19,9 @@ describe("select", () => {
 
     selectOption("Two", container, queryByText);
 
-    expect(callback).toHaveBeenCalledWith("two");
+    expect(callback).toHaveBeenCalledWith(
+      { label: "Two", value: "two" },
+      { action: "select-option", name: undefined, option: undefined }
+    );
   });
 });

--- a/src/AsyncSelect/AsyncSelect.story.js
+++ b/src/AsyncSelect/AsyncSelect.story.js
@@ -1,6 +1,6 @@
-/* eslint-disable react/prop-types */
 import React, { useRef } from "react";
 import { action } from "@storybook/addon-actions";
+import { useState } from "react";
 import { AsyncSelect, Button } from "../index";
 
 const northAmericanCountries = [
@@ -131,4 +131,30 @@ export const UsingRefToControlFocus = () => {
 
 UsingRefToControlFocus.story = {
   name: "using ref to control focus",
+};
+
+export const Controlled = () => {
+  const [value, setValue] = useState("");
+
+  const handleChange = (value) => {
+    setValue(value);
+  };
+  const handleClear = () => {
+    setValue(null);
+  };
+
+  return (
+    <>
+      <AsyncSelect
+        onChange={handleChange}
+        value={value}
+        labelText="Country"
+        loadOptions={loadMatchingCountries}
+      />
+      <Button onClick={handleClear}>Clear</Button>
+    </>
+  );
+};
+Controlled.story = {
+  name: "controlled",
 };

--- a/src/AsyncSelect/AsyncSelect.tsx
+++ b/src/AsyncSelect/AsyncSelect.tsx
@@ -19,14 +19,6 @@ import {
 import { SelectDefaultProps } from "../Select/Select";
 import { getSubset } from "../utils/subset";
 
-const extractValue = (options, isMulti) => {
-  if (options == null) return options;
-  if (isMulti) {
-    return options.map((o) => o.value);
-  } else {
-    return options.value;
-  }
-};
 const StyledAsyncReactSelect = styled(AsyncReactSelect)(({ showArrow }) => ({
   "[class*='indicatorContainer'] svg": {
     display: showArrow ? "block" : "none",
@@ -87,7 +79,7 @@ const AsyncSelect: React.SFC<AsyncSelectProps> = forwardRef(
             className={className}
             classNamePrefix={classNamePrefix}
             noOptionsMessage={noOptionsMessage}
-            inputValue={value}
+            value={value}
             ref={ref}
             defaultInputValue={defaultValue}
             placeholder={placeholder || t("select ...")}
@@ -106,10 +98,7 @@ const AsyncSelect: React.SFC<AsyncSelectProps> = forwardRef(
             defaultMenuIsOpen={initialIsOpen}
             inputId={id}
             onBlur={onBlur}
-            onChange={
-              onChange &&
-              ((option) => onChange(extractValue(option, multiselect)))
-            }
+            onChange={onChange}
             name={name}
             isMulti={multiselect}
             menuIsOpen={menuIsOpen}


### PR DESCRIPTION
## Description

AsyncSelect can now be used as a controlled component by setting the `value` prop. `onChange` now returns the complete option object that is selected rather than just the string value.

Here's an example of migrating an existing onChange handler: 

```
onChange = (newValue: string) => {
     setValue(value)
}

would need to change to 

onChange = (newValue: <{value: string,  label}>) => {
    setValue(newValue.value);
}
```
## Changes include

- [x] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
