### PR TITLE
fix: prevent jest from trying to run cypress tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,8 +178,6 @@
       "node_modules/(?!(@nulogy|storybook-addon-performance))"
     ],
     "testMatch": [
-      "**/src/**/*.spec.js",
-      "**/spec/**/*.spec.js",
       "**/src/**/*.spec.tsx",
       "**/spec/**/*.spec.tsx"
     ],


### PR DESCRIPTION
## Description

When we did the Typescript conversion we updated our filepaths in some places and one of those updates started making Jest attempt to run Cypress tests. This fix will stop that for now. If we start using Jest with Typescript we'll need to change the filepaths then, but it should feel natural to do so during that task.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
