### PR TITLE
More flexible BrandedNavBar custom rendering

### DIFF
--- a/src/BrandedNavBar/DesktopMenu.tsx
+++ b/src/BrandedNavBar/DesktopMenu.tsx
@@ -66,6 +66,7 @@ const renderMenuTrigger = (menuItem, themeColorObject) => (
       name={menuItem.name}
       aria-label={menuItem.ariaLabel}
       menuData={menuItem.items}
+      trigger={menuItem.trigger}
       {...themeColorObject}
     />
   </div>

--- a/src/BrandedNavBar/DesktopMenu.tsx
+++ b/src/BrandedNavBar/DesktopMenu.tsx
@@ -88,7 +88,7 @@ const renderMenuLink = (menuItem, themeColorObject) => (
 
 const renderCustom = (menuItem, _themeColorObject, layer) => (
   <div key={menuItem.key ?? menuItem.name}>
-    {menuItem.render({ mode: "desktop", layer })}
+    {menuItem.render({ size: "medium", layer })}
   </div>
 );
 

--- a/src/BrandedNavBar/DesktopMenu.tsx
+++ b/src/BrandedNavBar/DesktopMenu.tsx
@@ -60,13 +60,14 @@ const Nav = styled.nav({
   alignItems: "center",
 });
 
-const renderMenuTrigger = (menuItem, themeColorObject) => (
+const renderMenuTrigger = (menuItem, themeColorObject, layer) => (
   <div key={menuItem.key ?? menuItem.name}>
     <MenuTrigger
       name={menuItem.name}
       aria-label={menuItem.ariaLabel}
       menuData={menuItem.items}
       trigger={menuItem.trigger}
+      layer={layer}
       {...themeColorObject}
     />
   </div>
@@ -85,8 +86,10 @@ const renderMenuLink = (menuItem, themeColorObject) => (
   </div>
 );
 
-const renderCustom = (menuItem) => (
-  <div key={menuItem.key ?? menuItem.name}>{menuItem.render()}</div>
+const renderCustom = (menuItem, _themeColorObject, layer) => (
+  <div key={menuItem.key ?? menuItem.name}>
+    {menuItem.render({ mode: "desktop", layer })}
+  </div>
 );
 
 const renderText = (menuItem, themeColorObject) => (
@@ -107,8 +110,8 @@ const getRenderFunction = (menuItem) => {
   }
 };
 
-const renderMenuItem = (menuItem, themeColorObject) =>
-  getRenderFunction(menuItem)(menuItem, themeColorObject);
+const renderMenuItem = (menuItem, themeColorObject, layer) =>
+  getRenderFunction(menuItem)(menuItem, themeColorObject, layer);
 
 type BaseDesktopMenuProps = {
   menuData: any[];
@@ -121,7 +124,7 @@ const BaseDesktopMenu = ({
   ...props
 }: BaseDesktopMenuProps) => (
   <Nav {...props}>
-    {menuData.map((menuItem) => renderMenuItem(menuItem, themeColorObject))}
+    {menuData.map((menuItem) => renderMenuItem(menuItem, themeColorObject, 0))}
   </Nav>
 );
 

--- a/src/BrandedNavBar/MenuTrigger.tsx
+++ b/src/BrandedNavBar/MenuTrigger.tsx
@@ -60,7 +60,7 @@ const MenuTrigger = ({
       trigger={() => {
         const defaultRender = () => <MenuTriggerButton {...triggerProps} />;
         return trigger
-          ? trigger({ mode: "desktop", defaultRender, layer })
+          ? trigger({ size: "medium", defaultRender, layer })
           : defaultRender();
       }}
     >

--- a/src/BrandedNavBar/MenuTrigger.tsx
+++ b/src/BrandedNavBar/MenuTrigger.tsx
@@ -1,109 +1,21 @@
 import React from "react";
-import styled, { CSSObject } from "styled-components";
-import { themeGet } from "@styled-system/theme-get";
-import { Icon } from "../Icon";
-import { DefaultNDSThemeType } from "../theme.type";
 import NavBarDropdownMenu from "./NavBarDropdownMenu";
 import SubMenuTrigger from "./SubMenuTrigger";
 import renderSubMenuItems from "./renderSubMenuItems";
+import MenuTriggerButton from "./MenuTriggerButton";
 
-export type MenuTriggerProps = {
+export type TriggerFunctionProps = {
   name?: string;
   "aria-label"?: string;
+  color?: string;
+  hoverColor?: string;
+  hoverBackground?: string;
+};
+
+export type MenuTriggerProps = TriggerFunctionProps & {
   menuData?: any[];
-  color?: string;
-  hoverColor?: string;
-  hoverBackground?: string;
+  trigger?: (props: TriggerFunctionProps) => JSX.Element;
 };
-
-type StyledButtonProps = React.ComponentPropsWithRef<"button"> & {
-  color?: string;
-  hoverColor?: string;
-  hoverBackground?: string;
-  theme?: DefaultNDSThemeType;
-};
-
-const StyledButton = styled.button(
-  ({
-    color = "white",
-    hoverColor = "lightBlue",
-    hoverBackground = "black",
-    theme,
-  }: StyledButtonProps): CSSObject => ({
-    display: "flex",
-    alignItems: "center",
-    position: "relative",
-    fontWeight: theme.fontWeights.medium,
-    color: theme.colors[color] || color,
-    border: "none",
-    backgroundColor: "transparent",
-    textDecoration: "none",
-    lineHeight: theme.lineHeights.base,
-    transition: "background-color .2s",
-    fontSize: `${theme.fontSizes.medium}`,
-    padding: `${theme.space.x1} 28px ${theme.space.x1} ${theme.space.x2}`,
-    borderRadius: theme.radii.medium,
-    "&:hover, &:focus": {
-      outline: "none",
-      color: theme.colors[hoverColor] || hoverColor,
-      backgroundColor: theme.colors[hoverBackground] || hoverBackground,
-      cursor: "pointer",
-    },
-    "&:focus": {
-      boxShadow: theme.shadows.focus,
-    },
-    "&:disabled": {
-      opacity: ".5",
-    },
-  })
-);
-
-type MenuTriggerButtonProps = React.ComponentPropsWithRef<"button"> & {
-  name?: React.ReactNode;
-  color?: string;
-  hoverColor?: string;
-  hoverBackground?: string;
-};
-
-const MenuTriggerButton = React.forwardRef<
-  HTMLButtonElement,
-  MenuTriggerButtonProps
->(
-  (
-    {
-      name,
-      color,
-      hoverColor,
-      hoverBackground,
-      ...props
-    }: MenuTriggerButtonProps,
-    ref
-  ) => (
-    <StyledButton
-      color={color}
-      hoverColor={hoverColor}
-      hoverBackground={hoverBackground}
-      ref={ref}
-      {...props}
-    >
-      {name}
-      <Icon
-        style={{
-          position: "absolute",
-          top: "52%",
-          transform: "translateY(-50%)",
-          right: "8px",
-        }}
-        icon="downArrow"
-        color={themeGet(`colors.${color}`, color)(color)}
-        size="20px"
-        p="2px"
-      />
-    </StyledButton>
-  )
-);
-
-MenuTriggerButton.displayName = "MenuTriggerButton";
 
 const MenuTrigger = ({
   menuData,

--- a/src/BrandedNavBar/MenuTrigger.tsx
+++ b/src/BrandedNavBar/MenuTrigger.tsx
@@ -3,18 +3,16 @@ import NavBarDropdownMenu from "./NavBarDropdownMenu";
 import SubMenuTrigger from "./SubMenuTrigger";
 import renderSubMenuItems from "./renderSubMenuItems";
 import MenuTriggerButton from "./MenuTriggerButton";
+import { TriggerFunctionProps } from "./TriggerFunctionProps";
 
-export type TriggerFunctionProps = {
+export type MenuTriggerProps = {
   name?: string;
   "aria-label"?: string;
   color?: string;
   hoverColor?: string;
   hoverBackground?: string;
-};
-
-export type MenuTriggerProps = TriggerFunctionProps & {
   menuData?: any[];
-  trigger?: (props: TriggerFunctionProps) => JSX.Element;
+  trigger?: (props: TriggerFunctionProps) => JSX.Element | null;
 };
 
 const MenuTrigger = ({
@@ -57,11 +55,10 @@ const MenuTrigger = ({
           boundariesElement: "viewport",
         },
       }}
-      trigger={
-        trigger
-          ? () => trigger(triggerProps)
-          : () => <MenuTriggerButton {...triggerProps} />
-      }
+      trigger={() => {
+        const customTrigger = trigger && trigger({ mode: "desktop" });
+        return customTrigger || <MenuTriggerButton {...triggerProps} />;
+      }}
     >
       {({ closeMenu }) => (
         <ul

--- a/src/BrandedNavBar/MenuTrigger.tsx
+++ b/src/BrandedNavBar/MenuTrigger.tsx
@@ -13,6 +13,7 @@ export type MenuTriggerProps = {
   hoverBackground?: string;
   menuData?: any[];
   trigger?: (props: TriggerFunctionProps) => React.ReactNode;
+  layer: number;
 };
 
 const MenuTrigger = ({
@@ -23,6 +24,7 @@ const MenuTrigger = ({
   hoverBackground,
   "aria-label": ariaLabel,
   trigger,
+  layer,
   ...props
 }: MenuTriggerProps) => {
   let dropdownMinWidth = "auto";
@@ -58,7 +60,7 @@ const MenuTrigger = ({
       trigger={() => {
         const defaultRender = () => <MenuTriggerButton {...triggerProps} />;
         return trigger
-          ? trigger({ mode: "desktop", defaultRender })
+          ? trigger({ mode: "desktop", defaultRender, layer })
           : defaultRender();
       }}
     >
@@ -77,7 +79,8 @@ const MenuTrigger = ({
               closeMenu(e);
               e.stopPropagation();
             },
-            SubMenuTrigger
+            SubMenuTrigger,
+            layer + 1
           )}
         </ul>
       )}

--- a/src/BrandedNavBar/MenuTrigger.tsx
+++ b/src/BrandedNavBar/MenuTrigger.tsx
@@ -12,7 +12,7 @@ export type MenuTriggerProps = {
   hoverColor?: string;
   hoverBackground?: string;
   menuData?: any[];
-  trigger?: (props: TriggerFunctionProps) => JSX.Element | null;
+  trigger?: (props: TriggerFunctionProps) => React.ReactNode;
 };
 
 const MenuTrigger = ({
@@ -56,8 +56,10 @@ const MenuTrigger = ({
         },
       }}
       trigger={() => {
-        const customTrigger = trigger && trigger({ mode: "desktop" });
-        return customTrigger || <MenuTriggerButton {...triggerProps} />;
+        const defaultRender = () => <MenuTriggerButton {...triggerProps} />;
+        return trigger
+          ? trigger({ mode: "desktop", defaultRender })
+          : defaultRender();
       }}
     >
       {({ closeMenu }) => (

--- a/src/BrandedNavBar/MenuTrigger.tsx
+++ b/src/BrandedNavBar/MenuTrigger.tsx
@@ -24,6 +24,7 @@ const MenuTrigger = ({
   hoverColor,
   hoverBackground,
   "aria-label": ariaLabel,
+  trigger,
   ...props
 }: MenuTriggerProps) => {
   let dropdownMinWidth = "auto";
@@ -31,6 +32,13 @@ const MenuTrigger = ({
     // Popper.js throws an error if popperData is not returned from this fn
     dropdownMinWidth = `${popperData.instance.reference.clientWidth}px`;
     return popperData;
+  };
+  const triggerProps = {
+    color,
+    hoverColor,
+    hoverBackground,
+    name,
+    "aria-label": ariaLabel,
   };
   return (
     // @ts-ignore
@@ -49,15 +57,11 @@ const MenuTrigger = ({
           boundariesElement: "viewport",
         },
       }}
-      trigger={() => (
-        <MenuTriggerButton
-          color={color}
-          hoverColor={hoverColor}
-          hoverBackground={hoverBackground}
-          name={name}
-          aria-label={ariaLabel}
-        />
-      )}
+      trigger={
+        trigger
+          ? () => trigger(triggerProps)
+          : () => <MenuTriggerButton {...triggerProps} />
+      }
     >
       {({ closeMenu }) => (
         <ul

--- a/src/BrandedNavBar/MenuTriggerButton.tsx
+++ b/src/BrandedNavBar/MenuTriggerButton.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import styled, { CSSObject } from "styled-components";
+import { themeGet } from "@styled-system/theme-get";
+import { Icon } from "../Icon";
+import { DefaultNDSThemeType } from "../theme.type";
+
+type StyledButtonProps = React.ComponentPropsWithRef<"button"> & {
+  color?: string;
+  hoverColor?: string;
+  hoverBackground?: string;
+  theme?: DefaultNDSThemeType;
+};
+
+const StyledButton = styled.button(
+  ({
+    color = "white",
+    hoverColor = "lightBlue",
+    hoverBackground = "black",
+    theme,
+  }: StyledButtonProps): CSSObject => ({
+    display: "flex",
+    alignItems: "center",
+    position: "relative",
+    fontWeight: theme.fontWeights.medium,
+    color: theme.colors[color] || color,
+    border: "none",
+    backgroundColor: "transparent",
+    textDecoration: "none",
+    lineHeight: theme.lineHeights.base,
+    transition: "background-color .2s",
+    fontSize: `${theme.fontSizes.medium}`,
+    padding: `${theme.space.x1} 28px ${theme.space.x1} ${theme.space.x2}`,
+    borderRadius: theme.radii.medium,
+    "&:hover, &:focus": {
+      outline: "none",
+      color: theme.colors[hoverColor] || hoverColor,
+      backgroundColor: theme.colors[hoverBackground] || hoverBackground,
+      cursor: "pointer",
+    },
+    "&:focus": {
+      boxShadow: theme.shadows.focus,
+    },
+    "&:disabled": {
+      opacity: ".5",
+    },
+  })
+);
+
+type MenuTriggerButtonProps = React.ComponentPropsWithRef<"button"> & {
+  name?: React.ReactNode;
+  color?: string;
+  hoverColor?: string;
+  hoverBackground?: string;
+};
+
+const MenuTriggerButton = React.forwardRef<
+  HTMLButtonElement,
+  MenuTriggerButtonProps
+>(
+  (
+    {
+      name,
+      color,
+      hoverColor,
+      hoverBackground,
+      ...props
+    }: MenuTriggerButtonProps,
+    ref
+  ) => (
+    <StyledButton
+      color={color}
+      hoverColor={hoverColor}
+      hoverBackground={hoverBackground}
+      ref={ref}
+      {...props}
+    >
+      {name}
+      <Icon
+        style={{
+          position: "absolute",
+          top: "52%",
+          transform: "translateY(-50%)",
+          right: "8px",
+        }}
+        icon="downArrow"
+        color={themeGet(`colors.${color}`, color)(color)}
+        size="20px"
+        p="2px"
+      />
+    </StyledButton>
+  )
+);
+
+MenuTriggerButton.displayName = "MenuTriggerButton";
+
+export default MenuTriggerButton;

--- a/src/BrandedNavBar/MobileMenu.tsx
+++ b/src/BrandedNavBar/MobileMenu.tsx
@@ -107,7 +107,7 @@ const renderMenuLink = (menuItem, linkOnClick, themeColorObject, layer) => {
 
 const renderCustom = (menuItem, linkOnClick, themeColorObject, layer) => (
   <ChildIndentingLi layer={layer} key={menuItem.key ?? menuItem.name}>
-    {menuItem.render({ mode: "mobile", onItemClick: linkOnClick, layer })}
+    {menuItem.render({ size: "small", onItemClick: linkOnClick, layer })}
   </ChildIndentingLi>
 );
 
@@ -190,7 +190,7 @@ const SubMenu = ({
   return (
     <>
       {menuItem.trigger
-        ? menuItem.trigger({ mode: "mobile", defaultRender, layer })
+        ? menuItem.trigger({ size: "small", defaultRender, layer })
         : defaultRender()}
       <SubMenuItemsList>
         {renderMenuItems(

--- a/src/BrandedNavBar/MobileMenu.tsx
+++ b/src/BrandedNavBar/MobileMenu.tsx
@@ -107,7 +107,7 @@ const renderMenuLink = (menuItem, linkOnClick, themeColorObject, layer) => {
 
 const renderCustom = (menuItem, linkOnClick, themeColorObject, layer) => (
   <ChildIndentingLi layer={layer} key={menuItem.key ?? menuItem.name}>
-    {menuItem.render(linkOnClick, layer)}
+    {menuItem.render({ mode: "mobile", onItemClick: linkOnClick, layer })}
   </ChildIndentingLi>
 );
 
@@ -190,7 +190,7 @@ const SubMenu = ({
   return (
     <>
       {menuItem.trigger
-        ? menuItem.trigger({ mode: "mobile", defaultRender })
+        ? menuItem.trigger({ mode: "mobile", defaultRender, layer })
         : defaultRender()}
       <SubMenuItemsList>
         {renderMenuItems(

--- a/src/BrandedNavBar/MobileMenu.tsx
+++ b/src/BrandedNavBar/MobileMenu.tsx
@@ -9,6 +9,7 @@ import { DropdownLink, DropdownText, DropdownButton } from "../DropdownMenu";
 import { Link } from "../Link";
 import { LinkProps } from "../Link/Link";
 import NulogyLogo from "./NulogyLogo";
+import { TriggerFunctionProps } from "./TriggerFunctionProps";
 
 const borderStyle = "1px solid #e4e7eb";
 
@@ -169,6 +170,7 @@ type ThemeColorObject = {
 type MenuItem = {
   items?: any[];
   name?: string;
+  trigger?: (props: TriggerFunctionProps) => JSX.Element | null;
 };
 
 type SubMenuProps = {
@@ -183,19 +185,23 @@ const SubMenu = ({
   linkOnClick,
   themeColorObject,
   layer,
-}: SubMenuProps) => (
-  <>
-    {getSubMenuHeading(layer, menuItem.name)}
-    <SubMenuItemsList>
-      {renderMenuItems(
-        menuItem.items,
-        linkOnClick,
-        themeColorObject,
-        layer + 1
-      )}
-    </SubMenuItemsList>
-  </>
-);
+}: SubMenuProps) => {
+  const customHeading =
+    menuItem.trigger && menuItem.trigger({ mode: "mobile" });
+  return (
+    <>
+      {customHeading || getSubMenuHeading(layer, menuItem.name)}
+      <SubMenuItemsList>
+        {renderMenuItems(
+          menuItem.items,
+          linkOnClick,
+          themeColorObject,
+          layer + 1
+        )}
+      </SubMenuItemsList>
+    </>
+  );
+};
 
 const Menu = styled.ul(({ theme }) => ({
   listStyle: "none",

--- a/src/BrandedNavBar/MobileMenu.tsx
+++ b/src/BrandedNavBar/MobileMenu.tsx
@@ -170,7 +170,7 @@ type ThemeColorObject = {
 type MenuItem = {
   items?: any[];
   name?: string;
-  trigger?: (props: TriggerFunctionProps) => JSX.Element | null;
+  trigger?: (props: TriggerFunctionProps) => React.ReactNode;
 };
 
 type SubMenuProps = {
@@ -186,11 +186,12 @@ const SubMenu = ({
   themeColorObject,
   layer,
 }: SubMenuProps) => {
-  const customHeading =
-    menuItem.trigger && menuItem.trigger({ mode: "mobile" });
+  const defaultRender = () => getSubMenuHeading(layer, menuItem.name);
   return (
     <>
-      {customHeading || getSubMenuHeading(layer, menuItem.name)}
+      {menuItem.trigger
+        ? menuItem.trigger({ mode: "mobile", defaultRender })
+        : defaultRender()}
       <SubMenuItemsList>
         {renderMenuItems(
           menuItem.items,

--- a/src/BrandedNavBar/NavBar.story.tsx
+++ b/src/BrandedNavBar/NavBar.story.tsx
@@ -6,6 +6,7 @@ import { Heading1 } from "../Type";
 import { Icon } from "../Icon";
 import { DropdownButton, DropdownLink } from "../DropdownMenu";
 import theme from "../theme";
+import { Button } from "../Button";
 import { BrandedNavBar as NDSBrandedNavBar } from "./index";
 
 const sampleLogo =
@@ -53,9 +54,7 @@ const primaryMenu = [
           },
           {
             name: "Jobs",
-            items: [
-              { name: "Job 1", href: "/" },
-            ],
+            items: [{ name: "Job 1", href: "/" }],
           },
         ],
       },
@@ -328,3 +327,16 @@ CustomRenderingInHamburger.parameters = {
   },
   chromatic: { viewports: [parseInt(theme.breakpoints.small)] },
 };
+
+const primaryMenuWithCustomTrigger = [
+  {
+    name: "Submenu",
+    trigger: () => <Button>Custom trigger</Button>,
+    items: [{ name: "Submenu link", href: "/" }],
+  },
+];
+export const CustomMenuTrigger = () => (
+  <BrandedNavBar
+    menuData={{ primaryMenu: primaryMenuWithCustomTrigger, secondaryMenu }}
+  />
+);

--- a/src/BrandedNavBar/NavBar.story.tsx
+++ b/src/BrandedNavBar/NavBar.story.tsx
@@ -328,15 +328,31 @@ CustomRenderingInHamburger.parameters = {
   chromatic: { viewports: [parseInt(theme.breakpoints.small)] },
 };
 
-const primaryMenuWithCustomTrigger = [
+const primaryMenuWithCustomTriggers = [
   {
-    name: "Submenu",
-    trigger: () => <Button>Custom trigger</Button>,
-    items: [{ name: "Submenu link", href: "/" }],
+    name: "Menu",
+    trigger: () => <Button>Custom menu trigger</Button>,
+    items: [
+      { name: "Menu 1 link", href: "/" },
+      {
+        name: "Submenu 1",
+        trigger: () => <Button>Custom submenu trigger</Button>,
+        items: [{ name: "Submenu 1 link", href: "/" }],
+      },
+      {
+        name: "Submenu 2",
+        trigger: ({ openMenu, closeMenu }) => (
+          <Button onMouseEnter={openMenu} onMouseLeave={closeMenu}>
+            Custom submenu trigger w/ open on hover
+          </Button>
+        ),
+        items: [{ name: "Submenu 2 link", href: "/" }],
+      },
+    ],
   },
 ];
-export const CustomMenuTrigger = () => (
+export const CustomMenuTriggers = () => (
   <BrandedNavBar
-    menuData={{ primaryMenu: primaryMenuWithCustomTrigger, secondaryMenu }}
+    menuData={{ primaryMenu: primaryMenuWithCustomTriggers, secondaryMenu }}
   />
 );

--- a/src/BrandedNavBar/NavBar.story.tsx
+++ b/src/BrandedNavBar/NavBar.story.tsx
@@ -302,7 +302,9 @@ const customPrimaryMenu = [
       },
       {
         name: "Custom submenu DropdownButton",
-        render: () => <DropdownButton>DropdownButton</DropdownButton>,
+        render: ({ layer }) => (
+          <DropdownButton>DropdownButton at layer {layer}</DropdownButton>
+        ),
       },
     ],
   },
@@ -332,14 +334,18 @@ CustomRenderingInHamburger.parameters = {
 const primaryMenuWithCustomTriggers = [
   {
     name: "Menu",
-    trigger: ({ mode }) => <Button>Custom menu trigger for {mode}</Button>,
+    trigger: ({ mode, layer }) => (
+      <Button>
+        Custom menu trigger for {mode}. layer: {layer}
+      </Button>
+    ),
     items: [
       { name: "Menu 1 link", href: "/" },
       {
         name: "Submenu 1 (pass-through to hamburger default)",
-        trigger: ({ mode, defaultRender }) =>
+        trigger: ({ mode, defaultRender, layer }) =>
           mode === "desktop" ? (
-            <Button>Custom submenu trigger</Button>
+            <Button>Custom submenu trigger. layer: {layer}</Button>
           ) : (
             defaultRender()
           ),
@@ -347,25 +353,23 @@ const primaryMenuWithCustomTriggers = [
       },
       {
         name: "Submenu 2",
-        trigger: ({ mode, openMenu, closeMenu }) => {
+        trigger: ({ mode, openMenu, closeMenu, defaultRender, layer }) => {
           return mode === "desktop" ? (
             <Button onMouseEnter={openMenu} onMouseLeave={closeMenu}>
-              Custom submenu trigger w/ open on hover
+              Custom submenu trigger w/ open on hover. layer: {layer}
             </Button>
           ) : (
-            <Text color="black" pl="x6">
-              Custom submenu hamburger heading 1
-            </Text>
+            defaultRender()
           );
         },
         items: [{ name: "Submenu 2 link", href: "/" }],
       },
       {
         name: "Submenu 3 (pass-through to desktop default)",
-        trigger: ({ mode, defaultRender }) => {
+        trigger: ({ mode, defaultRender, layer }) => {
           return mode === "mobile" ? (
             <Text color="black" pl="x6">
-              Custom submenu hamburger heading 2
+              Custom submenu hamburger heading 2. layer: {layer}
             </Text>
           ) : (
             defaultRender()

--- a/src/BrandedNavBar/NavBar.story.tsx
+++ b/src/BrandedNavBar/NavBar.story.tsx
@@ -334,17 +334,17 @@ CustomRenderingInHamburger.parameters = {
 const primaryMenuWithCustomTriggers = [
   {
     name: "Menu",
-    trigger: ({ mode, layer }) => (
+    trigger: ({ size, layer }) => (
       <Button>
-        Custom menu trigger for {mode}. layer: {layer}
+        Custom menu trigger for {size}. layer: {layer}
       </Button>
     ),
     items: [
       { name: "Menu 1 link", href: "/" },
       {
         name: "Submenu 1 (pass-through to hamburger default)",
-        trigger: ({ mode, defaultRender, layer }) =>
-          mode === "desktop" ? (
+        trigger: ({ size, defaultRender, layer }) =>
+          size === "medium" ? (
             <Button>Custom submenu trigger. layer: {layer}</Button>
           ) : (
             defaultRender()
@@ -353,8 +353,8 @@ const primaryMenuWithCustomTriggers = [
       },
       {
         name: "Submenu 2",
-        trigger: ({ mode, openMenu, closeMenu, defaultRender, layer }) => {
-          return mode === "desktop" ? (
+        trigger: ({ size, openMenu, closeMenu, defaultRender, layer }) => {
+          return size === "medium" ? (
             <Button onMouseEnter={openMenu} onMouseLeave={closeMenu}>
               Custom submenu trigger w/ open on hover. layer: {layer}
             </Button>
@@ -366,8 +366,8 @@ const primaryMenuWithCustomTriggers = [
       },
       {
         name: "Submenu 3 (pass-through to desktop default)",
-        trigger: ({ mode, defaultRender, layer }) => {
-          return mode === "mobile" ? (
+        trigger: ({ size, defaultRender, layer }) => {
+          return size === "small" ? (
             <Text color="black" pl="x6">
               Custom submenu hamburger heading 2. layer: {layer}
             </Text>

--- a/src/BrandedNavBar/NavBar.story.tsx
+++ b/src/BrandedNavBar/NavBar.story.tsx
@@ -7,6 +7,7 @@ import { Icon } from "../Icon";
 import { DropdownButton, DropdownLink } from "../DropdownMenu";
 import theme from "../theme";
 import { Button } from "../Button";
+import { Text } from "../Type";
 import { BrandedNavBar as NDSBrandedNavBar } from "./index";
 
 const sampleLogo =
@@ -331,22 +332,40 @@ CustomRenderingInHamburger.parameters = {
 const primaryMenuWithCustomTriggers = [
   {
     name: "Menu",
-    trigger: () => <Button>Custom menu trigger</Button>,
+    trigger: ({ mode }) => <Button>Custom menu trigger for {mode}</Button>,
     items: [
       { name: "Menu 1 link", href: "/" },
       {
-        name: "Submenu 1",
-        trigger: () => <Button>Custom submenu trigger</Button>,
+        name: "Submenu 1 (pass-through to hamburger default)",
+        trigger: ({ mode }) =>
+          mode === "desktop" ? <Button>Custom submenu trigger</Button> : null,
         items: [{ name: "Submenu 1 link", href: "/" }],
       },
       {
         name: "Submenu 2",
-        trigger: ({ openMenu, closeMenu }) => (
-          <Button onMouseEnter={openMenu} onMouseLeave={closeMenu}>
-            Custom submenu trigger w/ open on hover
-          </Button>
-        ),
+        trigger: ({ mode, openMenu, closeMenu }) => {
+          return mode === "desktop" ? (
+            <Button onMouseEnter={openMenu} onMouseLeave={closeMenu}>
+              Custom submenu trigger w/ open on hover
+            </Button>
+          ) : (
+            <Text color="black" pl="x6">
+              Custom submenu hamburger heading 1
+            </Text>
+          );
+        },
         items: [{ name: "Submenu 2 link", href: "/" }],
+      },
+      {
+        name: "Submenu 3 (pass-through to desktop default)",
+        trigger: ({ mode }) => {
+          return mode === "mobile" ? (
+            <Text color="black" pl="x6">
+              Custom submenu hamburger heading 2
+            </Text>
+          ) : null;
+        },
+        items: [{ name: "Submenu 3 link", href: "/" }],
       },
     ],
   },
@@ -356,3 +375,16 @@ export const CustomMenuTriggers = () => (
     menuData={{ primaryMenu: primaryMenuWithCustomTriggers, secondaryMenu }}
   />
 );
+
+export const CustomMenuTriggersInHamburger = () => (
+  <BrandedNavBar
+    menuData={{ primaryMenu: primaryMenuWithCustomTriggers, secondaryMenu }}
+    defaultOpen
+  />
+);
+CustomMenuTriggersInHamburger.parameters = {
+  viewport: {
+    defaultViewport: "small", // for some reason this has to match the viewport key, NOT the name!
+  },
+  chromatic: { viewports: [parseInt(theme.breakpoints.small)] },
+};

--- a/src/BrandedNavBar/NavBar.story.tsx
+++ b/src/BrandedNavBar/NavBar.story.tsx
@@ -337,8 +337,12 @@ const primaryMenuWithCustomTriggers = [
       { name: "Menu 1 link", href: "/" },
       {
         name: "Submenu 1 (pass-through to hamburger default)",
-        trigger: ({ mode }) =>
-          mode === "desktop" ? <Button>Custom submenu trigger</Button> : null,
+        trigger: ({ mode, defaultRender }) =>
+          mode === "desktop" ? (
+            <Button>Custom submenu trigger</Button>
+          ) : (
+            defaultRender()
+          ),
         items: [{ name: "Submenu 1 link", href: "/" }],
       },
       {
@@ -358,12 +362,14 @@ const primaryMenuWithCustomTriggers = [
       },
       {
         name: "Submenu 3 (pass-through to desktop default)",
-        trigger: ({ mode }) => {
+        trigger: ({ mode, defaultRender }) => {
           return mode === "mobile" ? (
             <Text color="black" pl="x6">
               Custom submenu hamburger heading 2
             </Text>
-          ) : null;
+          ) : (
+            defaultRender()
+          );
         },
         items: [{ name: "Submenu 3 link", href: "/" }],
       },

--- a/src/BrandedNavBar/SubMenuTrigger.tsx
+++ b/src/BrandedNavBar/SubMenuTrigger.tsx
@@ -1,12 +1,7 @@
 import React from "react";
-import styled, {
-  CSSObject,
-  StyledComponentPropsWithRef,
-} from "styled-components";
-import { Icon } from "../Icon";
-import { DropdownButton } from "../DropdownMenu/index";
 import NavBarDropdownMenu from "./NavBarDropdownMenu";
 import renderSubMenuItems from "./renderSubMenuItems";
+import SubMenuTriggerButton from "./SubMenuTriggerButton";
 
 type SubMenuTriggerProps = React.ComponentPropsWithRef<"button"> & {
   name?: string;
@@ -14,35 +9,6 @@ type SubMenuTriggerProps = React.ComponentPropsWithRef<"button"> & {
   onItemClick?: any;
   menuData: any[];
 };
-
-const StyledButton: StyledComponentPropsWithRef<any> = styled(DropdownButton)(
-  ({ isOpen, theme }: any): CSSObject => ({
-    position: "relative",
-    backgroundColor: isOpen ? theme.colors.lightBlue : "transparent",
-    color: isOpen ? theme.colors.darkBlue : theme.colors.darkGrey,
-  })
-);
-type SubMenuTriggerButtonProps = React.ComponentPropsWithRef<"button"> & {
-  name?: string;
-  isOpen: boolean;
-};
-
-const SubMenuTriggerButton = React.forwardRef<
-  HTMLButtonElement,
-  SubMenuTriggerButtonProps
->(({ name, isOpen, ...props }, ref) => (
-  <StyledButton isOpen={isOpen} ref={ref} {...props}>
-    {name}
-    <Icon
-      style={{ position: "absolute", top: "10px" }}
-      icon="rightArrow"
-      size="20px"
-      p="2px"
-    />
-  </StyledButton>
-));
-
-SubMenuTriggerButton.displayName = "SubMenuTriggerButton";
 
 const SubMenuTrigger = ({
   menuData,

--- a/src/BrandedNavBar/SubMenuTrigger.tsx
+++ b/src/BrandedNavBar/SubMenuTrigger.tsx
@@ -43,7 +43,7 @@ const SubMenuTrigger = ({
           />
         );
         const triggerProps: TriggerFunctionProps = {
-          mode: "desktop",
+          size: "medium",
           closeMenu,
           openMenu,
           isOpen,

--- a/src/BrandedNavBar/SubMenuTrigger.tsx
+++ b/src/BrandedNavBar/SubMenuTrigger.tsx
@@ -10,6 +10,7 @@ type SubMenuTriggerProps = React.ComponentPropsWithRef<"button"> & {
   onItemClick?: any;
   menuData: any[];
   trigger: (props: TriggerFunctionProps) => React.ReactNode;
+  layer: number;
 };
 
 const SubMenuTrigger = ({
@@ -17,6 +18,7 @@ const SubMenuTrigger = ({
   name,
   onItemClick,
   trigger,
+  layer,
   ...props
 }: SubMenuTriggerProps) => {
   return (
@@ -46,12 +48,13 @@ const SubMenuTrigger = ({
           openMenu,
           isOpen,
           defaultRender,
+          layer,
         };
         return trigger ? trigger(triggerProps) : defaultRender();
       }}
     >
       <ul style={{ listStyle: "none", margin: "0", padding: "0" }}>
-        {renderSubMenuItems(menuData, onItemClick, SubMenuTrigger)}
+        {renderSubMenuItems(menuData, onItemClick, SubMenuTrigger, layer + 1)}
       </ul>
     </NavBarDropdownMenu>
   );

--- a/src/BrandedNavBar/SubMenuTrigger.tsx
+++ b/src/BrandedNavBar/SubMenuTrigger.tsx
@@ -3,17 +3,26 @@ import NavBarDropdownMenu from "./NavBarDropdownMenu";
 import renderSubMenuItems from "./renderSubMenuItems";
 import SubMenuTriggerButton from "./SubMenuTriggerButton";
 
+type SubMenuTriggerButtonProps = {
+  name?: string;
+  isOpen?: boolean;
+  closeMenu?: any;
+  openMenu?: any;
+};
+
 type SubMenuTriggerProps = React.ComponentPropsWithRef<"button"> & {
   name?: string;
   isOpen?: boolean;
   onItemClick?: any;
   menuData: any[];
+  trigger: (props: SubMenuTriggerButtonProps) => JSX.Element;
 };
 
 const SubMenuTrigger = ({
   menuData,
   name,
   onItemClick,
+  trigger,
   ...props
 }: SubMenuTriggerProps) => {
   return (
@@ -28,14 +37,19 @@ const SubMenuTrigger = ({
         onMouseEnter: openMenu,
         onMouseLeave: closeMenu,
       })}
-      trigger={({ closeMenu, openMenu, isOpen }) => (
-        <SubMenuTriggerButton
-          isOpen={isOpen}
-          name={name}
-          onMouseEnter={openMenu}
-          onMouseLeave={closeMenu}
-        />
-      )}
+      trigger={
+        trigger
+          ? ({ closeMenu, openMenu, isOpen }) =>
+              trigger({ closeMenu, openMenu, isOpen, name })
+          : ({ closeMenu, openMenu, isOpen }) => (
+              <SubMenuTriggerButton
+                isOpen={isOpen}
+                name={name}
+                onMouseEnter={openMenu}
+                onMouseLeave={closeMenu}
+              />
+            )
+      }
     >
       <ul style={{ listStyle: "none", margin: "0", padding: "0" }}>
         {renderSubMenuItems(menuData, onItemClick, SubMenuTrigger)}

--- a/src/BrandedNavBar/SubMenuTrigger.tsx
+++ b/src/BrandedNavBar/SubMenuTrigger.tsx
@@ -9,7 +9,7 @@ type SubMenuTriggerProps = React.ComponentPropsWithRef<"button"> & {
   isOpen?: boolean;
   onItemClick?: any;
   menuData: any[];
-  trigger: (props: TriggerFunctionProps) => JSX.Element | null;
+  trigger: (props: TriggerFunctionProps) => React.ReactNode;
 };
 
 const SubMenuTrigger = ({
@@ -32,18 +32,22 @@ const SubMenuTrigger = ({
         onMouseLeave: closeMenu,
       })}
       trigger={({ closeMenu, openMenu, isOpen }) => {
-        const customTrigger =
-          trigger && trigger({ mode: "desktop", closeMenu, openMenu, isOpen });
-        return (
-          customTrigger || (
-            <SubMenuTriggerButton
-              isOpen={isOpen}
-              name={name}
-              onMouseEnter={openMenu}
-              onMouseLeave={closeMenu}
-            />
-          )
+        const defaultRender = () => (
+          <SubMenuTriggerButton
+            isOpen={isOpen}
+            name={name}
+            onMouseEnter={openMenu}
+            onMouseLeave={closeMenu}
+          />
         );
+        const triggerProps: TriggerFunctionProps = {
+          mode: "desktop",
+          closeMenu,
+          openMenu,
+          isOpen,
+          defaultRender,
+        };
+        return trigger ? trigger(triggerProps) : defaultRender();
       }}
     >
       <ul style={{ listStyle: "none", margin: "0", padding: "0" }}>

--- a/src/BrandedNavBar/SubMenuTrigger.tsx
+++ b/src/BrandedNavBar/SubMenuTrigger.tsx
@@ -2,20 +2,14 @@ import React from "react";
 import NavBarDropdownMenu from "./NavBarDropdownMenu";
 import renderSubMenuItems from "./renderSubMenuItems";
 import SubMenuTriggerButton from "./SubMenuTriggerButton";
-
-type SubMenuTriggerButtonProps = {
-  name?: string;
-  isOpen?: boolean;
-  closeMenu?: any;
-  openMenu?: any;
-};
+import { TriggerFunctionProps } from "./TriggerFunctionProps";
 
 type SubMenuTriggerProps = React.ComponentPropsWithRef<"button"> & {
   name?: string;
   isOpen?: boolean;
   onItemClick?: any;
   menuData: any[];
-  trigger: (props: SubMenuTriggerButtonProps) => JSX.Element;
+  trigger: (props: TriggerFunctionProps) => JSX.Element | null;
 };
 
 const SubMenuTrigger = ({
@@ -37,19 +31,20 @@ const SubMenuTrigger = ({
         onMouseEnter: openMenu,
         onMouseLeave: closeMenu,
       })}
-      trigger={
-        trigger
-          ? ({ closeMenu, openMenu, isOpen }) =>
-              trigger({ closeMenu, openMenu, isOpen, name })
-          : ({ closeMenu, openMenu, isOpen }) => (
-              <SubMenuTriggerButton
-                isOpen={isOpen}
-                name={name}
-                onMouseEnter={openMenu}
-                onMouseLeave={closeMenu}
-              />
-            )
-      }
+      trigger={({ closeMenu, openMenu, isOpen }) => {
+        const customTrigger =
+          trigger && trigger({ mode: "desktop", closeMenu, openMenu, isOpen });
+        return (
+          customTrigger || (
+            <SubMenuTriggerButton
+              isOpen={isOpen}
+              name={name}
+              onMouseEnter={openMenu}
+              onMouseLeave={closeMenu}
+            />
+          )
+        );
+      }}
     >
       <ul style={{ listStyle: "none", margin: "0", padding: "0" }}>
         {renderSubMenuItems(menuData, onItemClick, SubMenuTrigger)}

--- a/src/BrandedNavBar/SubMenuTriggerButton.tsx
+++ b/src/BrandedNavBar/SubMenuTriggerButton.tsx
@@ -1,0 +1,38 @@
+import styled, {
+  CSSObject,
+  StyledComponentPropsWithRef,
+} from "styled-components";
+import React from "react";
+import { DropdownButton } from "../DropdownMenu";
+import { Icon } from "../Icon";
+
+const StyledButton: StyledComponentPropsWithRef<any> = styled(DropdownButton)(
+  ({ isOpen, theme }: any): CSSObject => ({
+    position: "relative",
+    backgroundColor: isOpen ? theme.colors.lightBlue : "transparent",
+    color: isOpen ? theme.colors.darkBlue : theme.colors.darkGrey,
+  })
+);
+type SubMenuTriggerButtonProps = React.ComponentPropsWithRef<"button"> & {
+  name?: string;
+  isOpen: boolean;
+};
+
+const SubMenuTriggerButton = React.forwardRef<
+  HTMLButtonElement,
+  SubMenuTriggerButtonProps
+>(({ name, isOpen, ...props }, ref) => (
+  <StyledButton isOpen={isOpen} ref={ref} {...props}>
+    {name}
+    <Icon
+      style={{ position: "absolute", top: "10px" }}
+      icon="rightArrow"
+      size="20px"
+      p="2px"
+    />
+  </StyledButton>
+));
+
+SubMenuTriggerButton.displayName = "SubMenuTriggerButton";
+
+export default SubMenuTriggerButton;

--- a/src/BrandedNavBar/TriggerFunctionProps.tsx
+++ b/src/BrandedNavBar/TriggerFunctionProps.tsx
@@ -6,4 +6,5 @@ export type TriggerFunctionProps = {
   closeMenu?: any;
   openMenu?: any;
   defaultRender: () => React.ReactNode;
+  layer: number;
 };

--- a/src/BrandedNavBar/TriggerFunctionProps.tsx
+++ b/src/BrandedNavBar/TriggerFunctionProps.tsx
@@ -1,6 +1,9 @@
+import React from "react";
+
 export type TriggerFunctionProps = {
-  mode: string;
+  mode: "mobile" | "desktop";
   isOpen?: boolean;
   closeMenu?: any;
   openMenu?: any;
+  defaultRender: () => React.ReactNode;
 };

--- a/src/BrandedNavBar/TriggerFunctionProps.tsx
+++ b/src/BrandedNavBar/TriggerFunctionProps.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 export type TriggerFunctionProps = {
-  mode: "mobile" | "desktop";
+  size: "small" | "medium";
   isOpen?: boolean;
   closeMenu?: any;
   openMenu?: any;

--- a/src/BrandedNavBar/TriggerFunctionProps.tsx
+++ b/src/BrandedNavBar/TriggerFunctionProps.tsx
@@ -1,0 +1,6 @@
+export type TriggerFunctionProps = {
+  mode: string;
+  isOpen?: boolean;
+  closeMenu?: any;
+  openMenu?: any;
+};

--- a/src/BrandedNavBar/renderSubMenuItems.tsx
+++ b/src/BrandedNavBar/renderSubMenuItems.tsx
@@ -2,13 +2,19 @@ import React from "react";
 import styled, { CSSObject } from "styled-components";
 import { DropdownText, DropdownLink } from "../DropdownMenu";
 
-const renderSubMenuTrigger = (subMenuItem, onItemClick, SubMenuTrigger) => (
+const renderSubMenuTrigger = (
+  subMenuItem,
+  onItemClick,
+  SubMenuTrigger,
+  layer
+) => (
   <NoWrapLi key={subMenuItem.key ?? subMenuItem.name}>
     <SubMenuTrigger
       onItemClick={onItemClick}
       name={subMenuItem.name}
       menuData={subMenuItem.items}
       trigger={subMenuItem.trigger}
+      layer={layer}
     />
   </NoWrapLi>
 );
@@ -27,9 +33,9 @@ const renderSubMenuLink = (subMenuItem, onItemClick) => (
   </NoWrapLi>
 );
 
-const renderCustom = (subMenuItem, onItemClick) => (
+const renderCustom = (subMenuItem, onItemClick, _SubMenuTrigger, layer) => (
   <NoWrapLi key={subMenuItem.key ?? subMenuItem.name}>
-    {subMenuItem.render(onItemClick)}
+    {subMenuItem.render({ mode: "desktop", onItemClick, layer })}
   </NoWrapLi>
 );
 
@@ -51,9 +57,14 @@ const getRenderFunction = (subMenuItem) => {
   }
 };
 
-const renderSubMenuItems = (subMenuItems, onItemClick, SubMenuTrigger) =>
+const renderSubMenuItems = (subMenuItems, onItemClick, SubMenuTrigger, layer) =>
   subMenuItems.map((subMenuItem) =>
-    getRenderFunction(subMenuItem)(subMenuItem, onItemClick, SubMenuTrigger)
+    getRenderFunction(subMenuItem)(
+      subMenuItem,
+      onItemClick,
+      SubMenuTrigger,
+      layer
+    )
   );
 
 const NoWrapLi = styled.li(

--- a/src/BrandedNavBar/renderSubMenuItems.tsx
+++ b/src/BrandedNavBar/renderSubMenuItems.tsx
@@ -8,6 +8,7 @@ const renderSubMenuTrigger = (subMenuItem, onItemClick, SubMenuTrigger) => (
       onItemClick={onItemClick}
       name={subMenuItem.name}
       menuData={subMenuItem.items}
+      trigger={subMenuItem.trigger}
     />
   </NoWrapLi>
 );

--- a/src/BrandedNavBar/renderSubMenuItems.tsx
+++ b/src/BrandedNavBar/renderSubMenuItems.tsx
@@ -35,7 +35,7 @@ const renderSubMenuLink = (subMenuItem, onItemClick) => (
 
 const renderCustom = (subMenuItem, onItemClick, _SubMenuTrigger, layer) => (
   <NoWrapLi key={subMenuItem.key ?? subMenuItem.name}>
-    {subMenuItem.render({ mode: "desktop", onItemClick, layer })}
+    {subMenuItem.render({ size: "medium", onItemClick, layer })}
   </NoWrapLi>
 );
 

--- a/src/DropdownMenu/DropdownButton.tsx
+++ b/src/DropdownMenu/DropdownButton.tsx
@@ -1,14 +1,15 @@
 import styled from "styled-components";
-import { color } from "styled-system";
 import { DefaultNDSThemeType } from "../theme.type";
+import { addStyledProps, StyledProps } from "../StyledProps";
 
-type DropdownButtonProps = React.ComponentPropsWithRef<"button"> & {
-  color?: string;
-  disabled?: boolean;
-  theme?: DefaultNDSThemeType;
-  hoverColor?: string;
-  bgHoverColor?: string;
-};
+type DropdownButtonProps = React.ComponentPropsWithRef<"button"> &
+  StyledProps & {
+    color?: string;
+    disabled?: boolean;
+    theme?: DefaultNDSThemeType;
+    hoverColor?: string;
+    bgHoverColor?: string;
+  };
 
 const DropdownButton: React.FC<DropdownButtonProps> = styled.button(
   ({ disabled, theme, hoverColor, bgHoverColor }: DropdownButtonProps) => ({
@@ -39,7 +40,7 @@ const DropdownButton: React.FC<DropdownButtonProps> = styled.button(
       opacity: ".5",
     },
   }),
-  color
+  addStyledProps
 );
 DropdownButton.defaultProps = {
   disabled: false,

--- a/src/DropdownMenu/DropdownLink.tsx
+++ b/src/DropdownMenu/DropdownLink.tsx
@@ -1,37 +1,41 @@
 import styled from "styled-components";
+import { addStyledProps } from "../StyledProps";
 
 const DropdownLink: React.FC<any> = styled.a.withConfig({
   shouldForwardProp: (prop, defaultValidatorFn) =>
     !["hoverColor", "bgHoverColor"].includes(prop) && defaultValidatorFn(prop),
-})(({ theme, color, bgHoverColor, hoverColor }: any) => ({
-  color: theme.colors[color],
-  fontWeight: theme.fontWeights.medium,
-  display: "block",
-  textDecoration: "none",
-  borderColor: "transparent",
-  backgroundColor: "transparent",
-  lineHeight: theme.lineHeights.base,
-  fontSize: theme.fontSizes.medium,
-  transition: ".2s",
-  padding: `${theme.space.x1} ${theme.space.x2} ${theme.space.x1} 12px`,
-  borderLeft: `${theme.space.half} solid transparent`,
-  "&:visited": {
+})(
+  ({ theme, color, bgHoverColor, hoverColor }: any) => ({
     color: theme.colors[color],
-  },
-  "&:hover": {
-    color: theme.colors[hoverColor],
-    backgroundColor: theme.colors[bgHoverColor],
-  },
-  "&:focus": {
-    outline: "none",
-    color: theme.colors[hoverColor],
-    backgroundColor: theme.colors[bgHoverColor],
-    borderLeft: `${theme.space.half}  solid ${theme.colors.blue}`,
-  },
-  "&:disabled": {
-    opacity: ".5",
-  },
-}));
+    fontWeight: theme.fontWeights.medium,
+    display: "block",
+    textDecoration: "none",
+    borderColor: "transparent",
+    backgroundColor: "transparent",
+    lineHeight: theme.lineHeights.base,
+    fontSize: theme.fontSizes.medium,
+    transition: ".2s",
+    padding: `${theme.space.x1} ${theme.space.x2} ${theme.space.x1} 12px`,
+    borderLeft: `${theme.space.half} solid transparent`,
+    "&:visited": {
+      color: theme.colors[color],
+    },
+    "&:hover": {
+      color: theme.colors[hoverColor],
+      backgroundColor: theme.colors[bgHoverColor],
+    },
+    "&:focus": {
+      outline: "none",
+      color: theme.colors[hoverColor],
+      backgroundColor: theme.colors[bgHoverColor],
+      borderLeft: `${theme.space.half}  solid ${theme.colors.blue}`,
+    },
+    "&:disabled": {
+      opacity: ".5",
+    },
+  }),
+  addStyledProps
+);
 DropdownLink.defaultProps = {
   disabled: false,
   color: "darkGrey",

--- a/src/DropdownMenu/DropdownText.tsx
+++ b/src/DropdownMenu/DropdownText.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import styled, { CSSObject } from "styled-components";
-import { color } from "styled-system";
 import { Text } from "../Type";
 import { TextProps } from "../Type/Text";
+import { addStyledProps } from "../StyledProps";
 
 const DropdownText: React.FC<TextProps> = styled(Text)(
   ({ theme }: TextProps): CSSObject => ({
@@ -16,7 +16,7 @@ const DropdownText: React.FC<TextProps> = styled(Text)(
     transition: ".2s",
     padding: `${theme.space.x1} ${theme.space.x2}`,
   }),
-  color
+  addStyledProps
 );
 
 export default DropdownText;

--- a/src/List/List.tsx
+++ b/src/List/List.tsx
@@ -1,28 +1,10 @@
 import styled from "styled-components";
-import {
-  space,
-  SpaceProps,
-  color,
-  ColorProps,
-  typography,
-  TypographyProps,
-  layout,
-  LayoutProps,
-  boxShadow,
-  BoxShadowProps,
-  border,
-  BorderProps,
-} from "styled-system";
-import ListItem from "./ListItem";
 import { DefaultNDSThemeType } from "../theme.type";
+import { addStyledProps, StyledProps } from "../StyledProps";
+import ListItem from "./ListItem";
 
 type ListProps = React.ComponentPropsWithRef<"ul"> &
-  SpaceProps &
-  BorderProps &
-  ColorProps &
-  LayoutProps &
-  TypographyProps &
-  BoxShadowProps & {
+  StyledProps & {
     theme?: DefaultNDSThemeType;
     className?: string;
     compact?: boolean;
@@ -38,12 +20,7 @@ const List: React.FC<ListProps> = styled.ul(
       marginBottom: compact ? 0 : theme.space.x1,
     },
   }),
-  space,
-  color,
-  typography,
-  layout,
-  boxShadow,
-  border
+  addStyledProps
 );
 List.defaultProps = {
   className: undefined,

--- a/src/NavBar/MenuTrigger.tsx
+++ b/src/NavBar/MenuTrigger.tsx
@@ -4,10 +4,18 @@ import PropTypes from "prop-types";
 import { themeGet } from "@styled-system/theme-get";
 import theme from "../theme";
 import { Icon } from "../Icon";
-import type { MenuTriggerProps } from "../BrandedNavBar/MenuTrigger";
 import NavBarDropdownMenu from "./NavBarDropdownMenu";
 import SubMenuTrigger from "./SubMenuTrigger";
 import renderSubMenuItems from "./renderSubMenuItems";
+
+export type MenuTriggerProps = {
+  name?: string;
+  "aria-label"?: string;
+  color?: string;
+  hoverColor?: string;
+  hoverBackground?: string;
+  menuData?: any[];
+};
 
 const StyledButton = styled.button<{
   hoverColor: string;

--- a/src/StyledProps/index.ts
+++ b/src/StyledProps/index.ts
@@ -1,0 +1,50 @@
+import {
+  space,
+  SpaceProps,
+  color,
+  ColorProps,
+  typography,
+  TypographyProps,
+  layout,
+  LayoutProps,
+  boxShadow,
+  BoxShadowProps,
+  border,
+  BorderProps,
+  compose,
+  overflow,
+  OverflowProps,
+} from "styled-system";
+import { textOverflow, TextOverflowProps } from "./textOverflow";
+import { cursor, CursorProps } from "./cursor";
+import { transform, TransformProps } from "./transform";
+import { transition, TransitionProps } from "./transition";
+import { visibility, VisibilityProps } from "./visibility";
+
+export const addStyledProps = compose(
+  border,
+  boxShadow,
+  color,
+  cursor,
+  layout,
+  overflow,
+  space,
+  textOverflow,
+  transform,
+  transition,
+  typography,
+  visibility
+);
+
+export type StyledProps = BorderProps &
+  BoxShadowProps &
+  ColorProps &
+  CursorProps &
+  LayoutProps &
+  OverflowProps &
+  SpaceProps &
+  TextOverflowProps &
+  TransformProps &
+  TransitionProps &
+  TypographyProps &
+  VisibilityProps;

--- a/src/Type/Text.tsx
+++ b/src/Type/Text.tsx
@@ -1,20 +1,6 @@
 import styled, { CSSObject } from "styled-components";
-import {
-  color,
-  space,
-  typography,
-  SpaceProps,
-  TypographyProps,
-  ColorProps,
-  OverflowProps,
-  overflow,
-  LayoutProps,
-  layout,
-  compose,
-} from "styled-system";
-import { TextOverflowProps, textOverflow } from "../StyledProps/textOverflow";
-import { CursorProps, cursor } from "../StyledProps/cursor";
 import type { DefaultNDSThemeType } from "../theme.type";
+import { addStyledProps, StyledProps } from "../StyledProps";
 const getAttrs = (inline?: boolean) => (inline ? { as: "span" } : null);
 
 export type TextProps = React.HTMLAttributes<HTMLParagraphElement> & {
@@ -34,13 +20,7 @@ export type TextProps = React.HTMLAttributes<HTMLParagraphElement> & {
     | "uppercase"
     | undefined;
   fontSize?: string;
-} & SpaceProps &
-  OverflowProps &
-  LayoutProps &
-  TextOverflowProps &
-  TypographyProps &
-  CursorProps &
-  ColorProps & { theme?: DefaultNDSThemeType };
+} & StyledProps & { theme?: DefaultNDSThemeType };
 
 const Text = styled.p.attrs<TextProps>((props: TextProps) =>
   getAttrs(props.inline)
@@ -54,7 +34,7 @@ const Text = styled.p.attrs<TextProps>((props: TextProps) =>
     lineHeight: theme.lineHeights.base,
     opacity: disabled ? "0.7" : undefined,
   }),
-  compose(space, typography, color, layout, overflow, textOverflow, cursor)
+  addStyledProps
 );
 Text.defaultProps = {
   inline: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,3 +82,5 @@ export { ApplicationFrame, Page, Sidebar } from "./Layout";
 export { useWindowDimensions } from "./utils";
 export { Divider } from "./Divider";
 export { SortingTable } from "./SortingTable";
+export { addStyledProps } from "./StyledProps";
+export type { StyledProps } from "./StyledProps";


### PR DESCRIPTION
## Description

1. Adds a `trigger` prop to the BrandedNavBar which allows the trigger for menus to be customized.
2. Pass `size` into BrandedNavBar custom `trigger` and `render` functions so that they know if they are being rendered in a `medium` (regular) or `small` (hamburger) format.
3. Pass `layer` into BrandedNavBar custom `trigger` and `render` functions so that they know how deep in the menu they are being rendered.
4. Adds a convenience method to make it easy to add styled-system props to components.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [x] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [x] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
