### PR TITLE
feat: increase the opacity of `disabled` Text from 33% to 70%

### DIFF
--- a/src/Type/Text.tsx
+++ b/src/Type/Text.tsx
@@ -52,7 +52,7 @@ const Text = styled.p.attrs<TextProps>((props: TextProps) =>
   cursor,
   ({ disabled, textTransform }: TextProps): CSSObject => ({
     textTransform,
-    opacity: disabled ? "0.3333" : undefined,
+    opacity: disabled ? "0.7" : undefined,
   })
 );
 Text.defaultProps = {


### PR DESCRIPTION
## Description

Before:
<img width="313" alt="Screen Shot 2021-02-05 at 12 36 38 PM" src="https://user-images.githubusercontent.com/5273370/107070262-168ace80-67b1-11eb-9571-2553204119b7.png">

After: 
<img width="277" alt="Screen Shot 2021-02-05 at 12 36 54 PM" src="https://user-images.githubusercontent.com/5273370/107070269-18ed2880-67b1-11eb-85cd-eb295a15ae38.png">

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [x] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
