### PR TITLE
fix: pass the width prop explicitly

### DIFF
--- a/src/BrandedNavBar/NavBar.tsx
+++ b/src/BrandedNavBar/NavBar.tsx
@@ -132,11 +132,14 @@ const BaseNavBar = ({ environment, breakpointUpper = "medium", ...props }: BaseN
   const { breakpoints } = useTheme();
   return (
     <ReactResizeDetector handleWidth>
-      <SelectNavBarBasedOnWidth
-        breakpointUpper={breakpoints[breakpointUpper] || breakpointUpper}
-        {...props}
-        environment={environment}
-      />
+      {({ width }) => (
+        <SelectNavBarBasedOnWidth
+          breakpointUpper={breakpoints[breakpointUpper] || breakpointUpper}
+          width={width}
+          environment={environment}
+          {...props}
+        />
+      )}
     </ReactResizeDetector>
   );
 };


### PR DESCRIPTION
## Description
The `ReactResizeDetector` component was passing a `width`, `height`, and `targetRef` props to its children. Given that we were spreading them they were rendered as HTML attributes. This caused React to throw a warning that `targetRef` is not a valid HTML attribute.

This PR makes passing the `width` prop explicit. 

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
