### PR TITLE
fix: modify iconic button props type

### DIFF
--- a/src/Button/IconicButton.tsx
+++ b/src/Button/IconicButton.tsx
@@ -8,15 +8,16 @@ import icons from "@nulogy/icons";
 import { Icon } from "../Icon";
 import { Text } from "../Type";
 
-type IconicButtonProps = React.HTMLProps<HTMLButtonElement> &
-  SpaceProps & {
-    color?: string;
-    labelHidden?: boolean;
-    icon?: any;
-    iconSize?: string;
-    fontSize?: string;
-    tooltip?: string;
-  };
+type BaseProps = {
+  color?: string;
+  labelHidden?: boolean;
+  icon?: any;
+  iconSize?: string;
+  fontSize?: string;
+  tooltip?: string;
+};
+
+type IconicButtonProps = BaseProps & SpaceProps & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseProps>;
 
 const HoverText: React.FC<any> = styled.div(({ theme }) => ({
   whiteSpace: "nowrap",


### PR DESCRIPTION
## Description
Change the IconicButton types to use `React.ButtonHTMLAttributes<HTMLButtonElement>`

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
