### PR TITLE
feat: allow setting a custom font size to the iconic button

### DIFF
--- a/src/Button/IconicButton.story.tsx
+++ b/src/Button/IconicButton.story.tsx
@@ -55,14 +55,14 @@ WithAHiddenLabel.story = {
   name: "with a hidden label",
 };
 
-export const WithACustomSize = () => (
+export const WithACustomIconSize = () => (
   <IconicButton icon="user" iconSize="50px" labelHidden>
     I am an Iconic Button
   </IconicButton>
 );
 
-WithACustomSize.story = {
-  name: "with a custom size",
+WithACustomIconSize.story = {
+  name: "with a custom icon size",
 };
 
 export const WithACustomColor = () => (
@@ -97,3 +97,21 @@ export const rightAligned = () => (
     </Flex>
   </Flex>
 );
+
+export const WithACustomFontSize = () => (
+  <Flex flexDirection="column">
+    <IconicButton fontSize="small" tooltip="Stop job" icon="close">
+      This is an IconicButton with a small font size
+    </IconicButton>
+    <IconicButton fontSize="large" tooltip="Stop job" icon="close">
+      This is an IconicButton with a large font size
+    </IconicButton>
+    <IconicButton fontSize="48px" tooltip="Stop job" icon="close">
+      This is an IconicButton with 48px font size
+    </IconicButton>
+  </Flex>
+);
+
+WithACustomFontSize.story = {
+  name: "with a custom font size",
+};

--- a/src/Button/IconicButton.tsx
+++ b/src/Button/IconicButton.tsx
@@ -16,11 +16,12 @@ type IconicButtonProps = SpaceProps & {
   onClick?: (...args: any[]) => any;
   icon?: any;
   iconSize?: string;
+  fontSize?: string;
   tooltip?: string;
   children?: any;
 };
 
-const HoverText: React.SFC<any> = styled.div(({ theme }) => ({
+const HoverText: React.FC<any> = styled.div(({ theme }) => ({
   whiteSpace: "nowrap",
   ontSize: theme.fontSizes.small,
   lineHeight: theme.lineHeights.smallTextCompressed,
@@ -31,7 +32,8 @@ const HoverText: React.SFC<any> = styled.div(({ theme }) => ({
   padding: `${theme.space.half} ${theme.space.x1}`,
   pointerEvents: "none",
 }));
-const WrapperButton: React.SFC<any> = styled.button(
+
+const WrapperButton: React.FC<any> = styled.button(
   ({ disabled, theme }: any) => ({
     background: "transparent",
     border: "none",
@@ -97,6 +99,7 @@ const IconicButton = React.forwardRef<HTMLButtonElement, IconicButtonProps>(
       labelHidden,
       className,
       iconSize,
+      fontSize,
       tooltip,
       ...props
     },
@@ -144,7 +147,7 @@ const IconicButton = React.forwardRef<HTMLButtonElement, IconicButtonProps>(
           </Popper>
         </Manager>
         {children && !labelHidden && (
-          <Text mr="half" ml="half" color={color}>
+          <Text fontSize={fontSize} mr="half" ml="half" color={color}>
             {children}
           </Text>
         )}
@@ -152,6 +155,7 @@ const IconicButton = React.forwardRef<HTMLButtonElement, IconicButtonProps>(
     );
   }
 );
+
 export const iconNames = Object.keys(icons);
 
 IconicButton.propTypes = {


### PR DESCRIPTION
## Description
Currently there's no way to set the font size on iconic buttons. This PR provides a `font-size` prop to the iconic component that allows setting the font size on the Text component inside of the Iconic button.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [x] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [x] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
