### PR TITLE
fix: don't focus the element on mount

### DIFF
--- a/cypress/integration/components/Switcher.spec.js
+++ b/cypress/integration/components/Switcher.spec.js
@@ -1,9 +1,10 @@
 describe("Switcher", () => {
   describe("with selected value", () => {
     beforeEach(() => {
-      cy.renderFromStorybook("switcher--with-selected-value");
+      cy.renderFromStorybook("switcher--with-other-interactive-elements");
     });
     it("focuses on the selected switch", () => {
+      cy.get("button").contains("Click me").tab();
       cy.focused().should("have.text", "Option 2");
     });
   });

--- a/cypress/integration/components/Tabs.spec.js
+++ b/cypress/integration/components/Tabs.spec.js
@@ -154,9 +154,10 @@ describe("Tabs", () => {
 
   describe("with default tab selection", () => {
     beforeEach(() => {
-      cy.renderFromStorybook("tabs--with-a-default-selected-index");
+      cy.renderFromStorybook("tabs--with-other-interactive-elements");
     });
     it("focuses on the default selected tab", () => {
+      cy.get("button").contains("Click me").tab();
       cy.focused().should("have.text", "Tab 2");
     });
   });

--- a/src/Radio/RadioGroup.story.tsx
+++ b/src/Radio/RadioGroup.story.tsx
@@ -51,6 +51,10 @@ RadioGroupWithAllProps.story = {
   name: "RadioGroup with all props",
 };
 
+RadioGroupWithAllProps.parameters = {
+  chromatic: { diffThreshold: 0.3 },
+};
+
 export const WithErrorMessage = () => (
   <RadioGroup
     errorMessage="Please select an option"

--- a/src/Switcher/Switcher.story.tsx
+++ b/src/Switcher/Switcher.story.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
 import { Box } from "../Box";
 import { Text } from "../Type";
+import { Button } from "../Button";
+import { Flex } from "../Flex";
 import Switcher from "./Switcher";
 import Switch from "./Switch";
 
@@ -14,6 +16,16 @@ export const WithSelectedValue = () => {
     </Switcher>
   );
 };
+
+export const WithOtherInteractiveElements = () => (
+  <Flex gap="x1" alignItems="center">
+    <Button>Click me</Button>
+    <Switcher aria-label="storybook-switcher" selected="option_2">
+      <Switch value="option_1">Option 1</Switch>
+      <Switch value="option_2">Option 2</Switch>
+    </Switcher>
+  </Flex>
+);
 
 export const WithContent = () => {
   const [selected, setSelected] = useState("all");

--- a/src/Tabs/Tabs.story.tsx
+++ b/src/Tabs/Tabs.story.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { Button } from "../Button";
+import { Flex } from "../Flex";
 import { TabsProps, TabsState } from "./Tabs";
 import { Tab, Tabs } from ".";
 
@@ -73,6 +75,18 @@ export const WithADefaultSelectedIndex = () => (
 WithADefaultSelectedIndex.story = {
   name: "with a defaultSelectedIndex",
 };
+
+export const WithOtherInteractiveElements = () => (
+  <Flex gap="x2" alignItems="flex-start" flexDirection="column">
+    <Button>Click me</Button>
+    <Tabs defaultSelectedIndex={1}>
+      <Tab label="Tab 1">Tab 1 Content</Tab>
+      <Tab label="Tab 2">Tab 2 Content</Tab>
+      <Tab label="Tab 3">Tab 3 Content</Tab>
+      <Tab label="Tab 4">Tab 4 Content</Tab>
+    </Tabs>
+  </Flex>
+);
 
 export const SetToFitted = () => (
   <Tabs fitted>

--- a/src/utils/ts/FocusManager.tsx
+++ b/src/utils/ts/FocusManager.tsx
@@ -51,9 +51,8 @@ const FocusManager: React.FC<FocusManagerProps> = ({ children, refs = undefined,
 
     if (prevFocusedIndex.current !== focusedIndex) {
       updateFocused();
+      prevFocusedIndex.current = focusedIndex;
     }
-
-    prevFocusedIndex.current = focusedIndex;
   }, [focusedIndex, refs]);
 
   return (

--- a/src/utils/ts/FocusManager.tsx
+++ b/src/utils/ts/FocusManager.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect, useState } from "react";
+import React, { ReactNode, useEffect, useRef, useState } from "react";
 
 type Reference = {
   current?: JSX.Element;
@@ -19,6 +19,7 @@ type FocusManagerProps = {
 
 const FocusManager: React.FC<FocusManagerProps> = ({ children, refs = undefined, defaultFocusedIndex }) => {
   const [focusedIndex, setFocusedIndex] = useState<number>(defaultFocusedIndex ?? 0);
+  const prevFocusedIndex = useRef<number>(focusedIndex);
 
   const focusPrevious = () => {
     setFocusedIndex((prevFocusedIndex) => (prevFocusedIndex - 1 + refs.length) % refs.length);
@@ -48,7 +49,11 @@ const FocusManager: React.FC<FocusManagerProps> = ({ children, refs = undefined,
       refs[focusedIndex].focus();
     };
 
-    updateFocused();
+    if (prevFocusedIndex.current !== focusedIndex) {
+      updateFocused();
+    }
+
+    prevFocusedIndex.current = focusedIndex;
   }, [focusedIndex, refs]);
 
   return (


### PR DESCRIPTION
## Description
Focus is currently automatically set to the first child of the `FocusManager` causing the page to be poorly accessible to non-mouse users in addition to a causing the page to scroll to the focused element if it is outside the viewport. 

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
