### PR TITLE
fix: Simplify rollup config and remove modulesOnly check that triggers unresolved dependencies error

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@nulogy/eslint-config-nulogy": "^0.0.1-alpha.2",
     "@nulogy/icons": "^4.14.0",
     "@rollup/plugin-babel": "^5.0.0",
-    "@rollup/plugin-node-resolve": "^7.1.3",
+    "@rollup/plugin-node-resolve": "^11.2.0",
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/commit-analyzer": "^8.0.1",
     "@semantic-release/git": "^9.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,106 +3,51 @@ import babel from "@rollup/plugin-babel";
 import commonjs from "rollup-plugin-commonjs";
 import replace from "rollup-plugin-replace";
 import typescript from "rollup-plugin-typescript2";
-
-/* Rollup outputs module and main bundles for the @nulogy/components package */
-import packageJson from "./package.json";
+import pkg from "./package.json";
 
 const PEER_DEPENDENCIES = {
   react: "React",
   "styled-components": "styled",
+  "@nulogy/icons": "icons",
+  "react-dom": "reactDom",
 };
 
 const GLOBALS = {
   ...PEER_DEPENDENCIES,
-  "prop-types": "PropTypes",
-  "react-windowed-select": "components",
   "@babel/runtime/helpers/typeof": "typeof",
   "@babel/runtime/helpers/defineProperty": "defineProperty",
   "@babel/runtime/helpers/classCallCheck": "classCallCheck",
   "@babel/runtime/helpers/createClass": "createClass",
   "@babel/runtime/helpers/slicedToArray": "slicedToArray",
   "@babel/runtime/helpers/objectWithoutProperties": "objectWithoutProperties",
-  "object-assign": "assign",
   "@babel/runtime/helpers/objectWithoutPropertiesLoose":
     "objectWithoutPropertiesLoose",
   "@babel/runtime/helpers/extends": "extends",
   "@babel/runtime/helpers/assertThisInitialized": "assertThisInitialized",
   "@babel/runtime/helpers/inheritsLoose": "inheritsLoose",
-  "deep-equal": "deepEqual",
-  "create-react-context": "createReactContext",
-  warning: "warning",
-  exenv: "exenv",
-  classnames: "t",
-  "react-input-autosize": "AutosizeInput",
-  "html-parse-stringify2": "HTML",
-  "smoothscroll-polyfill": "smoothscroll",
-  "react-fast-compare": "isEqual",
-  "path-to-regexp": "pathToRegexp",
-  "react-is": "reactIs",
-  "react-dom": "reactDom",
 };
 
-const externals = Object.keys(GLOBALS);
+const EXTENSIONS = [".js", ".jsx", ".ts", ".tsx", ".mjs"];
 
