### PR TITLE
fix: restore BrandedNavBar submenu item padding to normal 8px

### DIFF
--- a/src/BrandedNavBar/renderSubMenuItems.tsx
+++ b/src/BrandedNavBar/renderSubMenuItems.tsx
@@ -16,7 +16,7 @@ const renderSubMenuTrigger = (subMenuItem, onItemClick, SubMenuTrigger, layer) =
 
 const renderSubMenuLink = (subMenuItem, onItemClick) => (
   <NoWrapLi key={subMenuItem.key ?? subMenuItem.name}>
-    <DropdownLink py="half" onClick={onItemClick} href={subMenuItem.href} to={subMenuItem.to} as={subMenuItem.as}>
+    <DropdownLink onClick={onItemClick} href={subMenuItem.href} to={subMenuItem.to} as={subMenuItem.as}>
       {subMenuItem.name}
     </DropdownLink>
   </NoWrapLi>


### PR DESCRIPTION
## Description

1. Restores BrandedNavBar submenu item y-padding to the Dropdown default of 8px from 4px.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
