### PR TITLE
DES-481: Change default date format to match Nulogy content guide

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,13 +1,27 @@
-name: "Chromatic"
+name: Chromatic
 on:
   push:
 jobs:
   test:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v1
-      - run: |
-          yarn && yarn build-storybook
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Build Storybook
+        run: yarn build-storybook
+
       - uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_TOKEN }}

--- a/cypress/integration/components/DatePicker.spec.js
+++ b/cypress/integration/components/DatePicker.spec.js
@@ -10,7 +10,7 @@ describe("Datepicker", () => {
 
     describe("has the correct defaults", () => {
       it("has the correct date selected by default", () => {
-        getDateInputComponent().should("have.value", "01 Jan 2019");
+        getDateInputComponent().should("have.value", "2019-Jan-01");
       });
     });
 
@@ -48,12 +48,12 @@ describe("Datepicker", () => {
       it("allows the user to select a date by clicking", () => {
         getDateInputComponent().click();
         cy.get(".react-datepicker__day--002").first().click();
-        getDateInputComponent().should("have.value", "02 Jan 2019");
+        getDateInputComponent().should("have.value", "2019-Jan-02");
       });
 
       it("allows the user to select a date by typing", () => {
         getDateInputComponent().type("{backspace}{backspace}20");
-        getDateInputComponent().should("have.value", "01 Jan 2020");
+        getDateInputComponent().should("have.value", "2019-Jan-20");
       });
 
       it("hides the calendar when a date is selected", () => {
@@ -90,7 +90,7 @@ describe("Datepicker", () => {
           getDateInputComponent().click();
           getDateInputComponent().type("{downarrow}");
           cy.get(".react-datepicker__day--031.react-datepicker__day--selected").should("exist");
-          getDateInputComponent().should("have.value", "31 Dec 2018");
+          getDateInputComponent().should("have.value", "2018-Dec-31");
         });
         it("displays the current month", () => {
           getDateInputComponent().click();
@@ -101,7 +101,7 @@ describe("Datepicker", () => {
           getDateInputComponent().click();
           getDateInputComponent().type("{uparrow}");
           cy.get(".react-datepicker__day--002.react-datepicker__day--selected").should("exist");
-          getDateInputComponent().should("have.value", "02 Jan 2019");
+          getDateInputComponent().should("have.value", "2019-Jan-02");
         });
       });
     });
@@ -116,19 +116,19 @@ describe("Datepicker", () => {
           getDateInputComponent().click();
           getDateInputComponent().type("{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}");
           cy.get(".react-datepicker__day--010.react-datepicker__day--selected").should("exist");
-          getDateInputComponent().should("have.value", "10 Jan 2019");
+          getDateInputComponent().should("have.value", "2019-Jan-10");
           getDateInputComponent().type("{uparrow}");
           cy.get(".react-datepicker__day--010.react-datepicker__day--selected").should("exist");
-          getDateInputComponent().should("have.value", "10 Jan 2019");
+          getDateInputComponent().should("have.value", "2019-Jan-10");
         });
         it("pressing the down arrow selects a previous date up to the min date", () => {
           getDateInputComponent().click();
           getDateInputComponent().type("{downarrow}{downarrow}");
           cy.get(".react-datepicker__day--003.react-datepicker__day--selected").should("exist");
-          getDateInputComponent().should("have.value", "03 Jan 2019");
+          getDateInputComponent().should("have.value", "2019-Jan-03");
           getDateInputComponent().type("{downarrow}");
           cy.get(".react-datepicker__day--003.react-datepicker__day--selected").should("exist");
-          getDateInputComponent().should("have.value", "03 Jan 2019");
+          getDateInputComponent().should("have.value", "2019-Jan-03");
         });
       });
     });

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -29,8 +29,8 @@ type DatePickerProps = FieldProps & {
   className?: string;
 };
 
-const DEFAULT_DATE_FORMAT = "dd MMM yyyy";
-const DEFAULT_PLACEHOLDER = "DD Mon YYYY";
+const DEFAULT_DATE_FORMAT = "yyyy-MMM-dd";
+const DEFAULT_PLACEHOLDER = "YYYY-Mon-DD";
 
 const DatePicker: React.FC<DatePickerProps> = forwardRef(
   (


### PR DESCRIPTION
## Description

The current default date format in the Nulogy date picker is different from the recommendation of the Nulogy content guide. This PR reconciles the two.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
