### PR TITLE
feat(Sidebar): add overlay

### DIFF
--- a/cypress/integration/components/Sidebar.spec.js
+++ b/cypress/integration/components/Sidebar.spec.js
@@ -1,5 +1,7 @@
-const Sidebar = () => cy.get('[role="complementary"]');
-const trigger = () => cy.contains("Toggle Sidebar");
+const Sidebar = () => cy.get('[role="dialog"]');
+const trigger = () => cy.contains("Open Sidebar");
+const overlay = () => cy.get('[data-testid="sidebar-overlay"]');
+const closeButton = () => cy.get('[data-testid="sidebar-close-button"]');
 
 describe("Sidebar", () => {
   describe("Default", () => {
@@ -15,7 +17,8 @@ describe("Sidebar", () => {
     });
     it("slides out", () => {
       trigger().click();
-      trigger().click();
+      overlay().should("be.visible");
+      overlay().click({force: true});
       Sidebar().should("not.be.visible");
     });
   });
@@ -43,12 +46,16 @@ describe("Sidebar", () => {
     it("is shown", () => {
       Sidebar().should("be.visible");
     });
-    it("slides out when triggered", () => {
-      trigger().click();
+    it("slides out when overlay clicked", () => {
+      overlay().click({force: true});
+      Sidebar().should("not.be.visible");
+    });
+    it("slides out when close button clicked", () => {
+      closeButton().click({force: true});
       Sidebar().should("not.be.visible");
     });
     it("slides in", () => {
-      trigger().click();
+      overlay().click({force: true});
       trigger().click();
       Sidebar().should("be.visible");
     });
@@ -61,8 +68,13 @@ describe("Sidebar", () => {
       Sidebar().should("be.visible");
       Sidebar().should("have.css", "right", "400px");
     });
-    it("slides out when triggered", () => {
-      trigger().click();
+    it("slides out when close button clicked", () => {
+      closeButton().click();
+      Sidebar().should("not.be.visible");
+      Sidebar().should("have.css", "right", "0px");
+    });
+    it("slides out when overlay clicked", () => {
+      overlay().click({force: true});
       Sidebar().should("not.be.visible");
       Sidebar().should("have.css", "right", "0px");
     });
@@ -71,14 +83,32 @@ describe("Sidebar", () => {
       Sidebar().should("have.css", "right", "35px");
     });
   });
-  describe("Close on Outside Click", () => {
+  describe("Without overlay", () => {
     beforeEach(() => {
-      cy.renderFromStorybook("layout--with-close-sidebar-on-outside-click");
+      cy.renderFromStorybook("layout--with-sidebar-without-overlay");
     });
-    it("slides out when triggered", () => {
+    it("slides out when clicking on the body", () => {
       trigger().click();
       Sidebar().should("be.visible");
       cy.get("body").click();
+      Sidebar().should("not.be.visible");
+      Sidebar().should("have.css", "right", "0px");
+    });
+  });
+  describe("Don't close on outide click", () => {
+    beforeEach(() => {
+      cy.renderFromStorybook("layout--dont-close-sidebar-on-outside-click");
+    });
+    it("does not close when clicking on the body", () => {
+      trigger().click();
+      Sidebar().should("be.visible");
+      cy.get("body").click();
+      Sidebar().should("be.visible");
+    });
+    it("closes when the close button is pressed", () => {
+      trigger().click();
+      Sidebar().should("be.visible");
+      closeButton().click();
       Sidebar().should("not.be.visible");
       Sidebar().should("have.css", "right", "0px");
     });

--- a/src/Layout/Layout.story.js
+++ b/src/Layout/Layout.story.js
@@ -98,6 +98,7 @@ export default {
   title: "Components/Layout",
   parameters: {
     layout: "fullscreen",
+    chromatic: { delay: 300 }, // time for sidebar animation
   },
 };
 

--- a/src/Layout/Layout.story.js
+++ b/src/Layout/Layout.story.js
@@ -238,7 +238,7 @@ export const WithSidebar = () => {
             ref={triggerRef}
             id="openSidebarTrigger"
           >
-            Toggle Sidebar
+            Open Sidebar
           </PrimaryButton>
           <Box height="3000px" width="100%" bg="lightBlue" mt="x3" p="x2">
             Space for more content
@@ -249,6 +249,56 @@ export const WithSidebar = () => {
           onClose={closeSidebar}
           triggerRef={triggerRef}
           aria-controls="openSidebarTrigger"
+        />
+      </Page>
+    </ApplicationFrame>
+  );
+};
+
+export const WithSidebarWithoutOverlay = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const triggerRef = useRef(null);
+
+  const toggleSidebar = () => {
+    setIsOpen(!isOpen);
+  };
+  const closeSidebar = () => {
+    setIsOpen(false);
+  };
+
+  return (
+    <ApplicationFrame
+      navBar={<BrandedNavBar menuData={{ primaryMenu, secondaryMenu }} />}
+      overflowX="hidden"
+      height="100vh"
+    >
+      <Page
+        breadcrumbs={
+          <Breadcrumbs>
+            <Link href="/">Home</Link>
+            <Link href="/">Materials</Link>
+          </Breadcrumbs>
+        }
+        title="Materials Overview"
+      >
+        <Box minWidth="300px">
+          <PrimaryButton
+            onClick={toggleSidebar}
+            ref={triggerRef}
+            id="openSidebarTrigger"
+          >
+            Open Sidebar
+          </PrimaryButton>
+          <Box height="3000px" width="100%" bg="lightBlue" mt="x3" p="x2">
+            Space for more content
+          </Box>
+        </Box>
+        <ExampleSidebar
+          isOpen={isOpen}
+          onClose={closeSidebar}
+          triggerRef={triggerRef}
+          aria-controls="openSidebarTrigger"
+          overlay={false}
         />
       </Page>
     </ApplicationFrame>
@@ -287,7 +337,7 @@ export const WithSidebarOpenByDefault = () => {
             ref={triggerRef}
             id="openSidebarTrigger"
           >
-            Toggle Sidebar
+            Open Sidebar
           </PrimaryButton>
           <Box height="3000px" width="100%" bg="lightBlue" mt="x3" p="x2">
             Space for more content

--- a/src/Layout/Layout.story.js
+++ b/src/Layout/Layout.story.js
@@ -386,7 +386,7 @@ export const WithSidebarCustomOffset = () => {
             ref={triggerRef}
             id="openSidebarTrigger"
           >
-            Toggle Sidebar
+            Open Sidebar
           </PrimaryButton>
           <Box height="3000px" width="100%" bg="lightBlue" mt="x3" p="x2">
             Space for more content
@@ -405,7 +405,7 @@ export const WithSidebarCustomOffset = () => {
   );
 };
 
-export const WithCloseSidebarOnOutsideClick = () => {
+export const DontCloseSidebarOnOutsideClick = () => {
   const [isOpen, setIsOpen] = useState(false);
   const triggerRef = useRef(null);
 
@@ -437,7 +437,7 @@ export const WithCloseSidebarOnOutsideClick = () => {
             ref={triggerRef}
             id="openSidebarTrigger"
           >
-            Toggle Sidebar
+            Open Sidebar
           </PrimaryButton>
           <Box height="3000px" width="100%" bg="lightBlue" mt="x3" p="x2">
             Space for more content
@@ -448,7 +448,7 @@ export const WithCloseSidebarOnOutsideClick = () => {
           onClose={closeSidebar}
           triggerRef={triggerRef}
           aria-controls="openSideBarTrigger"
-          closeOnOutsideClick
+          closeSidebarOnOutsideClick={false}
         />
       </Page>
     </ApplicationFrame>

--- a/src/Layout/Sidebar.spec.js
+++ b/src/Layout/Sidebar.spec.js
@@ -19,23 +19,19 @@ describe("Sidebar", () => {
     });
 
     it("shows an overlay by default", () => {
-      renderWithNDSProvider(
-        <Sidebar isOpen>
-          Sidebar
-        </Sidebar>
+      const { queryByTestId } = renderWithNDSProvider(
+        <Sidebar isOpen>Sidebar</Sidebar>
       );
-      expect(queryByTestId(/sidebar-overlay/i)).toBeTruthy();
+      expect(queryByTestId("sidebar-overlay")).toBeTruthy();
     });
 
-
     it("doesn't show an overlay when set to false", () => {
-      renderWithNDSProvider(
+      const { queryByTestId } = renderWithNDSProvider(
         <Sidebar isOpen overlay={false}>
           Sidebar
         </Sidebar>
       );
-      expect(queryByTestId(/sidebar-overlay/i)).toBeNull();
+      expect(queryByTestId("sidebar-overlay")).toBeNull();
     });
-
   });
 });

--- a/src/Layout/Sidebar.spec.js
+++ b/src/Layout/Sidebar.spec.js
@@ -17,5 +17,25 @@ describe("Sidebar", () => {
       fireEvent.click(closeBtn);
       expect(onCloseHandler).toHaveBeenCalledTimes(1);
     });
+
+    it("shows an overlay by default", () => {
+      renderWithNDSProvider(
+        <Sidebar isOpen>
+          Sidebar
+        </Sidebar>
+      );
+      expect(queryByTestId(/sidebar-overlay/i)).toBeTruthy();
+    });
+
+
+    it("doesn't show an overlay when set to false", () => {
+      renderWithNDSProvider(
+        <Sidebar isOpen overlay={false}>
+          Sidebar
+        </Sidebar>
+      );
+      expect(queryByTestId(/sidebar-overlay/i)).toBeNull();
+    });
+
   });
 });

--- a/src/Layout/Sidebar.tsx
+++ b/src/Layout/Sidebar.tsx
@@ -45,6 +45,7 @@ const SidebarOverlay = ({transitionDuration}) => (
       animate={{opacity: 1}}
       exit={{opacity: 0}}
       transition={{duration: transitionDuration}}
+      data-testid="sidebar-overlay"
     />
 )
 

--- a/src/Layout/Sidebar.tsx
+++ b/src/Layout/Sidebar.tsx
@@ -130,7 +130,7 @@ const Sidebar = ({
       </AnimatePresence>
     )}
     <AnimatedBox
-      role="complementary"
+      role="dialog"
       bg="white"
       display="flex"
       flexDirection="column"

--- a/src/Layout/Sidebar.tsx
+++ b/src/Layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef, RefObject } from "react";
-
+import {AnimatePresence} from "framer-motion";
 import { Box } from "../Box";
 import { Flex } from "../Flex";
 import { IconicButton } from "../Button";
@@ -21,6 +21,7 @@ type SidebarProps = AnimatedBoxProps & {
   triggerRef?: RefObject<any>;
   duration?: number;
   closeOnOutsideClick?: boolean;
+  overlay?: boolean
 };
 
 const focusFirstElement = () => {
@@ -30,6 +31,22 @@ const focusFirstElement = () => {
     (focusable[0] as HTMLElement).focus();
   }
 }
+
+const SidebarOverlay = ({transitionDuration}) => (
+    <AnimatedBox
+      position="absolute"
+      top="0"
+      bottom="0"
+      left="0"
+      right="0"
+      zIndex={"799" as any}
+      bg="rgba(18, 43, 71, 0.5)"
+      initial={{opacity: 0}}
+      animate={{opacity: 1}}
+      exit={{opacity: 0}}
+      transition={{duration: transitionDuration}}
+    />
+)
 
 const Sidebar = ({
   p = "x3",
@@ -45,6 +62,7 @@ const Sidebar = ({
   triggerRef,
   duration = 0.25,
   closeOnOutsideClick,
+  overlay = true,
   ...props
 }: SidebarProps) => {
   const closeButton = useRef(null);
@@ -102,7 +120,14 @@ const Sidebar = ({
       },
     },
   };
+
   return (
+  <>
+    {overlay && (
+      <AnimatePresence>
+        {isOpen && (<SidebarOverlay transitionDuration={duration} />) }
+      </AnimatePresence>
+    )}
     <AnimatedBox
       role="complementary"
       bg="white"
@@ -157,6 +182,7 @@ const Sidebar = ({
       )}
       {closeOnOutsideClick && isOpen && <DetectOutsideClick onClick={onClose} clickRef={sideBarRef} />}
     </AnimatedBox>
+  </>
   );
 };
 

--- a/src/Layout/Sidebar.tsx
+++ b/src/Layout/Sidebar.tsx
@@ -62,7 +62,7 @@ const Sidebar = ({
   offset = "0px",
   triggerRef,
   duration = 0.25,
-  closeOnOutsideClick,
+  closeOnOutsideClick = true,
   overlay = true,
   ...props
 }: SidebarProps) => {


### PR DESCRIPTION
## Description

When you open a sidebar, a blue overlay covers the content. This can be set to false. 

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [x] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
