### PR TITLE
Stylistic updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.9.6",
-    "@nulogy/tokens": "^5.2.0",
+    "@nulogy/tokens": "^5.3.0",
     "@styled-system/prop-types": "^5.1.4",
     "@styled-system/theme-get": "^5.1.2",
     "body-scroll-lock": "^3.1.5",

--- a/src/BrandedNavBar/MobileMenu.tsx
+++ b/src/BrandedNavBar/MobileMenu.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import styled from "styled-components";
 import { display } from "styled-system";
 import { themeGet } from "@styled-system/theme-get";
@@ -7,6 +6,7 @@ import { Text, Heading3 } from "../Type";
 import { Flex } from "../Flex";
 import { BrandingText } from "../Branding";
 import { DefaultNDSThemeType } from "../theme.type";
+import { DropdownText } from "../DropdownMenu";
 import NulogyLogo from "./NulogyLogo";
 
 const borderStyle = "1px solid #e4e7eb";
@@ -17,7 +17,21 @@ const BrandingWrap = styled.div(({ theme }) => ({
   marginBottom: theme.space.x1,
 }));
 
+// eslint-disable-next-line no-mixed-operators
 const getPaddingLeft = (layer) => `${24 * layer + 24}px`;
+
+const TopLevelText = styled(Text)(({ theme }) => ({
+  color: theme.colors.blackBlue,
+  display: "block",
+  textDecoration: "none",
+  border: "none",
+  backgroundColor: "transparent",
+  fontSize: theme.fontSizes.large,
+  fontWeight: theme.fontWeights.medium,
+  lineHeight: theme.lineHeights.heading3,
+  padding: `${theme.space.x1} ${theme.space.x3}`,
+  paddingLeft: getPaddingLeft(0),
+}));
 
 const getSharedStyles = ({ color, layer, theme }) => ({
   display: "block",
@@ -110,14 +124,11 @@ const MenuLink = styled.a(
   })
 );
 
