### PR TITLE
fix: BrandedNavBar top-level custom hamburger menu item line heights

### DIFF
--- a/src/BrandedNavBar/MobileMenu.tsx
+++ b/src/BrandedNavBar/MobileMenu.tsx
@@ -198,6 +198,7 @@ const SubMenu = ({
 );
 
 const Menu = styled.ul(({ theme }) => ({
+  listStyle: "none",
   margin: "0",
   padding: `${theme.space.x1} 0`,
   zIndex: theme.zIndices.content,


### PR DESCRIPTION
## Description

1. Sets the `list-style` of the `ul` elements in the BrandedNavBar hamburger menu to blank to get rid of the `::marker` elements which play havoc with spacing because they take up space according to the `line-height` css property.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
