### PR TITLE
feat: allow select menu to open to the top

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,29 @@
+name: Chromatic
+on:
+  push:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Build Storybook
+        run: yarn build-storybook
+
+      - uses: chromaui/action@v1
+        with:
+          projectToken: ${{ secrets.CHROMATIC_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          storybookBuildDir: "storybook-static"

--- a/src/Select/Select.story.tsx
+++ b/src/Select/Select.story.tsx
@@ -6,7 +6,8 @@ import styled from "styled-components";
 import { text, boolean, select } from "@storybook/addon-knobs";
 import { Button, Select, SelectOption } from "../index";
 import { Box } from "../Box";
-import { SelectProps } from "../Select/Select";
+import { SelectProps } from "../Select";
+import { Flex } from "../Flex";
 
 const errorList = ["Error message 1", "Error message 2"];
 
@@ -564,6 +565,15 @@ export const WithCustomProps = () => {
         components={{ Option: CustomOption, SingleValue: CustomSingleValue }}
       />
     </>
+  );
+};
+
+export const WithTopMenuPlacement = () => {
+
+  return (
+    <Flex height="100vh" alignItems="center" justifyContent="center">
+      <Select options={options} menuPlacement="top" />
+    </Flex>
   );
 };
 

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -44,6 +44,7 @@ export type SelectProps = {
   id?: string;
   initialIsOpen?: boolean;
   menuPosition?: string;
+  menuPlacement?: string;
   maxHeight?: string;
   multiselect?: boolean;
   name?: string;
@@ -80,6 +81,7 @@ export const SelectDefaultProps = {
   initialIsOpen: undefined,
   maxHeight: "248px",
   menuPosition: "absolute",
+  menuPlacement: "bottom",
   multiselect: false,
   name: undefined,
   onBlur: undefined,

--- a/src/Select/customReactSelectStyles.spec.tsx
+++ b/src/Select/customReactSelectStyles.spec.tsx
@@ -1,4 +1,5 @@
-import { showIndicatorSeparator } from "./customReactSelectStyles";
+import { theme } from "..";
+import { getControlBorderRadius, getMenuBorderRadius, showIndicatorSeparator } from "./customReactSelectStyles";
 
 describe("custom react-select styles", () => {
   describe("showIndicatorSeparator", () => {
@@ -18,5 +19,106 @@ describe("custom react-select styles", () => {
         expect(showIndicatorSeparator({ isMulti, hasValue, hasDefaultOptions })).toBe(expected);
       }
     );
+  });
+
+  describe("getControlBorderRadius", () => {
+    it("doesn't have any top border radius when opening to the top", () => {
+      const expected = 0;
+      const result = getControlBorderRadius({
+        border: "top",
+        isMenuOpen: true,
+        menuLength: 2,
+        menuPlacement: "top",
+        theme,
+      });
+
+      expect(result).toEqual(expected);
+    });
+
+    it("doesn't have any bottom border radius when opening to the bottom", () => {
+      const expected = 0;
+      const result = getControlBorderRadius({
+        border: "bottom",
+        isMenuOpen: true,
+        menuLength: 2,
+        menuPlacement: "bottom",
+        theme,
+      });
+
+      expect(result).toEqual(expected);
+    });
+
+    it("has border radius when empty", () => {
+      const expected = theme.radii.medium;
+      const results = [];
+
+      results.push(
+        getControlBorderRadius({
+          border: "bottom",
+          isMenuOpen: true,
+          menuLength: 0,
+          menuPlacement: "bottom",
+          theme,
+        }),
+        getControlBorderRadius({
+          border: "top",
+          isMenuOpen: true,
+          menuLength: 0,
+          menuPlacement: "bottom",
+          theme,
+        }),
+        getControlBorderRadius({
+          border: "bottom",
+          isMenuOpen: true,
+          menuLength: 0,
+          menuPlacement: "top",
+          theme,
+        }),
+        getControlBorderRadius({
+          border: "top",
+          isMenuOpen: true,
+          menuLength: 0,
+          menuPlacement: "top",
+          theme,
+        })
+      );
+
+      for (const result of results) {
+        expect(result).toEqual(expected);
+      }
+    });
+
+    it("has border radius when closed", () => {
+      const expected = theme.radii.medium;
+      const result = getControlBorderRadius({
+        border: "bottom",
+        isMenuOpen: false,
+        menuLength: 2,
+        menuPlacement: "bottom",
+        theme,
+      });
+
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe("getMenuBorderRadius", () => {
+    it("should return a visible border radius when the border and menu placement are the same", () => {
+      const expected = { style: "solid", radius: theme.radii.medium };
+
+      const result = getMenuBorderRadius({ border: "bottom", menuPlacement: "bottom", theme });
+
+      expect(result.style).toEqual(expected.style);
+      expect(result.radius).toEqual(expected.radius);
+    });
+
+    it("should return no border when the border and menu placement are opposites", () => {
+      const expected = { style: "none", radius: 0 };
+
+      const result = getMenuBorderRadius({ border: "top", menuPlacement: "bottom", theme });
+
+      expect(result.style).toEqual(expected.style);
+      expect(result.radius).toEqual(expected.radius);
+    });
   });
 });

--- a/src/Select/customReactSelectStyles.tsx
+++ b/src/Select/customReactSelectStyles.tsx
@@ -1,4 +1,5 @@
 import { transparentize } from "polished";
+import { DefaultNDSThemeType } from "../theme.type";
 
 const getBorderColor = ({ errored, disabled, isOpen, isFocused, theme }) => {
   const { red, lightGrey, blue, grey } = theme.colors;
@@ -21,6 +22,40 @@ const getShadow = ({ errored, isOpen, theme }) => {
     return focus;
   }
 };
+
+type Placement = "top" | "bottom";
+
+export function getControlBorderRadius({
+  border,
+  isMenuOpen,
+  menuLength,
+  menuPlacement,
+  theme,
+}: {
+  border: Placement;
+  isMenuOpen: boolean;
+  menuLength: number;
+  menuPlacement: Placement;
+  theme: DefaultNDSThemeType;
+}) {
+  const isMenuEmpty = menuLength === 0;
+
+  if (!isMenuOpen || isMenuEmpty || border !== menuPlacement) return theme.radii.medium;
+
+  return 0;
+}
+
+export function getMenuBorderRadius({
+  border,
+  menuPlacement,
+  theme,
+}: {
+  border: Placement;
+  menuPlacement: Placement;
+  theme: DefaultNDSThemeType;
+}) {
+  return border === menuPlacement ? { radius: theme.radii.medium, style: "solid" } : { radius: 0, style: "none" };
+}
 
 export const showIndicatorSeparator = ({ isMulti, hasValue, hasDefaultOptions }) =>
   isMulti && hasValue && hasDefaultOptions;
@@ -55,9 +90,36 @@ const customStyles = ({ theme, error, maxHeight, windowed, hasDefaultOptions = t
         theme,
       }),
       borderRadius: theme.radii.medium,
-      borderBottomLeftRadius: state.selectProps.menuIsOpen && state.selectProps.options.length ? 0 : theme.radii.medium,
-      borderBottomRightRadius:
-        state.selectProps.menuIsOpen && state.selectProps.options.length ? 0 : theme.radii.medium,
+      borderBottomLeftRadius: getControlBorderRadius({
+        border: "bottom",
+        isMenuOpen: state.selectProps.menuIsOpen,
+        menuLength: state.selectProps.options.length,
+        menuPlacement: state.selectProps.menuPlacement,
+        theme: theme,
+      }),
+      borderBottomRightRadius: getControlBorderRadius({
+        border: "bottom",
+        isMenuOpen: state.selectProps.menuIsOpen,
+        menuLength: state.selectProps.options.length,
+        menuPlacement: state.selectProps.menuPlacement,
+        theme: theme,
+      }),
+
+      borderTopRightRadius: getControlBorderRadius({
+        border: "top",
+        isMenuOpen: state.selectProps.menuIsOpen,
+        menuLength: state.selectProps.options.length,
+        menuPlacement: state.selectProps.menuPlacement,
+        theme: theme,
+      }),
+      borderTopLeftRadius: getControlBorderRadius({
+        border: "top",
+        isMenuOpen: state.selectProps.menuIsOpen,
+        menuLength: state.selectProps.options.length,
+        menuPlacement: state.selectProps.menuPlacement,
+        theme: theme,
+      }),
+
       "&:hover, &:focus": {
         borderColor: getBorderColor({
           errored: error,
@@ -85,7 +147,9 @@ const customStyles = ({ theme, error, maxHeight, windowed, hasDefaultOptions = t
       maxHeight: "150px",
     }),
     menu: (provided, state) => ({
+      ...provided,
       marginTop: 0,
+      marginBottom: 0,
       position: "absolute",
       overflowX: "auto",
       zIndex: "100",
@@ -99,10 +163,32 @@ const customStyles = ({ theme, error, maxHeight, windowed, hasDefaultOptions = t
         isFocused: false,
         theme,
       }),
-      borderBottomStyle: "solid",
       borderLeftStyle: "solid",
       borderRightStyle: "solid",
-      borderRadius: `0 0 4px 4px`,
+      borderBottomStyle: getMenuBorderRadius({
+        border: "bottom",
+        menuPlacement: state.selectProps.menuPlacement,
+        theme,
+      }).style,
+      borderTopStyle: getMenuBorderRadius({ border: "top", menuPlacement: state.selectProps.menuPlacement, theme })
+        .style,
+      borderBottomLeftRadius: getMenuBorderRadius({
+        border: "bottom",
+        menuPlacement: state.selectProps.menuPlacement,
+        theme,
+      }).radius,
+      borderBottomRightRadius: getMenuBorderRadius({
+        border: "bottom",
+        menuPlacement: state.selectProps.menuPlacement,
+        theme,
+      }).radius,
+      borderTopLeftRadius: getMenuBorderRadius({ border: "top", menuPlacement: state.selectProps.menuPlacement, theme })
+        .radius,
+      borderTopRightRadius: getMenuBorderRadius({
+        border: "top",
+        menuPlacement: state.selectProps.menuPlacement,
+        theme,
+      }).radius,
       boxShadow: getShadow({ errored: error, isOpen: true, theme }),
     }),
     menuList: (provided) => ({


### PR DESCRIPTION
## Description

A fix to address DES-442 to allow select menus to open to the top by adding the `menuPlacement` prop to the `Select` component.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [x] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
