### PR TITLE
fix: Allow clearing all items in the AsyncSelect component

### DIFF
--- a/cypress/integration/components/AsyncSelect.spec.js
+++ b/cypress/integration/components/AsyncSelect.spec.js
@@ -29,7 +29,7 @@ describe("AsyncSelect", () => {
       getMultiselect().click();
 
       cy.focused().type("cana");
-      cy.wait(200);
+      assertDropDownIsOpen().contains("Canada");
       cy.focused().type("{enter}");
 
       getClearButton().click();

--- a/cypress/integration/components/AsyncSelect.spec.js
+++ b/cypress/integration/components/AsyncSelect.spec.js
@@ -3,6 +3,7 @@ describe("AsyncSelect", () => {
   const getDropdownMenu = () => cy.get("[data-testid='select-dropdown']");
   const getMultiselect = () => getSelectComponent();
   const getClearButton = () => cy.get("[data-testid='select-clear']");
+  const assertDropDownIsOpen = () => getDropdownMenu().should("exist");
 
   describe("Multiselect", () => {
     beforeEach(() => {
@@ -13,11 +14,11 @@ describe("AsyncSelect", () => {
       getMultiselect().click();
 
       cy.focused().type("cana");
-      cy.wait(200);
+      assertDropDownIsOpen().contains("Canada");
       cy.focused().type("{enter}");
 
       cy.focused().type("austra");
-      cy.wait(200);
+      assertDropDownIsOpen().contains("Australia");
       cy.focused().type("{enter}");
 
       getMultiselect().contains("Canada");

--- a/cypress/integration/components/AsyncSelect.spec.js
+++ b/cypress/integration/components/AsyncSelect.spec.js
@@ -3,6 +3,7 @@ describe("AsyncSelect", () => {
   const getDropdownMenu = () => cy.get("[data-testid='select-dropdown']");
   const getMultiselect = () => getSelectComponent();
   const getClearButton = () => cy.get("[data-testid='select-clear']");
+  const getDropdownButton = () => cy.get("[data-testid='select-arrow']");
   const assertDropDownIsOpen = () => getDropdownMenu().should("exist");
 
   describe("Multiselect", () => {
@@ -38,11 +39,23 @@ describe("AsyncSelect", () => {
     });
 
     it("does not show the dropdown arrow", () => {
-      getDropdownMenu().should("not.exist");
+      getDropdownButton().should("not.exist");
     });
+
+    it("does show the dropdown arrow if there are default options", () => {});
 
     it("does not show the clear button when no values are selected", () => {
       getClearButton().should("not.exist");
+    });
+  });
+
+  describe("with default options", () => {
+    beforeEach(() => {
+      cy.renderFromStorybook("asyncselect--with-default-options");
+    });
+
+    it("does show the dropdown arrow if there are default options", () => {
+      getDropdownButton().should("exist");
     });
   });
 });

--- a/cypress/integration/components/AsyncSelect.spec.js
+++ b/cypress/integration/components/AsyncSelect.spec.js
@@ -1,0 +1,47 @@
+describe("AsyncSelect", () => {
+  const getSelectComponent = () => cy.get("[data-testid='select-container']");
+  const getDropdownMenu = () => cy.get("[data-testid='select-dropdown']");
+  const getMultiselect = () => getSelectComponent();
+  const getClearButton = () => cy.get("[data-testid='select-clear']");
+
+  describe("Multiselect", () => {
+    beforeEach(() => {
+      cy.renderFromStorybook("asyncselect--multiselect");
+    });
+
+    it("can select multiple values", () => {
+      getMultiselect().click();
+
+      cy.focused().type("cana");
+      cy.wait(200);
+      cy.focused().type("{enter}");
+
+      cy.focused().type("austra");
+      cy.wait(200);
+      cy.focused().type("{enter}");
+
+      getMultiselect().contains("Canada");
+      getMultiselect().contains("Australia");
+    });
+
+    it("clears all selected values", () => {
+      getMultiselect().click();
+
+      cy.focused().type("cana");
+      cy.wait(200);
+      cy.focused().type("{enter}");
+
+      getClearButton().click();
+
+      getMultiselect().contains("Please select a countries");
+    });
+
+    it("does not show the dropdown arrow", () => {
+      getDropdownMenu().should("not.exist");
+    });
+
+    it("does not show the clear button when no values are selected", () => {
+      getClearButton().should("not.exist");
+    });
+  });
+});

--- a/cypress/integration/components/AsyncSelect.spec.js
+++ b/cypress/integration/components/AsyncSelect.spec.js
@@ -39,10 +39,8 @@ describe("AsyncSelect", () => {
     });
 
     it("does not show the dropdown arrow", () => {
-      getDropdownButton().should("not.exist");
+      getDropdownButton().should("not.be.visible");
     });
-
-    it("does show the dropdown arrow if there are default options", () => {});
 
     it("does not show the clear button when no values are selected", () => {
       getClearButton().should("not.exist");
@@ -54,8 +52,8 @@ describe("AsyncSelect", () => {
       cy.renderFromStorybook("asyncselect--with-default-options");
     });
 
-    it("does show the dropdown arrow if there are default options", () => {
-      getDropdownButton().should("exist");
+    it("shows the dropdown arrow if there are default options", () => {
+      getDropdownButton().should("be.visible");
     });
   });
 });

--- a/src/AsyncSelect/AsyncSelect.tsx
+++ b/src/AsyncSelect/AsyncSelect.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, forwardRef } from "react";
 import AsyncReactSelect from "react-select/async";
 import { useTranslation } from "react-i18next";
-import styled, { ThemeContext } from "styled-components";
+import { ThemeContext } from "styled-components";
 import propTypes from "@styled-system/prop-types";
 import { Field } from "../Form";
 import { MaybeFieldLabel } from "../FieldLabel";
@@ -17,13 +17,6 @@ import {
   SelectInput,
 } from "../Select";
 import { getSubset } from "../utils/subset";
-
-const StyledAsyncReactSelect = styled(AsyncReactSelect)(({ showArrow }) => ({
-  // These classes are only applied when classname prefix is set
-  "[class*='dropdown-indicator'], [class*='indicator-separator'], [class*='indicatorContainer']": {
-    display: showArrow ? "flex" : "none",
-  },
-}));
 
 type AsyncSelectProps = {
   windowThreshold?: number;

--- a/src/AsyncSelect/AsyncSelect.tsx
+++ b/src/AsyncSelect/AsyncSelect.tsx
@@ -15,6 +15,7 @@ import {
   SelectContainer,
   SelectMenu,
   SelectInput,
+  SelectDropdownIndicator,
 } from "../Select";
 import { getSubset } from "../utils/subset";
 
@@ -143,6 +144,7 @@ const AsyncSelect = forwardRef(
               Control: SelectControl,
               MultiValue: SelectMultiValue,
               ClearIndicator: SelectClearIndicator,
+              DropdownIndicator: SelectDropdownIndicator,
               SelectContainer: SelectContainer,
               Menu: SelectMenu,
               Input: SelectInput,

--- a/src/AsyncSelect/AsyncSelect.tsx
+++ b/src/AsyncSelect/AsyncSelect.tsx
@@ -105,7 +105,7 @@ const AsyncSelect = forwardRef(
           requirementText={requirementText}
           helpText={helpText}
         >
-          <StyledAsyncReactSelect
+          <AsyncReactSelect
             className={className}
             classNamePrefix={classNamePrefix}
             noOptionsMessage={noOptionsMessage}
@@ -119,6 +119,7 @@ const AsyncSelect = forwardRef(
               error,
               maxHeight,
               windowed: false,
+              isAsync: true,
             })}
             isDisabled={disabled}
             isSearchable={autocomplete}

--- a/src/AsyncSelect/AsyncSelect.tsx
+++ b/src/AsyncSelect/AsyncSelect.tsx
@@ -119,7 +119,7 @@ const AsyncSelect = forwardRef(
               error,
               maxHeight,
               windowed: false,
-              isAsync: true,
+              hasDefaultOptions: Boolean(defaultOptions),
             })}
             isDisabled={disabled}
             isSearchable={autocomplete}
@@ -148,7 +148,6 @@ const AsyncSelect = forwardRef(
               Input: SelectInput,
               ...components,
             }}
-            showArrow={defaultOptions}
             aria-label={ariaLabel}
             cacheOptions={cacheOptions}
             defaultOptions={defaultOptions}

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -16,6 +16,7 @@ import {
   SelectContainer,
   SelectMenu,
   SelectInput,
+  SelectDropdownIndicator,
 } from "./SelectComponents";
 import { getSubset } from "../utils/subset";
 
@@ -223,6 +224,7 @@ const ReactSelect = forwardRef(
               Control: SelectControl,
               MultiValue: SelectMultiValue,
               ClearIndicator: SelectClearIndicator,
+              DropdownIndicator: SelectDropdownIndicator,
               SelectContainer: SelectContainer,
               Menu: SelectMenu,
               Input: SelectInput,

--- a/src/Select/SelectComponents.tsx
+++ b/src/Select/SelectComponents.tsx
@@ -31,6 +31,14 @@ export const SelectClearIndicator = (props) => {
   );
 };
 
+export const SelectDropdownIndicator = (props) => {
+  return (
+    <div data-testid="select-arrow">
+      <selectComponents.DropdownIndicator {...props} />
+    </div>
+  );
+};
+
 export const SelectMenu = (props) => {
   return (
     <div data-testid="select-dropdown">

--- a/src/Select/customReactSelectStyles.spec.tsx
+++ b/src/Select/customReactSelectStyles.spec.tsx
@@ -1,23 +1,23 @@
-import { showDropdownIndicator } from "./customReactSelectStyles";
+import { showIndicatorSeparator } from "./customReactSelectStyles";
 
 describe("custom react-select styles", () => {
-  describe("showDropdownIndicator", () => {
+  describe("showIndicatorSeparator", () => {
     test.each`
-      isMulti  | hasValue | isAsync  | expected
-      ${true}  | ${false} | ${false} | ${false}
-      ${false} | ${true}  | ${false} | ${false}
-      ${false} | ${false} | ${true}  | ${false}
-      ${true}  | ${true}  | ${false} | ${true}
-      ${false} | ${true}  | ${true}  | ${false}
-      ${true}  | ${false} | ${true}  | ${false}
-      ${true}  | ${true}  | ${true}  | ${false}
-      ${false} | ${false} | ${false} | ${false}
+      isMulti  | hasValue | hasDefaultOptions | expected
+      ${true}  | ${true}  | ${true}           | ${true}
+      ${true}  | ${false} | ${false}          | ${false}
+      ${false} | ${true}  | ${false}          | ${false}
+      ${false} | ${false} | ${true}           | ${false}
+      ${true}  | ${true}  | ${false}          | ${false}
+      ${false} | ${true}  | ${true}           | ${false}
+      ${true}  | ${false} | ${true}           | ${false}
+      ${false} | ${false} | ${false}          | ${false}
     `(
-      "returns $expected when isMulti is $isMulti, hasValue is $hasValue, and isAsync is $isAsync",
-      ({ isMulti, hasValue, isAsync, expected }) => {
-        expect(showDropdownIndicator({ isMulti, hasValue, isAsync })).toBe(
-          expected
-        );
+      "returns $expected when isMulti is $isMulti, hasValue is $hasValue, and hasDefaultOptions is $hasDefaultOptions",
+      ({ isMulti, hasValue, hasDefaultOptions, expected }) => {
+        expect(
+          showIndicatorSeparator({ isMulti, hasValue, hasDefaultOptions })
+        ).toBe(expected);
       }
     );
   });

--- a/src/Select/customReactSelectStyles.spec.tsx
+++ b/src/Select/customReactSelectStyles.spec.tsx
@@ -1,0 +1,24 @@
+import { showDropdownIndicator } from "./customReactSelectStyles";
+
+describe("custom react-select styles", () => {
+  describe("showDropdownIndicator", () => {
+    test.each`
+      isMulti  | hasValue | isAsync  | expected
+      ${true}  | ${false} | ${false} | ${false}
+      ${false} | ${true}  | ${false} | ${false}
+      ${false} | ${false} | ${true}  | ${false}
+      ${true}  | ${true}  | ${false} | ${true}
+      ${false} | ${true}  | ${true}  | ${false}
+      ${true}  | ${false} | ${true}  | ${false}
+      ${true}  | ${true}  | ${true}  | ${false}
+      ${false} | ${false} | ${false} | ${false}
+    `(
+      "returns $expected when isMulti is $isMulti, hasValue is $hasValue, and isAsync is $isAsync",
+      ({ isMulti, hasValue, isAsync, expected }) => {
+        expect(showDropdownIndicator({ isMulti, hasValue, isAsync })).toBe(
+          expected
+        );
+      }
+    );
+  });
+});

--- a/src/Select/customReactSelectStyles.tsx
+++ b/src/Select/customReactSelectStyles.tsx
@@ -22,15 +22,18 @@ const getShadow = ({ errored, isOpen, theme }) => {
   }
 };
 
-export const showDropdownIndicator = ({ isMulti, hasValue, isAsync }) =>
-  isMulti && hasValue && !isAsync;
+export const showIndicatorSeparator = ({
+  isMulti,
+  hasValue,
+  hasDefaultOptions,
+}) => isMulti && hasValue && hasDefaultOptions;
 
 const customStyles = ({
   theme,
   error,
   maxHeight,
   windowed,
-  isAsync = false,
+  hasDefaultOptions = true,
 }) => {
   return {
     option: () => ({
@@ -85,11 +88,7 @@ const customStyles = ({
     }),
     dropdownIndicator: (provided, state) => ({
       ...provided,
-      ...(!showDropdownIndicator({
-        isMulti: state.isMulti,
-        hasValue: state.hasValue,
-        isAsync,
-      }) && { display: "none" }),
+      ...(!hasDefaultOptions && { display: "none" }),
       color: state.isHovered ? theme.colors.blackBlue : theme.colors.grey,
     }),
     indicatorsContainer: (provided) => ({
@@ -170,10 +169,10 @@ const customStyles = ({
     }),
     indicatorSeparator: (provided, state) => ({
       ...provided,
-      display: showDropdownIndicator({
+      display: showIndicatorSeparator({
         isMulti: state.isMulti,
         hasValue: state.hasValue,
-        isAsync,
+        hasDefaultOptions,
       })
         ? "block"
         : "none",

--- a/src/Select/customReactSelectStyles.tsx
+++ b/src/Select/customReactSelectStyles.tsx
@@ -22,7 +22,16 @@ const getShadow = ({ errored, isOpen, theme }) => {
   }
 };
 
-const customStyles = ({ theme, error, maxHeight, windowed }) => {
+export const showDropdownIndicator = ({ isMulti, hasValue, isAsync }) =>
+  isMulti && hasValue && !isAsync;
+
+const customStyles = ({
+  theme,
+  error,
+  maxHeight,
+  windowed,
+  isAsync = false,
+}) => {
   return {
     option: () => ({
       height: 38,
@@ -76,6 +85,11 @@ const customStyles = ({ theme, error, maxHeight, windowed }) => {
     }),
     dropdownIndicator: (provided, state) => ({
       ...provided,
+      ...(!showDropdownIndicator({
+        isMulti: state.isMulti,
+        hasValue: state.hasValue,
+        isAsync,
+      }) && { display: "none" }),
       color: state.isHovered ? theme.colors.blackBlue : theme.colors.grey,
     }),
     indicatorsContainer: (provided) => ({
@@ -156,7 +170,13 @@ const customStyles = ({ theme, error, maxHeight, windowed }) => {
     }),
     indicatorSeparator: (provided, state) => ({
       ...provided,
-      display: state.isMulti && state.hasValue ? "block" : "none",
+      display: showDropdownIndicator({
+        isMulti: state.isMulti,
+        hasValue: state.hasValue,
+        isAsync,
+      })
+        ? "block"
+        : "none",
       borderLeft: `1px solid ${theme.colors.grey}`,
     }),
     placeholder: (provided, state) => ({

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ export {
   SelectControl,
   SelectMultiValue,
   SelectClearIndicator,
+  SelectDropdownIndicator,
   SelectContainer,
   SelectMenu,
   SelectInput,


### PR DESCRIPTION
## Description

The AsyncSelect component hides the dropdown button and the clear button using an attribute selector CSS. This PR removes it in favour of a the react-select [config](https://react-select.com/props#prop-types) that only hides the dropdown button without affecting the clear button.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [x] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
