### PR TITLE
feat: Adds a prop to disableGlobalStyles in NDSProvider

### DIFF
--- a/src/NDSProvider/NDSProvider.tsx
+++ b/src/NDSProvider/NDSProvider.tsx
@@ -86,8 +86,13 @@ type AllNDSGlobalStylesProps = {
   children?: any;
 };
 
-const Styles = ({ theme, locale, disableGlobalStyles, children }) =>
-  disableGlobalStyles ? (
+const AllNDSGlobalStyles = ({
+  theme,
+  locale,
+  disableGlobalStyles,
+  children,
+}: AllNDSGlobalStylesProps) =>
+  !disableGlobalStyles ? (
     <>
       <Reset />
       <ModalStyleOverride theme={theme} locale={locale} />
@@ -111,13 +116,15 @@ const NDSProvider = ({
   const mergedTheme = mergeThemes(NDSTheme, theme);
   return (
     <LocaleContext.Provider value={{ locale }}>
-      <Reset />
-      <ModalStyleOverride theme={mergedTheme} locale={locale} />
-      <GlobalStyles theme={mergedTheme} locale={locale}>
+      <AllNDSGlobalStyles
+        theme={mergedTheme}
+        locale={locale}
+        disableGlobalStyles={disableGlobalStyles}
+      >
         <I18nextProvider i18n={i18n}>
           <ThemeProvider theme={mergedTheme}>{children}</ThemeProvider>
         </I18nextProvider>
-      </GlobalStyles>
+      </AllNDSGlobalStyles>
     </LocaleContext.Provider>
   );
 };

--- a/src/NDSProvider/NDSProvider.tsx
+++ b/src/NDSProvider/NDSProvider.tsx
@@ -7,13 +7,14 @@ import styled, {
 import { I18nextProvider } from "react-i18next";
 import NDSTheme from "../theme";
 import i18n from "../i18n";
+import { ThemeType, DefaultNDSThemeType } from "../theme.type";
 import { LocaleContext } from "./LocaleContext";
 import { mergeThemes } from "./mergeThemes.util";
-import { ThemeType, DefaultNDSThemeType } from '../theme.type';
 
 type NDSProviderProps = {
   theme?: ThemeType;
   locale?: string;
+  disableGlobalStyles?: boolean;
   children?: any;
 };
 
@@ -27,7 +28,7 @@ const Reset = createGlobalStyle(() => {
 type GlobalStylesProps = {
   theme?: DefaultNDSThemeType;
   locale?: string;
-}
+};
 
 const ModalStyleOverride = createGlobalStyle(
   ({ theme, locale }: GlobalStylesProps) => {
@@ -77,9 +78,31 @@ const GlobalStyles = styled.div(
     };
   }
 );
+
+type AllNDSGlobalStylesProps = {
+  theme?: ThemeType;
+  locale?: string;
+  disableGlobalStyles?: boolean;
+  children?: any;
+};
+
+const Styles = ({ theme, locale, disableGlobalStyles, children }) =>
+  disableGlobalStyles ? (
+    <>
+      <Reset />
+      <ModalStyleOverride theme={theme} locale={locale} />
+      <GlobalStyles theme={theme} locale={locale}>
+        {children}
+      </GlobalStyles>
+    </>
+  ) : (
+    children
+  );
+
 const NDSProvider = ({
   theme,
   children,
+  disableGlobalStyles = false,
   locale = "en_US",
 }: NDSProviderProps) => {
   useEffect(() => {

--- a/src/NDSProvider/NDSProvider.tsx
+++ b/src/NDSProvider/NDSProvider.tsx
@@ -80,7 +80,7 @@ const GlobalStyles = styled.div(
 );
 
 type AllNDSGlobalStylesProps = {
-  theme?: ThemeType;
+  theme?: DefaultNDSThemeType;
   locale?: string;
   disableGlobalStyles?: boolean;
   children?: any;


### PR DESCRIPTION
## Description

Adds a prop to disableGlobalStyles in NDSProvider so that it can be used in an app without pulling in gloabl styles or adding a wrapper div (usefule in the case of passing in component to bryntum scheduler or anywhere where else the NDSProvider needs to be used multiple times to re-establish theme and locale context only)

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [x] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
