### PR TITLE
fix: Allow conditional rendering in the Tabs component

### DIFF
--- a/src/Tabs/TabScrollIndicators.tsx
+++ b/src/Tabs/TabScrollIndicators.tsx
@@ -20,10 +20,6 @@ type TabScrollIndicatorsProps = {
 type TabScrollIndicatorsState = {
   contentHiddenLeft: boolean;
   contentHiddenRight: boolean;
-  contentHiddenLeft: boolean;
-  contentHiddenRight: boolean;
-  contentHiddenLeft: boolean;
-  contentHiddenRight: boolean;
 };
 class TabScrollIndicators extends React.Component<
   TabScrollIndicatorsProps,

--- a/src/Tabs/Tabs.story.tsx
+++ b/src/Tabs/Tabs.story.tsx
@@ -5,7 +5,7 @@ import { Tab, Tabs } from ".";
 class ControlledTabs extends React.Component<TabsProps, TabsState> {
   constructor(props) {
     super(props);
-  this.state = {
+    this.state = {
       selectedIndex: null,
     };
 
@@ -158,4 +158,24 @@ export const WithContentLoadedOnSelection = () => (
 
 WithContentLoadedOnSelection.story = {
   name: "with content loaded on selection",
+};
+
+export const WithConditionallyRenderedTabs = () => (
+  <Tabs>
+    {true && (
+      <Tab label="Tab 1" className="Tab1">
+        <input className="Input1" />
+      </Tab>
+    )}
+
+    {false && (
+      <Tab label="Tab 2" className="Tab2">
+        <input className="Input2" />
+      </Tab>
+    )}
+  </Tabs>
+);
+
+WithConditionallyRenderedTabs.story = {
+  name: "With conditionally rendered Tabs",
 };

--- a/src/Tabs/Tabs.tsx
+++ b/src/Tabs/Tabs.tsx
@@ -39,7 +39,6 @@ export type TabsProps = {
 };
 export type TabsState = {
   selectedIndex: any;
-  selectedIndex: any;
 };
 class Tabs extends React.Component<TabsProps, TabsState> {
   constructor(props) {
@@ -65,34 +64,36 @@ class Tabs extends React.Component<TabsProps, TabsState> {
   getTabs(setFocusToTab, focusedIndex, handleArrowNavigation) {
     const { fitted, children, onTabClick } = this.props;
     const selectedIndex = this.getSelectedIndex();
-    const tabs = React.Children.map(children, (tab, index) =>
-      React.cloneElement(tab, {
-        onClick: (e) => {
-          setFocusToTab(index);
-          if (tab.props.onClick) {
-            tab.props.onClick(e);
-          }
-          if (onTabClick) {
-            onTabClick(e, index);
-          } else {
-            this.handleTabClick(index);
-          }
-        },
-        onFocus: (e) => {
-          e.stopPropagation();
-        },
-        onKeyDown: handleArrowNavigation,
-        index,
-        tabIndex: index === focusedIndex ? 0 : -1,
-        selected: index === selectedIndex,
-        "aria-selected": index === selectedIndex,
-        fullWidth: fitted,
-        ref: (ref) => {
-          this.tabRefs[index] = ref;
-        },
-      })
-    );
-    return tabs;
+
+    return React.Children.map(children, (tab, index) => {
+      if (tab) {
+        return React.cloneElement(tab, {
+          onClick: (e) => {
+            setFocusToTab(index);
+            if (tab?.props?.onClick) {
+              tab?.props?.onClick(e);
+            }
+            if (onTabClick) {
+              onTabClick(e, index);
+            } else {
+              this.handleTabClick(index);
+            }
+          },
+          onFocus: (e) => {
+            e.stopPropagation();
+          },
+          onKeyDown: handleArrowNavigation,
+          index,
+          tabIndex: index === focusedIndex ? 0 : -1,
+          selected: index === selectedIndex,
+          "aria-selected": index === selectedIndex,
+          fullWidth: fitted,
+          ref: (ref) => {
+            this.tabRefs[index] = ref;
+          },
+        });
+      }
+    });
   }
   getTabContent() {
     const { children, renderTabContentOnlyWhenSelected } = this.props;
@@ -104,7 +105,7 @@ class Tabs extends React.Component<TabsProps, TabsState> {
       } else {
         return (
           <div aria-hidden={!selected} hidden={!selected} selected={selected}>
-            {tab.props.children}
+            {tab?.props?.children}
           </div>
         );
       }


### PR DESCRIPTION
## Description

If we attempt to conditionally render a `<Tab />` inside the `<Tabs />` component, it causes the component tree to crash. This is caused because we assume that all tabs are present when we perform a `React.cloneElement`.

This fix makes cloning the element conditional on their existence. In addition, it removes duplicate keys from the `TabScrollIndicatorsState` and `TabsState` types.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [x] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
