### PR TITLE
Make branded nav bar hamburger menu more extensible

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "parser": "babel-eslint",
+  "parser": "@typescript-eslint/parser",
   "extends": ["@nulogy/nulogy"],
   "rules": {
     "jsx-a11y/label-has-associated-control": [

--- a/src/BrandedNavBar/MobileMenu.tsx
+++ b/src/BrandedNavBar/MobileMenu.tsx
@@ -4,7 +4,6 @@ import { display } from "styled-system";
 import { Text, Heading3 } from "../Type";
 import { Flex } from "../Flex";
 import { BrandingText } from "../Branding";
-import { DefaultNDSThemeType } from "../theme.type";
 import { DropdownLink, DropdownText } from "../DropdownMenu";
 import { Link } from "../Link";
 import { LinkProps } from "../Link/Link";
@@ -209,10 +208,17 @@ type BaseMobileMenuProps = {
   subtext?: string;
   closeMenu?: Function;
   themeColorObject?: ThemeColorObject;
-  logoSrc?: string;
+  showNulogyLogo?: boolean;
 };
 
-const BaseMobileMenu = ({ menuData, closeMenu, subtext, themeColorObject, logoSrc, ...props }: BaseMobileMenuProps) => (
+const BaseMobileMenu: React.FC<BaseMobileMenuProps> = ({
+  menuData,
+  closeMenu,
+  subtext,
+  themeColorObject,
+  showNulogyLogo,
+  ...props
+}) => (
   <Nav backgroundColor={themeColorObject && themeColorObject.background} {...props}>
     <BrandingWrap>
       <BrandingText logoColor={themeColorObject && themeColorObject.logoColor} />
@@ -221,7 +227,7 @@ const BaseMobileMenu = ({ menuData, closeMenu, subtext, themeColorObject, logoSr
       {menuData.primaryMenu && renderTopLayerMenuItems(menuData.primaryMenu, closeMenu, themeColorObject)}
       {menuData.secondaryMenu && renderTopLayerMenuItems(menuData.secondaryMenu, closeMenu, themeColorObject)}
     </Menu>
-    {logoSrc && (
+    {showNulogyLogo && (
       <Flex textAlign="center" borderTop={borderStyle} height="40px" alignItems="center" justifyContent="center">
         <NulogyLogo />
         {subtext && (

--- a/src/BrandedNavBar/NavBar.tsx
+++ b/src/BrandedNavBar/NavBar.tsx
@@ -8,7 +8,7 @@ import { Box } from "../Box";
 import DesktopMenu from "./DesktopMenu";
 import { NulogyLogoContainer } from "./NulogyLogoContainer";
 import EnvironmentBanner from "./EnvironmentBanner";
-import BrandLogoContainer, { BrandLogoContainerProps } from "./BrandLogoContainer";
+import BrandLogoContainer from "./BrandLogoContainer";
 import SmallNavBar from "./SmallNavBar";
 import NavBarBackground from "./NavBarBackground";
 
@@ -23,35 +23,29 @@ const themeColorObject = {
   logoColor: "blue",
 };
 
-type MediumNavBarProps = BrandLogoContainerProps & {
-  subtext?: string;
+type MediumNavBarProps = {
   menuData?: any;
   environment?: "development" | "training";
+  logo: React.ReactNode;
+  showNulogyLogo?: boolean;
+  subtext?: string;
 };
 
-const MediumNavBar = ({
+const MediumNavBar: React.FC<MediumNavBarProps> = ({
   menuData,
-  subtext,
   environment,
-  logoSrc,
-  brandingLinkHref = "/",
-  brandingLinkTo,
-  brandingLinkComponent,
+  logo,
+  showNulogyLogo,
+  subtext,
   ...props
-}: MediumNavBarProps) => {
+}) => {
   const { t } = useTranslation();
   return (
     <>
       {environment && <EnvironmentBanner>{environment}</EnvironmentBanner>}
       <header {...props}>
         <NavBarBackground backgroundColor="white" height={NAVBAR_HEIGHT}>
-          <BrandLogoContainer
-            logoSrc={logoSrc}
-            brandingLinkHref={brandingLinkHref}
-            brandingLinkTo={brandingLinkTo}
-            brandingLinkComponent={brandingLinkComponent}
-            subtext={subtext}
-          />
+          {logo}
           <Flex justifyContent="space-between" alignContent="flex-end" flexGrow={1} ml="x3" alignItems="center">
             {menuData.primaryMenu && (
               <DesktopMenu
@@ -68,7 +62,7 @@ const MediumNavBar = ({
                   menuData={menuData.secondaryMenu}
                 />
               )}
-              {logoSrc && (
+              {showNulogyLogo && (
                 <Box pl="x3">
                   <NulogyLogoContainer height={NAVBAR_HEIGHT} subText={subtext} />
                 </Box>
@@ -83,19 +77,40 @@ const MediumNavBar = ({
 
 const pixelDigitsFrom = (pixelString) => parseInt(pixelString, 10);
 
-const SelectNavBarBasedOnWidth = ({ width, defaultOpen, breakpointUpper, ...props }: any) => {
+const SelectNavBarBasedOnWidth = ({
+  width,
+  defaultOpen,
+  breakpointUpper,
+  brandingLinkHref = "/",
+  brandingLinkTo,
+  brandingLinkComponent,
+  logoSrc,
+  ...props
+}: any) => {
   const currentWidth = width || (typeof window !== "undefined" && window.innerWidth);
 
+  const logo = (
+    <BrandLogoContainer
+      logoSrc={logoSrc}
+      brandingLinkHref={brandingLinkHref}
+      brandingLinkTo={brandingLinkTo}
+      brandingLinkComponent={brandingLinkComponent}
+      subtext={props.subtext}
+    />
+  );
+
   if (currentWidth >= pixelDigitsFrom(breakpointUpper)) {
-    return <MediumNavBar {...props} />;
+    return <MediumNavBar logo={logo} showNulogyLogo={logoSrc} {...props} />;
   } else {
     return (
       <SmallNavBar
-        {...props}
         width={currentWidth}
         defaultOpen={defaultOpen}
         themeColorObject={themeColorObject}
         navBarHeight={NAVBAR_HEIGHT}
+        logo={logo}
+        showNulogyLogo={logoSrc}
+        {...props}
       />
     );
   }

--- a/src/BrandedNavBar/SmallNavBar.story.tsx
+++ b/src/BrandedNavBar/SmallNavBar.story.tsx
@@ -1,0 +1,133 @@
+import React from "react";
+import styled from "styled-components";
+import { select } from "@storybook/addon-knobs";
+import { Heading1 } from "../Type";
+import { Branding } from "../Branding";
+import { Link } from "../Link";
+import { theme } from "../index";
+import BrandLogoContainer from "./BrandLogoContainer";
+import { SmallNavBar } from "./index";
+
+const ResetStorybookView = styled.div({
+  position: "absolute",
+  top: 0,
+  left: 0,
+  width: "100vw",
+  height: "100vh",
+});
+
+const WrappedSmallNavBar = (props) => (
+  <ResetStorybookView>
+    <SmallNavBar navBarHeight="56px" {...props} />
+    <Heading1 mt="x3" ml="x1">
+      Some content
+    </Heading1>
+  </ResetStorybookView>
+);
+
+const primaryMenu = [
+  {
+    name: "Dashboard",
+    items: [{ name: "Items", href: "/" }, { name: "Carriers", href: "/" }, { name: "Only text submenu" }],
+  },
+  {
+    name: "Operations",
+    items: [
+      {
+        name: "Production",
+        items: [
+          { name: "Dashboard", href: "/" },
+          {
+            name: "Projects",
+            items: [
+              { name: "Cycle Counts", href: "/" },
+              { name: "Blind Counts", href: "/" },
+            ],
+          },
+          {
+            name: "Jobs",
+            items: [{ name: "Job 1", href: "/" }],
+          },
+        ],
+      },
+    ],
+  },
+  { name: "Link", href: "/" },
+  { name: "Only text" },
+];
+
+const secondaryMenu = [
+  {
+    name: "User@Nulogy.com",
+    items: [
+      { name: "Profile", href: "/" },
+      { name: "Preferences", href: "/" },
+      { name: "Logout", href: "/" },
+    ],
+  },
+  {
+    name: "Settings",
+    items: [
+      { name: "Permissions", href: "/" },
+      { name: "Manage account", href: "/" },
+    ],
+  },
+];
+
+const smallViewport = {
+  viewport: {
+    defaultViewport: "small", // for some reason this has to match the viewport key, NOT the name!
+  },
+  chromatic: { viewports: [parseInt(theme.breakpoints.small)] },
+};
+
+export default {
+  title: "Components/BrandedNavBar/SmallNavBar",
+  parameters: smallViewport,
+};
+
+export const _SmallNavBar = () => <WrappedSmallNavBar menuData={{ primaryMenu, secondaryMenu }} />;
+
+export const SmallNavBarOpen = () => <WrappedSmallNavBar menuData={{ primaryMenu, secondaryMenu }} defaultOpen />;
+
+export const WithALogo = () => (
+  <WrappedSmallNavBar
+    menuData={{ primaryMenu, secondaryMenu }}
+    logo={
+      <Link aria-label="Home" href="/" underline={false} style={{ display: "block" }}>
+        <Branding size="medium" logoType="wordmark" logoColor="blue" />
+      </Link>
+    }
+  />
+);
+
+export const WithALogoOpen = () => (
+  <WrappedSmallNavBar
+    menuData={{ primaryMenu, secondaryMenu }}
+    defaultOpen
+    logo={
+      <Link aria-label="Home" href="/" underline={false} style={{ display: "block" }}>
+        <Branding size="medium" logoType="wordmark" logoColor="blue" />
+      </Link>
+    }
+  />
+);
+export const WithABrandLogoContainerLogo = () => (
+  <WrappedSmallNavBar menuData={{ primaryMenu, secondaryMenu }} logo={<BrandLogoContainer brandingLinkHref="/" />} />
+);
+
+export const WithANulogyLogoAndAppName = () => (
+  <WrappedSmallNavBar
+    menuData={{ primaryMenu, secondaryMenu }}
+    subtext="Quality control"
+    showNulogyLogo={true}
+    defaultOpen
+  />
+);
+
+export const WithEnvironmentBanner = () => (
+  <WrappedSmallNavBar
+    menuData={{ primaryMenu, secondaryMenu }}
+    environment={select("environment", ["training", "development"], "training")}
+  />
+);

--- a/src/BrandedNavBar/SmallNavBar.story.tsx
+++ b/src/BrandedNavBar/SmallNavBar.story.tsx
@@ -16,7 +16,7 @@ const ResetStorybookView = styled.div({
   height: "100vh",
 });
 
-const WrappedSmallNavBar = (props) => (
+const WrappedSmallNavBar = (props: Partial<SmallNavBarProps>) => (
   <ResetStorybookView>
     <SmallNavBar navBarHeight="56px" {...props} />
     <Heading1 mt="x3" ml="x1">

--- a/src/BrandedNavBar/SmallNavBar.story.tsx
+++ b/src/BrandedNavBar/SmallNavBar.story.tsx
@@ -4,7 +4,7 @@ import { select } from "@storybook/addon-knobs";
 import { Heading1 } from "../Type";
 import { Branding } from "../Branding";
 import { Link } from "../Link";
-import { theme } from "../index";
+import { Button, SmallNavBarProps, theme } from "../index";
 import BrandLogoContainer from "./BrandLogoContainer";
 import { SmallNavBar } from "./index";
 
@@ -129,5 +129,17 @@ export const WithEnvironmentBanner = () => (
   <WrappedSmallNavBar
     menuData={{ primaryMenu, secondaryMenu }}
     environment={select("environment", ["training", "development"], "training")}
+  />
+);
+
+export const WithCustomMenuButton = () => (
+  <WrappedSmallNavBar
+    menuData={{ primaryMenu, secondaryMenu }}
+    environment={select("environment", ["training", "development"], "training")}
+    renderMenuButton={({ onClick, ariaExpanded, isOpen }) => (
+      <Button onClick={onClick} aria-expanded={ariaExpanded}>
+        Click to {isOpen ? "close" : "open"}
+      </Button>
+    )}
   />
 );

--- a/src/BrandedNavBar/SmallNavBar.tsx
+++ b/src/BrandedNavBar/SmallNavBar.tsx
@@ -6,7 +6,6 @@ import { DefaultNDSThemeType } from "../theme.type";
 import { Flex } from "../Flex";
 import NavBarSearch from "../NavBarSearch/NavBarSearch";
 import { PreventBodyElementScrolling, subPx, withMenuState, WithMenuStateProps } from "../utils";
-import BrandLogoContainer, { BrandLogoContainerProps } from "./BrandLogoContainer";
 import EnvironmentBanner from "./EnvironmentBanner";
 import MobileMenu from "./MobileMenu";
 import NavBarBackground from "./NavBarBackground";
@@ -69,18 +68,18 @@ const MenuIcon = ({ isOpen }) => {
   return <Icon icon={icon} title={title} />;
 };
 
-type SmallNavBarNoStateProps = BrandLogoContainerProps & {
+type SmallNavBarNoStateProps = {
   menuState?: any;
   menuData?: any;
   subtext?: string;
-  brandingLinkHref?: string;
-  brandingLinkTo?: string;
   breakpointLower?: number | string;
   width?: number;
   themeColor?: "blue" | "white";
   themeColorObject: any;
   environment?: "development" | "training";
   navBarHeight: string;
+  logo: React.ReactElement;
+  showNulogyLogo?: boolean;
 };
 
 /* eslint-disable react/destructuring-assignment */
@@ -88,13 +87,12 @@ const SmallNavBarNoState = ({
   menuData,
   menuState: { isOpen, toggleMenu, closeMenu },
   subtext,
-  brandingLinkHref = "/",
-  brandingLinkTo,
   environment,
-  logoSrc,
+  showNulogyLogo,
   breakpointLower = "small",
   themeColorObject,
   navBarHeight,
+  logo,
   ...props
 }: SmallNavBarNoStateProps) => {
   const navRef = React.useRef(null);
@@ -115,12 +113,7 @@ const SmallNavBarNoState = ({
     >
       {environment && <EnvironmentBanner>{environment}</EnvironmentBanner>}
       <NavBarBackground backgroundColor="white" height={navBarHeight}>
-        <BrandLogoContainer
-          logoSrc={logoSrc}
-          brandingLinkHref={brandingLinkHref}
-          brandingLinkTo={brandingLinkTo}
-          subtext={subtext}
-        />
+        {logo}
         <Flex justifyContent="flex-end" ml="x3" flexGrow={1}>
           {menuData.search && (
             <Flex maxWidth="18em" alignItems="center" px="0">
@@ -141,7 +134,7 @@ const SmallNavBarNoState = ({
             subtext={subtext}
             menuData={menuData}
             closeMenu={closeMenu}
-            logoSrc={logoSrc}
+            showNulogyLogo={showNulogyLogo}
           />
         </PreventBodyElementScrolling>
       )}

--- a/src/BrandedNavBar/SmallNavBar.tsx
+++ b/src/BrandedNavBar/SmallNavBar.tsx
@@ -5,7 +5,7 @@ import { Icon } from "../Icon";
 import { DefaultNDSThemeType } from "../theme.type";
 import { Flex } from "../Flex";
 import NavBarSearch from "../NavBarSearch/NavBarSearch";
-import { PreventBodyElementScrolling, subPx, withMenuState, WithMenuStateProps } from "../utils";
+import { PreventBodyElementScrolling, subPx, withMenuState, WithMenuStateProps, AcceptsMenuStateProps } from "../utils";
 import EnvironmentBanner from "./EnvironmentBanner";
 import MobileMenu from "./MobileMenu";
 import NavBarBackground from "./NavBarBackground";
@@ -69,7 +69,6 @@ const MenuIcon = ({ isOpen }) => {
 };
 
 type SmallNavBarNoStateProps = {
-  menuState?: any;
   menuData?: any;
   subtext?: string;
   breakpointLower?: number | string;
@@ -80,7 +79,7 @@ type SmallNavBarNoStateProps = {
   navBarHeight: string;
   logo: React.ReactElement;
   showNulogyLogo?: boolean;
-};
+} & AcceptsMenuStateProps;
 
 /* eslint-disable react/destructuring-assignment */
 const SmallNavBarNoState = ({

--- a/src/BrandedNavBar/SmallNavBar.tsx
+++ b/src/BrandedNavBar/SmallNavBar.tsx
@@ -74,10 +74,10 @@ type SmallNavBarNoStateProps = {
   breakpointLower?: number | string;
   width?: number;
   themeColor?: "blue" | "white";
-  themeColorObject: any;
+  themeColorObject?: any;
   environment?: "development" | "training";
   navBarHeight: string;
-  logo: React.ReactElement;
+  logo?: React.ReactElement;
   showNulogyLogo?: boolean;
 } & AcceptsMenuStateProps;
 

--- a/src/BrandedNavBar/SmallNavBar.tsx
+++ b/src/BrandedNavBar/SmallNavBar.tsx
@@ -68,6 +68,13 @@ const MenuIcon = ({ isOpen }) => {
   return <Icon icon={icon} title={title} />;
 };
 
+export type RenderMenuButtonProps = {
+  themeColorObject: any;
+  onClick: () => void;
+  ariaExpanded: true | null;
+  isOpen: boolean;
+};
+
 type SmallNavBarNoStateProps = {
   menuData?: any;
   subtext?: string;
@@ -79,6 +86,7 @@ type SmallNavBarNoStateProps = {
   navBarHeight: string;
   logo?: React.ReactElement;
   showNulogyLogo?: boolean;
+  renderMenuButton?: (props: RenderMenuButtonProps) => React.ReactElement;
 } & AcceptsMenuStateProps;
 
 /* eslint-disable react/destructuring-assignment */
@@ -92,6 +100,7 @@ const SmallNavBarNoState = ({
   themeColorObject,
   navBarHeight,
   logo,
+  renderMenuButton,
   ...props
 }: SmallNavBarNoStateProps) => {
   const navRef = React.useRef(null);
@@ -103,6 +112,7 @@ const SmallNavBarNoState = ({
   }, [isOpen]);
 
   const { breakpoints } = useTheme();
+  const ariaExpanded = isOpen ? true : null;
   return (
     <SmallHeader
       ref={navRef}
@@ -119,11 +129,19 @@ const SmallNavBarNoState = ({
               <NavBarSearch {...menuData.search} />
             </Flex>
           )}
-          {(menuData.primaryMenu || menuData.secondaryMenu) && (
-            <MobileMenuTrigger {...themeColorObject} onClick={toggleMenu} aria-expanded={isOpen ? true : null}>
-              <MenuIcon isOpen={isOpen} />
-            </MobileMenuTrigger>
-          )}
+          {(menuData.primaryMenu || menuData.secondaryMenu) &&
+            (renderMenuButton ? (
+              renderMenuButton({
+                themeColorObject: themeColorObject,
+                onClick: toggleMenu,
+                ariaExpanded,
+                isOpen,
+              })
+            ) : (
+              <MobileMenuTrigger {...themeColorObject} onClick={toggleMenu} aria-expanded={ariaExpanded}>
+                <MenuIcon isOpen={isOpen} />
+              </MobileMenuTrigger>
+            ))}
         </Flex>
       </NavBarBackground>
       {isOpen && (

--- a/src/BrandedNavBar/index.ts
+++ b/src/BrandedNavBar/index.ts
@@ -10,4 +10,4 @@ export type { BrandLogoContainerProps } from "./BrandLogoContainer";
 export { default as DesktopMenu } from "./DesktopMenu";
 export type { DesktopMenuProps } from "./DesktopMenu";
 export { default as SmallNavBar } from "./SmallNavBar";
-export type { SmallNavBarProps } from "./SmallNavBar";
+export type { SmallNavBarProps, RenderMenuButtonProps } from "./SmallNavBar";

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,7 @@ export type {
   BrandLogoContainerProps,
   DesktopMenuProps,
   SmallNavBarProps,
+  RenderMenuButtonProps,
 } from "./BrandedNavBar";
 export { AsyncSelect } from "./AsyncSelect";
 export { ApplicationFrame, Page, Sidebar } from "./Layout";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,6 +7,6 @@ export { default as DetectOutsideClick } from "./DetectOutsideClick";
 export { default as PopperArrow } from "./PopperArrow";
 export { default as ScrollIndicators } from "./ScrollIndicators";
 export { default as withMenuState } from "./withMenuState";
-export type { WithMenuStateProps } from "./withMenuState";
+export type { WithMenuStateProps, AcceptsMenuStateProps } from "./withMenuState";
 export { default as PreventBodyElementScrolling } from "./PreventBodyElementScrolling";
 export { default as useWindowDimensions } from "./useWindowDimensions";

--- a/src/utils/withMenuState.tsx
+++ b/src/utils/withMenuState.tsx
@@ -104,14 +104,18 @@ class MenuState extends MenuStateInt {
   }
 }
 
-const withMenuState = (MenuComponent) => {
-  const MenuComponentWithState = ({ showDelay, hideDelay, defaultOpen, ...props }) => (
-    <MenuState showDelay={showDelay} hideDelay={hideDelay} defaultOpen={defaultOpen}>
+export type AcceptsMenuStateProps = {
+  menuState?: any;
+};
+
+function withMenuState<P extends AcceptsMenuStateProps>(
+  MenuComponent: React.JSXElementConstructor<P>
+): React.JSXElementConstructor<P & WithMenuStateProps> {
+  return (props) => (
+    <MenuState showDelay={props.showDelay} hideDelay={props.hideDelay} defaultOpen={props.defaultOpen}>
       {(menuComponentProps) => <MenuComponent menuState={menuComponentProps} {...props} />}
     </MenuState>
   );
-
-  return MenuComponentWithState;
-};
+}
 
 export default withMenuState;


### PR DESCRIPTION
## Description

These customization points are not available via the public API of the BrandedNavBar. They are only to be used by Eco's new NavBar.

1. Allow the BrandedNavBar left-hand logo to be customized.
2. Allow the BrandedNavBar hamburger menu trigger to be customized.
3. Add types to the `withMenuState` function.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [x] feature: a non-breaking change that adds functionality
- [x] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [x] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
