### PR TITLE
fix: don't use non-text children as aria-label

### DIFF
--- a/src/Button/IconicButton.story.tsx
+++ b/src/Button/IconicButton.story.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { IconicButton } from "../index";
 import { Flex } from "../Flex";
+import { StatusIndicator } from "../StatusIndicator";
+import { Box } from "../Box";
 
 export default {
   title: "Components/IconicButton",
@@ -114,4 +116,19 @@ export const WithACustomFontSize = () => (
 
 WithACustomFontSize.story = {
   name: "with a custom font size",
+};
+
+export const WithNonTextChildren = () => (
+  <IconicButton fontSize="small" aria-label="warnings" icon="warning">
+    <Flex>
+      <Box as="span" pr="x1">
+        Warnings
+      </Box>
+      <StatusIndicator type="informative">3</StatusIndicator>
+    </Flex>
+  </IconicButton>
+);
+
+WithNonTextChildren.story = {
+  name: "with non text children",
 };

--- a/src/Button/IconicButton.tsx
+++ b/src/Button/IconicButton.tsx
@@ -108,7 +108,13 @@ const IconicButton = React.forwardRef<HTMLButtonElement, IconicButtonProps>(
     return (
       <WrapperButton
         ref={forwardedRef}
-        aria-label={children}
+        aria-label={
+          props["aria-label"]
+            ? props["aria-label"]
+            : typeof children === "string"
+            ? children
+            : undefined
+        }
         className={className}
         {...props}
       >


### PR DESCRIPTION
## Description
Currently, If an `<IconicButton />` is passed non-text children, it uses it as the aria-label for the component resulting in DOM that shows `aria-label="[object Object]"`. 

This PR allows the user to specify an aria-label and only uses the children if it's a text node.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
