### PR TITLE
fix: Prevent validation errors from time when daterange does not show time

### DIFF
--- a/src/DateRange/DateRange.spec.tsx
+++ b/src/DateRange/DateRange.spec.tsx
@@ -108,7 +108,34 @@ describe("DateRange", () => {
       );
       expect(latestCall.error).toEqual("end date is before start date");
     });
-    it("returns the selected range with an error if the range is invalid", () => {
+    it("does not return an error if the end date is changed to the start date when times are not shown", () => {
+      const defaultStartDate = new Date();
+      const defaultEndDate = new Date(
+        defaultStartDate.getFullYear(),
+        defaultStartDate.getMonth(),
+        defaultStartDate.getDate() + 6
+      );
+      const onRangeChange = jest.fn();
+      const { container, getByLabelText } = renderWithNDSProvider(
+        <DateRange
+          defaultStartDate={defaultStartDate}
+          defaultEndDate={defaultEndDate}
+          onRangeChange={onRangeChange}
+        />
+      );
+      const endDateInput = getByLabelText("Select an end date");
+      fireEvent.click(endDateInput);
+      fireEvent.click(
+        container.querySelectorAll(".react-datepicker__day--001")[0]
+      );
+      const onChangeCalls = onRangeChange.mock.calls;
+      const latestCall = onChangeCalls[onChangeCalls.length - 1][0];
+      expect(latestCall.endDate).toMatchDate(
+        new Date("2020-02-01T11:01:58.135Z")
+      );
+      expect(latestCall.error).toBeUndefined();
+    });
+    it("returns the selected range with an error if the range is invalid based on time", () => {
       const onRangeChange = jest.fn();
       const { container, queryAllByText, getByLabelText } =
         renderWithNDSProvider(

--- a/src/DateRange/DateRange.tsx
+++ b/src/DateRange/DateRange.tsx
@@ -143,7 +143,10 @@ const DateRange: React.SFC<DateRangeProps> = forwardRef(
     const validateDateRange = () => {
       let error;
       if (endDate && startDate) {
-        if (isBefore(endDate, startDate)) {
+        if (
+          isBefore(endDate, startDate) &&
+          (showTimes || !isSameDay(endDate, startDate))
+        ) {
           error = "end date is before start date";
         }
         if (isSameDay(endDate, startDate) && showTimes) {


### PR DESCRIPTION
## Description

This change fixes a bug in the `DateRange` component which is configured such that:
- `defaultStartDate` and `defaultEndDate` are provided which contain millisecond components
- `showTimes` is falsy
- An end date is selected that is the same as the start date

The expected result was that there would not be a validation error
The actual result was that there was a validation error claiming that `end date is before start date`

The fix was to fix the validation logic to ignore times on the same day when `showTimes` is falsy. 

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [X] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [X] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
