### PR TITLE
Add prop to page component

### DIFF
--- a/cypress/integration/components/Sidebar.spec.js
+++ b/cypress/integration/components/Sidebar.spec.js
@@ -86,19 +86,19 @@ describe("Sidebar", () => {
     it("slides out when clicking on the body", () => {
       trigger().click();
       Sidebar().should("be.visible");
-      cy.get("body").click();
+      overlay().click({ force: true });
       Sidebar().should("not.be.visible");
       Sidebar().should("have.css", "right", "0px");
     });
   });
-  describe("Don't close on outide click", () => {
+  describe("Don't close on outside click", () => {
     beforeEach(() => {
       cy.renderFromStorybook("sidebar--dont-close-on-outside-click");
     });
     it("does not close when clicking on the body", () => {
       trigger().click();
       Sidebar().should("be.visible");
-      cy.get("body").click();
+      cy.get("body").click({ force: true });
       Sidebar().should("be.visible");
     });
     it("closes when the close button is pressed", () => {

--- a/src/Layout/ApplicationFrame.tsx
+++ b/src/Layout/ApplicationFrame.tsx
@@ -17,9 +17,9 @@ const ApplicationFrame = ({ navBar, children, environment, ...props }: Applicati
         {environment && <EnvironmentBanner>{environment}</EnvironmentBanner>}
         {navBar}
       </Box>
-      <Box position="relative" flexGrow={1}>
+      <Flex flexDirection="column" position="relative" flexGrow={1}>
         {children}
-      </Box>
+      </Flex>
     </Flex>
   );
 };

--- a/src/Layout/ApplicationFrame.tsx
+++ b/src/Layout/ApplicationFrame.tsx
@@ -12,7 +12,7 @@ type ApplicationFrameProps = FlexProps & {
 
 const ApplicationFrame = ({ navBar, children, environment, ...props }: ApplicationFrameProps) => {
   return (
-    <Flex flexDirection="column" minHeight="100vh" height="100vh" {...props}>
+    <Flex flexDirection="column" minHeight="100vh" {...props}>
       <Box position="sticky" top="0" zIndex={"navBar" as any}>
         {environment && <EnvironmentBanner>{environment}</EnvironmentBanner>}
         {navBar}

--- a/src/Layout/Page.story.tsx
+++ b/src/Layout/Page.story.tsx
@@ -133,3 +133,20 @@ export const NoBreadcrumbs = () => (
     </Page>
   </ApplicationFrame>
 );
+
+export const WithFullHeight = () => (
+  <ApplicationFrame navBar={<BrandedNavBar menuData={{ primaryMenu: [{ name: "Menu Link", href: "/" }] }} />}>
+    <Page
+      title="Materials Overview"
+      fullHeight
+      breadcrumbs={
+        <Breadcrumbs>
+          <Link href="/">Home</Link>
+          <Link href="/">Materials</Link>
+        </Breadcrumbs>
+      }
+    >
+      <Text>I am main content.</Text>
+    </Page>
+  </ApplicationFrame>
+);

--- a/src/Layout/Page.tsx
+++ b/src/Layout/Page.tsx
@@ -10,10 +10,11 @@ type PageProps = FlexProps & {
   title?: string;
   children?: React.ReactNode;
   headerContent?: React.ReactNode;
+  fullHeight?: boolean
 };
 
-export const Page = ({ breadcrumbs, title, children, headerContent, ...props }: PageProps) => (
-  <Flex flexDirection="column" py="x3" px="x3" {...props}>
+export const Page = ({ breadcrumbs, title, children, headerContent, fullHeight, ...props }: PageProps) => (
+  <Flex flexDirection="column" py="x3" px="x3" flexGrow={fullHeight ? 1 : 0} {...props}>
     {breadcrumbs}
     <Flex alignItems="center">
       {title && (


### PR DESCRIPTION
## Description
This PR adds a new prop called `fullHeight` to the Page component. It removes the preset `height: 100vh` which prevents the body from growing beyond the height of the viewport if its content is bigger.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [x] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [x] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
