### PR TITLE
feat: Allow setting openOnHover for DropdownMenu

### DIFF
--- a/cypress/integration/components/DropdownMenu.spec.js
+++ b/cypress/integration/components/DropdownMenu.spec.js
@@ -1,12 +1,27 @@
 describe("DropdownMenu", () => {
   const getOpenButton = () => cy.get("[aria-label='open dropdown']");
+  const getSubmenuButton = () => cy.get("[aria-label='open sub dropdown']");
   const getCloseButton = () => cy.get("[aria-label='close dropdown']");
+  const getSubCloseButton = () => cy.get("[aria-label='close sub dropdown']");
   const getDropdownLink = () => cy.contains("Dropdown Link");
   const getDropdownButton = () => cy.contains("Dropdown Button");
+  const getSubDropdownButton = () => cy.contains("Inner Dropdown Button");
+
   const assertDropdownIsOpen = () => {
     getCloseButton().should("exist");
     getDropdownButton().should("exist");
   };
+  const assertSubDropdownIsClosed = () => {
+    getSubmenuButton().should("exist");
+    getSubCloseButton().should("not.exist");
+    getSubDropdownButton().should("not.exist");
+  };
+
+  const assertSubDropdownIsOpen = () => {
+    getSubCloseButton().should("exist");
+    getSubDropdownButton().should("exist");
+  };
+
   const assertDropdownIsClosed = () => {
     getOpenButton().should("exist");
     getCloseButton().should("not.exist");
@@ -17,6 +32,7 @@ describe("DropdownMenu", () => {
     beforeEach(() => {
       cy.renderFromStorybook("dropdownmenu--dropdown-menu");
     });
+
     it("toggles the menu on click", () => {
       getOpenButton().click();
       assertDropdownIsOpen();
@@ -60,5 +76,18 @@ describe("DropdownMenu", () => {
     getOpenButton().click();
 
     assertDropdownIsOpen();
+  });
+
+  it("handles submenus that open on hover", () => {
+    cy.renderFromStorybook("dropdownmenu--with-submenu");
+
+    getOpenButton().click();
+    assertDropdownIsOpen();
+
+    getSubmenuButton().trigger('mouseover')
+    assertSubDropdownIsOpen();
+
+    getSubCloseButton().trigger('mouseout')
+    assertSubDropdownIsClosed();
   });
 });

--- a/src/DropdownMenu/DropdownMenu.story.tsx
+++ b/src/DropdownMenu/DropdownMenu.story.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { DropdownMenu, DropdownLink, DropdownButton, DropdownItem, DropdownText, Button, Flex, Text } from "../index";
+import { DropdownMenu, DropdownLink, DropdownButton, DropdownItem, DropdownText, Button, Flex, Text, Icon } from "../index";
 
 const customColors = {
   color: "white",
@@ -102,7 +102,7 @@ export const WithSubmenu = () => (
         <DropdownButton>
           <Flex justifyContent="space-between">
             <Text>Submenu</Text>
-            <Text>&gt;</Text>
+            <Icon icon="rightArrow" title="right arrow" />
           </Flex>
         </DropdownButton>
       )}

--- a/src/DropdownMenu/DropdownMenu.story.tsx
+++ b/src/DropdownMenu/DropdownMenu.story.tsx
@@ -109,8 +109,8 @@ export const WithSubmenu = () => (
       placement="left-start"
       showArrow={false}
       openOnHover
-      openAriaLabel="open dropdown"
-      closeAriaLabel="close dropdown"
+      openAriaLabel="open sub dropdown"
+      closeAriaLabel="close sub dropdown"
     >
       <DropdownButton onClick={() => {}}>Inner Dropdown Button</DropdownButton>
       <DropdownText> Inner Custom Text</DropdownText>

--- a/src/DropdownMenu/DropdownMenu.story.tsx
+++ b/src/DropdownMenu/DropdownMenu.story.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { DropdownMenu, DropdownLink, DropdownButton, DropdownItem, DropdownText, Button } from "../index";
+import { DropdownMenu, DropdownLink, DropdownButton, DropdownItem, DropdownText, Button, Flex, Text } from "../index";
 
 const customColors = {
   color: "white",
@@ -91,6 +91,35 @@ export const SetToDefaultOpen = () => (
 
 SetToDefaultOpen.story = {
   name: "set to defaultOpen",
+};
+
+export const WithSubmenu = () => (
+  <DropdownMenu openAriaLabel="open dropdown" closeAriaLabel="close dropdown">
+    <DropdownLink href="/never_been">Dropdown Link</DropdownLink>
+    <DropdownButton onClick={() => {}}>Dropdown Button</DropdownButton>
+    <DropdownMenu
+      trigger={() => (
+        <DropdownButton>
+          <Flex justifyContent="space-between">
+            <Text>Submenu</Text>
+            <Text>&gt;</Text>
+          </Flex>
+        </DropdownButton>
+      )}
+      placement="left-start"
+      showArrow={false}
+      openOnHover
+      openAriaLabel="open dropdown"
+      closeAriaLabel="close dropdown"
+    >
+      <DropdownButton onClick={() => {}}>Inner Dropdown Button</DropdownButton>
+      <DropdownText> Inner Custom Text</DropdownText>
+    </DropdownMenu>
+  </DropdownMenu>
+);
+
+WithSubmenu.story = {
+  name: "with submenu",
 };
 
 export const WithVisitedLinks = () => (

--- a/src/DropdownMenu/DropdownMenu.tsx
+++ b/src/DropdownMenu/DropdownMenu.tsx
@@ -34,6 +34,7 @@ type DropdownMenuProps = {
   boundariesElement?: string;
   openAriaLabel?: string;
   closeAriaLabel?: string;
+  openOnHover?: boolean;
 } & StyledProps;
 
 const DEFAULT_POPPER_MODIFIERS = {
@@ -62,6 +63,7 @@ const DropdownMenu: React.FC<DropdownMenuProps> = React.forwardRef<DropdownMenuP
       hideDelay = "200",
       openAriaLabel,
       closeAriaLabel,
+      openOnHover = false,
       ...props
     },
     ref
@@ -85,9 +87,9 @@ const DropdownMenu: React.FC<DropdownMenuProps> = React.forwardRef<DropdownMenuP
         popperPlacement={placement}
         defaultOpen={defaultOpen}
         showArrow={showArrow}
-        openOnClick
+        openOnClick={!openOnHover}
         ref={ref}
-        openOnHover={false}
+        openOnHover={openOnHover}
         modifiers={modifiers}
         backgroundColor={backgroundColor}
         borderColor={backgroundColor}


### PR DESCRIPTION
## Description

Allow openOnHover to be sent into DropdownMenu to enable a use case where we have nested DropdownMenus. Added a storybook story.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [x] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
