### PR TITLE
fix: clean up toast timeout on unmount

### DIFF
--- a/src/Toast/Toast.tsx
+++ b/src/Toast/Toast.tsx
@@ -99,6 +99,7 @@ export const Toast = ({
       setVisible(false);
       if (onHide) onHide();
     }
+    return () => {cancelHidingToast()}
   }, [triggered]);
   const onMouseIn = () => {
     if (!isCloseable) {


### PR DESCRIPTION
## Description
There is an issue where toasts do not always clean up their promises on dismount, we (ECO1 developers) believe this will fix the problem. Please reach out if you have any questions.

**Describe the change you're making, the motivations behind it, and any thing else a reviewer may need to know to approve this PR.**

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [x] Accessibility has been considered