-type MenuTextProps = {
-  textColor?: string;
-  layer?: number;
-  theme?: DefaultNDSThemeType;
-};
-
-const MenuText = styled.li(({ textColor, layer, theme }: MenuTextProps) => ({
-  ...getSharedStyles({ color: textColor, layer, theme }),
+const ApplyIndent = styled.li(({ layer, theme }: MenuLinkProps) => ({
+  marginBottom: theme.space.x1,
+  [`> ${DropdownText}`]: {
+    paddingLeft: `${24 * layer + 24}px`,
+  },
 }));
 
 const SubMenuItemsList = styled.ul({
@@ -168,15 +179,14 @@ const renderSubMenu = (menuItem, linkOnClick, themeColorObject, layer) => (
   </li>
 );
 
-const renderText = (menuItem, linkOnClick, themeColorObject, layer) => (
-  <MenuText
-    key={menuItem.key ?? menuItem.name}
-    layer={layer}
-    {...themeColorObject}
-  >
-    {menuItem.name}
-  </MenuText>
-);
+const renderText = (menuItem, linkOnClick, themeColorObject, layer) => {
+  const MenuText = layer === 0 ? TopLevelText : DropdownText;
+  return (
+    <ApplyIndent layer={layer} key={menuItem.key ?? menuItem.name}>
+      <MenuText>{menuItem.name}</MenuText>
+    </ApplyIndent>
+  );
+};
 
 const getRenderFunction = (menuItem) => {
   if (menuItem.items) {

--- a/src/BrandedNavBar/MobileMenu.tsx
+++ b/src/BrandedNavBar/MobileMenu.tsx
@@ -29,6 +29,7 @@ const getSharedStyles = (theme) => ({
   fontSize: theme.fontSizes.large,
   fontWeight: theme.fontWeights.medium,
   lineHeight: theme.lineHeights.heading3,
+  marginBottom: theme.space.x1,
   padding: `${theme.space.x1} ${theme.space.x3}`,
   paddingLeft: getPaddingLeft(0),
 });

--- a/src/BrandedNavBar/MobileMenu.tsx
+++ b/src/BrandedNavBar/MobileMenu.tsx
@@ -61,21 +61,24 @@ const TopLevelText = styled(Text)(({ theme }) => ({
   color: theme.colors.blackBlue,
 }));
 
-type ApplyIndentProps = {
+type ChildIndentingLiProps = {
   layer?: number;
   theme?: DefaultNDSThemeType;
   key?: string;
 };
 
-const ApplyIndent = styled.li(({ layer, theme }: ApplyIndentProps) => ({
-  marginBottom: theme.space.x1,
-  [`> ${DropdownButton}, > ${DropdownLink}`]: {
-    paddingLeft: `${24 * layer + 20}px`,
-  },
-  [`> ${DropdownText}`]: {
-    paddingLeft: getPaddingLeft(layer),
-  },
-}));
+const ChildIndentingLi = styled.li(
+  ({ layer, theme }: ChildIndentingLiProps) => ({
+    marginBottom: theme.space.x1,
+    [`> ${DropdownButton}, > ${DropdownLink}`]: {
+      // eslint-disable-next-line no-mixed-operators
+      paddingLeft: `${24 * layer + 20}px`,
+    },
+    [`> ${DropdownText}`]: {
+      paddingLeft: getPaddingLeft(layer),
+    },
+  })
+);
 
 const SubMenuItemsList = styled.ul({
   listStyle: "none",
@@ -87,7 +90,7 @@ const renderMenuLink = (menuItem, linkOnClick, themeColorObject, layer) => {
   const MenuLink: React.FC<LinkProps> =
     layer === 0 ? TopLevelLink : DropdownLink;
   return (
-    <ApplyIndent layer={layer} key={menuItem.key ?? menuItem.name}>
+    <ChildIndentingLi layer={layer} key={menuItem.key ?? menuItem.name}>
       <MenuLink
         onClick={linkOnClick}
         href={menuItem.href}
@@ -96,14 +99,14 @@ const renderMenuLink = (menuItem, linkOnClick, themeColorObject, layer) => {
       >
         {menuItem.name}
       </MenuLink>
-    </ApplyIndent>
+    </ChildIndentingLi>
   );
 };
 
 const renderCustom = (menuItem, linkOnClick, themeColorObject, layer) => (
-  <ApplyIndent layer={layer} key={menuItem.key ?? menuItem.name}>
+  <ChildIndentingLi layer={layer} key={menuItem.key ?? menuItem.name}>
     {menuItem.render(linkOnClick, layer)}
-  </ApplyIndent>
+  </ChildIndentingLi>
 );
 
 const renderSubMenu = (menuItem, linkOnClick, themeColorObject, layer) => (
@@ -120,9 +123,9 @@ const renderSubMenu = (menuItem, linkOnClick, themeColorObject, layer) => (
 const renderText = (menuItem, linkOnClick, themeColorObject, layer) => {
   const MenuText = layer === 0 ? TopLevelText : DropdownText;
   return (
-    <ApplyIndent layer={layer} key={menuItem.key ?? menuItem.name}>
+    <ChildIndentingLi layer={layer} key={menuItem.key ?? menuItem.name}>
       <MenuText>{menuItem.name}</MenuText>
-    </ApplyIndent>
+    </ChildIndentingLi>
   );
 };
 

--- a/src/BrandedNavBar/MobileMenu.tsx
+++ b/src/BrandedNavBar/MobileMenu.tsx
@@ -5,7 +5,7 @@ import { Text, Heading3 } from "../Type";
 import { Flex } from "../Flex";
 import { BrandingText } from "../Branding";
 import { DefaultNDSThemeType } from "../theme.type";
-import { DropdownLink, DropdownText } from "../DropdownMenu";
+import { DropdownLink, DropdownText, DropdownButton } from "../DropdownMenu";
 import { Link } from "../Link";
 import { LinkProps } from "../Link/Link";
 import NulogyLogo from "./NulogyLogo";
@@ -21,8 +21,7 @@ const BrandingWrap = styled.div(({ theme }) => ({
 // eslint-disable-next-line no-mixed-operators
 const getPaddingLeft = (layer) => `${24 * layer + 24}px`;
 
-const TopLevelLink = styled(Link)(({ theme }) => ({
-  color: theme.colors.darkBlue,
+const getSharedStyles = (theme) => ({
   display: "block",
   textDecoration: "none",
   border: "none",
@@ -32,6 +31,11 @@ const TopLevelLink = styled(Link)(({ theme }) => ({
   lineHeight: theme.lineHeights.heading3,
   padding: `${theme.space.x1} ${theme.space.x3}`,
   paddingLeft: getPaddingLeft(0),
+});
+
+const TopLevelLink = styled(Link)(({ theme }) => ({
+  ...getSharedStyles(theme),
+  color: theme.colors.darkBlue,
   "&:visited": {
     color: theme.colors.darkBlue,
   },
@@ -53,76 +57,9 @@ const TopLevelLink = styled(Link)(({ theme }) => ({
 }));
 
 const TopLevelText = styled(Text)(({ theme }) => ({
+  ...getSharedStyles(theme),
   color: theme.colors.blackBlue,
-  display: "block",
-  textDecoration: "none",
-  border: "none",
-  backgroundColor: "transparent",
-  fontSize: theme.fontSizes.large,
-  fontWeight: theme.fontWeights.medium,
-  lineHeight: theme.lineHeights.heading3,
-  padding: `${theme.space.x1} ${theme.space.x3}`,
-  paddingLeft: getPaddingLeft(0),
 }));
-
-const getSharedStyles = ({ color, layer, theme }) => ({
-  display: "block",
-  color: theme.colors[color] || color,
-  textDecoration: "none",
-  border: "none",
-  backgroundColor: "transparent",
-  borderRadius: theme.radii.medium,
-  fontSize: layer === 0 ? theme.fontSizes.large : theme.fontSizes.medium,
-  lineHeight: layer === 0 ? theme.lineHeights.heading3 : theme.lineHeights.base,
-  padding:
-    layer === 0
-      ? `${theme.space.x1} ${theme.space.x3}`
-      : `${theme.space.x1} ${theme.space.x2}`,
-  paddingLeft: getPaddingLeft(layer),
-  marginBottom: theme.space.x1,
-  "&:visited": {
-    color: theme.colors[color] || color,
-  },
-  "&:hover": {
-    color: "#434d59", // darkGrey
-    background: "#f0f2f5", // whiteGrey
-  },
-});
-
-type ApplyMenuLinkStylesProps = {
-  layer?: number;
-  color?: string;
-  hoverColor?: string;
-  hoverBackground?: string;
-  theme?: DefaultNDSThemeType;
-};
-
-const ApplyMenuLinkStyles = styled.li(
-  ({
-    color = "white",
-    hoverColor = "lightBlue",
-    hoverBackground = "white",
-    layer = 0,
-    theme,
-  }: ApplyMenuLinkStylesProps) => ({
-    display: "block",
-    "button, a": {
-      ...getSharedStyles({ color, layer, theme }),
-      textDecoration: "none",
-      "&:hover, &:focus": {
-        outline: "none",
-        color: theme.colors[hoverColor] || hoverColor,
-        backgroundColor: theme.colors[hoverBackground] || hoverBackground,
-      },
-      "&:disabled": {
-        opacity: ".5",
-      },
-      "&:focus": {
-        boxShadow: theme.shadows.focus,
-      },
-    },
-  })
-);
 
 type ApplyIndentProps = {
   layer?: number;
@@ -132,7 +69,7 @@ type ApplyIndentProps = {
 
 const ApplyIndent = styled.li(({ layer, theme }: ApplyIndentProps) => ({
   marginBottom: theme.space.x1,
-  [`> ${DropdownLink}`]: {
+  [`> ${DropdownButton}, > ${DropdownLink}`]: {
     paddingLeft: `${24 * layer + 20}px`,
   },
   [`> ${DropdownText}`]: {
@@ -164,14 +101,9 @@ const renderMenuLink = (menuItem, linkOnClick, themeColorObject, layer) => {
 };
 
 const renderCustom = (menuItem, linkOnClick, themeColorObject, layer) => (
-  <ApplyMenuLinkStyles
-    key={menuItem.key ?? menuItem.name}
-    {...themeColorObject}
-    layer={layer}
-    onClick={linkOnClick}
-  >
-    {menuItem.render()}
-  </ApplyMenuLinkStyles>
+  <ApplyIndent layer={layer} key={menuItem.key ?? menuItem.name}>
+    {menuItem.render(linkOnClick, layer)}
+  </ApplyIndent>
 );
 
 const renderSubMenu = (menuItem, linkOnClick, themeColorObject, layer) => (

--- a/src/BrandedNavBar/MobileMenu.tsx
+++ b/src/BrandedNavBar/MobileMenu.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import styled from "styled-components";
 import { display } from "styled-system";
-import { themeGet } from "@styled-system/theme-get";
 import { Text, Heading3 } from "../Type";
 import { Flex } from "../Flex";
 import { BrandingText } from "../Branding";
 import { DefaultNDSThemeType } from "../theme.type";
-import { DropdownText } from "../DropdownMenu";
+import { DropdownLink, DropdownText } from "../DropdownMenu";
+import { Link } from "../Link";
+import { LinkProps } from "../Link/Link";
 import NulogyLogo from "./NulogyLogo";
 
 const borderStyle = "1px solid #e4e7eb";
@@ -19,6 +20,37 @@ const BrandingWrap = styled.div(({ theme }) => ({
 
 // eslint-disable-next-line no-mixed-operators
 const getPaddingLeft = (layer) => `${24 * layer + 24}px`;
+
+const TopLevelLink = styled(Link)(({ theme }) => ({
+  color: theme.colors.darkBlue,
+  display: "block",
+  textDecoration: "none",
+  border: "none",
+  backgroundColor: "transparent",
+  fontSize: theme.fontSizes.large,
+  fontWeight: theme.fontWeights.medium,
+  lineHeight: theme.lineHeights.heading3,
+  padding: `${theme.space.x1} ${theme.space.x3}`,
+  paddingLeft: getPaddingLeft(0),
+  "&:visited": {
+    color: theme.colors.darkBlue,
+  },
+  width: "100%",
+  borderRadius: "0",
+  transition: ".2s",
+  "&:hover, &:focus": {
+    outline: "none",
+    color: theme.colors.blackBlue,
+    backgroundColor: theme.colors.whiteGrey,
+    cursor: "pointer",
+  },
+  "&:focus": {
+    boxShadow: theme.shadows.focus,
+  },
+  "&:disabled": {
+    opacity: ".5",
+  },
+}));
 
 const TopLevelText = styled(Text)(({ theme }) => ({
   color: theme.colors.blackBlue,
@@ -92,42 +124,19 @@ const ApplyMenuLinkStyles = styled.li(
   })
 );
 
-type MenuLinkProps = {
+type ApplyIndentProps = {
   layer?: number;
-  color?: string;
-  hoverColor?: string;
-  hoverBackground?: string;
   theme?: DefaultNDSThemeType;
+  key?: string;
 };
 
-const MenuLink = styled.a(
-  ({ color, hoverColor, hoverBackground, layer, theme }: MenuLinkProps) => ({
-    ...getSharedStyles({ color, layer, theme }),
-    width: "100%",
-    borderRadius: "0",
-    transition: ".2s",
-    "&:hover, &:focus": {
-      outline: "none",
-      color: themeGet(`colors.${hoverColor}`, hoverColor)(hoverColor),
-      backgroundColor: themeGet(
-        `colors.${hoverBackground}`,
-        hoverBackground
-      )(hoverBackground),
-      cursor: "pointer",
-    },
-    "&:focus": {
-      boxShadow: theme.shadows.focus,
-    },
-    "&:disabled": {
-      opacity: ".5",
-    },
-  })
-);
-
-const ApplyIndent = styled.li(({ layer, theme }: MenuLinkProps) => ({
+const ApplyIndent = styled.li(({ layer, theme }: ApplyIndentProps) => ({
   marginBottom: theme.space.x1,
+  [`> ${DropdownLink}`]: {
+    paddingLeft: `${24 * layer + 20}px`,
+  },
   [`> ${DropdownText}`]: {
-    paddingLeft: `${24 * layer + 24}px`,
+    paddingLeft: getPaddingLeft(layer),
   },
 }));
 
@@ -137,25 +146,22 @@ const SubMenuItemsList = styled.ul({
   margin: "0",
 });
 
-const StyledLi = styled.li(({ theme }) => ({
-  marginBottom: theme.space.x1,
-  display: "block",
-}));
-
-const renderMenuLink = (menuItem, linkOnClick, themeColorObject, layer) => (
-  <StyledLi key={menuItem.key ?? menuItem.name}>
-    <MenuLink
-      layer={layer}
-      {...themeColorObject}
-      onClick={linkOnClick}
-      href={menuItem.href}
-      as={menuItem.as}
-      to={menuItem.to}
-    >
-      {menuItem.name}
-    </MenuLink>
-  </StyledLi>
-);
+const renderMenuLink = (menuItem, linkOnClick, themeColorObject, layer) => {
+  const MenuLink: React.FC<LinkProps> =
+    layer === 0 ? TopLevelLink : DropdownLink;
+  return (
+    <ApplyIndent layer={layer} key={menuItem.key ?? menuItem.name}>
+      <MenuLink
+        onClick={linkOnClick}
+        href={menuItem.href}
+        as={menuItem.as}
+        to={menuItem.to}
+      >
+        {menuItem.name}
+      </MenuLink>
+    </ApplyIndent>
+  );
+};
 
 const renderCustom = (menuItem, linkOnClick, themeColorObject, layer) => (
   <ApplyMenuLinkStyles

--- a/src/BrandedNavBar/MobileMenu.tsx
+++ b/src/BrandedNavBar/MobileMenu.tsx
@@ -215,20 +215,13 @@ const renderMenuItems = (menuItems, linkOnClick, themeColorObject, layer) =>
 const renderTopLayerMenuItems = (menuData, linkOnClick, themeColorObject) =>
   renderMenuItems(menuData, linkOnClick, themeColorObject, 0);
 
-const getSubMenuHeading = (layer, color, name) =>
+const getSubMenuHeading = (layer, name) =>
   layer === 0 ? (
-    <Heading3 mb="x1" color={color}>
-      {name}
-    </Heading3>
+    <TopLevelText as="h3">{name}</TopLevelText>
   ) : (
-    <Text
-      mb="x1"
-      color={color}
-      py="x1"
-      style={{ paddingLeft: getPaddingLeft(layer) }}
-    >
+    <DropdownText mb="x1" style={{ paddingLeft: getPaddingLeft(layer) }}>
       {name}
-    </Text>
+    </DropdownText>
   );
 
 type ThemeColorObject = {
@@ -256,11 +249,7 @@ const SubMenu = ({
   layer,
 }: SubMenuProps) => (
   <>
-    {getSubMenuHeading(
-      layer,
-      themeColorObject && themeColorObject.textColor,
-      menuItem.name
-    )}
+    {getSubMenuHeading(layer, menuItem.name)}
     <SubMenuItemsList>
       {renderMenuItems(
         menuItem.items,

--- a/src/BrandedNavBar/NavBar.tsx
+++ b/src/BrandedNavBar/NavBar.tsx
@@ -40,7 +40,7 @@ const NavBarBackground = styled(Flex)(
   ({ backgroundColor, theme }: NavBarBackgroundProps): CSSObject => ({
     background: backgroundColor,
     padding: `0 ${theme.space.x3}`,
-    boxShadow: theme.shadows.large,
+    borderBottom: `1px solid ${theme.colors.lightGrey}`,
     alignItems: "center",
     height: NAVBAR_HEIGHT,
     zIndex: theme.zIndices.navBar,

--- a/src/BrandedNavBar/NavBarDropdownMenu.tsx
+++ b/src/BrandedNavBar/NavBarDropdownMenu.tsx
@@ -144,8 +144,8 @@ class StatelessNavBarDropdownMenu extends StatelessNavBarDropdownMenuClass {
                     {...popperProps.arrowProps}
                     placement={placement}
                     ref={popperProps.arrowProps.ref}
-                    backgroundColor="whiteGrey"
-                    borderColor="whiteGrey"
+                    backgroundColor="white"
+                    borderColor="white"
                   />
                   <DetectOutsideClick
                     onClick={this.handleOutsideClick}

--- a/src/BrandedNavBar/NavBarDropdownMenu.tsx
+++ b/src/BrandedNavBar/NavBarDropdownMenu.tsx
@@ -1,4 +1,4 @@
-/* TS IGNORED: due to problems typing propTypes and defaultProps, 
+/* TS IGNORED: due to problems typing propTypes and defaultProps,
 it can stop being ingnored when its refactored to a functional component */
 import React from "react";
 import PropTypes from "prop-types";

--- a/src/BrandedNavBar/SubMenuTrigger.tsx
+++ b/src/BrandedNavBar/SubMenuTrigger.tsx
@@ -3,8 +3,8 @@ import styled, {
   CSSObject,
   StyledComponentPropsWithRef,
 } from "styled-components";
-import theme from "../theme";
 import { Icon } from "../Icon";
+import { DropdownButton } from "../DropdownMenu/index";
 import NavBarDropdownMenu from "./NavBarDropdownMenu";
 import renderSubMenuItems from "./renderSubMenuItems";
 
@@ -15,36 +15,13 @@ type SubMenuTriggerProps = React.ComponentPropsWithRef<"button"> & {
   menuData: any[];
 };
 
-const StyledButton: StyledComponentPropsWithRef<any> = styled.button(
-  ({ isOpen }: any): CSSObject => ({
-    display: "block",
+const StyledButton: StyledComponentPropsWithRef<any> = styled(DropdownButton)(
+  ({ isOpen, theme }: any): CSSObject => ({
     position: "relative",
-    color: theme.colors.darkBlue,
-    fontSize: theme.fontSizes.small,
-    lineHeight: theme.lineHeights.smallTextBase,
-    width: "100%",
-    padding: `${theme.space.half} 28px ${theme.space.half} 12px`,
-    border: "none",
-    borderLeft: `${theme.space.half} solid transparent`,
-    "&:hover": {
-      backgroundColor: theme.colors.lightGrey,
-    },
-    "&:disabled": {
-      opacity: ".5",
-    },
-    "&:focus": {
-      outline: "none",
-      color: theme.colors.darkBlue,
-      backgroundColor: theme.colors.lightGrey,
-      borderLeft: `${theme.space.half}  solid ${theme.colors.blue}`,
-    },
-    backgroundColor: isOpen ? theme.colors.lightGrey : "transparent",
-    textDecoration: "none",
-    textAlign: "left",
-    cursor: "pointer",
+    backgroundColor: isOpen ? theme.colors.lightBlue : "transparent",
+    color: isOpen ? theme.colors.darkBlue : theme.colors.darkGrey,
   })
 );
-
 type SubMenuTriggerButtonProps = React.ComponentPropsWithRef<"button"> & {
   name?: string;
   isOpen: boolean;
@@ -57,9 +34,8 @@ const SubMenuTriggerButton = React.forwardRef<
   <StyledButton isOpen={isOpen} ref={ref} {...props}>
     {name}
     <Icon
-      style={{ position: "absolute", top: "7px" }}
+      style={{ position: "absolute", top: "10px" }}
       icon="rightArrow"
-      color="darkBlue"
       size="20px"
       p="2px"
     />

--- a/src/BrandedNavBar/SubMenuTrigger.tsx
+++ b/src/BrandedNavBar/SubMenuTrigger.tsx
@@ -78,6 +78,6 @@ const SubMenuTrigger = ({
   );
 };
 
-SubMenuTrigger.displayName = "SubMenuTriggerButton";
+SubMenuTrigger.displayName = "SubMenuTrigger";
 
 export default SubMenuTrigger;

--- a/src/BrandedNavBar/renderSubMenuItems.tsx
+++ b/src/BrandedNavBar/renderSubMenuItems.tsx
@@ -1,23 +1,5 @@
 import React from "react";
-import styled, { CSSObject } from "styled-components";
-import theme from "../theme";
-import { DropdownLink } from "../DropdownMenu";
-
-const getSharedStyles = (): CSSObject => ({
-  display: "block",
-  whiteSpace: "nowrap",
-  textDecoration: "none",
-  borderColor: "transparent",
-  backgroundColor: "transparent",
-  lineHeight: theme.lineHeights.smallTextBase,
-  fontSize: `${theme.fontSizes.small}`,
-  padding: `${theme.space.half} ${theme.space.x2}`,
-});
-
-const SubMenuText = styled.li((): any => ({
-  color: theme.colors.darkGrey,
-  ...getSharedStyles(),
-}));
+import { DropdownText, DropdownLink } from "../DropdownMenu";
 
 const renderSubMenuTrigger = (subMenuItem, onItemClick, SubMenuTrigger) => (
   <li
@@ -59,9 +41,12 @@ const renderCustom = (subMenuItem, onItemClick) => (
 );
 
 const renderText = (subMenuItem) => (
-  <SubMenuText key={subMenuItem.key ?? subMenuItem.name}>
-    {subMenuItem.name}
-  </SubMenuText>
+  <li
+    style={{ whiteSpace: "nowrap" }}
+    key={subMenuItem.key ?? subMenuItem.name}
+  >
+    <DropdownText>{subMenuItem.name}</DropdownText>
+  </li>
 );
 
 const getRenderFunction = (subMenuItem) => {

--- a/src/BrandedNavBar/renderSubMenuItems.tsx
+++ b/src/BrandedNavBar/renderSubMenuItems.tsx
@@ -14,26 +14,6 @@ const getSharedStyles = (): CSSObject => ({
   padding: `${theme.space.half} ${theme.space.x2}`,
 });
 
-const ApplySubMenuLinkStyles = styled.li((): any => ({
-  color: theme.colors.darkBlue,
-  verticalAlign: "middle",
-  "> *": {
-    ...getSharedStyles(),
-    transition: ".2s",
-    textDecoration: "none",
-    "&:hover, &:focus": {
-      outline: "none",
-      backgroundColor: theme.colors.lightGrey,
-    },
-    "&:disabled": {
-      opacity: ".5",
-    },
-    "&:focus": {
-      boxShadow: theme.shadows.focus,
-    },
-  },
-}));
-
 const SubMenuText = styled.li((): any => ({
   color: theme.colors.darkGrey,
   ...getSharedStyles(),
@@ -70,12 +50,12 @@ const renderSubMenuLink = (subMenuItem, onItemClick) => (
 );
 
 const renderCustom = (subMenuItem, onItemClick) => (
-  <ApplySubMenuLinkStyles
+  <li
+    style={{ whiteSpace: "nowrap" }}
     key={subMenuItem.key ?? subMenuItem.name}
-    onClick={onItemClick}
   >
-    {subMenuItem.render()}
-  </ApplySubMenuLinkStyles>
+    {subMenuItem.render(onItemClick)}
+  </li>
 );
 
 const renderText = (subMenuItem) => (

--- a/src/BrandedNavBar/renderSubMenuItems.tsx
+++ b/src/BrandedNavBar/renderSubMenuItems.tsx
@@ -1,17 +1,7 @@
 import React from "react";
 import styled, { CSSObject } from "styled-components";
-import { fontSize, lineHeight, space } from "styled-system";
-import propTypes from "@styled-system/prop-types";
 import theme from "../theme";
 import { DropdownLink } from "../DropdownMenu";
-
-const SubMenuLink = styled(DropdownLink)(fontSize, lineHeight, space);
-
-SubMenuLink.propTypes = {
-  ...propTypes.fontSize,
-  ...propTypes.lineHeight,
-  ...propTypes.space,
-};
 
 const getSharedStyles = (): CSSObject => ({
   display: "block",
@@ -67,9 +57,7 @@ const renderSubMenuLink = (subMenuItem, onItemClick) => (
     style={{ whiteSpace: "nowrap" }}
     key={subMenuItem.key ?? subMenuItem.name}
   >
-    <SubMenuLink
-      fontSize="small"
-      lineHeight="smallTextBase"
+    <DropdownLink
       py="half"
       onClick={onItemClick}
       href={subMenuItem.href}
@@ -77,7 +65,7 @@ const renderSubMenuLink = (subMenuItem, onItemClick) => (
       as={subMenuItem.as}
     >
       {subMenuItem.name}
-    </SubMenuLink>
+    </DropdownLink>
   </li>
 );
 

--- a/src/BrandedNavBar/renderSubMenuItems.tsx
+++ b/src/BrandedNavBar/renderSubMenuItems.tsx
@@ -1,24 +1,19 @@
 import React from "react";
+import styled, { CSSObject } from "styled-components";
 import { DropdownText, DropdownLink } from "../DropdownMenu";
 
 const renderSubMenuTrigger = (subMenuItem, onItemClick, SubMenuTrigger) => (
-  <li
-    style={{ whiteSpace: "nowrap" }}
-    key={subMenuItem.key ?? subMenuItem.name}
-  >
+  <NoWrapLi key={subMenuItem.key ?? subMenuItem.name}>
     <SubMenuTrigger
       onItemClick={onItemClick}
       name={subMenuItem.name}
       menuData={subMenuItem.items}
     />
-  </li>
+  </NoWrapLi>
 );
 
 const renderSubMenuLink = (subMenuItem, onItemClick) => (
-  <li
-    style={{ whiteSpace: "nowrap" }}
-    key={subMenuItem.key ?? subMenuItem.name}
-  >
+  <NoWrapLi key={subMenuItem.key ?? subMenuItem.name}>
     <DropdownLink
       py="half"
       onClick={onItemClick}
@@ -28,25 +23,19 @@ const renderSubMenuLink = (subMenuItem, onItemClick) => (
     >
       {subMenuItem.name}
     </DropdownLink>
-  </li>
+  </NoWrapLi>
 );
 
 const renderCustom = (subMenuItem, onItemClick) => (
-  <li
-    style={{ whiteSpace: "nowrap" }}
-    key={subMenuItem.key ?? subMenuItem.name}
-  >
+  <NoWrapLi key={subMenuItem.key ?? subMenuItem.name}>
     {subMenuItem.render(onItemClick)}
-  </li>
+  </NoWrapLi>
 );
 
 const renderText = (subMenuItem) => (
-  <li
-    style={{ whiteSpace: "nowrap" }}
-    key={subMenuItem.key ?? subMenuItem.name}
-  >
+  <NoWrapLi key={subMenuItem.key ?? subMenuItem.name}>
     <DropdownText>{subMenuItem.name}</DropdownText>
-  </li>
+  </NoWrapLi>
 );
 
 const getRenderFunction = (subMenuItem) => {
@@ -65,5 +54,11 @@ const renderSubMenuItems = (subMenuItems, onItemClick, SubMenuTrigger) =>
   subMenuItems.map((subMenuItem) =>
     getRenderFunction(subMenuItem)(subMenuItem, onItemClick, SubMenuTrigger)
   );
+
+const NoWrapLi = styled.li(
+  (): CSSObject => ({
+    whiteSpace: "nowrap",
+  })
+);
 
 export default renderSubMenuItems;

--- a/src/DropdownMenu/DropdownButton.tsx
+++ b/src/DropdownMenu/DropdownButton.tsx
@@ -16,7 +16,7 @@ const DropdownButton: React.FC<DropdownButtonProps> = styled.button(
     disabled = false,
     theme,
     hoverColor = "darkBlue",
-    bgHoverColor = "lightGrey",
+    bgHoverColor = "lightBlue",
   }: DropdownButtonProps) => ({
     display: "block",
     width: "100%",
@@ -45,9 +45,9 @@ const DropdownButton: React.FC<DropdownButtonProps> = styled.button(
   })
 );
 DropdownButton.defaultProps = {
-  color: "darkBlue",
+  color: "darkGrey",
   disabled: false,
   hoverColor: "darkBlue",
-  bgHoverColor: "lightGrey",
+  bgHoverColor: "lightBlue",
 };
 export default DropdownButton;

--- a/src/DropdownMenu/DropdownButton.tsx
+++ b/src/DropdownMenu/DropdownButton.tsx
@@ -11,13 +11,9 @@ type DropdownButtonProps = React.ComponentPropsWithRef<"button"> & {
 };
 
 const DropdownButton: React.FC<DropdownButtonProps> = styled.button(
-  color,
-  ({
-    disabled = false,
-    theme,
-    hoverColor = "darkBlue",
-    bgHoverColor = "lightBlue",
-  }: DropdownButtonProps) => ({
+  ({ disabled, theme, hoverColor, bgHoverColor }: DropdownButtonProps) => ({
+    color: theme.colors.darkGrey,
+    fontWeight: theme.fontWeights.medium,
     display: "block",
     width: "100%",
     cursor: disabled ? "default" : "pointer",
@@ -42,10 +38,10 @@ const DropdownButton: React.FC<DropdownButtonProps> = styled.button(
     "&:disabled": {
       opacity: ".5",
     },
-  })
+  }),
+  color
 );
 DropdownButton.defaultProps = {
-  color: "darkGrey",
   disabled: false,
   hoverColor: "darkBlue",
   bgHoverColor: "lightBlue",

--- a/src/DropdownMenu/DropdownItem.tsx
+++ b/src/DropdownMenu/DropdownItem.tsx
@@ -11,12 +11,13 @@ type DropdownItemProps = {
 const DropdownItem: React.FC<DropdownItemProps> = styled.div(
   ({
     theme,
-    color = "darkGrey",
-    hoverColor = "darkBlue",
-    bgHoverColor = "lightBlue",
+    color,
+    hoverColor,
+    bgHoverColor,
   }: DropdownItemProps): CSSObject => ({
     "*": {
       color: theme.colors[color],
+      fontWeight: theme.fontWeights.medium,
       display: "block",
       width: "100%",
       cursor: "pointer",
@@ -44,5 +45,9 @@ const DropdownItem: React.FC<DropdownItemProps> = styled.div(
     },
   })
 );
-
+DropdownItem.defaultProps = {
+  color: "darkGrey",
+  hoverColor: "darkBlue",
+  bgHoverColor: "lightBlue",
+};
 export default DropdownItem;

--- a/src/DropdownMenu/DropdownItem.tsx
+++ b/src/DropdownMenu/DropdownItem.tsx
@@ -11,9 +11,9 @@ type DropdownItemProps = {
 const DropdownItem: React.FC<DropdownItemProps> = styled.div(
   ({
     theme,
-    color = "darkBlue",
+    color = "darkGrey",
     hoverColor = "darkBlue",
-    bgHoverColor = "lightGrey",
+    bgHoverColor = "lightBlue",
   }: DropdownItemProps): CSSObject => ({
     "*": {
       color: theme.colors[color],

--- a/src/DropdownMenu/DropdownLink.tsx
+++ b/src/DropdownMenu/DropdownLink.tsx
@@ -3,40 +3,39 @@ import styled from "styled-components";
 const DropdownLink: React.FC<any> = styled.a.withConfig({
   shouldForwardProp: (prop, defaultValidatorFn) =>
     !["hoverColor", "bgHoverColor"].includes(prop) && defaultValidatorFn(prop),
-})(
-  ({
-    theme,
-    bgHoverColor = "lightBlue",
-    hoverColor = "darkBlue",
-    color = "darkGrey",
-  }: any) => ({
-    display: "block",
-    textDecoration: "none",
-    borderColor: "transparent",
-    backgroundColor: "transparent",
-    lineHeight: theme.lineHeights.base,
-    fontSize: theme.fontSizes.medium,
-    transition: ".2s",
+})(({ theme, color, bgHoverColor, hoverColor }: any) => ({
+  color: theme.colors[color],
+  fontWeight: theme.fontWeights.medium,
+  display: "block",
+  textDecoration: "none",
+  borderColor: "transparent",
+  backgroundColor: "transparent",
+  lineHeight: theme.lineHeights.base,
+  fontSize: theme.fontSizes.medium,
+  transition: ".2s",
+  padding: `${theme.space.x1} ${theme.space.x2} ${theme.space.x1} 12px`,
+  borderLeft: `${theme.space.half} solid transparent`,
+  "&:visited": {
     color: theme.colors[color],
-    padding: `${theme.space.x1} ${theme.space.x2} ${theme.space.x1} 12px`,
-    borderLeft: `${theme.space.half} solid transparent`,
-    "&:visited": {
-      color: theme.colors[color],
-    },
-    "&:hover": {
-      color: theme.colors[hoverColor],
-      backgroundColor: theme.colors[bgHoverColor],
-    },
-    "&:focus": {
-      outline: "none",
-      color: theme.colors[hoverColor],
-      backgroundColor: theme.colors[bgHoverColor],
-      borderLeft: `${theme.space.half}  solid ${theme.colors.blue}`,
-    },
-    "&:disabled": {
-      opacity: ".5",
-    },
-  })
-);
-
+  },
+  "&:hover": {
+    color: theme.colors[hoverColor],
+    backgroundColor: theme.colors[bgHoverColor],
+  },
+  "&:focus": {
+    outline: "none",
+    color: theme.colors[hoverColor],
+    backgroundColor: theme.colors[bgHoverColor],
+    borderLeft: `${theme.space.half}  solid ${theme.colors.blue}`,
+  },
+  "&:disabled": {
+    opacity: ".5",
+  },
+}));
+DropdownLink.defaultProps = {
+  disabled: false,
+  color: "darkGrey",
+  hoverColor: "darkBlue",
+  bgHoverColor: "lightBlue",
+};
 export default DropdownLink;

--- a/src/DropdownMenu/DropdownLink.tsx
+++ b/src/DropdownMenu/DropdownLink.tsx
@@ -6,9 +6,9 @@ const DropdownLink: React.FC<any> = styled.a.withConfig({
 })(
   ({
     theme,
-    bgHoverColor = "lightGrey",
+    bgHoverColor = "lightBlue",
     hoverColor = "darkBlue",
-    color = "darkBlue",
+    color = "darkGrey",
   }: any) => ({
     display: "block",
     textDecoration: "none",
@@ -20,12 +20,12 @@ const DropdownLink: React.FC<any> = styled.a.withConfig({
     color: theme.colors[color],
     padding: `${theme.space.x1} ${theme.space.x2} ${theme.space.x1} 12px`,
     borderLeft: `${theme.space.half} solid transparent`,
+    "&:visited": {
+      color: theme.colors[color],
+    },
     "&:hover": {
       color: theme.colors[hoverColor],
       backgroundColor: theme.colors[bgHoverColor],
-    },
-    "&:visited": {
-      color: theme.colors[color],
     },
     "&:focus": {
       outline: "none",

--- a/src/DropdownMenu/DropdownMenu.story.tsx
+++ b/src/DropdownMenu/DropdownMenu.story.tsx
@@ -89,7 +89,7 @@ export const WithCustomLink = () => (
 );
 
 export const WithCustomText = () => (
-  <DropdownMenu defaultOpen openAriaLabel="open dropdown" closeAriaLabel="close dropdown">
+  <DropdownMenu defaultOpen>
     <DropdownText>Custom Text</DropdownText>
   </DropdownMenu>
 );
@@ -107,6 +107,7 @@ export const SetToDefaultOpen = () => (
         Custom Link Component
       </a>
     </DropdownItem>
+    <DropdownText>Custom Text</DropdownText>
   </DropdownMenu>
 );
 

--- a/src/DropdownMenu/DropdownMenu.story.tsx
+++ b/src/DropdownMenu/DropdownMenu.story.tsx
@@ -4,6 +4,7 @@ import {
   DropdownLink,
   DropdownButton,
   DropdownItem,
+  DropdownText,
   Button,
 } from "../index";
 
@@ -75,7 +76,7 @@ WithButtonClosingMenu.story = {
   name: "with button closing menu",
 };
 
-export const WithCustomItem = () => (
+export const WithCustomLink = () => (
   <DropdownMenu
     defaultOpen
     openAriaLabel="open dropdown"
@@ -87,9 +88,11 @@ export const WithCustomItem = () => (
   </DropdownMenu>
 );
 
-WithCustomItem.story = {
-  name: "with custom item",
-};
+export const WithCustomText = () => (
+  <DropdownMenu defaultOpen openAriaLabel="open dropdown" closeAriaLabel="close dropdown">
+    <DropdownText>Custom Text</DropdownText>
+  </DropdownMenu>
+);
 
 export const SetToDefaultOpen = () => (
   <DropdownMenu

--- a/src/DropdownMenu/DropdownMenu.tsx
+++ b/src/DropdownMenu/DropdownMenu.tsx
@@ -55,7 +55,7 @@ const DropdownMenu: React.FC<DropdownMenuProps> = React.forwardRef<
       showArrow = true,
       disabled,
       defaultOpen,
-      backgroundColor = "whiteGrey",
+      backgroundColor = "white",
       placement = "bottom-start",
       className,
       id,

--- a/src/DropdownMenu/DropdownMenuContainer.tsx
+++ b/src/DropdownMenu/DropdownMenuContainer.tsx
@@ -48,7 +48,7 @@ const DropdownMenuContainer: React.FC<DropdownMenuContainerProps> = styled(Box)(
     backgroundColor: theme.colors[backgroundColor],
     borderTop: `1px solid  ${theme.colors[backgroundColor]}`,
     borderBottom: `1px solid ${theme.colors[backgroundColor]}`,
-    boxShadow: theme.shadows.small,
+    boxShadow: theme.shadows.medium,
     padding: "7px 0",
     zIndex: "100",
     ...getMenuMargin(dataPlacement, showArrow),

--- a/src/DropdownMenu/DropdownMenuContainer.tsx
+++ b/src/DropdownMenu/DropdownMenuContainer.tsx
@@ -41,7 +41,7 @@ const DropdownMenuContainer: React.FC<DropdownMenuContainerProps> = styled(Box)(
   ({
     dataPlacement,
     showArrow = true,
-    backgroundColor = "whiteGrey",
+    backgroundColor = "white",
     theme,
   }: DropdownMenuContainerProps): any => ({
     borderRadius: theme.radii.medium,

--- a/src/DropdownMenu/DropdownText.tsx
+++ b/src/DropdownMenu/DropdownText.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import styled, { CSSObject } from "styled-components";
+import { color } from "styled-system";
 import { Text } from "../Type";
 import { TextProps } from "../Type/Text";
 
 const DropdownText: React.FC<TextProps> = styled(Text)(
   ({ theme }: TextProps): CSSObject => ({
     color: theme.colors.darkGrey,
+    fontWeight: theme.fontWeights.medium,
     display: "block",
     width: "100%",
     border: "none",
@@ -13,7 +15,8 @@ const DropdownText: React.FC<TextProps> = styled(Text)(
     backgroundColor: "transparent",
     transition: ".2s",
     padding: `${theme.space.x1} ${theme.space.x2}`,
-  })
+  }),
+  color
 );
 
 export default DropdownText;

--- a/src/DropdownMenu/DropdownText.tsx
+++ b/src/DropdownMenu/DropdownText.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import styled, { CSSObject } from "styled-components";
+import { DefaultNDSThemeType } from "../theme.type";
+import { Text } from "../Type";
+
+type DropdownTextProps = {
+  theme?: DefaultNDSThemeType;
+  color?: string;
+};
+
+const DropdownText: React.FC<DropdownTextProps> = styled(Text)(
+  ({ theme }: DropdownTextProps): CSSObject => ({
+    color: theme.colors.darkGrey,
+    display: "block",
+    width: "100%",
+    border: "none",
+    textAlign: "left",
+    backgroundColor: "transparent",
+    transition: ".2s",
+    padding: `${theme.space.x1} ${theme.space.x2}`,
+  })
+);
+
+export default DropdownText;

--- a/src/DropdownMenu/DropdownText.tsx
+++ b/src/DropdownMenu/DropdownText.tsx
@@ -1,15 +1,10 @@
 import React from "react";
 import styled, { CSSObject } from "styled-components";
-import { DefaultNDSThemeType } from "../theme.type";
 import { Text } from "../Type";
+import { TextProps } from "../Type/Text";
 
-type DropdownTextProps = {
-  theme?: DefaultNDSThemeType;
-  color?: string;
-};
-
-const DropdownText: React.FC<DropdownTextProps> = styled(Text)(
-  ({ theme }: DropdownTextProps): CSSObject => ({
+const DropdownText: React.FC<TextProps> = styled(Text)(
+  ({ theme }: TextProps): CSSObject => ({
     color: theme.colors.darkGrey,
     display: "block",
     width: "100%",

--- a/src/DropdownMenu/index.ts
+++ b/src/DropdownMenu/index.ts
@@ -2,3 +2,4 @@ export { default as DropdownMenu } from "./DropdownMenu";
 export { default as DropdownButton } from "./DropdownButton";
 export { default as DropdownLink } from "./DropdownLink";
 export { default as DropdownItem } from "./DropdownItem";
+export { default as DropdownText } from "./DropdownText";

--- a/src/Layout/Sidebar.tsx
+++ b/src/Layout/Sidebar.tsx
@@ -158,7 +158,6 @@ const Sidebar: React.FC<SidebarProps> = ({
         display="flex"
         flexDirection="column"
         height={`calc(100% - ${NAVBAR_HEIGHT})`}
-        boxShadow="large"
         borderLeftWidth="1px"
         borderLeftStyle="solid"
         borderLeftColor="lightGrey"

--- a/src/Toggle/ToggleButton.tsx
+++ b/src/Toggle/ToggleButton.tsx
@@ -4,7 +4,8 @@ import type { TransformProperties } from "framer-motion/types/motion/types";
 import type { Transition } from "framer-motion";
 import styled, { CSSObject } from "styled-components";
 import { DefaultNDSThemeType } from "../theme.type";
-import { AnimatedBox, theme } from "..";
+import { default as theme } from "../theme";
+import { AnimatedBox } from "../Box";
 
 type SwitchProps = {
   disabled?: boolean;

--- a/src/Tooltip/TooltipContainer.tsx
+++ b/src/Tooltip/TooltipContainer.tsx
@@ -59,7 +59,7 @@ const TooltipContainer = styled(Box)(
     backgroundColor: tooltipStyles(theme).backgroundColor,
     borderRadius: theme.radii.medium,
     border: `1px solid ${tooltipStyles(theme).borderColor}`,
-    boxShadow: "0 2px 4px rgba(0, 0, 0, 0.18)",
+    boxShadow: theme.shadows.medium,
     padding: theme.space.x1,
     transition: "opacity 0.3s",
     zIndex: theme.zIndices.content,

--- a/src/Type/Text.tsx
+++ b/src/Type/Text.tsx
@@ -13,6 +13,7 @@ import {
 } from "styled-system";
 import { TextOverflowProps, textOverflow } from "../StyledProps/textOverflow";
 import { CursorProps, cursor } from "../StyledProps/cursor";
+import type { DefaultNDSThemeType } from "../theme.type";
 const getAttrs = (inline?: boolean) => (inline ? { as: "span" } : null);
 
 export type TextProps = React.HTMLAttributes<HTMLParagraphElement> & {
@@ -38,7 +39,7 @@ export type TextProps = React.HTMLAttributes<HTMLParagraphElement> & {
   TextOverflowProps &
   TypographyProps &
   CursorProps &
-  ColorProps;
+  ColorProps & { theme?: DefaultNDSThemeType };
 
 const Text = styled.p.attrs<TextProps>((props: TextProps) =>
   getAttrs(props.inline)
@@ -50,19 +51,18 @@ const Text = styled.p.attrs<TextProps>((props: TextProps) =>
   overflow,
   textOverflow,
   cursor,
-  ({ disabled, textTransform }: TextProps): CSSObject => ({
+  ({ disabled, textTransform, theme }: TextProps): CSSObject => ({
     textTransform,
+    color: "currentColor",
+    marginTop: 0,
+    marginBottom: 0,
+    fontSize: theme.fontSizes.medium,
+    lineHeight: theme.lineHeights.base,
     opacity: disabled ? "0.7" : undefined,
   })
 );
 Text.defaultProps = {
   inline: false,
   disabled: false,
-  mt: 0,
-  mb: 0,
-  fontSize: "medium",
-  lineHeight: "base",
-  textTransform: undefined,
-  color: "currentColor",
 };
 export default Text;

--- a/src/Type/Text.tsx
+++ b/src/Type/Text.tsx
@@ -10,6 +10,7 @@ import {
   overflow,
   LayoutProps,
   layout,
+  compose,
 } from "styled-system";
 import { TextOverflowProps, textOverflow } from "../StyledProps/textOverflow";
 import { CursorProps, cursor } from "../StyledProps/cursor";
@@ -44,13 +45,6 @@ export type TextProps = React.HTMLAttributes<HTMLParagraphElement> & {
 const Text = styled.p.attrs<TextProps>((props: TextProps) =>
   getAttrs(props.inline)
 )<TextProps>(
-  space,
-  typography,
-  color,
-  layout,
-  overflow,
-  textOverflow,
-  cursor,
   ({ disabled, textTransform, theme }: TextProps): CSSObject => ({
     textTransform,
     color: "currentColor",
@@ -59,7 +53,8 @@ const Text = styled.p.attrs<TextProps>((props: TextProps) =>
     fontSize: theme.fontSizes.medium,
     lineHeight: theme.lineHeights.base,
     opacity: disabled ? "0.7" : undefined,
-  })
+  }),
+  compose(space, typography, color, layout, overflow, textOverflow, cursor)
 );
 Text.defaultProps = {
   inline: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export {
   DropdownLink,
   DropdownButton,
   DropdownItem,
+  DropdownText,
 } from "./DropdownMenu";
 export { HelpText, RequirementText, FieldLabel } from "./FieldLabel";
 export { Input } from "./Input";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2133,10 +2133,10 @@
     fs "^0.0.1-security"
     svgi "^1.1.0"
 
-"@nulogy/tokens@^5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@nulogy/tokens/-/tokens-5.2.0.tgz#fd43dc64d05038234591a93d853896c599443f90"
-  integrity sha512-HrlSDNBGlYRG3jZVKyRvjHvLHTnX5gBLFXO8Ioisw8i5NlEfbWwLqTi3OvGjpUvVyvo5Auk534OaYH2b0fUblg==
+"@nulogy/tokens@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@nulogy/tokens/-/tokens-5.3.0.tgz#29ba9848407762f940bae6bce9ef54155685daca"
+  integrity sha512-e5aNb249jhoZUA4Iutw/wj1xV5VKPY8TqHZi37nGte5teb27xjJZIMTV5PcBJA75IP5NMiNX/r1yc4prKNxU6g==
 
 "@octokit/auth-token@^2.4.4":
   version "2.4.5"


### PR DESCRIPTION
## Description

Executing https://nulogy-go.atlassian.net/browse/GO-4538

Implement the visual design changes from here: https://www.figma.com/file/eTgLkFDHd8GLNFmD9tBp72/Multi-Echelon?node-id=658%3A30413

Summary of changes:

1. The Tooltip has been updated to use the medium shadow.
2. For the DropdownMenu and BrandedNavBar menus and submenus (but not top-level menu triggers!):
2.1. Update shadow from small to medium.
2.2. Update background colour to white.
2.3. Update hover colour to darkBlue.
2.4. Update colour to darkGrey.
2.5. Update hover background colour to lightBlue.
3. The Sidebar shadow has been removed.

Potentially breaking changes:

1. The BrandedNavBar no longer attempts to style components rendered via the `render` property. If you want NDS styles, use an NDS component like the DropdownLink, DropdownButton, or DropdownText.

## Changes include

- [x] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [x] feature: a non-breaking change that adds functionality
- [x] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
