### PR TITLE
feat: Open navbar links in new tab

### DIFF
--- a/src/BrandedNavBar/DesktopMenu.tsx
+++ b/src/BrandedNavBar/DesktopMenu.tsx
@@ -79,7 +79,7 @@ const renderMenuLink = (menuItem, themeColorObject) => {
     href: menuItem.href,
     to: menuItem.to,
     as: menuItem.as,
-    target: menuItem.openInNew ? "_blank" : null,
+    target: menuItem.openInNew ? "_blank" : undefined,
   };
 
   return (

--- a/src/BrandedNavBar/DesktopMenu.tsx
+++ b/src/BrandedNavBar/DesktopMenu.tsx
@@ -86,7 +86,7 @@ const renderMenuLink = (menuItem, themeColorObject) => {
     <div key={menuItem.key ?? menuItem.name}>
       <MenuLink {...linkProps} {...themeColorObject}>
         {menuItem.name}
-        {menuItem.openInNew && <Icon size="16px" ml="4px" icon="openInNew" />}
+        {menuItem.openInNew && <Icon size="16px" mb="-2px" ml="4px" icon="openInNew" />}
       </MenuLink>
     </div>
   );

--- a/src/BrandedNavBar/DesktopMenu.tsx
+++ b/src/BrandedNavBar/DesktopMenu.tsx
@@ -1,13 +1,16 @@
 import React from "react";
 import styled from "styled-components";
+import type { CSSObject } from "styled-components";
 import { Icon } from "../Icon";
 import { DefaultNDSThemeType } from "../theme.type";
 import MenuTrigger from "./MenuTrigger";
 import type { MenuType } from "./MenuTrigger";
 
-const getSharedStyles = (color, theme) => {
+const getSharedStyles = (color, theme): CSSObject => {
   return {
-    display: "block",
+    display: "flex",
+    alignItems: "center",
+    gap: theme.space.half,
     color: theme.colors[color] || color,
     textDecoration: "none",
     border: "none",
@@ -86,7 +89,7 @@ const renderMenuLink = (menuItem, themeColorObject) => {
     <div key={menuItem.key ?? menuItem.name}>
       <MenuLink {...linkProps} {...themeColorObject}>
         {menuItem.name}
-        {menuItem.openInNew && <Icon size="16px" mb="-2px" ml="4px" icon="openInNew" />}
+        {menuItem.openInNew && <Icon size="16px" icon="openInNew" />}
       </MenuLink>
     </div>
   );

--- a/src/BrandedNavBar/DesktopMenu.tsx
+++ b/src/BrandedNavBar/DesktopMenu.tsx
@@ -105,13 +105,17 @@ const renderText = (menuItem, themeColorObject) => (
 const getRenderFunction = (menuItem) => {
   if (menuItem.items) {
     return renderMenuTrigger;
-  } else if (menuItem.href || menuItem.to) {
-    return renderMenuLink;
-  } else if (menuItem.render) {
-    return renderCustom;
-  } else {
-    return renderText;
   }
+
+  if (menuItem.href || menuItem.to) {
+    return renderMenuLink;
+  }
+
+  if (menuItem.render) {
+    return renderCustom;
+  }
+
+  return renderText;
 };
 
 const renderMenuItem = (menuItem, themeColorObject, layer, menuType) =>

--- a/src/BrandedNavBar/DesktopMenu.tsx
+++ b/src/BrandedNavBar/DesktopMenu.tsx
@@ -89,7 +89,7 @@ const renderMenuLink = (menuItem, themeColorObject) => {
     <div key={menuItem.key ?? menuItem.name}>
       <MenuLink {...linkProps} {...themeColorObject}>
         {menuItem.name}
-        {menuItem.openInNew && <Icon size="16px" icon="openInNew" />}
+        {menuItem.openInNew && <Icon size="x2" icon="openInNew" />}
       </MenuLink>
     </div>
   );

--- a/src/BrandedNavBar/DesktopMenu.tsx
+++ b/src/BrandedNavBar/DesktopMenu.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "styled-components";
+import { Icon } from "../Icon";
 import { DefaultNDSThemeType } from "../theme.type";
 import MenuTrigger from "./MenuTrigger";
 import type { MenuType } from "./MenuTrigger";
@@ -73,13 +74,23 @@ const renderMenuTrigger = (menuItem, themeColorObject, layer, menuType) => (
   </div>
 );
 
-const renderMenuLink = (menuItem, themeColorObject) => (
-  <div key={menuItem.key ?? menuItem.name}>
-    <MenuLink href={menuItem.href} to={menuItem.to} as={menuItem.as} {...themeColorObject}>
-      {menuItem.name}
-    </MenuLink>
-  </div>
-);
+const renderMenuLink = (menuItem, themeColorObject) => {
+  const linkProps = {
+    href: menuItem.href,
+    to: menuItem.to,
+    as: menuItem.as,
+    target: menuItem.openInNew ? "_blank" : null,
+  };
+
+  return (
+    <div key={menuItem.key ?? menuItem.name}>
+      <MenuLink {...linkProps} {...themeColorObject}>
+        {menuItem.name}
+        {menuItem.openInNew && <Icon size="16px" ml="4px" icon="openInNew" />}
+      </MenuLink>
+    </div>
+  );
+};
 
 const renderCustom = (menuItem, _themeColorObject, layer) => (
   <div key={menuItem.key ?? menuItem.name}>{menuItem.render({ size: "medium", layer })}</div>

--- a/src/BrandedNavBar/MobileMenu.tsx
+++ b/src/BrandedNavBar/MobileMenu.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "styled-components";
+import type { CSSObject } from "styled-components";
 import { display } from "styled-system";
 import { Text, Heading3 } from "../Type";
 import { Flex } from "../Flex";
@@ -23,8 +24,10 @@ const BrandingWrap = styled.div(({ theme }) => ({
 // eslint-disable-next-line no-mixed-operators
 const getPaddingLeft = (layer) => `${24 * layer + 24}px`;
 
-const getSharedStyles = (theme) => ({
-  display: "block",
+const getSharedStyles = (theme): CSSObject => ({
+  display: "flex",
+  alignItems: "center",
+  gap: theme.space.half,
   textDecoration: "none",
   border: "none",
   backgroundColor: "transparent",
@@ -91,7 +94,7 @@ const renderMenuLink = (menuItem, linkOnClick, themeColorObject, layer) => {
     <li key={menuItem.key ?? menuItem.name}>
       <MenuLink {...sharedLinkProps}>
         {menuItem.name}
-        {menuItem.openInNew && <Icon size={topLevel ? "24px" : "16px"} mb="-2px" ml="4px" icon="openInNew" />}
+        {menuItem.openInNew && <Icon size={topLevel ? "24px" : "16px"} icon="openInNew" />}
       </MenuLink>
     </li>
   );

--- a/src/BrandedNavBar/MobileMenu.tsx
+++ b/src/BrandedNavBar/MobileMenu.tsx
@@ -91,7 +91,7 @@ const renderMenuLink = (menuItem, linkOnClick, themeColorObject, layer) => {
     <li key={menuItem.key ?? menuItem.name}>
       <MenuLink {...sharedLinkProps}>
         {menuItem.name}
-        {menuItem.openInNew && <Icon size={topLevel ? "24px" : "16px"} ml="4px" icon="openInNew" />}
+        {menuItem.openInNew && <Icon size={topLevel ? "24px" : "16px"} mb="-2px" ml="4px" icon="openInNew" />}
       </MenuLink>
     </li>
   );

--- a/src/BrandedNavBar/MobileMenu.tsx
+++ b/src/BrandedNavBar/MobileMenu.tsx
@@ -83,7 +83,7 @@ const renderMenuLink = (menuItem, linkOnClick, themeColorObject, layer) => {
     // eslint-disable-next-line no-mixed-operators
     pl: layer === 0 ? getPaddingLeft(layer) : `${24 * layer + 20}px`,
     mb: "x1",
-    target: menuItem.openInNew ? "_blank" : null,
+    target: menuItem.openInNew ? "_blank" : undefined,
   };
   const topLevel = layer === 0;
   const MenuLink: React.FC<LinkProps> = topLevel ? TopLevelLink : DropdownLink;

--- a/src/BrandedNavBar/MobileMenu.tsx
+++ b/src/BrandedNavBar/MobileMenu.tsx
@@ -5,6 +5,7 @@ import { Text, Heading3 } from "../Type";
 import { Flex } from "../Flex";
 import { BrandingText } from "../Branding";
 import { DropdownLink, DropdownText } from "../DropdownMenu";
+import { Icon } from "../Icon";
 import { Link } from "../Link";
 import { LinkProps } from "../Link/Link";
 import { addStyledProps } from "../StyledProps";
@@ -82,11 +83,16 @@ const renderMenuLink = (menuItem, linkOnClick, themeColorObject, layer) => {
     // eslint-disable-next-line no-mixed-operators
     pl: layer === 0 ? getPaddingLeft(layer) : `${24 * layer + 20}px`,
     mb: "x1",
+    target: menuItem.openInNew ? "_blank" : null,
   };
-  const MenuLink: React.FC<LinkProps> = layer === 0 ? TopLevelLink : DropdownLink;
+  const topLevel = layer === 0;
+  const MenuLink: React.FC<LinkProps> = topLevel ? TopLevelLink : DropdownLink;
   return (
     <li key={menuItem.key ?? menuItem.name}>
-      <MenuLink {...sharedLinkProps}>{menuItem.name}</MenuLink>
+      <MenuLink {...sharedLinkProps}>
+        {menuItem.name}
+        {menuItem.openInNew && <Icon size={topLevel ? "24px" : "16px"} ml="4px" icon="openInNew" />}
+      </MenuLink>
     </li>
   );
 };

--- a/src/BrandedNavBar/MobileMenu.tsx
+++ b/src/BrandedNavBar/MobileMenu.tsx
@@ -94,7 +94,7 @@ const renderMenuLink = (menuItem, linkOnClick, themeColorObject, layer) => {
     <li key={menuItem.key ?? menuItem.name}>
       <MenuLink {...sharedLinkProps}>
         {menuItem.name}
-        {menuItem.openInNew && <Icon size={topLevel ? "24px" : "16px"} icon="openInNew" />}
+        {menuItem.openInNew && <Icon size={topLevel ? "x3" : "x2"} icon="openInNew" />}
       </MenuLink>
     </li>
   );

--- a/src/BrandedNavBar/NavBar.story.tsx
+++ b/src/BrandedNavBar/NavBar.story.tsx
@@ -243,6 +243,55 @@ export const WithPrimaryAndSecondarySubMenus = () => (
   />
 );
 
+export const WithExternalLinks = () => (
+  <BrandedNavBar
+    menuData={{
+      primaryMenu: [
+        {
+          name: "Top level open in new tab link",
+          href: "https://www.google.com",
+          openInNew: true,
+        },
+        {
+          name: "Top level open in same tab link",
+          href: "https://www.google.com",
+          openInNew: false,
+        },
+        {
+          name: "Dropdown",
+          items: [
+            {
+              name: "New tab link in dropdown",
+              href: "https://www.google.com",
+              openInNew: true,
+            },
+            {
+              name: "Same tab link in dropdown",
+              href: "https://www.google.com",
+              openInNew: false,
+            },
+            {
+              name: "Sub Menu",
+              items: [
+                {
+                  name: "New tab link in submenu",
+                  href: "https://www.google.com",
+                  openInNew: true,
+                },
+                {
+                  name: "Same tab link in submenu",
+                  href: "https://www.google.com",
+                  openInNew: false,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }}
+  />
+);
+
 const primaryMenuReactRouter = [
   {
     name: "Dashboard",

--- a/src/BrandedNavBar/renderSubMenuItems.tsx
+++ b/src/BrandedNavBar/renderSubMenuItems.tsx
@@ -22,7 +22,7 @@ const renderSubMenuLink = (subMenuItem, onItemClick) => {
     href: subMenuItem.href,
     to: subMenuItem.to,
     as: subMenuItem.as,
-    target: subMenuItem.openInNew ? "_blank" : null,
+    target: subMenuItem.openInNew ? "_blank" : undefined,
   };
 
   return (

--- a/src/BrandedNavBar/renderSubMenuItems.tsx
+++ b/src/BrandedNavBar/renderSubMenuItems.tsx
@@ -29,7 +29,7 @@ const renderSubMenuLink = (subMenuItem, onItemClick) => {
     <NoWrapLi key={subMenuItem.key ?? subMenuItem.name}>
       <DropdownLink {...linkProps}>
         {subMenuItem.name}
-        {subMenuItem.openInNew && <Icon size="16px" mb="-2px" ml="4px" icon="openInNew" />}
+        {subMenuItem.openInNew && <Icon size="16px" icon="openInNew" />}
       </DropdownLink>
     </NoWrapLi>
   );

--- a/src/BrandedNavBar/renderSubMenuItems.tsx
+++ b/src/BrandedNavBar/renderSubMenuItems.tsx
@@ -29,7 +29,7 @@ const renderSubMenuLink = (subMenuItem, onItemClick) => {
     <NoWrapLi key={subMenuItem.key ?? subMenuItem.name}>
       <DropdownLink {...linkProps}>
         {subMenuItem.name}
-        {subMenuItem.openInNew && <Icon size="16px" icon="openInNew" />}
+        {subMenuItem.openInNew && <Icon size="x2" icon="openInNew" />}
       </DropdownLink>
     </NoWrapLi>
   );

--- a/src/BrandedNavBar/renderSubMenuItems.tsx
+++ b/src/BrandedNavBar/renderSubMenuItems.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled, { CSSObject } from "styled-components";
 import { DropdownText, DropdownLink } from "../DropdownMenu";
+import { Icon } from "../Icon";
 
 const renderSubMenuTrigger = (subMenuItem, onItemClick, SubMenuTrigger, layer, menuType) => (
   <NoWrapLi key={subMenuItem.key ?? subMenuItem.name}>
@@ -15,13 +16,24 @@ const renderSubMenuTrigger = (subMenuItem, onItemClick, SubMenuTrigger, layer, m
   </NoWrapLi>
 );
 
-const renderSubMenuLink = (subMenuItem, onItemClick) => (
-  <NoWrapLi key={subMenuItem.key ?? subMenuItem.name}>
-    <DropdownLink onClick={onItemClick} href={subMenuItem.href} to={subMenuItem.to} as={subMenuItem.as}>
-      {subMenuItem.name}
-    </DropdownLink>
-  </NoWrapLi>
-);
+const renderSubMenuLink = (subMenuItem, onItemClick) => {
+  const linkProps = {
+    onClick: onItemClick,
+    href: subMenuItem.href,
+    to: subMenuItem.to,
+    as: subMenuItem.as,
+    target: subMenuItem.openInNew ? "_blank" : null,
+  };
+
+  return (
+    <NoWrapLi key={subMenuItem.key ?? subMenuItem.name}>
+      <DropdownLink {...linkProps}>
+        {subMenuItem.name}
+        {subMenuItem.openInNew && <Icon size="16px" ml="4px" icon="openInNew" />}
+      </DropdownLink>
+    </NoWrapLi>
+  );
+};
 
 const renderCustom = (subMenuItem, onItemClick, _SubMenuTrigger, layer) => (
   <NoWrapLi key={subMenuItem.key ?? subMenuItem.name}>

--- a/src/BrandedNavBar/renderSubMenuItems.tsx
+++ b/src/BrandedNavBar/renderSubMenuItems.tsx
@@ -29,7 +29,7 @@ const renderSubMenuLink = (subMenuItem, onItemClick) => {
     <NoWrapLi key={subMenuItem.key ?? subMenuItem.name}>
       <DropdownLink {...linkProps}>
         {subMenuItem.name}
-        {subMenuItem.openInNew && <Icon size="16px" ml="4px" icon="openInNew" />}
+        {subMenuItem.openInNew && <Icon size="16px" mb="-2px" ml="4px" icon="openInNew" />}
       </DropdownLink>
     </NoWrapLi>
   );

--- a/src/DropdownMenu/DropdownLink.tsx
+++ b/src/DropdownMenu/DropdownLink.tsx
@@ -8,7 +8,9 @@ const DropdownLink: React.FC<any> = styled.a.withConfig({
   ({ theme, color, bgHoverColor, hoverColor }: any) => ({
     color: theme.colors[color],
     fontWeight: theme.fontWeights.medium,
-    display: "block",
+    display: "flex",
+    alignItems: "center",
+    gap: theme.space.half,
     textDecoration: "none",
     borderColor: "transparent",
     backgroundColor: "transparent",

--- a/src/NavBar/DesktopMenu.tsx
+++ b/src/NavBar/DesktopMenu.tsx
@@ -1,12 +1,15 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
+import type { CSSObject } from "styled-components";
 import { themeGet } from "@styled-system/theme-get";
 import theme from "../theme";
 import MenuTrigger from "./MenuTrigger";
 
-const getSharedStyles = (color) => ({
-  display: "block",
+const getSharedStyles = (color): CSSObject => ({
+  display: "flex",
+  alignItems: "center",
+  gap: theme.space.half,
   color: themeGet(`colors.${color}`, color)(color),
   textDecoration: "none",
   border: "none",

--- a/src/NavBar/MobileMenu.tsx
+++ b/src/NavBar/MobileMenu.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
+import type { CSSObject } from "styled-components";
 import { display } from "styled-system";
 import { themeGet } from "@styled-system/theme-get";
 import { Text, Heading3 } from "../Type";
@@ -16,8 +17,10 @@ const BrandingWrap = styled.div({
 
 const getPaddingLeft = (layer) => `${24 * layer + 24}px`;
 
-const getSharedStyles = ({ color, layer }) => ({
-  display: "block",
+const getSharedStyles = ({ color, layer }): CSSObject => ({
+  display: "flex",
+  alignItems: "center",
+  gap: theme.space.half,
   color: themeGet(`colors.${color}`, color)(color),
   textDecoration: "none",
   border: "none",

--- a/src/NavBar/renderSubMenuItems.tsx
+++ b/src/NavBar/renderSubMenuItems.tsx
@@ -8,7 +8,9 @@ import { DropdownLink } from "../DropdownMenu";
 const SubMenuLink = styled(DropdownLink)(fontSize, lineHeight, space);
 
 const getSharedStyles = (): CSSObject => ({
-  display: "block",
+  display: "flex",
+  alignItems: "center",
+  gap: theme.space.half,
   whiteSpace: "nowrap",
   textDecoration: "none",
   borderColor: "transparent",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2133,10 +2133,10 @@
     fs "^0.0.1-security"
     svgi "^1.1.0"
 
-"@nulogy/tokens@^5.3.0":
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/@nulogy/tokens/-/tokens-5.3.0.tgz#29ba9848407762f940bae6bce9ef54155685daca"
-  integrity sha512-e5aNb249jhoZUA4Iutw/wj1xV5VKPY8TqHZi37nGte5teb27xjJZIMTV5PcBJA75IP5NMiNX/r1yc4prKNxU6g==
+"@nulogy/tokens@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@nulogy/tokens/-/tokens-5.4.0.tgz#3c28ad90db1f502b1b05af192913fee59b56d668"
+  integrity sha512-qriIBNNsvSuXSfFVk3LumGfowsHX9YXAQzo67he0CQWRAfosqtV3rphdHlypH2Q8qPhUBMSYBxw0wX7TGiW1cw==
 
 "@octokit/auth-token@^2.4.4":
   version "2.4.5"


### PR DESCRIPTION
## Description

This allows us to configure links inside the `BrandedNavBar` component to open in a new tab, using the `openOnNew` property of a menu item.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [X] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [X] Documentation has been updated
- [ ] Accessibility has been considered
