### PR TITLE
fix: Add spacing to the Toast close button and align it with text 

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,5 @@
+# A configuration file for the Semantic Pull Requests GitHub check 
+# Docs: https://github.com/zeke/semantic-pull-requests  
+
+# Always validate the PR title, and ignore the commits
+titleOnly: true

--- a/src/Alert/Alert.tsx
+++ b/src/Alert/Alert.tsx
@@ -2,23 +2,23 @@ import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { Box } from "../Box";
-import {BoxProps} from "../Box/Box";
+import { BoxProps } from "../Box/Box";
 import { Icon } from "../Icon";
 import { Link } from "../Link";
 import { Flex } from "../Flex";
 import { Text } from "../Type";
 
 export type AlertProps = BoxProps & {
-    children?: React.ReactNode;
-    className?: string;
-    isCloseable?: boolean;
-    closeAriaLabel?: string;
-    title?: string;
-    type?: "danger" | "informative" | "success" | "warning" | undefined;
-    onClose?: any;
-    controlled?: boolean;
-    style?: React.CSSProperties;
-  };
+  children?: React.ReactNode;
+  className?: string;
+  isCloseable?: boolean;
+  closeAriaLabel?: string;
+  title?: string;
+  type?: "danger" | "informative" | "success" | "warning" | undefined;
+  onClose?: any;
+  controlled?: boolean;
+  style?: React.CSSProperties;
+};
 
 const AlertStyles = ({ theme }) => ({
   [`${Link}`]: {
@@ -56,17 +56,18 @@ const CloseButton = ({
 }: CloseButtonProps) => {
   const { t } = useTranslation();
   return (
-    <Box>
+    <Flex ml="x2">
       <Link
         as="button"
         color="darkGrey"
+        lineHeight="0"
         hover="blue"
         onClick={onClick}
         aria-label={ariaLabel || t("close")}
       >
         <Icon icon="close" size="16" />
       </Link>
-    </Box>
+    </Flex>
   );
 };
 
@@ -76,7 +77,6 @@ const Alert = styled(
     isCloseable = false,
     title,
     type = "informative",
-    className,
     closeAriaLabel,
     onClose,
     controlled = false,
@@ -99,7 +99,6 @@ const Alert = styled(
         borderLeftColor={alertColours[type].borderColor}
         borderLeftStyle="solid"
         role="alert"
-        className={className}
         {...props}
       >
         {type === "danger" && (

--- a/src/Link/Link.tsx
+++ b/src/Link/Link.tsx
@@ -6,6 +6,7 @@ import {
   ColorProps,
   SpaceProps,
   LayoutProps,
+  TypographyProps,
 } from "styled-system";
 import { darken } from "polished";
 import { themeGet } from "@styled-system/theme-get";
@@ -14,7 +15,8 @@ import { DefaultNDSThemeType } from "../theme.type";
 export type LinkProps = React.ComponentPropsWithRef<"a"> &
   ColorProps &
   SpaceProps &
-  LayoutProps & {
+  LayoutProps &
+  TypographyProps & {
     className?: string;
     underline?: boolean;
     hover?: string;
@@ -36,6 +38,7 @@ const getHoverColor = (props: LinkProps) =>
   props.hover
     ? props.color
     : darken("0.1", themeGet(`colors.${props.color}`, props.color)(props));
+
 const Link = styled.a.withConfig({
   shouldForwardProp: (prop, defaultValidatorFn) =>
     !["underline", "hover"].includes(prop) && defaultValidatorFn(prop),
@@ -53,10 +56,12 @@ const Link = styled.a.withConfig({
     },
   })
 );
+
 Link.defaultProps = {
   className: undefined,
   underline: true,
   fontSize: "medium",
   color: "blue",
 };
+
 export default Link;

--- a/src/Toast/Toast.story.tsx
+++ b/src/Toast/Toast.story.tsx
@@ -166,7 +166,7 @@ export const WithCloseButton = () => {
       <>
         <Button onClick={triggerToast}>Save Changes</Button>
         <Toast triggered={triggered} onHide={onHideHandler} isCloseable>
-          Saved
+          An error occurred while saving results. Please try again
         </Toast>
       </>
     );
@@ -178,7 +178,7 @@ WithCloseButton.story = {
   name: "with close button",
 };
 
-export const CloseableWithLongMessage = () => {
+export const CloseableWithMultiLineMessage = () => {
   const [triggered, setTriggered] = useState(false);
 
   const triggerToast = () => {
@@ -198,14 +198,16 @@ export const CloseableWithLongMessage = () => {
         type="danger"
         isCloseable
       >
-        An error occurred while saving results. Please try again
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolorum quidem
+        eveniet, repellat accusamus error reiciendis libero. Totam autem
+        distinctio vo
       </Toast>
     </>
   );
 };
 
-CloseableWithLongMessage.story = {
-  name: "closeable with a long message",
+CloseableWithMultiLineMessage.story = {
+  name: "closeable with a 150 character long multi-line message",
 };
 
 export const MultipleCloseableToastsExample = () => {

--- a/src/Toast/Toast.story.tsx
+++ b/src/Toast/Toast.story.tsx
@@ -178,6 +178,36 @@ WithCloseButton.story = {
   name: "with close button",
 };
 
+export const CloseableWithLongMessage = () => {
+  const [triggered, setTriggered] = useState(false);
+
+  const triggerToast = () => {
+    setTriggered(!triggered);
+  };
+
+  const onHideHandler = () => {
+    setTriggered(false);
+  };
+
+  return (
+    <>
+      <Button onClick={triggerToast}>Save Changes</Button>
+      <Toast
+        triggered={triggered}
+        onHide={onHideHandler}
+        type="danger"
+        isCloseable
+      >
+        An error occurred while saving results. Please try again
+      </Toast>
+    </>
+  );
+};
+
+CloseableWithLongMessage.story = {
+  name: "closeable with a long message",
+};
+
 export const MultipleCloseableToastsExample = () => {
   const MultipleToastsExample = () => {
     const [currentToasts, setCurrentToasts] = useState([]);


### PR DESCRIPTION
## Description

Fixes the issue with the close button in the `<Toast />` component being vertically misaligned with the text and sitting super close to the text.  

**Describe the change you're making, the motiviations behind it, and any thing else a reviewer may need to know to approve this PR.**

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [x] Appropriate tests have been added 
- [x] Documentation has been updated
- [x] Accessibility has been considered
