### PR TITLE
fix: allow variable width of daterange component

### DIFF
--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -119,6 +119,7 @@ const DatePicker: React.SFC<DatePickerProps> = forwardRef(
     };
     const customInputProps = {
       ...InputFieldDefaultProps,
+      inputWidth:"184px",
       ...inputProps,
       error: !!(errorMessage || errorList),
       placeholder:
@@ -138,7 +139,11 @@ const DatePicker: React.SFC<DatePickerProps> = forwardRef(
     );
     const spaceProps = getSubset(props, propTypes.space);
     return (
-      <Field className={`${className} nds-date-picker`} fitContent={fitContent} {...spaceProps}>
+      <Field
+        className={`${className} nds-date-picker`}
+        fitContent={fitContent}
+        {...spaceProps}
+      >
         <DatePickerStyles />
         <LocaleContext.Consumer>
           {({ locale }) => (

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -52,7 +52,6 @@ const DatePicker: React.SFC<DatePickerProps> = forwardRef(
       onInputChange,
       onChange,
       selected,
-      fitContent,
       ...props
     },
     datePickerRef
@@ -141,7 +140,6 @@ const DatePicker: React.SFC<DatePickerProps> = forwardRef(
     return (
       <Field
         className={`${className} nds-date-picker`}
-        fitContent={fitContent}
         {...spaceProps}
       >
         <DatePickerStyles />

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -19,10 +19,11 @@ import { LocaleContext } from "../NDSProvider/LocaleContext";
 import { NDS_TO_DATE_FN_LOCALES_MAP } from "../locales.const";
 import propTypes from "@styled-system/prop-types";
 import { getSubset } from "../utils/subset";
+import { FieldProps } from '../Form/Field';
 
 const DEFAULT_DATE_FORMAT = "dd MMM yyyy";
 const DEFAULT_PLACEHOLDER = "DD Mon YYYY";
-type DatePickerProps = {
+type DatePickerProps = FieldProps & {
   selected?: any;
   dateFormat?: string;
   onChange?: (...args: any[]) => any;
@@ -39,7 +40,7 @@ type DatePickerProps = {
 const DatePicker: React.SFC<DatePickerProps> = forwardRef(
   (
     {
-      dateFormat,
+      dateFormat = DEFAULT_DATE_FORMAT,
       errorMessage,
       errorList,
       inputProps,
@@ -51,6 +52,7 @@ const DatePicker: React.SFC<DatePickerProps> = forwardRef(
       onInputChange,
       onChange,
       selected,
+      fitContent,
       ...props
     },
     datePickerRef
@@ -116,12 +118,14 @@ const DatePicker: React.SFC<DatePickerProps> = forwardRef(
       return (props) => <DatePickerHeader locale={locale} {...props} />;
     };
     const customInputProps = {
+      ...InputFieldDefaultProps,
       ...inputProps,
       error: !!(errorMessage || errorList),
       placeholder:
         inputProps.placeholder ||
         (dateFormat === DEFAULT_DATE_FORMAT ? DEFAULT_PLACEHOLDER : dateFormat),
     };
+
     const customInput = (
       <DatePickerInput
         inputProps={customInputProps}
@@ -134,7 +138,7 @@ const DatePicker: React.SFC<DatePickerProps> = forwardRef(
     );
     const spaceProps = getSubset(props, propTypes.space);
     return (
-      <Field className={`${className} nds-date-picker`} {...spaceProps}>
+      <Field className={`${className} nds-date-picker`} fitContent={fitContent} {...spaceProps}>
         <DatePickerStyles />
         <LocaleContext.Consumer>
           {({ locale }) => (
@@ -172,18 +176,4 @@ const DatePicker: React.SFC<DatePickerProps> = forwardRef(
     );
   }
 );
-DatePicker.defaultProps = {
-  selected: undefined,
-  dateFormat: DEFAULT_DATE_FORMAT,
-  onChange: undefined,
-  onInputChange: undefined,
-  inputProps: InputFieldDefaultProps,
-  errorMessage: undefined,
-  errorList: undefined,
-  minDate: undefined,
-  maxDate: undefined,
-  highlightDates: undefined,
-  disableFlipping: false,
-  className: "",
-};
 export default DatePicker;

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -8,18 +8,18 @@ import {
 } from "date-fns";
 import React, { useEffect, useState, forwardRef } from "react";
 import ReactDatePicker from "react-datepicker";
-import { DatePickerStyles } from "./DatePickerStyles";
-import DatePickerInput from "./DatePickerInput";
-import DatePickerHeader from "./DatePickerHeader";
+import propTypes from "@styled-system/prop-types";
 import { InlineValidation } from "../Validation";
 import { Field } from "../Form";
 import { InputFieldDefaultProps } from "../Input/InputField.type";
 import { registerDatePickerLocales } from "../utils/datePickerLocales";
 import { LocaleContext } from "../NDSProvider/LocaleContext";
 import { NDS_TO_DATE_FN_LOCALES_MAP } from "../locales.const";
-import propTypes from "@styled-system/prop-types";
 import { getSubset } from "../utils/subset";
-import { FieldProps } from '../Form/Field';
+import { FieldProps } from "../Form/Field";
+import DatePickerHeader from "./DatePickerHeader";
+import DatePickerInput from "./DatePickerInput";
+import { DatePickerStyles } from "./DatePickerStyles";
 
 const DEFAULT_DATE_FORMAT = "dd MMM yyyy";
 const DEFAULT_PLACEHOLDER = "DD Mon YYYY";
@@ -119,11 +119,11 @@ const DatePicker: React.SFC<DatePickerProps> = forwardRef(
     };
     const customInputProps = {
       ...InputFieldDefaultProps,
-      inputWidth:"184px",
+      inputWidth: "184px",
       ...inputProps,
       error: !!(errorMessage || errorList),
       placeholder:
-        inputProps.placeholder ||
+        (inputProps && inputProps.placeholder) ||
         (dateFormat === DEFAULT_DATE_FORMAT ? DEFAULT_PLACEHOLDER : dateFormat),
     };
 

--- a/src/DatePicker/DatePickerStyles.js
+++ b/src/DatePicker/DatePickerStyles.js
@@ -2,6 +2,9 @@ import { createGlobalStyle } from "styled-components";
 
 export const DatePickerStyles = createGlobalStyle(({ theme }) => ({
   ".nds-date-picker": {
+    ".react-datepicker-wrapper": {
+      width: "fit-content",
+    },
     ".react-datepicker__input-container": {
       input: {
         position: "relative",

--- a/src/DatePicker/DatePickerStyles.js
+++ b/src/DatePicker/DatePickerStyles.js
@@ -3,7 +3,6 @@ import { createGlobalStyle } from "styled-components";
 export const DatePickerStyles = createGlobalStyle(({ theme }) => ({
   ".nds-date-picker": {
     ".react-datepicker__input-container": {
-      width: "184px",
       input: {
         position: "relative",
       },

--- a/src/DateRange/DateRange.story.js
+++ b/src/DateRange/DateRange.story.js
@@ -68,8 +68,8 @@ WithCustomError.story = {
 
 export const CustomizingInputProps = () => (
   <DateRange
-    startDateInputProps={{ placeholder: "From (Mon YYYY)" }}
-    endDateInputProps={{ placeholder: "To (Mon YYYY)" }}
+    startDateInputProps={{ placeholder: "From (Mon YYYY)", inputWidth: "160px" }}
+    endDateInputProps={{ placeholder: "To (Mon YYYY)", inputWidth: "140px" }}
     onRangeChange={action("range changed")}
     onStartDateChange={action("start date changed")}
     onEndDateChange={action("end date changed")}
@@ -105,6 +105,21 @@ export const WithTimes = () => (
     showTimes
   />
 );
+
+export const CustomizingInputPropsWithTimes = () => (
+  <DateRange
+    startDateInputProps={{ placeholder: "From", inputWidth: "130px" }}
+    endDateInputProps={{ placeholder: "To", inputWidth: "130px"  }}
+    onRangeChange={action("range changed")}
+    onStartDateChange={action("start date changed")}
+    onEndDateChange={action("end date changed")}
+    showTimes
+  />
+);
+
+CustomizingInputPropsWithTimes.story = {
+  name: "customizing input props with times",
+};
 
 WithTimes.story = {
   name: "with times",

--- a/src/DateRange/DateRange.tsx
+++ b/src/DateRange/DateRange.tsx
@@ -166,6 +166,7 @@ const DateRange: React.SFC<DateRangeProps> = forwardRef(
             error: rangeError,
             ...startDateInputProps,
           }}
+          fitContent
           errorMessage={startDateErrorMessage}
           minDate={minDate}
           maxDate={maxDate}
@@ -216,6 +217,7 @@ const DateRange: React.SFC<DateRangeProps> = forwardRef(
             "aria-label": t("select an end date"),
             ...endDateInputProps,
           }}
+          fitContent
           errorMessage={endDateErrorMessage}
           minDate={minDate}
           maxDate={maxDate}

--- a/src/DateRange/DateRange.tsx
+++ b/src/DateRange/DateRange.tsx
@@ -166,7 +166,6 @@ const DateRange: React.SFC<DateRangeProps> = forwardRef(
             error: rangeError,
             ...startDateInputProps,
           }}
-          fitContent
           errorMessage={startDateErrorMessage}
           minDate={minDate}
           maxDate={maxDate}
@@ -217,7 +216,6 @@ const DateRange: React.SFC<DateRangeProps> = forwardRef(
             "aria-label": t("select an end date"),
             ...endDateInputProps,
           }}
-          fitContent
           errorMessage={endDateErrorMessage}
           minDate={minDate}
           maxDate={maxDate}

--- a/src/Form/Field.tsx
+++ b/src/Form/Field.tsx
@@ -1,7 +1,12 @@
 import styled from "styled-components";
 import { Box } from "../Box";
+import { BoxProps } from '../Box/Box';
 
-const Field = styled(Box)({
-  width: "100%",
-});
+export type FieldProps = BoxProps & {
+  fitContent?: boolean;
+};
+
+const Field = styled(Box)(({ fitContent }: FieldProps) => ({
+  width: !fitContent ? "100%" : "auto",
+}));
 export default Field;

--- a/src/Form/Field.tsx
+++ b/src/Form/Field.tsx
@@ -2,11 +2,10 @@ import styled from "styled-components";
 import { Box } from "../Box";
 import { BoxProps } from '../Box/Box';
 
-export type FieldProps = BoxProps & {
-  fitContent?: boolean;
-};
+export type FieldProps = BoxProps;
 
-const Field = styled(Box)(({ fitContent }: FieldProps) => ({
-  width: !fitContent ? "100%" : "auto",
-}));
+const Field = styled(Box)({
+  width: "100%",
+});
+
 export default Field;

--- a/src/Input/InputField.tsx
+++ b/src/Input/InputField.tsx
@@ -57,6 +57,7 @@ const StyledInput: React.SFC<StyledInputProps> = styled.input(
     lineHeight: theme.lineHeights.base,
     margin: theme.space.none,
     minHeight: theme.space.x5,
+    maxWidth: inputWidth,
     width: inputWidth,
     "&:focus": {
       outline: "none",
@@ -134,7 +135,7 @@ export const InputField: React.SFC<InputFieldProps> = forwardRef<
           prefixWidth={prefixWidth}
           textAlign={prefixAlignment}
         />
-        <Box position="relative" display="flex" flexGrow={1}>
+        <Box position="relative" display="flex" flexGrow={1} maxWidth={inputWidth}>
           <StyledInput
             aria-invalid={error}
             aria-required={required}

--- a/src/RangeContainer/RangeContainer.tsx
+++ b/src/RangeContainer/RangeContainer.tsx
@@ -30,11 +30,15 @@ const RangeContainer: React.SFC<RangeContainerProps> = ({
         mt="x1"
         mb={errorMessages.length ? "x1" : "x3"}
       >
-        {startComponent}
+        <Flex>
+          {startComponent}
+        </Flex>
         <Flex px="half" alignItems="center" maxHeight="38px">
           <Text>-</Text>
         </Flex>
-        {endComponent}
+        <Flex>
+          {endComponent}
+        </Flex>
       </Flex>
       {errorMessages.map((errorMessage, i) => (
         // eslint-disable-next-line react/no-array-index-key

--- a/src/RangeContainer/RangeContainer.tsx
+++ b/src/RangeContainer/RangeContainer.tsx
@@ -22,26 +22,26 @@ const RangeContainer: React.SFC<RangeContainerProps> = ({
 }) => {
   const spaceProps = getSubset(props, propTypes.space);
   const restProps = omitSubset(props, propTypes.space);
-  return <Box {...spaceProps} display="inline-block">
-    <FieldLabel {...labelProps} {...restProps} />
-    <Box
-      display="inline-flex"
-      justifyContent="center"
-      alignItems="flex-start"
-      mt="x1"
-      mb={errorMessages.length ? "x1" : "x3"}
-    >
-      {startComponent}
-      <Flex px="half" alignItems="center" maxHeight="38px">
-        <Text>-</Text>
+  return (
+    <Flex {...spaceProps} flexDirection="column">
+      <FieldLabel {...labelProps} {...restProps} />
+      <Flex
+        flexWrap="wrap"
+        mt="x1"
+        mb={errorMessages.length ? "x1" : "x3"}
+      >
+        {startComponent}
+        <Flex px="half" alignItems="center" maxHeight="38px">
+          <Text>-</Text>
+        </Flex>
+        {endComponent}
       </Flex>
-      {endComponent}
-    </Box>
-    {errorMessages.map((errorMessage, i) => (
-      // eslint-disable-next-line react/no-array-index-key
-      <InlineValidation key={i} errorMessage={errorMessage} />
-    ))}
-  </Box>
+      {errorMessages.map((errorMessage, i) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <InlineValidation key={i} errorMessage={errorMessage} />
+      ))}
+    </Flex>
+  );
 };
 RangeContainer.defaultProps = {
   labelProps: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2424,21 +2424,6 @@
     global "^4.3.2"
     util-deprecate "^1.0.2"
 
-"@storybook/addons@^6.0.26":
-  version "6.1.11"
-  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-6.1.11.tgz#cb4578411ca00ccb206b484df5a171ccaca34719"
-  integrity sha512-OZXsdmn60dVe482l9zWxzOqqJApD2jggk/8QJKn3/Ub9posmqdqg712bW6v71BBe0UXXG/QfkZA7gcyiyEENbw==
-  dependencies:
-    "@storybook/api" "6.1.11"
-    "@storybook/channels" "6.1.11"
-    "@storybook/client-logger" "6.1.11"
-    "@storybook/core-events" "6.1.11"
-    "@storybook/router" "6.1.11"
-    "@storybook/theming" "6.1.11"
-    core-js "^3.0.1"
-    global "^4.3.2"
-    regenerator-runtime "^0.13.7"
-
 "@storybook/api@5.3.21", "@storybook/api@^5.3.19":
   version "5.3.21"
   resolved "https://registry.yarnpkg.com/@storybook/api/-/api-5.3.21.tgz#8f1772de53b65e1a65d2f0257463d621a8617c58"
@@ -2813,18 +2798,6 @@
   version "6.1.9"
   resolved "https://registry.yarnpkg.com/@storybook/router/-/router-6.1.9.tgz#c0b24dc3ab53d58541b81c7abea2f11d7fbbebf6"
   integrity sha512-kIlmSFBnqI198oMCncFZR7MxoV5/kP6KS0paFcyu1XE1zO2ovV6eQZ8pPpOjSsD/ISu4Y44uE+ZDNsEehjj6GQ==
-  dependencies:
-    "@reach/router" "^1.3.3"
-    "@types/reach__router" "^1.3.5"
-    core-js "^3.0.1"
-    global "^4.3.2"
-    memoizerific "^1.11.3"
-    qs "^6.6.0"
-
-"@storybook/router@6.1.11":
-  version "6.1.11"
-  resolved "https://registry.yarnpkg.com/@storybook/router/-/router-6.1.11.tgz#d58e0c8324d8b16d71e09c017a4e3c844b1a4139"
-  integrity sha512-YEYOoKMo/WI13MZCkdqI9X3H1G0Oj5OUxi7So4qd3khX3zcCjSr3LjiMDBcmIVZpFo5VAvzjhIY4KqpgvzTG0A==
   dependencies:
     "@reach/router" "^1.3.3"
     "@types/reach__router" "^1.3.5"
@@ -14891,7 +14864,7 @@ react-popper-tooltip@^3.1.0:
     "@popperjs/core" "^2.5.4"
     react-popper "^2.2.4"
 
-react-popper@^1.3.3, react-popper@^1.3.4, react-popper@^1.3.7:
+react-popper@^1.3.4, react-popper@^1.3.6, react-popper@^1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.3.7.tgz#f6a3471362ef1f0d10a4963673789de1baca2324"
   integrity sha512-nmqYTx7QVjCm3WUZLeuOomna138R1luC4EqkW3hxJUrAe+3eNz3oFCLYdnPwILfn0mX1Ew2c3wctrjlUMYYUww==


### PR DESCRIPTION
## Description
- change styles on range container so that it will wrap the fields when there isn't enough space
- add ability to set inputWidth on the datepicker inputs in DateRange

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
