### PR TITLE
fix: align checkbox check with first line of multiline labels

### DIFF
--- a/src/Checkbox/Checkbox.story.tsx
+++ b/src/Checkbox/Checkbox.story.tsx
@@ -46,6 +46,9 @@ export default {
 };
 
 export const _Checkbox = () => <Checkbox p="x3" id="checkbox" labelText="I am a checkbox" />;
+export const Multiline = () => <Checkbox p="x3" id="checkbox" labelText="Lorem ipsum dolor sit amet consecutor" />;
+Multiline.decorators = [(story) => <div style={{ width: "200px" }}>{story()}</div>];
+
 export const SetToDefaultChecked = () => <Checkbox id="checkbox" defaultChecked labelText="I am checked by default" />;
 
 SetToDefaultChecked.story = {

--- a/src/Checkbox/Checkbox.tsx
+++ b/src/Checkbox/Checkbox.tsx
@@ -6,6 +6,7 @@ import { Text } from "../Type";
 import { ClickInputLabel } from "../utils";
 import { getSubset, omitSubset } from "../utils/subset";
 import { DefaultNDSThemeType } from "../theme.type";
+import { addStyledProps } from "../StyledProps";
 
 type CheckboxProps = React.ComponentPropsWithRef<"input"> & {
   labelText?: string;
@@ -79,7 +80,6 @@ const VisualCheckbox: React.FunctionComponent<any> = styled.div(
     borderRadius: theme.radii.small,
     border: "solid 1px",
     position: "relative",
-    alignSelf: "center",
     // checkmark
     "&:before": {
       content: "''",
@@ -91,7 +91,8 @@ const VisualCheckbox: React.FunctionComponent<any> = styled.div(
       border: `solid ${theme.colors.white}`,
       ...(indeterminate ? indeterminateStyles : checkedStyles),
     },
-  })
+  }),
+  addStyledProps
 );
 const CheckboxInput: React.FunctionComponent<CheckboxProps> = styled.input((props) => ({
   position: "absolute",
@@ -132,6 +133,7 @@ const Checkbox: React.FC<any> = forwardRef((props, ref) => {
           checked={checked}
           indeterminate={indeterminate}
           data-testid="visual-checkbox"
+          marginTop={labelText ? "half" : "0px"}
         />
         {labelText && (
           <Text disabled={disabled} ml="x1">


### PR DESCRIPTION
## Description

For multiline checkbox labels, the check should be aligned with the first line of text, not the entire label body.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
