### PR TITLE
fix: Prevent certain Icons from being cut off when used inside an IconicButton

### DIFF
--- a/src/Button/IconicButton.story.tsx
+++ b/src/Button/IconicButton.story.tsx
@@ -6,7 +6,7 @@ export default {
   title: "Components/IconicButton",
 };
 
-export const WithoutALabel = () => <IconicButton icon="delete" />;
+export const WithoutALabel = () => <IconicButton icon="chatBubble" />;
 
 WithoutALabel.story = {
   name: "without a label",

--- a/src/Button/IconicButton.tsx
+++ b/src/Button/IconicButton.tsx
@@ -118,6 +118,9 @@ const IconicButton = React.forwardRef<HTMLButtonElement, IconicButtonProps>(
                 icon={icon}
                 p="half"
                 color={color}
+                style={{
+                  overflow: "visible"
+                }}
               />
             )}
           </Reference>


### PR DESCRIPTION
## Description

![Screen Shot 2021-07-15 at 3 47 17 PM](https://user-images.githubusercontent.com/5273370/125949623-85636a82-a144-4ac7-982f-8a6cb9c5adf2.png)

The icon on the left was jealous of the way the icon on the right doesn't get cut off so this PR fixes that.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [x] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
