### PR TITLE
fix: change the arrow direction for the secondary menu sub-items

### DIFF
--- a/src/BrandedNavBar/DesktopMenu.tsx
+++ b/src/BrandedNavBar/DesktopMenu.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import { DefaultNDSThemeType } from "../theme.type";
 import MenuTrigger from "./MenuTrigger";
+import type { MenuType } from "./MenuTrigger";
 
 const getSharedStyles = (color, theme) => {
   return {
@@ -107,7 +108,7 @@ const renderMenuItem = (menuItem, themeColorObject, layer, menuType) =>
 
 export type DesktopMenuProps = {
   menuData: any[];
-  menuType: "primary" | "secondary";
+  menuType: MenuType;
   themeColorObject: any;
 };
 

--- a/src/BrandedNavBar/DesktopMenu.tsx
+++ b/src/BrandedNavBar/DesktopMenu.tsx
@@ -58,9 +58,10 @@ const Nav = styled.nav({
   alignItems: "center",
 });
 
-const renderMenuTrigger = (menuItem, themeColorObject, layer) => (
+const renderMenuTrigger = (menuItem, themeColorObject, layer, menuType) => (
   <div key={menuItem.key ?? menuItem.name}>
     <MenuTrigger
+      menuType={menuType}
       name={menuItem.name}
       aria-label={menuItem.ariaLabel}
       menuData={menuItem.items}
@@ -101,18 +102,19 @@ const getRenderFunction = (menuItem) => {
   }
 };
 
-const renderMenuItem = (menuItem, themeColorObject, layer) =>
-  getRenderFunction(menuItem)(menuItem, themeColorObject, layer);
+const renderMenuItem = (menuItem, themeColorObject, layer, menuType) =>
+  getRenderFunction(menuItem)(menuItem, themeColorObject, layer, menuType);
 
 export type DesktopMenuProps = {
   menuData: any[];
+  menuType: "primary" | "secondary";
   themeColorObject: any;
 };
 
 const BaseDesktopMenu = React.forwardRef<HTMLElement, DesktopMenuProps>(
-  ({ menuData, themeColorObject, ...props }, ref) => (
+  ({ menuData, menuType, themeColorObject, ...props }, ref) => (
     <Nav {...props} ref={ref}>
-      {menuData.map((menuItem) => renderMenuItem(menuItem, themeColorObject, 0))}
+      {menuData.map((menuItem) => renderMenuItem(menuItem, themeColorObject, 0, menuType))}
     </Nav>
   )
 );

--- a/src/BrandedNavBar/MenuTrigger.tsx
+++ b/src/BrandedNavBar/MenuTrigger.tsx
@@ -25,6 +25,7 @@ const MenuTrigger = ({
   "aria-label": ariaLabel,
   trigger,
   layer,
+  menuType,
   ...props
 }: MenuTriggerProps) => {
   let dropdownMinWidth = "auto";
@@ -78,7 +79,8 @@ const MenuTrigger = ({
               e.stopPropagation();
             },
             SubMenuTrigger,
-            layer + 1
+            layer + 1,
+            menuType
           )}
         </ul>
       )}

--- a/src/BrandedNavBar/MenuTrigger.tsx
+++ b/src/BrandedNavBar/MenuTrigger.tsx
@@ -5,6 +5,8 @@ import renderSubMenuItems from "./renderSubMenuItems";
 import MenuTriggerButton from "./MenuTriggerButton";
 import { TriggerFunctionProps } from "./TriggerFunctionProps";
 
+export type MenuType = "primary" | "secondary";
+
 export type MenuTriggerProps = {
   name?: string;
   "aria-label"?: string;
@@ -14,6 +16,7 @@ export type MenuTriggerProps = {
   menuData?: any[];
   trigger?: (props: TriggerFunctionProps) => React.ReactNode;
   layer: number;
+  menuType: MenuType;
 };
 
 const MenuTrigger = ({

--- a/src/BrandedNavBar/NavBar.story.tsx
+++ b/src/BrandedNavBar/NavBar.story.tsx
@@ -163,6 +163,61 @@ WithIcon.story = {
   name: "With icon",
 };
 
+export const WithPrimaryAndSecondarySubMenus = () => (
+  <BrandedNavBar
+    menuData={{
+      primaryMenu: [
+        {
+          name: "Operations",
+          items: [
+            {
+              name: "Production",
+              items: [
+                { name: "Dashboard", href: "/" },
+                {
+                  name: "Projects",
+                  items: [
+                    { name: "Cycle Counts", href: "/" },
+                    { name: "Blind Counts", href: "/" },
+                  ],
+                },
+                {
+                  name: "Jobs",
+                  items: [{ name: "Job 1", href: "/" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      secondaryMenu: [
+        {
+          name: "Settings",
+          items: [
+            {
+              name: "Production",
+              items: [
+                { name: "Dashboard", href: "/" },
+                {
+                  name: "Projects",
+                  items: [
+                    { name: "Cycle Counts", href: "/" },
+                    { name: "Blind Counts", href: "/" },
+                  ],
+                },
+                {
+                  name: "Jobs",
+                  items: [{ name: "Job 1", href: "/" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }}
+  />
+);
+
 const primaryMenuReactRouter = [
   {
     name: "Dashboard",

--- a/src/BrandedNavBar/NavBar.tsx
+++ b/src/BrandedNavBar/NavBar.tsx
@@ -51,6 +51,7 @@ const MediumNavBar: React.FC<MediumNavBarProps> = ({
               <DesktopMenu
                 themeColorObject={themeColorObject}
                 aria-label={t("primary navigation")}
+                menuType="primary"
                 menuData={menuData.primaryMenu}
               />
             )}
@@ -59,6 +60,7 @@ const MediumNavBar: React.FC<MediumNavBarProps> = ({
                 <DesktopMenu
                   themeColorObject={themeColorObject}
                   aria-label={t("secondary navigation")}
+                  menuType="secondary"
                   menuData={menuData.secondaryMenu}
                 />
               )}

--- a/src/BrandedNavBar/NavBarDropdownMenu.tsx
+++ b/src/BrandedNavBar/NavBarDropdownMenu.tsx
@@ -18,7 +18,7 @@ type NavBarDropdownMenuProps = {
   trigger?: Function;
   menuState?: MenuState;
   showArrow?: boolean;
-  placement?: "bottom-start" | "right-start";
+  placement?: "bottom-start" | "right-start" | "left-start";
   modifiers?: any;
   triggerTogglesMenuState?: boolean;
   dropdownMenuContainerEventHandlers?: Function;
@@ -88,6 +88,7 @@ class StatelessNavBarDropdownMenu extends StatelessNavBarDropdownMenuClass {
       dropdownMenuContainerEventHandlers,
       menuState: { isOpen, closeMenu, openMenu },
     } = this.props;
+
     const childrenFnc = typeof children === "function" ? children : () => children;
     return (
       <Manager>
@@ -170,7 +171,7 @@ StatelessNavBarDropdownMenu.propTypes = {
     toggleMenu: PropTypes.func,
   }).isRequired,
   showArrow: PropTypes.bool,
-  placement: PropTypes.oneOf(["bottom-start", "right-start"]),
+  placement: PropTypes.oneOf(["bottom-start", "right-start", "left-start"]),
   modifiers: PropTypes.shape({}),
   triggerTogglesMenuState: PropTypes.bool,
   dropdownMenuContainerEventHandlers: PropTypes.func,

--- a/src/BrandedNavBar/SubMenuTrigger.tsx
+++ b/src/BrandedNavBar/SubMenuTrigger.tsx
@@ -13,13 +13,13 @@ type SubMenuTriggerProps = React.ComponentPropsWithRef<"button"> & {
   layer: number;
 };
 
-const SubMenuTrigger = ({ menuData, name, onItemClick, trigger, layer, ...props }: SubMenuTriggerProps) => {
+const SubMenuTrigger = ({ menuData, name, onItemClick, trigger, layer, menuType, ...props }: SubMenuTriggerProps) => {
   return (
     // @ts-ignore
     <NavBarDropdownMenu
-      placement="right-start"
+      placement={getPlacement(menuType)}
       modifiers={null}
-      showArrow={false}
+      showArrow={true}
       triggerTogglesMenuState={false}
       {...props}
       dropdownMenuContainerEventHandlers={({ openMenu, closeMenu }) => ({
@@ -42,11 +42,20 @@ const SubMenuTrigger = ({ menuData, name, onItemClick, trigger, layer, ...props 
       }}
     >
       <ul style={{ listStyle: "none", margin: "0", padding: "0" }}>
-        {renderSubMenuItems(menuData, onItemClick, SubMenuTrigger, layer + 1)}
+        {renderSubMenuItems(menuData, onItemClick, SubMenuTrigger, layer + 1, menuType)}
       </ul>
     </NavBarDropdownMenu>
   );
 };
+
+function getPlacement(menuType) {
+  switch (menuType) {
+    case "primary":
+      return "right-start";
+    case "secondary":
+      return "left-start";
+  }
+}
 
 SubMenuTrigger.displayName = "SubMenuTrigger";
 

--- a/src/BrandedNavBar/SubMenuTrigger.tsx
+++ b/src/BrandedNavBar/SubMenuTrigger.tsx
@@ -3,6 +3,7 @@ import NavBarDropdownMenu from "./NavBarDropdownMenu";
 import renderSubMenuItems from "./renderSubMenuItems";
 import SubMenuTriggerButton from "./SubMenuTriggerButton";
 import { TriggerFunctionProps } from "./TriggerFunctionProps";
+import type { MenuType } from "./MenuTrigger";
 
 type SubMenuTriggerProps = React.ComponentPropsWithRef<"button"> & {
   name?: string;
@@ -11,6 +12,7 @@ type SubMenuTriggerProps = React.ComponentPropsWithRef<"button"> & {
   menuData: any[];
   trigger: (props: TriggerFunctionProps) => React.ReactNode;
   layer: number;
+  menuType: MenuType;
 };
 
 const SubMenuTrigger = ({ menuData, name, onItemClick, trigger, layer, menuType, ...props }: SubMenuTriggerProps) => {

--- a/src/BrandedNavBar/renderSubMenuItems.tsx
+++ b/src/BrandedNavBar/renderSubMenuItems.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styled, { CSSObject } from "styled-components";
 import { DropdownText, DropdownLink } from "../DropdownMenu";
 
-const renderSubMenuTrigger = (subMenuItem, onItemClick, SubMenuTrigger, layer) => (
+const renderSubMenuTrigger = (subMenuItem, onItemClick, SubMenuTrigger, layer, menuType) => (
   <NoWrapLi key={subMenuItem.key ?? subMenuItem.name}>
     <SubMenuTrigger
       onItemClick={onItemClick}
@@ -10,6 +10,7 @@ const renderSubMenuTrigger = (subMenuItem, onItemClick, SubMenuTrigger, layer) =
       menuData={subMenuItem.items}
       trigger={subMenuItem.trigger}
       layer={layer}
+      menuType={menuType}
     />
   </NoWrapLi>
 );
@@ -46,8 +47,10 @@ const getRenderFunction = (subMenuItem) => {
   }
 };
 
-const renderSubMenuItems = (subMenuItems, onItemClick, SubMenuTrigger, layer) =>
-  subMenuItems.map((subMenuItem) => getRenderFunction(subMenuItem)(subMenuItem, onItemClick, SubMenuTrigger, layer));
+const renderSubMenuItems = (subMenuItems, onItemClick, SubMenuTrigger, layer, menuType) =>
+  subMenuItems.map((subMenuItem) =>
+    getRenderFunction(subMenuItem)(subMenuItem, onItemClick, SubMenuTrigger, layer, menuType)
+  );
 
 const NoWrapLi = styled.li(
   (): CSSObject => ({


### PR DESCRIPTION
## Description
Currently the arrow rendered for submenu items is reversed when the sub-menu opens to the right in the secondary menu. This fix changes the arrow direction based on whether its rendered from the primary or secondary menu.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [x] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