-const EXTENSIONS = [".js", ".jsx", "ts", ".tsx", ".mjs"];
-
-const CORE_PLUGINS = [
-  /* typescript: see tsconfig.json for settings */
-  typescript(),
-  /* commonJS: convert CommonJS modules to ES6,
-  so they can be included in a Rollup bundle */
-  commonjs({
-    /* include: include all items in node_modules folders (in entire monorepo) */
-    include: [/node_modules/],
-    /* namedExports: sometimes commonjs can't resolve named exports from certain libraries, 
-    ex: import {exportName} from "package-name"; => exportName module not found
-    in those cases, it needs to be added as ["package-name"]: "exportName" here */
-    namedExports: {
-      debounce: ["debounce"],
-      "react-windowed-select": ["components"],
-    },
-  }),
-  /* babel: transiles the bundle according to babel.config */
-  babel({
-    /* babelHelpers: runtime tells babel to import from @babel/runtime instead of duplicated them */
-    babelHelpers: "runtime",
-    /* exclude: globs to exclude */
-    exclude: ["./node_modules/**/*"],
-    /* exclude: files to be transpiled by babel */
-    extensions: EXTENSIONS,
-  }),
-  /* replace: replaces strings when bundling */
-  replace({
-    exclude: /node_modules/,
-    /* ENV is replaced by environment setting */
-    ENV: JSON.stringify(process.env.NODE_ENV || "development"),
-  }),
-];
-
-const ENTRY_FILE = "src/index.ts";
-
-const mainBundles = {
-  /* input: main export file */
-  input: ENTRY_FILE,
-  /* external: external dependencies, all peerDependencies */
-  external: externals,
+export default {
+  input: "src/index.ts",
   output: [
-    // UMD format for compatibility with most script loaders
     {
-      file: packageJson.main,
+      file: pkg.main,
       name: "NDSComponents",
       format: "umd",
-      // globals: global variable names of external dependencies
       globals: GLOBALS,
     },
-    // ES module format for package.module field, auto-imports and optimal tree-shaking
     {
-      file: packageJson.module,
+      file: pkg.module,
       format: "es",
       globals: GLOBALS,
     },
   ],
+  external: Object.keys(PEER_DEPENDENCIES),
   plugins: [
+    /* typescript: see tsconfig.json for settings */
+    typescript(),
     // resolve: resolves node_modules imports
     resolve({
       /* mainFields: specifies the which package fields to look for first
@@ -110,12 +55,38 @@ const mainBundles = {
       package.main */
       mainFields: ["module", "main"],
       /* modulesOnly: inspect resolved files are es2015 modules */
-      modulesOnly: true,
+      // modulesOnly: true,
       /* extensions: specifies the file extensions to accept as imports */
       extensions: EXTENSIONS,
     }),
-    ...CORE_PLUGINS,
+    /* commonJS: convert CommonJS modules to ES6,
+    so they can be included in a Rollup bundle */
+    commonjs({
+      exclude: ["src/**"],
+      /* include: include all items in node_modules folders (in entire monorepo) */
+      include: ["./node_modules/**"],
+      /* namedExports: sometimes commonjs can't resolve named exports from certain libraries, 
+    ex: import {exportName} from "package-name"; => exportName module not found
+    in those cases, it needs to be added as ["package-name"]: "exportName" here */
+      namedExports: {
+        debounce: ["debounce"],
+        "react-windowed-select": ["components"],
+        "body-scroll-lock": ["disableBodyScroll", "clearAllBodyScrollLocks"],
+        "react-is": ["isValidElementType"]
+      },
+    }),
+    /* babel: transiles the bundle according to babel.config */
+    babel({
+      /* babelHelpers: runtime tells babel to import from @babel/runtime instead of duplicated them */
+      babelHelpers: "runtime",
+      /* exclude: globs to exclude */
+      exclude: "./node_modules/**",
+    }),
+    /* replace: replaces strings when bundling */
+    replace({
+      exclude: /node_modules/,
+      /* ENV is replaced by environment setting */
+      ENV: JSON.stringify(process.env.NODE_ENV || "development"),
+    }),
   ],
 };
-
-export default [mainBundles];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2163,18 +2163,19 @@
     "@babel/helper-module-imports" "^7.10.4"
     "@rollup/pluginutils" "^3.1.0"
 
-"@rollup/plugin-node-resolve@^7.1.3":
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz#80de384edfbd7bfc9101164910f86078151a3eca"
-  integrity sha512-RxtSL3XmdTAE2byxekYLnx+98kEUOrPHF/KRVjLH+DEIHy6kjIw7YINQzn+NXiH/NTrQLAwYs0GWB+csWygA9Q==
+"@rollup/plugin-node-resolve@latest":
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.2.0.tgz#a5ab88c35bb7622d115f44984dee305112b6f714"
+  integrity sha512-qHjNIKYt5pCcn+5RUBQxK8krhRvf1HnyVgUCcFFcweDS7fhkOLZeYh0mhHK6Ery8/bb9tvN/ubPzmfF0qjDCTA==
   dependencies:
-    "@rollup/pluginutils" "^3.0.8"
-    "@types/resolve" "0.0.8"
+    "@rollup/pluginutils" "^3.1.0"
+    "@types/resolve" "1.17.1"
     builtin-modules "^3.1.0"
+    deepmerge "^4.2.2"
     is-module "^1.0.0"
-    resolve "^1.14.2"
+    resolve "^1.19.0"
 
-"@rollup/pluginutils@^3.0.8", "@rollup/pluginutils@^3.1.0":
+"@rollup/pluginutils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
   integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
@@ -3404,10 +3405,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/resolve@0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
-  integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
+"@types/resolve@1.17.1":
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"
+  integrity sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
   dependencies:
     "@types/node" "*"
 
@@ -9938,7 +9939,7 @@ is-cidr@^3.0.0:
   dependencies:
     cidr-regex "^2.0.10"
 
-is-core-module@^2.1.0:
+is-core-module@^2.1.0, is-core-module@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.2.0.tgz#97037ef3d52224d85163f5597b2b63d9afed981a"
   integrity sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==
@@ -15770,12 +15771,20 @@ resolve@1.17.0:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.3.2, resolve@^1.8.1:
+resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.3.2, resolve@^1.8.1:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
   integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==
   dependencies:
     is-core-module "^2.1.0"
+    path-parse "^1.0.6"
+
+resolve@^1.19.0:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
+  integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
+  dependencies:
+    is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
 restore-cursor@^1.0.1:


### PR DESCRIPTION
Fixes two issues
1. Externals were incorrectly set and should be only peerDependencies
2. We couldn't remove all the extra globals before due to unresolved modules errors, which seem to crop up when using the modulesOnly resolve setting: https://github.com/rollup/rollup-plugin-node-resolve/issues/200

## Description

**Describe the change you're making, the motiviations behind it, and any thing else a reviewer may need to know to approve this PR.**

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
