### PR TITLE
fix: add a button type to the sidebar close button

### DIFF
--- a/src/Button/IconicButton.tsx
+++ b/src/Button/IconicButton.tsx
@@ -8,18 +8,15 @@ import icons from "@nulogy/icons";
 import { Icon } from "../Icon";
 import { Text } from "../Type";
 
-type IconicButtonProps = SpaceProps & {
-  className?: string;
-  color?: string;
-  labelHidden?: boolean;
-  disabled?: boolean;
-  onClick?: (...args: any[]) => any;
-  icon?: any;
-  iconSize?: string;
-  fontSize?: string;
-  tooltip?: string;
-  children?: any;
-};
+type IconicButtonProps = React.HTMLProps<HTMLButtonElement> &
+  SpaceProps & {
+    color?: string;
+    labelHidden?: boolean;
+    icon?: any;
+    iconSize?: string;
+    fontSize?: string;
+    tooltip?: string;
+  };
 
 const HoverText: React.FC<any> = styled.div(({ theme }) => ({
   whiteSpace: "nowrap",

--- a/src/Layout/Sidebar.spec.tsx
+++ b/src/Layout/Sidebar.spec.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 import { fireEvent } from "@testing-library/react";
+import { PrimaryButton } from "../Button";
 import { renderWithNDSProvider } from "../NDSProvider/renderWithNDSProvider.spec-utils";
 import { Sidebar } from ".";
 
 describe("Sidebar", () => {
   describe("callbacks", () => {
-    const onCloseHandler = jest.fn();
-
     it("calls onClose callback when dismissed with a close button", () => {
+      const onCloseHandler = jest.fn();
+
       const { getByLabelText } = renderWithNDSProvider(
         <Sidebar isOpen onClose={onCloseHandler}>
           Sidebar
@@ -31,6 +32,7 @@ describe("Sidebar", () => {
       );
       expect(queryByTestId("sidebar-overlay")).toHaveStyle("opacity: 0");
     });
+
     it("doesn't use an overlay if the sidebar stays open on outside clicks", () => {
       const { queryByTestId } = renderWithNDSProvider(
         <Sidebar isOpen overlay={false} closeOnOutsideClick={false}>
@@ -38,6 +40,23 @@ describe("Sidebar", () => {
         </Sidebar>
       );
       expect(queryByTestId("sidebar-overlay")).toBeNull();
+    });
+
+    it("does not submit the form when closing the sidebar", () => {
+      const onSubmit = jest.fn();
+
+      const { getByLabelText } = renderWithNDSProvider(
+        <form onSubmit={onSubmit}>
+          <Sidebar isOpen footer={<PrimaryButton type="submit" />}>
+            Sidebar
+          </Sidebar>
+        </form>
+      );
+
+      const closeBtn = getByLabelText("Close");
+      fireEvent.click(closeBtn);
+
+      expect(onSubmit).not.toHaveBeenCalled();
     });
   });
 

--- a/src/Layout/Sidebar.tsx
+++ b/src/Layout/Sidebar.tsx
@@ -182,6 +182,7 @@ const Sidebar: React.FC<SidebarProps> = ({
             {!hideCloseButton && (
               <Box marginLeft="x2">
                 <IconicButton
+                  type="button"
                   ref={closeButton}
                   icon="close"
                   onClick={onClose}


### PR DESCRIPTION
## Description
Currently when used within a form, the sidebar close button causes the form to submit since the default type for a button when used inside of a form if the type attribute is not specified is "submit".

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [x] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
