### PR TITLE
feat: add new z-index to the theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.9.6",
-    "@nulogy/tokens": "^5.1.0",
+    "@nulogy/tokens": "^5.2.0",
     "@styled-system/prop-types": "^5.1.4",
     "@styled-system/theme-get": "^5.1.2",
     "body-scroll-lock": "^3.1.5",

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -110,6 +110,7 @@ const Theme: DefaultNDSThemeType = {
     tabsScollIndicator: tokens.z_indices_tabs_scroll_indicator,
     tabsBar: tokens.z_indices_tabs_bar,
     overlay: tokens.z_indices_overlay,
+    aboveOverlay: tokens.z_indices_above_overlay,
     tableHeader: tokens.z_indices_table_header,
     modalHeaderAndFooter: tokens.z_indices_modal_header_and_footer,
     openControl: tokens.z_indices_open_control,

--- a/src/theme.type.ts
+++ b/src/theme.type.ts
@@ -105,6 +105,7 @@ type ZIndices = {
   tabsScollIndicator: number;
   tabsBar: number;
   overlay: number;
+  aboveOverlay: number;
   tableHeader: number;
   modalHeaderAndFooter: number;
   openControl: number;


### PR DESCRIPTION
## Description
This PR adds the new z-index token to the NDS theme. 

It can only be merged after https://github.com/nulogy/nds-tokens/pull/47/files is fully merged and released.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [x] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
