### PR TITLE
fix: Ensure tab focus takes into account defaultSelectedIndex

### DIFF
--- a/cypress/integration/components/Switcher.spec.js
+++ b/cypress/integration/components/Switcher.spec.js
@@ -1,0 +1,10 @@
+describe("Switcher", () => {
+  describe("with selected value", () => {
+    beforeEach(() => {
+      cy.renderFromStorybook("switcher--with-selected-value");
+    });
+    it("focuses on the selected switch", () => {
+      cy.focused().should("have.text", "Option 2");
+    });
+  })
+});

--- a/cypress/integration/components/Tabs.spec.js
+++ b/cypress/integration/components/Tabs.spec.js
@@ -166,4 +166,13 @@ describe("Tabs", () => {
       );
     });
   });
+
+  describe("with default tab selection", () => {
+    beforeEach(() => {
+      cy.renderFromStorybook("tabs--with-a-default-selected-index");
+    });
+    it("focuses on the default selected tab", () => {
+      cy.focused().should("have.text", "Tab 2");
+    });
+  })
 });

--- a/src/Switcher/Switcher.story.tsx
+++ b/src/Switcher/Switcher.story.tsx
@@ -5,7 +5,7 @@ import Switcher from "./Switcher";
 import Switch from "./Switch";
 
 export const WithSelectedValue = () => {
-  const [selected, setSelected] = useState("option_1");
+  const [selected, setSelected] = useState("option_2");
 
   return (
     <Switcher

--- a/src/Switcher/Switcher.tsx
+++ b/src/Switcher/Switcher.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ReactElement } from "react";
 import PropTypes from "prop-types";
 import { Box } from "../Box";
 import FocusManager from "../utils/ts/FocusManager";
@@ -19,6 +19,12 @@ const Switcher: React.FC<SwitcherProps> = ({ selected, onChange, ...rest }) => {
 
     return value === selected;
   };
+
+  const getSelectedIndex = () => {
+    return React.Children.toArray(rest.children).findIndex(
+      (child) => (child as ReactElement)?.props?.value === selected
+    )
+  }
 
   const options = (focusedIndex, setFocusedIndex, handleArrowNavigation) => {
     return React.Children.map(rest.children, (child, index) => {
@@ -44,7 +50,7 @@ const Switcher: React.FC<SwitcherProps> = ({ selected, onChange, ...rest }) => {
 
   return (
     <Box display="inline-flex" bg="whiteGrey" borderRadius="20px" {...rest}>
-      <FocusManager refs={optionRefs}>
+      <FocusManager refs={optionRefs} defaultFocusedIndex={getSelectedIndex()}>
         {({ focusedIndex, setFocusedIndex, handleArrowNavigation }) =>
           options(focusedIndex, setFocusedIndex, handleArrowNavigation)
         }

--- a/src/Tabs/Tabs.tsx
+++ b/src/Tabs/Tabs.tsx
@@ -109,7 +109,7 @@ class Tabs extends React.Component<TabsProps, TabsState> {
     const spaceProps = getSubset(this.props, propTypes.space);
     return (
       <Box position="relative">
-        <FocusManager refs={this.tabRefs}>
+        <FocusManager refs={this.tabRefs} defaultFocusedIndex={this.getSelectedIndex()}>
           {({ focusedIndex, setFocusedIndex, handleArrowNavigation }) => (
             <TabScrollIndicators
               tabRefs={this.tabRefs}

--- a/src/utils/ts/FocusManager.tsx
+++ b/src/utils/ts/FocusManager.tsx
@@ -13,14 +13,16 @@ type ChildrenHandlers = {
 
 type FocusManagerProps = {
   refs?: Array<Reference>;
+  defaultFocusedIndex: number | null;
   children: (handlers: ChildrenHandlers) => ReactNode;
 };
 
 const FocusManager: React.FC<FocusManagerProps> = ({
   children,
   refs = undefined,
+  defaultFocusedIndex,
 }) => {
-  const [focusedIndex, setFocusedIndex] = useState<number>(0);
+  const [focusedIndex, setFocusedIndex] = useState<number>(defaultFocusedIndex ?? 0);
 
   const focusPrevious = () => {
     setFocusedIndex(


### PR DESCRIPTION
## Description

This change fixes a bug in the `Tab` component which always set the initial focus to the first tab even when a `defaultSelectedIndex` was set.

This change also fixes a similar issue in the `Switcher` component with a `selected` value.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [x] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
