### PR TITLE
Stylistic updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Logs
+ # Logs
 logs
 *.log
 npm-debug.log*
@@ -90,3 +90,6 @@ yarn-error.log*
 
 # RubyMine settings
 .idea
+
+# asdf version manager
+.tool-versions

--- a/src/BrandedNavBar/MobileMenu.tsx
+++ b/src/BrandedNavBar/MobileMenu.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import styled from "styled-components";
 import { display } from "styled-system";
 import { themeGet } from "@styled-system/theme-get";
@@ -7,6 +6,7 @@ import { Text, Heading3 } from "../Type";
 import { Flex } from "../Flex";
 import { BrandingText } from "../Branding";
 import { DefaultNDSThemeType } from "../theme.type";
+import { DropdownText } from "../DropdownMenu";
 import NulogyLogo from "./NulogyLogo";
 
 const borderStyle = "1px solid #e4e7eb";
@@ -17,7 +17,21 @@ const BrandingWrap = styled.div(({ theme }) => ({
   marginBottom: theme.space.x1,
 }));
 
+// eslint-disable-next-line no-mixed-operators
 const getPaddingLeft = (layer) => `${24 * layer + 24}px`;
+
+const TopLevelText = styled(Text)(({ theme }) => ({
+  color: theme.colors.blackBlue,
+  display: "block",
+  textDecoration: "none",
+  border: "none",
+  backgroundColor: "transparent",
+  fontSize: theme.fontSizes.large,
+  fontWeight: theme.fontWeights.medium,
+  lineHeight: theme.lineHeights.heading3,
+  padding: `${theme.space.x1} ${theme.space.x3}`,
+  paddingLeft: getPaddingLeft(0),
+}));
 
 const getSharedStyles = ({ color, layer, theme }) => ({
   display: "block",
@@ -110,14 +124,11 @@ const MenuLink = styled.a(
   })
 );
 
