### PR TITLE
feat: pass along custom props to the Select component

### DIFF
--- a/src/Select/Select.spec.tsx
+++ b/src/Select/Select.spec.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { fireEvent } from "@testing-library/react";
 import { renderWithNDSProvider } from "../NDSProvider/renderWithNDSProvider.spec-utils";
 import { selectOption } from "./Select.spec-utils";
-import { UsingRefToControlFocus, WithMultiselect, WithState } from "./Select.story";
+import { UsingRefToControlFocus, WithCustomProps, WithMultiselect, WithState } from "./Select.story";
 import { Select } from ".";
 
 describe("select", () => {
@@ -37,6 +37,15 @@ describe("select", () => {
     selectOption("Three", container, queryByText);
     expect(container).toHaveTextContent("Three");
   });
+
+  it("passes along the custom props to custom components", () => {
+    const { container, queryByText } = renderWithNDSProvider(<WithCustomProps />);
+
+    selectOption("custom prop value", container, queryByText);
+
+    expect(container).toHaveTextContent("custom prop value");
+  });
+
   describe("with state", () => {
     it("clears the selected option", () => {
       const { container, queryByText } = renderWithNDSProvider(<WithState />);

--- a/src/Select/Select.story.tsx
+++ b/src/Select/Select.story.tsx
@@ -548,6 +548,26 @@ export const UsingRefToControlFocus = () => {
   );
 };
 
+const CustomOption = (props) => {
+  return <SelectOption {...props}>{props.selectProps.myCustomProp}</SelectOption>;
+};
+
+const CustomSingleValue = ({ innerProps, ...props }) => {
+  return <div {...innerProps}>{props.selectProps.myCustomProp}</div>;
+};
+
+export const WithCustomProps = () => {
+  return (
+    <>
+      <Select
+        options={[{ value: "accepted", label: "Accepted" }]}
+        myCustomProp="custom prop value"
+        components={{ Option: CustomOption, SingleValue: CustomSingleValue }}
+      />
+    </>
+  );
+};
+
 UsingRefToControlFocus.story = {
   name: "using ref to control focus",
 };

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -132,7 +132,6 @@ const ReactSelect = forwardRef(
       required,
       requirementText,
       helpText,
-      noOptionsMessage,
       disabled,
       errorMessage,
       errorList,
@@ -140,25 +139,14 @@ const ReactSelect = forwardRef(
       id,
       initialIsOpen,
       maxHeight,
-      menuPosition,
       multiselect,
-      name,
       onChange,
       placeholder,
       value,
       defaultValue,
-      className,
-      classNamePrefix,
-      onBlur,
-      menuIsOpen,
-      onMenuOpen,
-      onMenuClose,
-      onInputChange,
       components,
       "aria-label": ariaLabel,
       windowThreshold = 300,
-      filterOption,
-      closeMenuOnSelect,
       ...props
     }: SelectProps,
     ref
@@ -176,12 +164,7 @@ const ReactSelect = forwardRef(
         <MaybeFieldLabel labelText={labelText} requirementText={requirementText} helpText={helpText}>
           <WindowedSelect
             ref={ref}
-            className={className}
-            classNamePrefix={classNamePrefix}
-            noOptionsMessage={noOptionsMessage}
             placeholder={placeholder || t("select ...")}
-            options={options}
-            labelText={labelText}
             windowThreshold={windowThreshold}
             styles={customStyles({
               theme: themeContext,
@@ -195,17 +178,10 @@ const ReactSelect = forwardRef(
             aria-invalid={error}
             defaultMenuIsOpen={initialIsOpen}
             inputId={id}
-            onBlur={onBlur}
             onChange={onChange && ((option) => onChange(extractValue(option, multiselect)))}
             defaultValue={getReactSelectValue(options, defaultValue)}
             value={getReactSelectValue(options, value)}
-            name={name}
             isMulti={multiselect}
-            menuIsOpen={menuIsOpen}
-            onMenuOpen={onMenuOpen}
-            onMenuClose={onMenuClose}
-            menuPosition={menuPosition}
-            onInputChange={onInputChange}
             theme={themeContext}
             components={{
               Option: SelectOption,
@@ -219,8 +195,8 @@ const ReactSelect = forwardRef(
               ...components,
             }}
             aria-label={ariaLabel}
-            filterOption={filterOption}
-            closeMenuOnSelect={closeMenuOnSelect}
+            options={options}
+            labelText={labelText}
             {...props}
           />
           <InlineValidation mt="x1" errorMessage={errorMessage} errorList={errorList} />

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -221,6 +221,7 @@ const ReactSelect = forwardRef(
             aria-label={ariaLabel}
             filterOption={filterOption}
             closeMenuOnSelect={closeMenuOnSelect}
+            {...props}
           />
           <InlineValidation mt="x1" errorMessage={errorMessage} errorList={errorList} />
         </MaybeFieldLabel>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5619,15 +5619,10 @@ camelize@^1.0.0:
   resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
-caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001280:
-  version "1.0.30001282"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz#38c781ee0a90ccfe1fe7fefd00e43f5ffdcb96fd"
-  integrity sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg==
-
-caniuse-lite@^1.0.30001219:
-  version "1.0.30001239"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001239.tgz#66e8669985bb2cb84ccb10f68c25ce6dd3e4d2b8"
-  integrity sha512-cyBkXJDMeI4wthy8xJ2FvDU6+0dtcZSJW3voUF8+e9f1bBeuvyZfc3PNbkOETyhbR+dGCPzn9E7MA3iwzusOhQ==
+caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001280:
+  version "1.0.30001367"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001367.tgz"
+  integrity sha512-XDgbeOHfifWV3GEES2B8rtsrADx4Jf+juKX2SICJcaUhjYBO3bR96kvEIHa15VU6ohtOhBZuPGGYGbXMRn0NCw==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description
The `<Select />` currently swallows unknown props and doesn't drill them down to the `WindowedSelect` we are using underneath it. We sometimes need to pass custom props to the custom components like the `Option` and use them via `props.selectProps`. 

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [x] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
