### PR TITLE
chore: fix sidebar story

### DIFF
--- a/src/Layout/Layout.story.js
+++ b/src/Layout/Layout.story.js
@@ -449,7 +449,7 @@ export const DontCloseSidebarOnOutsideClick = () => {
           onClose={closeSidebar}
           triggerRef={triggerRef}
           aria-controls="openSideBarTrigger"
-          closeSidebarOnOutsideClick={false}
+          closeOnOutsideClick={false}
         />
       </Page>
     </ApplicationFrame>


### PR DESCRIPTION
## Description

The `closeOnOutsideClick` story was incorrect.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [x] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [x] Documentation has been updated
- [ ] Accessibility has been considered
