### PR TITLE
fix: Give Sidebar's zIndex prop to overlay

### DIFF
--- a/src/Layout/Sidebar.spec.tsx
+++ b/src/Layout/Sidebar.spec.tsx
@@ -42,4 +42,13 @@ describe("Sidebar", () => {
       expect(queryByTestId("sidebar-overlay")).toBeNull();
     });
   });
+
+  describe("zIndex", () => {
+    it("provides a custom zIndex to the overlay", () => {
+      const { queryByTestId } = renderWithNDSProvider(
+        <Sidebar isOpen zIndex={1001}>Sidebar</Sidebar>
+      );
+      expect(queryByTestId("sidebar-overlay")).toHaveStyle("z-index: 1001");
+    });
+  });
 });

--- a/src/Layout/Sidebar.tsx
+++ b/src/Layout/Sidebar.tsx
@@ -34,14 +34,14 @@ const focusFirstElement = () => {
   }
 }
 
-const SidebarOverlay = ({ transitionDuration, top, transparent, onClick }) => (
+const SidebarOverlay = ({ transitionDuration, top, transparent, zIndex = 799 as any, onClick }) => (
   <AnimatedBox
     position="fixed"
     top={top}
     bottom="0"
     left="0"
     right="0"
-    zIndex={"799" as any}
+    zIndex={zIndex}
     bg={!transparent && "rgba(18, 43, 71, 0.5)"}
     initial={{ opacity: 0 }}
     animate={{ opacity: 1 }}
@@ -70,6 +70,7 @@ const Sidebar = ({
   overlay = true,
   disableScroll = true,
   hideCloseButton = false,
+  zIndex,
   ...props
 }: SidebarProps) => {
   const closeButton = useRef(null);
@@ -133,7 +134,7 @@ const Sidebar = ({
   <>
     {closeOnOutsideClick && (
       <AnimatePresence>
-          {isOpen && (<SidebarOverlay top={top} transparent={!overlay} transitionDuration={duration} onClick={closeOnOutsideClick && isOpen && onClose} />) }
+          {isOpen && (<SidebarOverlay top={top} transparent={!overlay} transitionDuration={duration} zIndex={zIndex} onClick={closeOnOutsideClick && isOpen && onClose} />) }
       </AnimatePresence>
     )}
     <AnimatedBox
@@ -153,7 +154,7 @@ const Sidebar = ({
       top={top}
       right={offset}
       width={typeof width === 'string' ? { default: "100%", small: width } : width}
-      zIndex={"sidebar" as any}
+      zIndex={zIndex || "sidebar" as any}
       ref={sideBarRef as any}
       {...props}
     >


### PR DESCRIPTION
## Description

This change passes a zIndex prop from a Sidebar to its overlay. This is motivated by us wanting to cover up the footer when using the Sidebar and ops core, and having zIndex put the Sidebar over the footer, but not the overlay.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [X ] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [X ] Appropriate tests have been added (for a given value of appropriate)
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
