### PR TITLE
fix: bump react-modal to 3.14.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "react-fast-compare": "^3.2.0",
     "react-i18next": "^11.14.2",
     "react-input-autosize": "^2.2.2",
-    "react-modal": "^3.10.1",
+    "react-modal": "^3.14.4",
     "react-popper": "1.3.7",
     "react-popper-2": "npm:react-popper@2.2.4",
     "react-resize-detector": "^7.1.2",


### PR DESCRIPTION
## Description
Upgrades `react-modal` version.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
