### PR TITLE
feat: add hoverBackgroundColor prop to the IconicButton component

### DIFF
--- a/src/Button/IconicButton.story.tsx
+++ b/src/Button/IconicButton.story.tsx
@@ -132,3 +132,26 @@ export const WithNonTextChildren = () => (
 WithNonTextChildren.story = {
   name: "with non text children",
 };
+
+export const WithCustomHoverBackgroundThemeColor = () => (
+  <IconicButton hoverBackgroundColor="lightYellow" fontSize="small" aria-label="warnings" icon="warning">
+    <Flex>
+      <Box as="span" pr="x1">
+        Warnings
+      </Box>
+    </Flex>
+  </IconicButton>
+);
+
+export const WithCustomHoverBackgroundNonThemeColor = () => (
+  <IconicButton hoverBackgroundColor="#FA8072" fontSize="small" aria-label="warnings" icon="warning">
+    <Flex>
+      <Box as="span" pr="x1">
+        Warnings
+      </Box>
+    </Flex>
+  </IconicButton>
+);
+WithNonTextChildren.story = {
+  name: "with non text children",
+};

--- a/src/Button/IconicButton.tsx
+++ b/src/Button/IconicButton.tsx
@@ -13,6 +13,7 @@ type BaseProps = {
   labelHidden?: boolean;
   icon?: any;
   iconSize?: string;
+  hoverBackgroundColor?: string;
   fontSize?: string;
   tooltip?: string;
 };
@@ -32,7 +33,7 @@ const HoverText: React.FC<any> = styled.div(({ theme }) => ({
 }));
 
 const WrapperButton: React.FC<any> = styled.button(
-  ({ disabled, theme }: any) => ({
+  ({ disabled, hoverBackgroundColor, theme }: any) => ({
     background: "transparent",
     border: "none",
     position: "relative",
@@ -54,7 +55,7 @@ const WrapperButton: React.FC<any> = styled.button(
     },
     "&:hover": {
       [`${Icon}`]: {
-        backgroundColor: theme.colors.lightBlue,
+        backgroundColor: theme.colors[hoverBackgroundColor] ?? hoverBackgroundColor,
       },
       [`${HoverText}`]: {
         opacity: "1",
@@ -90,7 +91,18 @@ const WrapperButton: React.FC<any> = styled.button(
 
 const IconicButton = React.forwardRef<HTMLButtonElement, IconicButtonProps>(
   (
-    { children, color = "darkBlue", icon, labelHidden, className, iconSize, fontSize, tooltip, ...props },
+    {
+      children,
+      color = "darkBlue",
+      hoverBackgroundColor = "lightBlue",
+      icon,
+      labelHidden,
+      className,
+      iconSize,
+      fontSize,
+      tooltip,
+      ...props
+    },
     forwardedRef
   ) => {
     return (
@@ -98,6 +110,7 @@ const IconicButton = React.forwardRef<HTMLButtonElement, IconicButtonProps>(
         ref={forwardedRef}
         aria-label={props["aria-label"] ? props["aria-label"] : typeof children === "string" ? children : undefined}
         className={className}
+        hoverBackgroundColor={hoverBackgroundColor}
         {...props}
       >
         <Manager>


### PR DESCRIPTION
## Description
Add hoverBackgroundColor prop to the IconicButton component.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [x] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [x] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
