### PR TITLE
fix: vertically centre the BrandedNavBar hamburger open and close buttons

### DIFF
--- a/src/BrandedNavBar/SmallNavBar.tsx
+++ b/src/BrandedNavBar/SmallNavBar.tsx
@@ -5,7 +5,7 @@ import { Icon } from "../Icon";
 import { DefaultNDSThemeType } from "../theme.type";
 import { Flex } from "../Flex";
 import NavBarSearch from "../NavBarSearch/NavBarSearch";
-import { PreventBodyElementScrolling, subPx, withMenuState, WithMenuStateProps, AcceptsMenuStateProps } from "../utils";
+import { PreventBodyElementScrolling, withMenuState, WithMenuStateProps, AcceptsMenuStateProps } from "../utils";
 import EnvironmentBanner from "./EnvironmentBanner";
 import MobileMenu from "./MobileMenu";
 import NavBarBackground from "./NavBarBackground";
@@ -21,7 +21,7 @@ const MobileMenuTrigger = styled.button(({ color, hoverColor, hoverBackground, t
   color: theme.colors[color] || color,
   background: "none",
   border: "none",
-  padding: `${subPx(theme.space.x1)} ${theme.space.x1}`,
+  padding: theme.space.x1,
   marginLeft: theme.space.x1,
   borderRadius: theme.radii.medium,
   transition: ".2s",


### PR DESCRIPTION
## Description

Henrique noticed that the BrandedNavBar hamburger open and close buttons weren't quite vertically centred. Not sure why the vertical margins on those buttons was being set to 7px instead of 8px, but the fix is quite straightforward!

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [x] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
