### PR TITLE
feat!: allow custom rendered menu items to specify their own styles

### DIFF
--- a/src/BrandedNavBar/DesktopMenu.tsx
+++ b/src/BrandedNavBar/DesktopMenu.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import styled from "styled-components";
 import { DefaultNDSThemeType } from "../theme.type";
 import MenuTrigger from "./MenuTrigger";
@@ -18,39 +17,6 @@ const getSharedStyles = (color, theme) => {
     borderRadius: theme.radii.medium,
   };
 };
-
-type ApplyMenuLinkStylesProps = {
-  color?: string;
-  hoverColor?: string;
-  hoverBackground?: string;
-  theme?: DefaultNDSThemeType;
-};
-
-const ApplyMenuLinkStyles = styled.div(
-  ({
-    color = "white",
-    hoverColor = "lightBlue",
-    hoverBackground = "black",
-    theme,
-  }: ApplyMenuLinkStylesProps) => ({
-    "button, a": {
-      ...getSharedStyles(color, theme),
-      transition: ".2s",
-      "&:hover, &:focus": {
-        outline: "none",
-        color: theme.colors[hoverColor] || hoverColor,
-        backgroundColor: theme.colors[hoverBackground] || hoverBackground,
-        cursor: "pointer",
-      },
-      "&:disabled": {
-        opacity: ".5",
-      },
-      "&:focus": {
-        boxShadow: theme.shadows.focus,
-      },
-    },
-  })
-);
 
 type MenuLinkProps = {
   color?: string;
@@ -118,13 +84,8 @@ const renderMenuLink = (menuItem, themeColorObject) => (
   </div>
 );
 
-const renderCustom = (menuItem, themeColorObject) => (
-  <ApplyMenuLinkStyles
-    {...themeColorObject}
-    key={menuItem.key ?? menuItem.name}
-  >
-    {menuItem.render()}
-  </ApplyMenuLinkStyles>
+const renderCustom = (menuItem) => (
+  <div key={menuItem.key ?? menuItem.name}>{menuItem.render()}</div>
 );
 
 const renderText = (menuItem, themeColorObject) => (


### PR DESCRIPTION
## Description

When specifying a `render` function for a BrandedNavBar menu item, don't attempt to set any styles on the components created by the `render` function. Doing so does not allow users of NDS to style their components using `styled-components`.

## Changes include

- [x] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [x] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
