### PR TITLE
fix: remove title id from <LoadingSpinner /> component

### DIFF
--- a/src/LoadingAnimation/LoadingAnimation.tsx
+++ b/src/LoadingAnimation/LoadingAnimation.tsx
@@ -6,8 +6,10 @@ type LoadingAnimationProps = React.ComponentPropsWithRef<"svg"> & {
 };
 const LoadingAnimation: React.SFC<LoadingAnimationProps> = ({ inactive }) => {
   const { colors } = useTheme();
+
   const color1 = inactive ? colors.grey : colors.blue;
   const color2 = inactive ? colors.lightGrey : colors.yellow;
+
   return (
     // Modified svg By Sam Herbert (@sherb), for everyone. More @ http://goo.gl/7AJzbL
     <svg
@@ -18,7 +20,7 @@ const LoadingAnimation: React.SFC<LoadingAnimationProps> = ({ inactive }) => {
       preserveAspectRatio="xMidYMid"
       role="img"
     >
-      <title id="lightbulb11">Loading animation</title>
+      <title>Loading animation</title>
       <g transform="translate(4 5)">
         <circle
           cx="0"


### PR DESCRIPTION
## Description
Removes the title id that was added in a previous commit. 

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
