### PR TITLE
Fix close button type alert

### DIFF
--- a/src/Alert/CloseButton.tsx
+++ b/src/Alert/CloseButton.tsx
@@ -15,6 +15,7 @@ const CloseButton = ({ onClick, "aria-label": ariaLabel }: CloseButtonProps) => 
     <Flex ml="x2">
       <Link
         as="button"
+        type="button"
         color="darkGrey"
         lineHeight="0"
         hover="blue"

--- a/src/Button/IconicButton.story.tsx
+++ b/src/Button/IconicButton.story.tsx
@@ -84,7 +84,7 @@ WithATooltipAndLabel.story = {
 };
 
 export const rightAligned = () => (
-  <Flex px="x3" height="15000px">
+  <Flex px="x3" height="150px">
     <Flex justifyContent="flex-end" alignItems="flex-start" width="100%">
       <IconicButton icon="rightArrow" labelHidden>
         I am an Iconic Button


### PR DESCRIPTION
## Description
Change the button type to be "button" to prevent it from submitting forms. 

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
