### PR TITLE
chore: Remove cypress storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,4 @@
 import { create } from "@storybook/theming";
-import "cypress-storybook/react";
 import { theme } from "../src";
 import withNDSTheme from "./nds-theme";
 

--- a/cypress/integration/components/Alert.spec.js
+++ b/cypress/integration/components/Alert.spec.js
@@ -1,9 +1,6 @@
 describe("Alert", () => {
   before(() => {
-    cy.visitStorybook();
-  });
-  beforeEach(() => {
-    cy.loadStory("Components/Alert", "With a close button");
+    cy.renderFromStorybook("alert--with-a-close-button");
   });
   it("shows an alert", () => {
     cy.get('[role="alert"]').should("be.visible");

--- a/cypress/integration/components/Alert.spec.js
+++ b/cypress/integration/components/Alert.spec.js
@@ -14,17 +14,4 @@ describe("Alert", () => {
     cy.get('[role="alert"]').should("not.be.visible");
     cy.get('[role="alert"]').should("not.exist");
   });
-  it("updates text content when knob is changed", () => {
-    cy.get('[role="alert"]').should("be.visible");
-    cy.get('[role="alert"]').should("have.text", "Warning alert");
-    cy.changeKnob("Alert Text", "New text value");
-    cy.get('[role="alert"]').should("have.text", "New text value");
-    cy.isInViewport('[role="alert"]');
-  });
-  it("removes the close button when know is unchecked", () => {
-    cy.isInViewport('[role="alert"]');
-    cy.get('[aria-label="Close"]').should("be.visible");
-    cy.changeKnob("isCloseable", false);
-    cy.get('[aria-label="Close"]').should("not.be.visible");
-  });
 });

--- a/cypress/integration/components/Sidebar.spec.js
+++ b/cypress/integration/components/Sidebar.spec.js
@@ -18,7 +18,7 @@ describe("Sidebar", () => {
     it("slides out", () => {
       trigger().click();
       overlay().should("be.visible");
-      overlay().click({force: true});
+      overlay().click({ force: true });
       Sidebar().should("not.be.visible");
     });
   });
@@ -47,15 +47,15 @@ describe("Sidebar", () => {
       Sidebar().should("be.visible");
     });
     it("slides out when overlay clicked", () => {
-      overlay().click({force: true});
+      overlay().click({ force: true });
       Sidebar().should("not.be.visible");
     });
     it("slides out when close button clicked", () => {
-      closeButton().click({force: true});
+      closeButton().click({ force: true });
       Sidebar().should("not.be.visible");
     });
     it("slides in", () => {
-      overlay().click({force: true});
+      overlay().click({ force: true });
       trigger().click();
       Sidebar().should("be.visible");
     });
@@ -74,13 +74,9 @@ describe("Sidebar", () => {
       Sidebar().should("have.css", "right", "0px");
     });
     it("slides out when overlay clicked", () => {
-      overlay().click({force: true});
+      overlay().click({ force: true });
       Sidebar().should("not.be.visible");
       Sidebar().should("have.css", "right", "0px");
-    });
-    it("updates offset", () => {
-    cy.changeKnob("offset", "35px");
-      Sidebar().should("have.css", "right", "35px");
     });
   });
   describe("Without overlay", () => {

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -17,7 +17,6 @@ require("cypress-plugin-tab");
 
 // Import commands.js using ES2015 syntax:
 import "./commands";
-import "cypress-storybook/cypress";
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "cypress": "^4.0.0",
     "cypress-enter-plugin": "^1.0.1",
     "cypress-plugin-tab": "^1.0.1",
-    "cypress-storybook": "^0.2.3",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.2",
     "enzyme-to-json": "3.4.4",

--- a/plopfile.js
+++ b/plopfile.js
@@ -16,12 +16,12 @@ module.exports = function (plop) {
       },
       {
         type: "add",
-        path: "./src/{{name}}/index.js",
+        path: "./src/{{name}}/index.ts",
         templateFile: "./src/template/index.hbs",
       },
       {
         type: "add",
-        path: "./src/{{name}}/{{name}}.story.js",
+        path: "./src/{{name}}/{{name}}.story.tsx",
         templateFile: "./src/template/component.story.hbs",
       },
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6599,11 +6599,6 @@ cypress-plugin-tab@^1.0.1:
   dependencies:
     ally.js "^1.4.1"
 
-cypress-storybook@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/cypress-storybook/-/cypress-storybook-0.2.3.tgz#b7459004612b5e824e2f38182a0ffd2d0972747a"
-  integrity sha512-/cEtnsP3ui8H2wG1wBAbM8lqdDobu3xHqJGuUael+bB4GHNp+eoQxK5fgu8n4Ti+wBxoln8giYKhUOqk8+Ja+Q==
-
 cypress@^4.0.0:
   version "4.12.1"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-4.12.1.tgz#0ead1b9f4c0917d69d8b57f996b6e01fe693b6ec"


### PR DESCRIPTION
## Description

Remove cypress-storybook since knobs are being removed, we don't want to propogate these types of tests

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
