### PR TITLE
test: open dropdown by default to get chromatic diff

### DIFF
--- a/src/DropdownMenu/DropdownMenu.story.tsx
+++ b/src/DropdownMenu/DropdownMenu.story.tsx
@@ -76,7 +76,11 @@ WithButtonClosingMenu.story = {
 };
 
 export const WithCustomItem = () => (
-  <DropdownMenu openAriaLabel="open dropdown" closeAriaLabel="close dropdown">
+  <DropdownMenu
+    defaultOpen
+    openAriaLabel="open dropdown"
+    closeAriaLabel="close dropdown"
+  >
     <DropdownItem>
       <a href="/never_been">Custom Link Component</a>
     </DropdownItem>


### PR DESCRIPTION
## Description

Make it so that we get a chromatic screenshot for the DropdownMenu with a custom HTML link.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [x] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
