### PR TITLE
fix: handle absent children in the TruncatedText component

### DIFF
--- a/cypress/integration/components/TruncatedText.spec.js
+++ b/cypress/integration/components/TruncatedText.spec.js
@@ -91,4 +91,12 @@ describe("TruncatedText", () => {
         .contains("Instructions fit here.");
     });
   });
+  describe("without children", () => {
+    beforeEach(() => {
+      cy.renderFromStorybook("truncatedtext--without-children");
+    });
+    it("renders without crashing", () => {
+      cy.get("[data-testid='truncated-text']").should("exist");
+    });
+  });
 });

--- a/src/TruncatedText/TruncatedText.story.tsx
+++ b/src/TruncatedText/TruncatedText.story.tsx
@@ -76,3 +76,18 @@ export const FullWidth = () => (
 FullWidth.story = {
   name: "full width",
 };
+
+export const WithoutChildren = () => (
+  <Box>
+    <Heading1>
+      No text should appear after this sentence, neither should the page crash.
+    </Heading1>
+    <TruncatedText>{null}</TruncatedText>
+    <TruncatedText>{undefined}</TruncatedText>
+    <TruncatedText />
+  </Box>
+);
+
+WithoutChildren.story = {
+  name: "Without children",
+};

--- a/src/TruncatedText/TruncatedText.tsx
+++ b/src/TruncatedText/TruncatedText.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { Tooltip } from "../Tooltip";
 import { Text } from "../Type";
-import { TooltipProps } from '../Tooltip/Tooltip';
+import { TooltipProps } from "../Tooltip/Tooltip";
 
 type TruncatedTextProps = {
   children?: string;
@@ -17,10 +17,18 @@ type TruncatedTextProps = {
 
 type MaybeTooltipProps = TooltipProps & {
   showTooltip?: boolean;
-}
+};
 
-const MaybeTooltip = ({ children, showTooltip, ...props }: MaybeTooltipProps) => {
-  return showTooltip ? <Tooltip {...props}>{children}</Tooltip> : <>{children}</>;
+const MaybeTooltip = ({
+  children,
+  showTooltip,
+  ...props
+}: MaybeTooltipProps) => {
+  return showTooltip ? (
+    <Tooltip {...props}>{children}</Tooltip>
+  ) : (
+    <>{children}</>
+  );
 };
 
 MaybeTooltip.propTypes = {
@@ -84,12 +92,14 @@ const TruncatedTextMaxCharacters = ({
   "data-testid": testId,
   ...props
 }: TruncatedTextProps) => {
-  const innerText = children;
+  const innerText = children ?? "";
   const requiresTruncation = innerText.length > maxCharacters;
+
   const truncatedText = requiresTruncation
     ? innerText.slice(0, maxCharacters) + indicator
-    : children;
+    : innerText;
   const hasTooltip = showTooltip && requiresTruncation;
+
   return (
     <MaybeTooltip
       showTooltip={hasTooltip}


### PR DESCRIPTION
## Description

Currently if you introduce a `<TruncatedText />` component to a page without any children, or if the string passed is null, it crashes the application. This is not consistent with the Prop type of the component because it states that it's optional: `children?: string`.

This PR uses nullish coalescing and assigns the innerText to an empty string incase the children string is absent.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [x] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
