### PR TITLE
More BrandedNavBar styling freedom

### DIFF
--- a/src/BrandedNavBar/MobileMenu.tsx
+++ b/src/BrandedNavBar/MobileMenu.tsx
@@ -31,7 +31,6 @@ const getSharedStyles = (theme) => ({
   fontSize: theme.fontSizes.large,
   fontWeight: theme.fontWeights.medium,
   lineHeight: theme.lineHeights.heading3,
-  marginBottom: theme.space.x1,
   padding: `${theme.space.x1} ${theme.space.x3}`,
 });
 
@@ -69,15 +68,6 @@ const TopLevelText = styled(Text)(
   addStyledProps
 );
 
-type LiWithSpaceProps = {
-  theme?: DefaultNDSThemeType;
-  key?: string;
-};
-
-const LiWithSpace = styled.li(({ theme }: LiWithSpaceProps) => ({
-  marginBottom: theme.space.x1,
-}));
-
 const SubMenuItemsList = styled.ul({
   listStyle: "none",
   paddingLeft: "0",
@@ -92,12 +82,13 @@ const renderMenuLink = (menuItem, linkOnClick, themeColorObject, layer) => {
     to: menuItem.to,
     // eslint-disable-next-line no-mixed-operators
     pl: layer === 0 ? getPaddingLeft(layer) : `${24 * layer + 20}px`,
+    mb: "x1",
   };
   const MenuLink: React.FC<LinkProps> = layer === 0 ? TopLevelLink : DropdownLink;
   return (
-    <LiWithSpace key={menuItem.key ?? menuItem.name}>
+    <li key={menuItem.key ?? menuItem.name}>
       <MenuLink {...sharedLinkProps}>{menuItem.name}</MenuLink>
-    </LiWithSpace>
+    </li>
   );
 };
 
@@ -114,9 +105,11 @@ const renderSubMenu = (menuItem, linkOnClick, themeColorObject, layer) => (
 const renderText = (menuItem, linkOnClick, themeColorObject, layer) => {
   const MenuText = layer === 0 ? TopLevelText : DropdownText;
   return (
-    <LiWithSpace key={menuItem.key ?? menuItem.name}>
-      <MenuText pl={getPaddingLeft(layer)}>{menuItem.name}</MenuText>
-    </LiWithSpace>
+    <li key={menuItem.key ?? menuItem.name}>
+      <MenuText pl={getPaddingLeft(layer)} mb="x1">
+        {menuItem.name}
+      </MenuText>
+    </li>
   );
 };
 
@@ -143,7 +136,9 @@ const renderTopLayerMenuItems = (menuData, linkOnClick, themeColorObject) =>
 
 const getSubMenuHeading = (layer, name) =>
   layer === 0 ? (
-    <TopLevelText as="h3">{name}</TopLevelText>
+    <TopLevelText as="h3" mb="x1">
+      {name}
+    </TopLevelText>
   ) : (
     <DropdownText mb="x1" pl={getPaddingLeft(layer)}>
       {name}

--- a/src/BrandedNavBar/MobileMenu.tsx
+++ b/src/BrandedNavBar/MobileMenu.tsx
@@ -102,9 +102,7 @@ const renderMenuLink = (menuItem, linkOnClick, themeColorObject, layer) => {
 };
 
 const renderCustom = (menuItem, linkOnClick, themeColorObject, layer) => (
-  <LiWithSpace key={menuItem.key ?? menuItem.name}>
-    {menuItem.render({ size: "small", onItemClick: linkOnClick, layer })}
-  </LiWithSpace>
+  <li key={menuItem.key ?? menuItem.name}>{menuItem.render({ size: "small", onItemClick: linkOnClick, layer })}</li>
 );
 
 const renderSubMenu = (menuItem, linkOnClick, themeColorObject, layer) => (

--- a/src/BrandedNavBar/MobileMenu.tsx
+++ b/src/BrandedNavBar/MobileMenu.tsx
@@ -5,9 +5,10 @@ import { Text, Heading3 } from "../Type";
 import { Flex } from "../Flex";
 import { BrandingText } from "../Branding";
 import { DefaultNDSThemeType } from "../theme.type";
-import { DropdownLink, DropdownText, DropdownButton } from "../DropdownMenu";
+import { DropdownLink, DropdownText } from "../DropdownMenu";
 import { Link } from "../Link";
 import { LinkProps } from "../Link/Link";
+import { addStyledProps } from "../StyledProps";
 import NulogyLogo from "./NulogyLogo";
 import { TriggerFunctionProps } from "./TriggerFunctionProps";
 
@@ -32,52 +33,49 @@ const getSharedStyles = (theme) => ({
   lineHeight: theme.lineHeights.heading3,
   marginBottom: theme.space.x1,
   padding: `${theme.space.x1} ${theme.space.x3}`,
-  paddingLeft: getPaddingLeft(0),
 });
 
-const TopLevelLink = styled(Link)(({ theme }) => ({
-  ...getSharedStyles(theme),
-  color: theme.colors.darkBlue,
-  "&:visited": {
+const TopLevelLink = styled(Link)(
+  ({ theme }) => ({
+    ...getSharedStyles(theme),
     color: theme.colors.darkBlue,
-  },
-  width: "100%",
-  borderRadius: "0",
-  transition: ".2s",
-  "&:hover, &:focus": {
-    outline: "none",
+    "&:visited": {
+      color: theme.colors.darkBlue,
+    },
+    width: "100%",
+    borderRadius: "0",
+    transition: ".2s",
+    "&:hover, &:focus": {
+      outline: "none",
+      color: theme.colors.blackBlue,
+      backgroundColor: theme.colors.whiteGrey,
+      cursor: "pointer",
+    },
+    "&:focus": {
+      boxShadow: theme.shadows.focus,
+    },
+    "&:disabled": {
+      opacity: ".5",
+    },
+  }),
+  addStyledProps
+);
+
+const TopLevelText = styled(Text)(
+  ({ theme }) => ({
+    ...getSharedStyles(theme),
     color: theme.colors.blackBlue,
-    backgroundColor: theme.colors.whiteGrey,
-    cursor: "pointer",
-  },
-  "&:focus": {
-    boxShadow: theme.shadows.focus,
-  },
-  "&:disabled": {
-    opacity: ".5",
-  },
-}));
+  }),
+  addStyledProps
+);
 
-const TopLevelText = styled(Text)(({ theme }) => ({
-  ...getSharedStyles(theme),
-  color: theme.colors.blackBlue,
-}));
-
-type ChildIndentingLiProps = {
-  layer?: number;
+type LiWithSpaceProps = {
   theme?: DefaultNDSThemeType;
   key?: string;
 };
 
-const ChildIndentingLi = styled.li(({ layer, theme }: ChildIndentingLiProps) => ({
+const LiWithSpace = styled.li(({ theme }: LiWithSpaceProps) => ({
   marginBottom: theme.space.x1,
-  [`> ${DropdownButton}, > ${DropdownLink}`]: {
-    // eslint-disable-next-line no-mixed-operators
-    paddingLeft: `${24 * layer + 20}px`,
-  },
-  [`> ${DropdownText}`]: {
-    paddingLeft: getPaddingLeft(layer),
-  },
 }));
 
 const SubMenuItemsList = styled.ul({
@@ -87,20 +85,26 @@ const SubMenuItemsList = styled.ul({
 });
 
 const renderMenuLink = (menuItem, linkOnClick, themeColorObject, layer) => {
+  const sharedLinkProps = {
+    onClick: linkOnClick,
+    href: menuItem.href,
+    as: menuItem.as,
+    to: menuItem.to,
+    // eslint-disable-next-line no-mixed-operators
+    pl: layer === 0 ? getPaddingLeft(layer) : `${24 * layer + 20}px`,
+  };
   const MenuLink: React.FC<LinkProps> = layer === 0 ? TopLevelLink : DropdownLink;
   return (
-    <ChildIndentingLi layer={layer} key={menuItem.key ?? menuItem.name}>
-      <MenuLink onClick={linkOnClick} href={menuItem.href} as={menuItem.as} to={menuItem.to}>
-        {menuItem.name}
-      </MenuLink>
-    </ChildIndentingLi>
+    <LiWithSpace key={menuItem.key ?? menuItem.name}>
+      <MenuLink {...sharedLinkProps}>{menuItem.name}</MenuLink>
+    </LiWithSpace>
   );
 };
 
 const renderCustom = (menuItem, linkOnClick, themeColorObject, layer) => (
-  <ChildIndentingLi layer={layer} key={menuItem.key ?? menuItem.name}>
+  <LiWithSpace key={menuItem.key ?? menuItem.name}>
     {menuItem.render({ size: "small", onItemClick: linkOnClick, layer })}
-  </ChildIndentingLi>
+  </LiWithSpace>
 );
 
 const renderSubMenu = (menuItem, linkOnClick, themeColorObject, layer) => (
@@ -112,9 +116,9 @@ const renderSubMenu = (menuItem, linkOnClick, themeColorObject, layer) => (
 const renderText = (menuItem, linkOnClick, themeColorObject, layer) => {
   const MenuText = layer === 0 ? TopLevelText : DropdownText;
   return (
-    <ChildIndentingLi layer={layer} key={menuItem.key ?? menuItem.name}>
-      <MenuText>{menuItem.name}</MenuText>
-    </ChildIndentingLi>
+    <LiWithSpace key={menuItem.key ?? menuItem.name}>
+      <MenuText pl={getPaddingLeft(layer)}>{menuItem.name}</MenuText>
+    </LiWithSpace>
   );
 };
 
@@ -143,7 +147,7 @@ const getSubMenuHeading = (layer, name) =>
   layer === 0 ? (
     <TopLevelText as="h3">{name}</TopLevelText>
   ) : (
-    <DropdownText mb="x1" style={{ paddingLeft: getPaddingLeft(layer) }}>
+    <DropdownText mb="x1" pl={getPaddingLeft(layer)}>
       {name}
     </DropdownText>
   );

--- a/src/Link/Link.tsx
+++ b/src/Link/Link.tsx
@@ -1,14 +1,11 @@
 import styled, { CSSObject } from "styled-components";
-import { color, space, typography, ColorProps, SpaceProps, LayoutProps, TypographyProps } from "styled-system";
 import { darken } from "polished";
 import { themeGet } from "@styled-system/theme-get";
 import { DefaultNDSThemeType } from "../theme.type";
+import { addStyledProps, StyledProps } from "../StyledProps";
 
 export type LinkProps = React.ComponentPropsWithRef<"a"> &
-  ColorProps &
-  SpaceProps &
-  LayoutProps &
-  TypographyProps & {
+  StyledProps & {
     className?: string;
     underline?: boolean;
     hover?: string;
@@ -26,31 +23,35 @@ const resetButtonStyles = {
   border: "none",
 };
 
-const getHoverColor = (props: LinkProps) =>
-  props.hover ? props.color : darken("0.1", themeGet(`colors.${props.color}`, props.color)(props));
+function getColorFromProps(props: LinkProps) {
+  return themeGet(`colors.${props.color}`, props.color)(props);
+}
+
+function getColor(props: LinkProps) {
+  return getColorFromProps(props) || props.theme.colors.blue;
+}
+
+const getHoverColor = (props: LinkProps) => (props.hover ? getColor(props) : darken("0.1", getColor(props)));
 
 const Link = styled.a.withConfig({
   shouldForwardProp: (prop, defaultValidatorFn) => !["underline", "hover"].includes(prop) && defaultValidatorFn(prop),
 })<LinkProps>(
-  color,
-  space,
-  typography,
   ({ underline, as, ...props }: LinkProps): CSSObject => ({
     ...resetButtonStyles,
     padding: as === "button" ? "0" : undefined,
     textDecoration: underline ? "underline" : "none",
+    fontSize: props.theme.fontSizes.medium,
+    color: getColor(props),
     "&:hover": {
       cursor: "pointer",
       color: getHoverColor(props),
     },
-  })
+  }),
+  addStyledProps
 );
 
 Link.defaultProps = {
-  className: undefined,
   underline: true,
-  fontSize: "medium",
-  color: "blue",
 };
 
 export default Link;


### PR DESCRIPTION
## Description

1. Stops setting left padding on custom rendered BrandedNavBar items when they are custom-rendered instances of `DropdownMenu`, `DropdownText`, or `DropdownButton`.
2. Stops adding 8px to the bottom margin of custom rendered BrandedNavBar items.
3. Fix Link to accept styled-system props.

The changes in this ticket are non-breaking because no one is using the API that is being modified except for Eco.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [x] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
