### PR TITLE
chore: fix duplicate story titles

### DIFF
--- a/cypress/integration/components/Table.spec.js
+++ b/cypress/integration/components/Table.spec.js
@@ -161,7 +161,7 @@ describe("Table", () => {
   describe("with filtering and pagination", () => {
     const filterIinput = () => cy.get('input[name="Name"]');
     beforeEach(() => {
-      cy.renderFromStorybook("table--with-filtering-and-pagination");
+      cy.renderFromStorybook("table-with-filtering--with-filtering-and-pagination");
     });
     it("filters down to fewer pages", () => {
       paginationButtons(3).should("exist");

--- a/src/Table/BaseTable.story.tsx
+++ b/src/Table/BaseTable.story.tsx
@@ -266,7 +266,7 @@ const rowDataWithSections = [
 ];
 
 export default {
-  title: "Components/Table",
+  title: "Components/Table/Base",
 };
 
 export const WithData = () => (

--- a/src/Table/Table.story.tsx
+++ b/src/Table/Table.story.tsx
@@ -372,7 +372,3 @@ export const WithOnHoverActions = () => {
     />
   );
 };
-
-WithOnHoverActions.story = {
-  name: "with hover actions",
-};

--- a/src/Table/TableWithCustomSorting.story.tsx
+++ b/src/Table/TableWithCustomSorting.story.tsx
@@ -85,7 +85,7 @@ const TableWithCustomSorting = () => {
 };
 
 export default {
-  title: "Components/Table",
+  title: "Components/Table/with custom sorting",
 };
 
 export const WithCustomSorting = () => <TableWithCustomSorting />;

--- a/src/Table/TableWithFiltering.story.tsx
+++ b/src/Table/TableWithFiltering.story.tsx
@@ -86,7 +86,7 @@ const TableWithFilters = ({ rowsPerPage }: TableWithFiltersProps) => {
 };
 
 export default {
-  title: "Components/Table",
+  title: "Components/Table/with filtering",
 };
 
 export const WithFiltering = () => <TableWithFilters />;

--- a/src/Table/TableWithServerSidePagination.story.tsx
+++ b/src/Table/TableWithServerSidePagination.story.tsx
@@ -85,7 +85,7 @@ class TableWithServerSidePagination extends React.Component<{}, TableState> {
 }
 
 export default {
-  title: "Components/Table",
+  title: "Components/Table/with server side pagination",
 };
 
 export const WithServerSidePagination = () => <TableWithServerSidePagination />;


### PR DESCRIPTION
## Description

Many storybooks under the Table component had duplicate names, causing Chromatic to not render them.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [x] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
