### PR TITLE
fix: pass compact prop to table footer

### DIFF
--- a/src/Table/BaseTable.story.tsx
+++ b/src/Table/BaseTable.story.tsx
@@ -93,6 +93,40 @@ const rowData = [
     id: "r9",
   },
 ];
+
+const compactRowData = [
+  {
+    date: "2019-10-01",
+    expectedQuantity: "2,025 eaches",
+    actualQuantity: "1,800 eaches",
+    id: "r1",
+  },
+  {
+    date: "2019-10-02",
+    expectedQuantity: "2,475 eaches",
+    actualQuantity: "2,250 eaches",
+    id: "r2",
+  },
+  {
+    date: "2019-10-03",
+    expectedQuantity: "2,475 eaches",
+    actualQuantity: "1,425 eaches",
+    id: "r3",
+  },
+  {
+    date: "2019-10-04",
+    expectedQuantity: "2,475 eaches",
+    actualQuantity: "675 eaches",
+    id: "r4",
+  },
+  {
+    date: "2019-10-07",
+    expectedQuantity: "2,475 eaches",
+    actualQuantity: "1,575 eaches",
+    id: "r5",
+  },
+];
+
 const rowDataWithWidths = [
   {
     date: "2019-10-01",
@@ -350,6 +384,7 @@ WithFullWidthSection.story = {
 };
 
 export const WithAFooter = () => (
+  <>
   <Table
     columns={columns}
     keyField="date"
@@ -357,6 +392,15 @@ export const WithAFooter = () => (
     footerRows={footerRowData}
     loading={boolean("Show loading state", false)}
   />
+  <Table
+    compact
+    columns={columns}
+    keyField="date"
+    rows={compactRowData}
+    footerRows={footerRowData}
+    loading={boolean("Show loading state", false)}
+  />
+  </>
 );
 
 WithAFooter.story = {

--- a/src/Table/BaseTable.tsx
+++ b/src/Table/BaseTable.tsx
@@ -68,6 +68,7 @@ const BaseTable: React.SFC<BaseTableProps> = ({
         rows={footerRows}
         keyField={keyField}
         loading={loading}
+        compact={compact}
       />
     )}
   </StyledTable>

--- a/src/Table/TableFoot.tsx
+++ b/src/Table/TableFoot.tsx
@@ -11,17 +11,18 @@ const StyledFooterRow = styled.tr(({ theme }) => ({
   },
 }));
 
-const renderRows = (rows, columns, keyField, loading) =>
+const renderRows = (rows, columns, keyField, loading, compact) =>
   rows.map((row) => (
     <TableFooterRow
       row={row}
       columns={columns}
       key={row[keyField]}
       loading={loading}
+      compact={compact}
     />
   ));
 
-const TableFooterRow = ({ row, columns, loading }) => {
+const TableFooterRow = ({ row, columns, loading, compact }) => {
   const columnsWithoutControls = columns.filter(
     (column) => column.dataKey !== "selected" && column.dataKey !== "expanded"
   );
@@ -34,6 +35,7 @@ const TableFooterRow = ({ row, columns, loading }) => {
             key={column.dataKey}
             scope="row"
             colSpan={numberOfControlColumns + 1}
+            compact={compact}
           >
             {row[column.dataKey]}
           </StyledTh>
@@ -44,6 +46,7 @@ const TableFooterRow = ({ row, columns, loading }) => {
               row={row}
               column={{ dataKey: column.dataKey, label: column.label, align: column.align }}
               cellData={row[column.dataKey]}
+              compact={compact}
             />
           )
         )
@@ -56,10 +59,11 @@ TableFooterRow.propTypes = {
   row: rowPropType.isRequired,
   columns: columnsPropType.isRequired,
   loading: PropTypes.bool.isRequired,
+  compact: PropTypes.bool.isRequired,
 };
 
-const TableFoot = ({ columns, rows, keyField, loading }) => (
-  <tfoot>{renderRows(rows, columns, keyField, loading)}</tfoot>
+const TableFoot = ({ columns, rows, keyField, loading, compact }) => (
+  <tfoot>{renderRows(rows, columns, keyField, loading, compact)}</tfoot>
 );
 
 TableFoot.propTypes = {
@@ -67,11 +71,13 @@ TableFoot.propTypes = {
   rows: rowsPropType.isRequired,
   keyField: PropTypes.string,
   loading: PropTypes.bool,
+  compact: PropTypes.bool,
 };
 
 TableFoot.defaultProps = {
   keyField: "id",
   loading: false,
+  compact: false,
 };
 
 export default TableFoot;


### PR DESCRIPTION
## Description

The <TableFoot> component does not currently receive the `compact` prop from its parent Table. This results in mismatching padding between the footer and a compact parent Table.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [x] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
