### PR TITLE
fix: Respect a Table's column alignment setting in the footer

### DIFF
--- a/src/Table/BaseTable.story.tsx
+++ b/src/Table/BaseTable.story.tsx
@@ -34,7 +34,7 @@ const dropdownCellRenderer = ({ cellData }) => (
 const columns = [
   { label: "Date", dataKey: "date" },
   { label: "Expected Quantity", dataKey: "expectedQuantity" },
-  { label: "Actual Quantity", dataKey: "actualQuantity" },
+  { label: "Actual Quantity", dataKey: "actualQuantity", align: "right" },
 ];
 
 const columnsWithWidths = [

--- a/src/Table/TableFoot.tsx
+++ b/src/Table/TableFoot.tsx
@@ -42,7 +42,7 @@ const TableFooterRow = ({ row, columns, loading }) => {
             <TableCell
               key={column.dataKey}
               row={row}
-              column={{ dataKey: column.dataKey, label: column.label }}
+              column={{ dataKey: column.dataKey, label: column.label, align: column.align }}
               cellData={row[column.dataKey]}
             />
           )


### PR DESCRIPTION
## Description

A column's alignment setting wasn't being applied in the footer. e.g if you told a column to align to the right, and passed in `footerRows`, the column in the footer would still be to the left. This PR fixes that.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

