### PR TITLE
feat(IconicButton): Add ability to add  a tooltip in addition to the label with `tooltip` prop

### DIFF
--- a/src/Button/IconicButton.story.js
+++ b/src/Button/IconicButton.story.js
@@ -65,6 +65,7 @@ WithACustomSize.story = {
   name: "with a custom size",
 };
 
+
 export const WithACustomColor = () => (
   <IconicButton color="red" icon="close">
     Close
@@ -73,6 +74,16 @@ export const WithACustomColor = () => (
 
 WithACustomColor.story = {
   name: "with a custom color",
+};
+
+export const WithATooltipAndLabel = () => (
+  <IconicButton tooltip="Stop job" icon="close">
+    Stop
+  </IconicButton>
+);
+
+WithATooltipAndLabel.story = {
+  name: "with a tooltip and label",
 };
 
 export const rightAligned = () => (

--- a/src/Button/IconicButton.tsx
+++ b/src/Button/IconicButton.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "styled-components";
+import PropTypes from 'prop-types';
 import { space, SpaceProps } from "styled-system";
 import { Manager, Reference, Popper } from "react-popper-latest";
 import { transparentize } from "polished";
@@ -7,6 +8,7 @@ import icons from "@nulogy/icons";
 import { Icon } from "../Icon";
 import { Text } from "../Type";
 import NDSTheme from "../theme";
+import { deprecatedProp } from "../utils/deprecatedProp";
 
 const HoverText: React.SFC<any> = styled.div(({ theme }) => ({
   whiteSpace: "nowrap",
@@ -83,6 +85,7 @@ type IconicButtonProps = SpaceProps & {
   onClick?: (...args: any[]) => any;
   icon?: any;
   iconSize?: string;
+  tooltip?: string;
   children?: any;
 };
 const IconicButton = React.forwardRef<HTMLButtonElement, IconicButtonProps>(
@@ -94,6 +97,7 @@ const IconicButton = React.forwardRef<HTMLButtonElement, IconicButtonProps>(
       labelHidden,
       className,
       iconSize,
+      tooltip,
       ...props
     },
     forwardedRef
@@ -131,9 +135,9 @@ const IconicButton = React.forwardRef<HTMLButtonElement, IconicButtonProps>(
             ]}
           >
             {({ ref, style, placement }) =>
-              labelHidden ? (
+              labelHidden || tooltip ? (
                 <HoverText ref={ref} style={style} placement={placement}>
-                  {children}
+                  {tooltip ? tooltip : children}
                 </HoverText>
               ) : null
             }
@@ -149,5 +153,17 @@ const IconicButton = React.forwardRef<HTMLButtonElement, IconicButtonProps>(
   }
 );
 export const iconNames = Object.keys(icons);
+
+IconicButton.propTypes = {
+  className: PropTypes.string,
+  color: PropTypes.string,
+  labelHidden: deprecatedProp(PropTypes.bool, "tooltip"),
+  disabled: PropTypes.bool,
+  onClick: PropTypes.func,
+  icon: PropTypes.string,
+  iconSize: PropTypes.string,
+  tooltip: PropTypes.string,
+  children: PropTypes.node,
+};
 
 export default IconicButton;


### PR DESCRIPTION

## Description

Add ability to add  a tooltip in addition to the label with `tooltip` prop. `labelHidden` prop will be deprecated, use `tooltip` with the label text instead and remove children.


## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [x] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