-type MenuTextProps = {
-  textColor?: string;
-  layer?: number;
-  theme?: DefaultNDSThemeType;
-};
-
-const MenuText = styled.li(({ textColor, layer, theme }: MenuTextProps) => ({
-  ...getSharedStyles({ color: textColor, layer, theme }),
+const ApplyIndent = styled.li(({ layer, theme }: MenuLinkProps) => ({
+  marginBottom: theme.space.x1,
+  [`> ${DropdownText}`]: {
+    paddingLeft: `${24 * layer + 24}px`,
+  },
 }));
 
 const SubMenuItemsList = styled.ul({
@@ -168,15 +179,14 @@ const renderSubMenu = (menuItem, linkOnClick, themeColorObject, layer) => (
   </li>
 );
 
-const renderText = (menuItem, linkOnClick, themeColorObject, layer) => (
-  <MenuText
-    key={menuItem.key ?? menuItem.name}
-    layer={layer}
-    {...themeColorObject}
-  >
-    {menuItem.name}
-  </MenuText>
-);
+const renderText = (menuItem, linkOnClick, themeColorObject, layer) => {
+  const MenuText = layer === 0 ? TopLevelText : DropdownText;
+  return (
+    <ApplyIndent layer={layer} key={menuItem.key ?? menuItem.name}>
+      <MenuText>{menuItem.name}</MenuText>
+    </ApplyIndent>
+  );
+};
 
 const getRenderFunction = (menuItem) => {
   if (menuItem.items) {

--- a/src/BrandedNavBar/MobileMenu.tsx
+++ b/src/BrandedNavBar/MobileMenu.tsx
@@ -5,7 +5,7 @@ import { Text, Heading3 } from "../Type";
 import { Flex } from "../Flex";
 import { BrandingText } from "../Branding";
 import { DefaultNDSThemeType } from "../theme.type";
-import { DropdownLink, DropdownText } from "../DropdownMenu";
+import { DropdownLink, DropdownText, DropdownButton } from "../DropdownMenu";
 import { Link } from "../Link";
 import { LinkProps } from "../Link/Link";
 import NulogyLogo from "./NulogyLogo";
@@ -22,16 +22,8 @@ const BrandingWrap = styled.div(({ theme }) => ({
 const getPaddingLeft = (layer) => `${24 * layer + 24}px`;
 
 const TopLevelLink = styled(Link)(({ theme }) => ({
+  ...getSharedStyles(theme),
   color: theme.colors.darkBlue,
-  display: "block",
-  textDecoration: "none",
-  border: "none",
-  backgroundColor: "transparent",
-  fontSize: theme.fontSizes.large,
-  fontWeight: theme.fontWeights.medium,
-  lineHeight: theme.lineHeights.heading3,
-  padding: `${theme.space.x1} ${theme.space.x3}`,
-  paddingLeft: getPaddingLeft(0),
   "&:visited": {
     color: theme.colors.darkBlue,
   },
@@ -53,7 +45,11 @@ const TopLevelLink = styled(Link)(({ theme }) => ({
 }));
 
 const TopLevelText = styled(Text)(({ theme }) => ({
+  ...getSharedStyles(theme),
   color: theme.colors.blackBlue,
+}));
+
+const getSharedStyles = (theme) => ({
   display: "block",
   textDecoration: "none",
   border: "none",
@@ -63,66 +59,7 @@ const TopLevelText = styled(Text)(({ theme }) => ({
   lineHeight: theme.lineHeights.heading3,
   padding: `${theme.space.x1} ${theme.space.x3}`,
   paddingLeft: getPaddingLeft(0),
-}));
-
-const getSharedStyles = ({ color, layer, theme }) => ({
-  display: "block",
-  color: theme.colors[color] || color,
-  textDecoration: "none",
-  border: "none",
-  backgroundColor: "transparent",
-  borderRadius: theme.radii.medium,
-  fontSize: layer === 0 ? theme.fontSizes.large : theme.fontSizes.medium,
-  lineHeight: layer === 0 ? theme.lineHeights.heading3 : theme.lineHeights.base,
-  padding:
-    layer === 0
-      ? `${theme.space.x1} ${theme.space.x3}`
-      : `${theme.space.x1} ${theme.space.x2}`,
-  paddingLeft: getPaddingLeft(layer),
-  marginBottom: theme.space.x1,
-  "&:visited": {
-    color: theme.colors[color] || color,
-  },
-  "&:hover": {
-    color: "#434d59", // darkGrey
-    background: "#f0f2f5", // whiteGrey
-  },
 });
-
-type ApplyMenuLinkStylesProps = {
-  layer?: number;
-  color?: string;
-  hoverColor?: string;
-  hoverBackground?: string;
-  theme?: DefaultNDSThemeType;
-};
-
-const ApplyMenuLinkStyles = styled.li(
-  ({
-    color = "white",
-    hoverColor = "lightBlue",
-    hoverBackground = "white",
-    layer = 0,
-    theme,
-  }: ApplyMenuLinkStylesProps) => ({
-    display: "block",
-    "button, a": {
-      ...getSharedStyles({ color, layer, theme }),
-      textDecoration: "none",
-      "&:hover, &:focus": {
-        outline: "none",
-        color: theme.colors[hoverColor] || hoverColor,
-        backgroundColor: theme.colors[hoverBackground] || hoverBackground,
-      },
-      "&:disabled": {
-        opacity: ".5",
-      },
-      "&:focus": {
-        boxShadow: theme.shadows.focus,
-      },
-    },
-  })
-);
 
 type ApplyIndentProps = {
   layer?: number;
@@ -132,7 +69,7 @@ type ApplyIndentProps = {
 
 const ApplyIndent = styled.li(({ layer, theme }: ApplyIndentProps) => ({
   marginBottom: theme.space.x1,
-  [`> ${DropdownLink}`]: {
+  [`> ${DropdownButton}, > ${DropdownLink}`]: {
     paddingLeft: `${24 * layer + 20}px`,
   },
   [`> ${DropdownText}`]: {
@@ -164,14 +101,9 @@ const renderMenuLink = (menuItem, linkOnClick, themeColorObject, layer) => {
 };
 
 const renderCustom = (menuItem, linkOnClick, themeColorObject, layer) => (
-  <ApplyMenuLinkStyles
-    key={menuItem.key ?? menuItem.name}
-    {...themeColorObject}
-    layer={layer}
-    onClick={linkOnClick}
-  >
-    {menuItem.render()}
-  </ApplyMenuLinkStyles>
+  <ApplyIndent layer={layer} key={menuItem.key ?? menuItem.name}>
+    {menuItem.render(linkOnClick, layer)}
+  </ApplyIndent>
 );
 
 const renderSubMenu = (menuItem, linkOnClick, themeColorObject, layer) => (

--- a/src/BrandedNavBar/MobileMenu.tsx
+++ b/src/BrandedNavBar/MobileMenu.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import styled from "styled-components";
 import { display } from "styled-system";
-import { themeGet } from "@styled-system/theme-get";
 import { Text, Heading3 } from "../Type";
 import { Flex } from "../Flex";
 import { BrandingText } from "../Branding";
 import { DefaultNDSThemeType } from "../theme.type";
-import { DropdownText } from "../DropdownMenu";
+import { DropdownLink, DropdownText } from "../DropdownMenu";
+import { Link } from "../Link";
+import { LinkProps } from "../Link/Link";
 import NulogyLogo from "./NulogyLogo";
 
 const borderStyle = "1px solid #e4e7eb";
@@ -19,6 +20,37 @@ const BrandingWrap = styled.div(({ theme }) => ({
 
 // eslint-disable-next-line no-mixed-operators
 const getPaddingLeft = (layer) => `${24 * layer + 24}px`;
+
+const TopLevelLink = styled(Link)(({ theme }) => ({
+  color: theme.colors.darkBlue,
+  display: "block",
+  textDecoration: "none",
+  border: "none",
+  backgroundColor: "transparent",
+  fontSize: theme.fontSizes.large,
+  fontWeight: theme.fontWeights.medium,
+  lineHeight: theme.lineHeights.heading3,
+  padding: `${theme.space.x1} ${theme.space.x3}`,
+  paddingLeft: getPaddingLeft(0),
+  "&:visited": {
+    color: theme.colors.darkBlue,
+  },
+  width: "100%",
+  borderRadius: "0",
+  transition: ".2s",
+  "&:hover, &:focus": {
+    outline: "none",
+    color: theme.colors.blackBlue,
+    backgroundColor: theme.colors.whiteGrey,
+    cursor: "pointer",
+  },
+  "&:focus": {
+    boxShadow: theme.shadows.focus,
+  },
+  "&:disabled": {
+    opacity: ".5",
+  },
+}));
 
 const TopLevelText = styled(Text)(({ theme }) => ({
   color: theme.colors.blackBlue,
@@ -92,42 +124,19 @@ const ApplyMenuLinkStyles = styled.li(
   })
 );
 
-type MenuLinkProps = {
+type ApplyIndentProps = {
   layer?: number;
-  color?: string;
-  hoverColor?: string;
-  hoverBackground?: string;
   theme?: DefaultNDSThemeType;
+  key?: string;
 };
 
-const MenuLink = styled.a(
-  ({ color, hoverColor, hoverBackground, layer, theme }: MenuLinkProps) => ({
-    ...getSharedStyles({ color, layer, theme }),
-    width: "100%",
-    borderRadius: "0",
-    transition: ".2s",
-    "&:hover, &:focus": {
-      outline: "none",
-      color: themeGet(`colors.${hoverColor}`, hoverColor)(hoverColor),
-      backgroundColor: themeGet(
-        `colors.${hoverBackground}`,
-        hoverBackground
-      )(hoverBackground),
-      cursor: "pointer",
-    },
-    "&:focus": {
-      boxShadow: theme.shadows.focus,
-    },
-    "&:disabled": {
-      opacity: ".5",
-    },
-  })
-);
-
-const ApplyIndent = styled.li(({ layer, theme }: MenuLinkProps) => ({
+const ApplyIndent = styled.li(({ layer, theme }: ApplyIndentProps) => ({
   marginBottom: theme.space.x1,
+  [`> ${DropdownLink}`]: {
+    paddingLeft: `${24 * layer + 20}px`,
+  },
   [`> ${DropdownText}`]: {
-    paddingLeft: `${24 * layer + 24}px`,
+    paddingLeft: getPaddingLeft(layer),
   },
 }));
 
@@ -137,25 +146,22 @@ const SubMenuItemsList = styled.ul({
   margin: "0",
 });
 
-const StyledLi = styled.li(({ theme }) => ({
-  marginBottom: theme.space.x1,
-  display: "block",
-}));
-
-const renderMenuLink = (menuItem, linkOnClick, themeColorObject, layer) => (
-  <StyledLi key={menuItem.key ?? menuItem.name}>
-    <MenuLink
-      layer={layer}
-      {...themeColorObject}
-      onClick={linkOnClick}
-      href={menuItem.href}
-      as={menuItem.as}
-      to={menuItem.to}
-    >
-      {menuItem.name}
-    </MenuLink>
-  </StyledLi>
-);
+const renderMenuLink = (menuItem, linkOnClick, themeColorObject, layer) => {
+  const MenuLink: React.FC<LinkProps> =
+    layer === 0 ? TopLevelLink : DropdownLink;
+  return (
+    <ApplyIndent layer={layer} key={menuItem.key ?? menuItem.name}>
+      <MenuLink
+        onClick={linkOnClick}
+        href={menuItem.href}
+        as={menuItem.as}
+        to={menuItem.to}
+      >
+        {menuItem.name}
+      </MenuLink>
+    </ApplyIndent>
+  );
+};
 
 const renderCustom = (menuItem, linkOnClick, themeColorObject, layer) => (
   <ApplyMenuLinkStyles

--- a/src/BrandedNavBar/MobileMenu.tsx
+++ b/src/BrandedNavBar/MobileMenu.tsx
@@ -215,20 +215,13 @@ const renderMenuItems = (menuItems, linkOnClick, themeColorObject, layer) =>
 const renderTopLayerMenuItems = (menuData, linkOnClick, themeColorObject) =>
   renderMenuItems(menuData, linkOnClick, themeColorObject, 0);
 
-const getSubMenuHeading = (layer, color, name) =>
+const getSubMenuHeading = (layer, name) =>
   layer === 0 ? (
-    <Heading3 mb="x1" color={color}>
-      {name}
-    </Heading3>
+    <TopLevelText as="h3">{name}</TopLevelText>
   ) : (
-    <Text
-      mb="x1"
-      color={color}
-      py="x1"
-      style={{ paddingLeft: getPaddingLeft(layer) }}
-    >
+    <DropdownText mb="x1" style={{ paddingLeft: getPaddingLeft(layer) }}>
       {name}
-    </Text>
+    </DropdownText>
   );
 
 type ThemeColorObject = {
@@ -256,11 +249,7 @@ const SubMenu = ({
   layer,
 }: SubMenuProps) => (
   <>
-    {getSubMenuHeading(
-      layer,
-      themeColorObject && themeColorObject.textColor,
-      menuItem.name
-    )}
+    {getSubMenuHeading(layer, menuItem.name)}
     <SubMenuItemsList>
       {renderMenuItems(
         menuItem.items,

--- a/src/BrandedNavBar/NavBar.story.tsx
+++ b/src/BrandedNavBar/NavBar.story.tsx
@@ -31,9 +31,6 @@ const primaryMenu = [
   {
     name: "Dashboard",
     items: [
-      { name: "Customers", href: "/" },
-      { name: "Invoices", href: "/" },
-      { name: "Projects", href: "/" },
       { name: "Items", href: "/" },
       { name: "Vendors", href: "/" },
       { name: "Carriers", href: "/" },
@@ -279,6 +276,15 @@ export const WithReactRouter = () => (
 
 WithReactRouter.story = {
   name: "With react router",
+};
+
+export const WithHamburgerMenu = () => {
+  return <BrandedNavBar menuData={{ primaryMenu, secondaryMenu }} />;
+};
+WithHamburgerMenu.parameters = {
+  viewport: {
+    defaultViewport: "small", // for some reason this has to match the viewport key, NOT the name!
+  },
 };
 
 const customPrimaryMenu = [

--- a/src/BrandedNavBar/NavBar.story.tsx
+++ b/src/BrandedNavBar/NavBar.story.tsx
@@ -4,6 +4,7 @@ import { select } from "@storybook/addon-knobs";
 import { BrowserRouter, Link as ReactRouterLink } from "react-router-dom";
 import { Heading1 } from "../Type";
 import { Icon } from "../Icon";
+import { DropdownButton, DropdownLink } from "../DropdownMenu";
 import { BrandedNavBar as NDSBrandedNavBar } from "./index";
 
 const sampleLogo =
@@ -38,7 +39,6 @@ const primaryMenu = [
       { name: "Carriers", href: "/" },
     ],
   },
-
   {
     name: "Inspector",
     items: [
@@ -295,4 +295,42 @@ export const WithReactRouter = () => (
 
 WithReactRouter.story = {
   name: "With react router",
+};
+
+const customPrimaryMenu = [
+  {
+    name: "Submenu",
+    items: [
+      { name: "Submenu link", href: "/" },
+      {
+        name: "Custom submenu HTML Link",
+        render: () => <a href="/">Submenu Raw HTML Link</a>,
+      },
+      {
+        name: "Custom submenu DropdownLink",
+        render: () => <DropdownLink href="/">DropdownLink</DropdownLink>,
+      },
+      {
+        name: "Custom submenu DropdownButton",
+        render: () => <DropdownButton>DropdownButton</DropdownButton>,
+      },
+    ],
+  },
+  { name: "Menu link", href: "/" },
+  {
+    name: "Custom Menu HTML Link",
+    render: () => <a href="/">Menu Raw HTML Link</a>,
+  },
+];
+export const CustomRendering = () => (
+  <BrandedNavBar menuData={{ primaryMenu: customPrimaryMenu, secondaryMenu }} />
+);
+
+export const CustomRenderingInHamburger = () => (
+  <BrandedNavBar menuData={{ primaryMenu: customPrimaryMenu, secondaryMenu }} />
+);
+CustomRenderingInHamburger.parameters = {
+  viewport: {
+    defaultViewport: "small", // for some reason this has to match the viewport key, NOT the name!
+  },
 };

--- a/src/BrandedNavBar/NavBar.story.tsx
+++ b/src/BrandedNavBar/NavBar.story.tsx
@@ -37,24 +37,7 @@ const primaryMenu = [
       { name: "Items", href: "/" },
       { name: "Vendors", href: "/" },
       { name: "Carriers", href: "/" },
-    ],
-  },
-  {
-    name: "Inspector",
-    items: [
-      { name: "Dashboard", href: "/" },
-      { name: "Moves", href: "/" },
-      { name: "Pick Lists", href: "/" },
-      { name: "Receive Orders", href: "/" },
-      { name: "Receipts", href: "/" },
-      { name: "Ship Orders", href: "/" },
-      { name: "Shipments", href: "/" },
-      { name: "Item Lists", href: "/" },
-      { name: "Cycle Counts", href: "/" },
-      { name: "Blind Counts", href: "/" },
-      { name: "Inbound Stock Transfer Orders", href: "/" },
-      { name: "Inbound Stock Transfers", href: "/" },
-      { name: "Outbound Stock Transfers", href: "/" },
+      { name: "Only text submenu" },
     ],
   },
   {
@@ -85,6 +68,7 @@ const primaryMenu = [
     ],
   },
   { name: "Link", href: "/" },
+  { name: "Only text" },
 ];
 
 const secondaryMenu = [

--- a/src/BrandedNavBar/NavBarDropdownMenu.tsx
+++ b/src/BrandedNavBar/NavBarDropdownMenu.tsx
@@ -1,4 +1,4 @@
-/* TS IGNORED: due to problems typing propTypes and defaultProps, 
+/* TS IGNORED: due to problems typing propTypes and defaultProps,
 it can stop being ingnored when its refactored to a functional component */
 import React from "react";
 import PropTypes from "prop-types";

--- a/src/BrandedNavBar/NavBarDropdownMenu.tsx
+++ b/src/BrandedNavBar/NavBarDropdownMenu.tsx
@@ -101,7 +101,6 @@ class StatelessNavBarDropdownMenu extends StatelessNavBarDropdownMenuClass {
               trigger({
                 closeMenu,
                 openMenu,
-                isOpen,
               }),
               {
                 "aria-haspopup": true,
@@ -144,8 +143,8 @@ class StatelessNavBarDropdownMenu extends StatelessNavBarDropdownMenuClass {
                     {...popperProps.arrowProps}
                     placement={placement}
                     ref={popperProps.arrowProps.ref}
-                    backgroundColor="whiteGrey"
-                    borderColor="whiteGrey"
+                    backgroundColor="white"
+                    borderColor="white"
                   />
                   <DetectOutsideClick
                     onClick={this.handleOutsideClick}

--- a/src/BrandedNavBar/SubMenuTrigger.tsx
+++ b/src/BrandedNavBar/SubMenuTrigger.tsx
@@ -69,6 +69,6 @@ const SubMenuTrigger = ({
   );
 };
 
-SubMenuTrigger.displayName = "SubMenuTriggerButton";
+SubMenuTrigger.displayName = "SubMenuTrigger";
 
 export default SubMenuTrigger;

--- a/src/BrandedNavBar/SubMenuTrigger.tsx
+++ b/src/BrandedNavBar/SubMenuTrigger.tsx
@@ -1,65 +1,33 @@
 import React from "react";
-import styled, {
-  CSSObject,
-  StyledComponentPropsWithRef,
-} from "styled-components";
-import theme from "../theme";
+import styled, { StyledComponentPropsWithRef } from "styled-components";
 import { Icon } from "../Icon";
+import { DropdownButton } from "../DropdownMenu/index";
 import NavBarDropdownMenu from "./NavBarDropdownMenu";
 import renderSubMenuItems from "./renderSubMenuItems";
 
 type SubMenuTriggerProps = React.ComponentPropsWithRef<"button"> & {
   name?: string;
-  isOpen?: boolean;
   onItemClick?: any;
   menuData: any[];
 };
 
-const StyledButton: StyledComponentPropsWithRef<any> = styled.button(
-  ({ isOpen }: any): CSSObject => ({
-    display: "block",
-    position: "relative",
-    color: theme.colors.darkBlue,
-    fontSize: theme.fontSizes.small,
-    lineHeight: theme.lineHeights.smallTextBase,
-    width: "100%",
-    padding: `${theme.space.half} 28px ${theme.space.half} 12px`,
-    border: "none",
-    borderLeft: `${theme.space.half} solid transparent`,
-    "&:hover": {
-      backgroundColor: theme.colors.lightGrey,
-    },
-    "&:disabled": {
-      opacity: ".5",
-    },
-    "&:focus": {
-      outline: "none",
-      color: theme.colors.darkBlue,
-      backgroundColor: theme.colors.lightGrey,
-      borderLeft: `${theme.space.half}  solid ${theme.colors.blue}`,
-    },
-    backgroundColor: isOpen ? theme.colors.lightGrey : "transparent",
-    textDecoration: "none",
-    textAlign: "left",
-    cursor: "pointer",
-  })
-);
+const StyledButton: StyledComponentPropsWithRef<any> = styled(DropdownButton)({
+  position: "relative",
+});
 
 type SubMenuTriggerButtonProps = React.ComponentPropsWithRef<"button"> & {
   name?: string;
-  isOpen: boolean;
 };
 
 const SubMenuTriggerButton = React.forwardRef<
   HTMLButtonElement,
   SubMenuTriggerButtonProps
->(({ name, isOpen, ...props }, ref) => (
-  <StyledButton isOpen={isOpen} ref={ref} {...props}>
+>(({ name, ...props }, ref) => (
+  <StyledButton ref={ref} {...props}>
     {name}
     <Icon
-      style={{ position: "absolute", top: "7px" }}
+      style={{ position: "absolute", top: "10px" }}
       icon="rightArrow"
-      color="darkBlue"
       size="20px"
       p="2px"
     />
@@ -86,9 +54,8 @@ const SubMenuTrigger = ({
         onMouseEnter: openMenu,
         onMouseLeave: closeMenu,
       })}
-      trigger={({ closeMenu, openMenu, isOpen }) => (
+      trigger={({ closeMenu, openMenu }) => (
         <SubMenuTriggerButton
-          isOpen={isOpen}
           name={name}
           onMouseEnter={openMenu}
           onMouseLeave={closeMenu}

--- a/src/BrandedNavBar/renderSubMenuItems.tsx
+++ b/src/BrandedNavBar/renderSubMenuItems.tsx
@@ -1,23 +1,5 @@
 import React from "react";
-import styled, { CSSObject } from "styled-components";
-import theme from "../theme";
-import { DropdownLink } from "../DropdownMenu";
-
-const getSharedStyles = (): CSSObject => ({
-  display: "block",
-  whiteSpace: "nowrap",
-  textDecoration: "none",
-  borderColor: "transparent",
-  backgroundColor: "transparent",
-  lineHeight: theme.lineHeights.smallTextBase,
-  fontSize: `${theme.fontSizes.small}`,
-  padding: `${theme.space.half} ${theme.space.x2}`,
-});
-
-const SubMenuText = styled.li((): any => ({
-  color: theme.colors.darkGrey,
-  ...getSharedStyles(),
-}));
+import { DropdownText, DropdownLink } from "../DropdownMenu";
 
 const renderSubMenuTrigger = (subMenuItem, onItemClick, SubMenuTrigger) => (
   <li
@@ -59,9 +41,12 @@ const renderCustom = (subMenuItem, onItemClick) => (
 );
 
 const renderText = (subMenuItem) => (
-  <SubMenuText key={subMenuItem.key ?? subMenuItem.name}>
-    {subMenuItem.name}
-  </SubMenuText>
+  <li
+    style={{ whiteSpace: "nowrap" }}
+    key={subMenuItem.key ?? subMenuItem.name}
+  >
+    <DropdownText>{subMenuItem.name}</DropdownText>
+  </li>
 );
 
 const getRenderFunction = (subMenuItem) => {

--- a/src/BrandedNavBar/renderSubMenuItems.tsx
+++ b/src/BrandedNavBar/renderSubMenuItems.tsx
@@ -14,26 +14,6 @@ const getSharedStyles = (): CSSObject => ({
   padding: `${theme.space.half} ${theme.space.x2}`,
 });
 
-const ApplySubMenuLinkStyles = styled.li((): any => ({
-  color: theme.colors.darkBlue,
-  verticalAlign: "middle",
-  "> *": {
-    ...getSharedStyles(),
-    transition: ".2s",
-    textDecoration: "none",
-    "&:hover, &:focus": {
-      outline: "none",
-      backgroundColor: theme.colors.lightGrey,
-    },
-    "&:disabled": {
-      opacity: ".5",
-    },
-    "&:focus": {
-      boxShadow: theme.shadows.focus,
-    },
-  },
-}));
-
 const SubMenuText = styled.li((): any => ({
   color: theme.colors.darkGrey,
   ...getSharedStyles(),
@@ -70,12 +50,12 @@ const renderSubMenuLink = (subMenuItem, onItemClick) => (
 );
 
 const renderCustom = (subMenuItem, onItemClick) => (
-  <ApplySubMenuLinkStyles
+  <li
+    style={{ whiteSpace: "nowrap" }}
     key={subMenuItem.key ?? subMenuItem.name}
-    onClick={onItemClick}
   >
-    {subMenuItem.render()}
-  </ApplySubMenuLinkStyles>
+    {subMenuItem.render(onItemClick)}
+  </li>
 );
 
 const renderText = (subMenuItem) => (

--- a/src/BrandedNavBar/renderSubMenuItems.tsx
+++ b/src/BrandedNavBar/renderSubMenuItems.tsx
@@ -1,17 +1,7 @@
 import React from "react";
 import styled, { CSSObject } from "styled-components";
-import { fontSize, lineHeight, space } from "styled-system";
-import propTypes from "@styled-system/prop-types";
 import theme from "../theme";
 import { DropdownLink } from "../DropdownMenu";
-
-const SubMenuLink = styled(DropdownLink)(fontSize, lineHeight, space);
-
-SubMenuLink.propTypes = {
-  ...propTypes.fontSize,
-  ...propTypes.lineHeight,
-  ...propTypes.space,
-};
 
 const getSharedStyles = (): CSSObject => ({
   display: "block",
@@ -67,9 +57,7 @@ const renderSubMenuLink = (subMenuItem, onItemClick) => (
     style={{ whiteSpace: "nowrap" }}
     key={subMenuItem.key ?? subMenuItem.name}
   >
-    <SubMenuLink
-      fontSize="small"
-      lineHeight="smallTextBase"
+    <DropdownLink
       py="half"
       onClick={onItemClick}
       href={subMenuItem.href}
@@ -77,7 +65,7 @@ const renderSubMenuLink = (subMenuItem, onItemClick) => (
       as={subMenuItem.as}
     >
       {subMenuItem.name}
-    </SubMenuLink>
+    </DropdownLink>
   </li>
 );
 

--- a/src/DropdownMenu/DropdownButton.tsx
+++ b/src/DropdownMenu/DropdownButton.tsx
@@ -16,7 +16,7 @@ const DropdownButton: React.FC<DropdownButtonProps> = styled.button(
     disabled = false,
     theme,
     hoverColor = "darkBlue",
-    bgHoverColor = "lightGrey",
+    bgHoverColor = "lightBlue",
   }: DropdownButtonProps) => ({
     display: "block",
     width: "100%",
@@ -45,9 +45,9 @@ const DropdownButton: React.FC<DropdownButtonProps> = styled.button(
   })
 );
 DropdownButton.defaultProps = {
-  color: "darkBlue",
+  color: "darkGrey",
   disabled: false,
   hoverColor: "darkBlue",
-  bgHoverColor: "lightGrey",
+  bgHoverColor: "lightBlue",
 };
 export default DropdownButton;

--- a/src/DropdownMenu/DropdownItem.tsx
+++ b/src/DropdownMenu/DropdownItem.tsx
@@ -11,9 +11,9 @@ type DropdownItemProps = {
 const DropdownItem: React.FC<DropdownItemProps> = styled.div(
   ({
     theme,
-    color = "darkBlue",
+    color = "darkGrey",
     hoverColor = "darkBlue",
-    bgHoverColor = "lightGrey",
+    bgHoverColor = "lightBlue",
   }: DropdownItemProps): CSSObject => ({
     "*": {
       color: theme.colors[color],

--- a/src/DropdownMenu/DropdownLink.tsx
+++ b/src/DropdownMenu/DropdownLink.tsx
@@ -6,9 +6,9 @@ const DropdownLink: React.FC<any> = styled.a.withConfig({
 })(
   ({
     theme,
-    bgHoverColor = "lightGrey",
+    bgHoverColor = "lightBlue",
     hoverColor = "darkBlue",
-    color = "darkBlue",
+    color = "darkGrey",
   }: any) => ({
     display: "block",
     textDecoration: "none",
@@ -20,12 +20,12 @@ const DropdownLink: React.FC<any> = styled.a.withConfig({
     color: theme.colors[color],
     padding: `${theme.space.x1} ${theme.space.x2} ${theme.space.x1} 12px`,
     borderLeft: `${theme.space.half} solid transparent`,
+    "&:visited": {
+      color: theme.colors[color],
+    },
     "&:hover": {
       color: theme.colors[hoverColor],
       backgroundColor: theme.colors[bgHoverColor],
-    },
-    "&:visited": {
-      color: theme.colors[color],
     },
     "&:focus": {
       outline: "none",

--- a/src/DropdownMenu/DropdownMenu.story.tsx
+++ b/src/DropdownMenu/DropdownMenu.story.tsx
@@ -75,7 +75,7 @@ WithButtonClosingMenu.story = {
   name: "with button closing menu",
 };
 
-export const WithCustomItem = () => (
+export const WithCustomLink = () => (
   <DropdownMenu openAriaLabel="open dropdown" closeAriaLabel="close dropdown">
     <DropdownItem>
       <a href="/never_been">Custom Link Component</a>
@@ -83,9 +83,15 @@ export const WithCustomItem = () => (
   </DropdownMenu>
 );
 
-WithCustomItem.story = {
+WithCustomLink.story = {
   name: "with custom item",
 };
+
+export const WithCustomText = () => (
+  <DropdownMenu openAriaLabel="open dropdown" closeAriaLabel="close dropdown">
+    <DropdownItem><span>Custom Text</span></DropdownItem>
+  </DropdownMenu>
+);
 
 export const SetToDefaultOpen = () => (
   <DropdownMenu

--- a/src/DropdownMenu/DropdownMenu.story.tsx
+++ b/src/DropdownMenu/DropdownMenu.story.tsx
@@ -19,7 +19,7 @@ export default {
 
 export const _DropdownMenu = () => (
   <DropdownMenu openAriaLabel="open dropdown" closeAriaLabel="close dropdown">
-    <DropdownLink href="/">Dropdown Link</DropdownLink>
+    <DropdownLink href="/never_been">Dropdown Link</DropdownLink>
     <DropdownButton onClick={() => {}}>Dropdown Button</DropdownButton>
   </DropdownMenu>
 );
@@ -34,7 +34,7 @@ export const WithCustomTrigger = () => (
     closeAriaLabel="close dropdown"
     trigger={() => <Button>Custom Trigger</Button>}
   >
-    <DropdownLink href="/">Dropdown Link</DropdownLink>
+    <DropdownLink href="/never_been">Dropdown Link</DropdownLink>
     <DropdownButton onClick={() => {}}>Dropdown Button</DropdownButton>
   </DropdownMenu>
 );
@@ -50,7 +50,7 @@ export const WithCustomColors = () => (
     openAriaLabel="open dropdown"
     closeAriaLabel="close dropdown"
   >
-    <DropdownLink href="/" {...customColors}>
+    <DropdownLink href="/never_been" {...customColors}>
       Dropdown Link
     </DropdownLink>
     <DropdownButton onClick={() => {}} {...customColors}>
@@ -78,7 +78,7 @@ WithButtonClosingMenu.story = {
 export const WithCustomItem = () => (
   <DropdownMenu openAriaLabel="open dropdown" closeAriaLabel="close dropdown">
     <DropdownItem>
-      <a href="/">Custom Link Component</a>
+      <a href="/never_been">Custom Link Component</a>
     </DropdownItem>
   </DropdownMenu>
 );
@@ -93,10 +93,10 @@ export const SetToDefaultOpen = () => (
     openAriaLabel="open dropdown"
     closeAriaLabel="close dropdown"
   >
-    <DropdownLink href="/">Dropdown Link</DropdownLink>
+    <DropdownLink href="/never_been">Dropdown Link</DropdownLink>
     <DropdownButton onClick={() => {}}>Dropdown Button</DropdownButton>
     <DropdownItem>
-      <a href="/" style={{ textDecoration: "none" }}>
+      <a href="/never_been" style={{ textDecoration: "none" }}>
         Custom Link Component
       </a>
     </DropdownItem>
@@ -107,13 +107,28 @@ SetToDefaultOpen.story = {
   name: "set to defaultOpen",
 };
 
+export const WithVisitedLinks = () => (
+  <DropdownMenu
+    defaultOpen
+    openAriaLabel="open dropdown"
+    closeAriaLabel="close dropdown"
+  >
+    <DropdownLink href="/">Dropdown Link</DropdownLink>
+    <DropdownItem>
+      <a href="/" style={{ textDecoration: "none" }}>
+        Custom Link Component
+      </a>
+    </DropdownItem>
+  </DropdownMenu>
+);
+
 export const SetToDisabled = () => (
   <DropdownMenu
     disabled
     openAriaLabel="open dropdown"
     closeAriaLabel="close dropdown"
   >
-    <DropdownLink href="/">Dropdown Link</DropdownLink>
+    <DropdownLink href="/never_been">Dropdown Link</DropdownLink>
     <DropdownButton onClick={() => {}}>Dropdown Button</DropdownButton>
   </DropdownMenu>
 );

--- a/src/DropdownMenu/DropdownMenu.tsx
+++ b/src/DropdownMenu/DropdownMenu.tsx
@@ -55,7 +55,7 @@ const DropdownMenu: React.FC<DropdownMenuProps> = React.forwardRef<
       showArrow = true,
       disabled,
       defaultOpen,
-      backgroundColor = "whiteGrey",
+      backgroundColor = "white",
       placement = "bottom-start",
       className,
       id,

--- a/src/DropdownMenu/DropdownMenuContainer.tsx
+++ b/src/DropdownMenu/DropdownMenuContainer.tsx
@@ -48,7 +48,7 @@ const DropdownMenuContainer: React.FC<DropdownMenuContainerProps> = styled(Box)(
     backgroundColor: theme.colors[backgroundColor],
     borderTop: `1px solid  ${theme.colors[backgroundColor]}`,
     borderBottom: `1px solid ${theme.colors[backgroundColor]}`,
-    boxShadow: theme.shadows.small,
+    boxShadow: theme.shadows.medium,
     padding: "7px 0",
     zIndex: "100",
     ...getMenuMargin(dataPlacement, showArrow),

--- a/src/DropdownMenu/DropdownMenuContainer.tsx
+++ b/src/DropdownMenu/DropdownMenuContainer.tsx
@@ -41,7 +41,7 @@ const DropdownMenuContainer: React.FC<DropdownMenuContainerProps> = styled(Box)(
   ({
     dataPlacement,
     showArrow = true,
-    backgroundColor = "whiteGrey",
+    backgroundColor = "white",
     theme,
   }: DropdownMenuContainerProps): any => ({
     borderRadius: theme.radii.medium,

--- a/src/DropdownMenu/DropdownText.tsx
+++ b/src/DropdownMenu/DropdownText.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import styled, { CSSObject } from "styled-components";
+import { DefaultNDSThemeType } from "../theme.type";
+import { Text } from "../Type";
+
+type DropdownTextProps = {
+  theme?: DefaultNDSThemeType;
+  color?: string;
+};
+
+const DropdownText: React.FC<DropdownTextProps> = styled(Text)(
+  ({ theme }: DropdownTextProps): CSSObject => ({
+    color: theme.colors.darkGrey,
+    display: "block",
+    width: "100%",
+    border: "none",
+    textAlign: "left",
+    backgroundColor: "transparent",
+    transition: ".2s",
+    padding: `${theme.space.x1} ${theme.space.x2}`,
+  })
+);
+
+export default DropdownText;

--- a/src/DropdownMenu/DropdownText.tsx
+++ b/src/DropdownMenu/DropdownText.tsx
@@ -1,15 +1,10 @@
 import React from "react";
 import styled, { CSSObject } from "styled-components";
-import { DefaultNDSThemeType } from "../theme.type";
 import { Text } from "../Type";
+import { TextProps } from "../Type/Text";
 
-type DropdownTextProps = {
-  theme?: DefaultNDSThemeType;
-  color?: string;
-};
-
-const DropdownText: React.FC<DropdownTextProps> = styled(Text)(
-  ({ theme }: DropdownTextProps): CSSObject => ({
+const DropdownText: React.FC<TextProps> = styled(Text)(
+  ({ theme }: TextProps): CSSObject => ({
     color: theme.colors.darkGrey,
     display: "block",
     width: "100%",

--- a/src/DropdownMenu/index.ts
+++ b/src/DropdownMenu/index.ts
@@ -2,3 +2,4 @@ export { default as DropdownMenu } from "./DropdownMenu";
 export { default as DropdownButton } from "./DropdownButton";
 export { default as DropdownLink } from "./DropdownLink";
 export { default as DropdownItem } from "./DropdownItem";
+export { default as DropdownText } from "./DropdownText";

--- a/src/Layout/Sidebar.tsx
+++ b/src/Layout/Sidebar.tsx
@@ -158,7 +158,6 @@ const Sidebar: React.FC<SidebarProps> = ({
         display="flex"
         flexDirection="column"
         height={`calc(100% - ${NAVBAR_HEIGHT})`}
-        boxShadow="large"
         borderLeftWidth="1px"
         borderLeftStyle="solid"
         borderLeftColor="lightGrey"

--- a/src/Table/BaseTable.story.tsx
+++ b/src/Table/BaseTable.story.tsx
@@ -266,7 +266,7 @@ const rowDataWithSections = [
 ];
 
 export default {
-  title: "Components/Table",
+  title: "Components/Table/Base",
 };
 
 export const WithData = () => (

--- a/src/Table/TableWithCustomSorting.story.tsx
+++ b/src/Table/TableWithCustomSorting.story.tsx
@@ -85,7 +85,7 @@ const TableWithCustomSorting = () => {
 };
 
 export default {
-  title: "Components/Table",
+  title: "Components/Table/with custom sorting",
 };
 
 export const WithCustomSorting = () => <TableWithCustomSorting />;

--- a/src/Table/TableWithFiltering.story.tsx
+++ b/src/Table/TableWithFiltering.story.tsx
@@ -86,7 +86,7 @@ const TableWithFilters = ({ rowsPerPage }: TableWithFiltersProps) => {
 };
 
 export default {
-  title: "Components/Table",
+  title: "Components/Table/with filtering",
 };
 
 export const WithFiltering = () => <TableWithFilters />;

--- a/src/Table/TableWithServerSidePagination.story.tsx
+++ b/src/Table/TableWithServerSidePagination.story.tsx
@@ -85,7 +85,7 @@ class TableWithServerSidePagination extends React.Component<{}, TableState> {
 }
 
 export default {
-  title: "Components/Table",
+  title: "Components/Table/with server side pagination",
 };
 
 export const WithServerSidePagination = () => <TableWithServerSidePagination />;

--- a/src/Toggle/ToggleButton.tsx
+++ b/src/Toggle/ToggleButton.tsx
@@ -4,7 +4,8 @@ import type { TransformProperties } from "framer-motion/types/motion/types";
 import type { Transition } from "framer-motion";
 import styled, { CSSObject } from "styled-components";
 import { DefaultNDSThemeType } from "../theme.type";
-import { AnimatedBox, theme } from "..";
+import { default as theme } from "../theme";
+import { AnimatedBox } from "../Box";
 
 type SwitchProps = {
   disabled?: boolean;

--- a/src/Tooltip/TooltipContainer.tsx
+++ b/src/Tooltip/TooltipContainer.tsx
@@ -59,7 +59,7 @@ const TooltipContainer = styled(Box)(
     backgroundColor: tooltipStyles(theme).backgroundColor,
     borderRadius: theme.radii.medium,
     border: `1px solid ${tooltipStyles(theme).borderColor}`,
-    boxShadow: "0 2px 4px rgba(0, 0, 0, 0.18)",
+    boxShadow: theme.shadows.medium,
     padding: theme.space.x1,
     transition: "opacity 0.3s",
     zIndex: theme.zIndices.content,

--- a/src/Type/Text.tsx
+++ b/src/Type/Text.tsx
@@ -13,6 +13,7 @@ import {
 } from "styled-system";
 import { TextOverflowProps, textOverflow } from "../StyledProps/textOverflow";
 import { CursorProps, cursor } from "../StyledProps/cursor";
+import type { DefaultNDSThemeType } from "../theme.type";
 const getAttrs = (inline?: boolean) => (inline ? { as: "span" } : null);
 
 export type TextProps = React.HTMLAttributes<HTMLParagraphElement> & {
@@ -38,7 +39,7 @@ export type TextProps = React.HTMLAttributes<HTMLParagraphElement> & {
   TextOverflowProps &
   TypographyProps &
   CursorProps &
-  ColorProps;
+  ColorProps & { theme?: DefaultNDSThemeType };
 
 const Text = styled.p.attrs<TextProps>((props: TextProps) =>
   getAttrs(props.inline)
@@ -50,19 +51,18 @@ const Text = styled.p.attrs<TextProps>((props: TextProps) =>
   overflow,
   textOverflow,
   cursor,
-  ({ disabled, textTransform }: TextProps): CSSObject => ({
+  ({ disabled, textTransform, theme }: TextProps): CSSObject => ({
     textTransform,
+    color: "currentColor",
+    marginTop: 0,
+    marginBottom: 0,
+    fontSize: theme.fontSizes.medium,
+    lineHeight: theme.lineHeights.base,
     opacity: disabled ? "0.7" : undefined,
   })
 );
 Text.defaultProps = {
   inline: false,
   disabled: false,
-  mt: 0,
-  mb: 0,
-  fontSize: "medium",
-  lineHeight: "base",
-  textTransform: undefined,
-  color: "currentColor",
 };
 export default Text;

--- a/src/Type/Text.tsx
+++ b/src/Type/Text.tsx
@@ -10,6 +10,7 @@ import {
   overflow,
   LayoutProps,
   layout,
+  compose,
 } from "styled-system";
 import { TextOverflowProps, textOverflow } from "../StyledProps/textOverflow";
 import { CursorProps, cursor } from "../StyledProps/cursor";
@@ -44,13 +45,6 @@ export type TextProps = React.HTMLAttributes<HTMLParagraphElement> & {
 const Text = styled.p.attrs<TextProps>((props: TextProps) =>
   getAttrs(props.inline)
 )<TextProps>(
-  space,
-  typography,
-  color,
-  layout,
-  overflow,
-  textOverflow,
-  cursor,
   ({ disabled, textTransform, theme }: TextProps): CSSObject => ({
     textTransform,
     color: "currentColor",
@@ -59,7 +53,8 @@ const Text = styled.p.attrs<TextProps>((props: TextProps) =>
     fontSize: theme.fontSizes.medium,
     lineHeight: theme.lineHeights.base,
     opacity: disabled ? "0.7" : undefined,
-  })
+  }),
+  compose(space, typography, color, layout, overflow, textOverflow, cursor)
 );
 Text.defaultProps = {
   inline: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export {
   DropdownLink,
   DropdownButton,
   DropdownItem,
+  DropdownText,
 } from "./DropdownMenu";
 export { HelpText, RequirementText, FieldLabel } from "./FieldLabel";
 export { Input } from "./Input";


### PR DESCRIPTION
## Description

Executing https://nulogy-go.atlassian.net/browse/GO-4538

Implement the visual design changes from here: https://www.figma.com/file/eTgLkFDHd8GLNFmD9tBp72/Multi-Echelon?node-id=658%3A30413

Summary of changes:

1. The Tooltip has been updated to use the medium shadow.
2. For the DropdownMenu and BrandedNavBar menus and submenus (but not top-level menu triggers!):
2.1. Update shadow from small to medium.
2.2. Update background colour to white.
2.3. Update hover colour to darkBlue.
2.4. Update colour to darkGrey.
2.5. Update hover background colour to lightBlue.
3. The Sidebar shadow has been removed.

Potentially breaking changes:

1. The BrandedNavBar no longer attempts to style components rendered via the `render()` function. If you want NDS styles, use an NDS component like the DropdownLink, DropdownButton, or DropdownItem.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [x] feature: a non-breaking change that adds functionality
- [x] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
