### PR TITLE
fix: memoize dropdown popper modifiers

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Description
 
-**Describe the change you're making, the motiviations behind it, and any thing else a reviewer may need to know to approve this PR.**
+**Describe the change you're making, the motivations behind it, and any thing else a reviewer may need to know to approve this PR.**
 
 ## Changes include
 

--- a/src/DropdownMenu/DropdownMenu.tsx
+++ b/src/DropdownMenu/DropdownMenu.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import React from "react";
+import React, { useMemo } from "react";
 import DropdownMenuContainer from "./DropdownMenuContainer";
 import { IconicButton } from "../Button";
 import { Popper } from "../Popper";
@@ -70,6 +70,10 @@ const DropdownMenu: React.SFC<DropdownMenuProps> = React.forwardRef<
   ) => {
     const spaceProps = getSubset(props, propTypes.space);
     const restProps = omitSubset(props, propTypes.space);
+    const modifiers = useMemo(() => {
+      return transformPropsToModifiers({ boundariesElement });
+    }, [boundariesElement]);
+
     return (
       <Popper
         trigger={React.cloneElement(trigger(), {
@@ -86,7 +90,7 @@ const DropdownMenu: React.SFC<DropdownMenuProps> = React.forwardRef<
         openOnClick
         ref={ref}
         openOnHover={false}
-        modifiers={transformPropsToModifiers({ boundariesElement })}
+        modifiers={modifiers}
         backgroundColor={backgroundColor}
         borderColor={backgroundColor}
         openAriaLabel={openAriaLabel}


### PR DESCRIPTION
## Description

This change memoizes `modifiers` that are passed to popper inside of `DropdownMenu`. We were seeing console warnings that recommended this change when `DropdownMenu` was rendered as an optional part of a table cell.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [X] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
