### PR TITLE
fix: align title with close button vertically

### DIFF
--- a/src/Layout/Sidebar.story.tsx
+++ b/src/Layout/Sidebar.story.tsx
@@ -419,3 +419,52 @@ export const WithoutCloseButton = () => {
     </ApplicationFrame>
   );
 };
+
+export const WithALongTitle = () => {
+  const [isOpen, setIsOpen] = useState(true);
+  const triggerRef = useRef(null);
+
+  const toggleSidebar = () => {
+    setIsOpen(!isOpen);
+  };
+  const closeSidebar = () => {
+    setIsOpen(false);
+  };
+
+  return (
+    <ApplicationFrame
+      navBar={<BrandedNavBar menuData={{ primaryMenu, secondaryMenu }} />}
+      overflowX="hidden"
+    >
+      <Page
+        breadcrumbs={
+          <Breadcrumbs>
+            <Link href="/">Home</Link>
+            <Link href="/">Materials</Link>
+          </Breadcrumbs>
+        }
+        title="Materials Overview"
+      >
+        <Box minWidth="300px">
+          <PrimaryButton
+            onClick={toggleSidebar}
+            ref={triggerRef}
+            id="openSidebarTrigger"
+          >
+            Open Sidebar
+          </PrimaryButton>
+          <Box height="3000px" width="50%" bg="lightBlue" mt="x3" p="x2">
+            Space for more content
+          </Box>
+        </Box>
+        <ExampleSidebar
+          title="A very very very very very very very long title"
+          isOpen={isOpen}
+          onClose={closeSidebar}
+          triggerRef={triggerRef}
+          aria-controls="openSidebarTrigger"
+        />
+      </Page>
+    </ApplicationFrame>
+  );
+};

--- a/src/Layout/Sidebar.tsx
+++ b/src/Layout/Sidebar.tsx
@@ -59,7 +59,7 @@ const SidebarOverlay = ({
   />
 );
 
-const Sidebar = ({
+const Sidebar: React.FC<SidebarProps> = ({
   p = "x3",
   width = "400px",
   children,
@@ -79,7 +79,7 @@ const Sidebar = ({
   hideCloseButton = false,
   zIndex,
   ...props
-}: SidebarProps) => {
+}) => {
   const closeButton = useRef(null);
   const [shouldUpdateFocus, setShouldUpdateFocus] = useState(false);
   const { t } = useTranslation();
@@ -183,10 +183,14 @@ const Sidebar = ({
           flexDirection="column"
           style={{ overflowBehaviour: "contain" } as any}
         >
-          <Flex justifyContent="space-between" alignItems="flex-start">
-            <Box>{title && <Heading3>{title}</Heading3>}</Box>
+          <Flex justifyContent="space-between" alignItems="flex-start" pb="x3">
+            {title && (
+              <Flex alignItems="center" height="100%">
+                <Heading3 mb={0}>{title}</Heading3>
+              </Flex>
+            )}
             {!hideCloseButton && (
-              <Box>
+              <Box marginLeft="x2">
                 <IconicButton
                   ref={closeButton}
                   icon="close"

--- a/src/Radio/RadioGroup.story.tsx
+++ b/src/Radio/RadioGroup.story.tsx
@@ -5,6 +5,9 @@ const errorList = ["Error message 1", "Error message 2"];
 
 export default {
   title: "Components/RadioGroup",
+  parameters: {
+    chromatic: { diffThreshold: 0.2 },
+  },
 };
 
 export const _RadioGroup = () => (


### PR DESCRIPTION
## Description
Aligns the SideBar title with the close button vertically if the title does not span more than 1 line.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [x] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
