### PR TITLE
Minor fixes for the DatePicker, and DateRange components

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@types/jest": "^29.5.1",
     "@types/node": "^14.0.14",
     "@types/react": "^17.0.9",
+    "@types/react-datepicker": "^4.1.0",
     "@types/react-dom": "^17.0.6",
     "@types/styled-components": "^5.1.9",
     "@types/styled-system": "^5.1.11",

--- a/src/DatePicker/DatePicker.story.tsx
+++ b/src/DatePicker/DatePicker.story.tsx
@@ -19,6 +19,8 @@ export const Default = () => (
   <DatePicker
     selected={select("selected", selectedDateExamples, selectedDateExamples[0], "selected")}
     onChange={action("date changed")}
+    onFocus={action("date selector focused")}
+    onBlur={action("date selector blurred")}
     onInputChange={action("input changed")}
     inputProps={{ labelText: "Expiry Date" }}
   />
@@ -33,6 +35,8 @@ export const WithCustomDateFormat = () => (
     selected={select("selected", selectedDateExamples, selectedDateExamples[0], "selected")}
     dateFormat="MMMM d, yyyy"
     onChange={action("date changed")}
+    onFocus={action("date selector focused")}
+    onBlur={action("date selector blurred")}
     onInputChange={action("input changed")}
     inputProps={{ labelText: "Expiry Date" }}
   />
@@ -45,6 +49,8 @@ WithCustomDateFormat.story = {
 export const WithCustomPlaceholder = () => (
   <DatePicker
     dateFormat="MMMM d, yyyy"
+    onFocus={action("date selector focused")}
+    onBlur={action("date selector blurred")}
     onChange={action("date changed")}
     onInputChange={action("input changed")}
     inputProps={{ labelText: "Expiry Date", placeholder: "Month day, year" }}
@@ -58,6 +64,8 @@ WithCustomPlaceholder.story = {
 export const WithErrorState = () => (
   <DatePicker
     dateFormat="MMMM d, yyyy"
+    onFocus={action("date selector focused")}
+    onBlur={action("date selector blurred")}
     onChange={action("date changed")}
     onInputChange={action("input changed")}
     inputProps={{ labelText: "Expiry Date" }}
@@ -74,6 +82,8 @@ export const WithMinAndMaxDate = () => (
     selected={new Date("2019-01-05T05:00:00.000Z")}
     minDate={new Date("2019-01-03T05:00:00.000Z")}
     maxDate={new Date("2019-01-10T05:00:00.000Z")}
+    onFocus={action("date selector focused")}
+    onBlur={action("date selector blurred")}
     onChange={action("date changed")}
     onInputChange={action("input changed")}
     inputProps={{ labelText: "Expiry Date" }}
@@ -87,6 +97,8 @@ WithMinAndMaxDate.story = {
 export const DisableFlipping = () => (
   <DatePicker
     selected={select("selected", selectedDateExamples, selectedDateExamples[0], "selected")}
+    onBlur={action("date selector blurred")}
+    onFocus={action("date selector focused")}
     onChange={action("date changed")}
     onInputChange={action("input changed")}
     inputProps={{ labelText: "Expiry Date" }}
@@ -109,6 +121,8 @@ export const UsingRefToControlFocus = () => {
       <DatePicker
         dateFormat="MMMM d, yyyy"
         onChange={action("date changed")}
+        onFocus={action("date selector focused")}
+        onBlur={action("date selector blurred")}
         onInputChange={action("input changed")}
         inputProps={{ labelText: "Expiry Date" }}
         ref={ref}

--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -1,6 +1,7 @@
 import { subDays, addDays, isValid, isAfter, isBefore, isSameDay } from "date-fns";
 import React, { useEffect, useState, forwardRef } from "react";
 import ReactDatePicker from "react-datepicker";
+import type { ReactDatePickerProps } from "react-datepicker";
 import propTypes from "@styled-system/prop-types";
 import { InlineValidation } from "../Validation";
 import { Field } from "../Form";
@@ -17,7 +18,9 @@ import { DatePickerStyles } from "./DatePickerStyles";
 type DatePickerProps = FieldProps & {
   selected?: any;
   dateFormat?: string;
-  onChange?: (...args: any[]) => any;
+  onChange?: ReactDatePickerProps["onChange"];
+  onBlur?: ReactDatePickerProps["onBlur"];
+  onFocus?: ReactDatePickerProps["onFocus"];
   onInputChange?: (...args: any[]) => any;
   inputProps?: any;
   errorMessage?: string;
@@ -46,6 +49,8 @@ const DatePicker: React.FC<DatePickerProps> = forwardRef(
       className,
       onInputChange,
       onChange,
+      onBlur,
+      onFocus,
       selected,
       ...props
     },
@@ -88,6 +93,7 @@ const DatePicker: React.FC<DatePickerProps> = forwardRef(
         handleSelectedDateChange(newSelectedDate);
       }
     };
+
     const handleEnterKey = () => {
       if (ref) {
         // @ts-ignore
@@ -119,7 +125,9 @@ const DatePicker: React.FC<DatePickerProps> = forwardRef(
         onEnterKeyPress={handleEnterKey}
       />
     );
+
     const spaceProps = getSubset(props, propTypes.space);
+
     return (
       <Field className={`${className} nds-date-picker`} {...spaceProps}>
         <DatePickerStyles />
@@ -144,7 +152,10 @@ const DatePicker: React.FC<DatePickerProps> = forwardRef(
                 }
                 onRefChange(r);
               }}
+              onFocus={onFocus}
+              onBlur={onBlur}
               popperModifiers={{
+                // @ts-ignore
                 flip: { enabled: !disableFlipping },
               }}
             />

--- a/src/DatePicker/DatePickerInput.tsx
+++ b/src/DatePicker/DatePickerInput.tsx
@@ -4,6 +4,8 @@ import { InputField } from "../Input/InputField";
 import { InputFieldDefaultProps } from "../Input/InputField.type";
 
 type DatePickerInputProps = {
+  onBlur?: React.ComponentPropsWithRef<"input">["onBlur"];
+  onFocus?: React.ComponentPropsWithRef<"input">["onFocus"];
   onClick?: (...args: any[]) => any;
   onChange?: (...args: any[]) => any;
   onUpKeyPress?: (...args: any[]) => any;
@@ -22,6 +24,8 @@ const DatePickerInput: React.FC<DatePickerInputProps> = forwardRef(
     {
       onChange,
       onClick,
+      onBlur,
+      onFocus,
       onInputChange,
       value,
       inputProps = InputFieldDefaultProps,
@@ -50,6 +54,8 @@ const DatePickerInput: React.FC<DatePickerInputProps> = forwardRef(
     const { t } = useTranslation();
     return (
       <InputField
+        onBlur={onBlur}
+        onFocus={onFocus}
         ref={ref}
         aria-label={ariaLabel || t("select a date")}
         autoComplete="off"

--- a/src/DateRange/DateRange.story.tsx
+++ b/src/DateRange/DateRange.story.tsx
@@ -90,6 +90,8 @@ CustomizingInputProps.story = {
   name: "customizing input props",
 };
 
+const NON_BREAKING_SPACE = "\u00A0";
+
 export const Disabled = () => (
   <DateRange
     startDateInputProps={{
@@ -104,15 +106,17 @@ export const Disabled = () => (
       labelText: "To",
       disabled: true,
     }}
-    labelProps={{ labelText: "" }}
     onRangeChange={action("range changed")}
     onStartDateChange={action("start date changed")}
     onEndDateChange={action("end date changed")}
+    labelProps={{ labelText: "" }}
     showTimes
     endTimeProps={{
+      labelText: NON_BREAKING_SPACE,
       disabled: true,
     }}
     startTimeProps={{
+      labelText: NON_BREAKING_SPACE,
       disabled: true,
     }}
   />

--- a/src/DateRange/EndTime.tsx
+++ b/src/DateRange/EndTime.tsx
@@ -3,8 +3,6 @@ import { TimePicker } from "../TimePicker";
 
 const EndTime = styled(TimePicker)(({ theme }) => ({
   marginRight: theme.space.x1,
-  display: "flex",
-  alignItems: "flex-end",
 }));
 
 export default EndTime;

--- a/src/DateRange/StartTime.tsx
+++ b/src/DateRange/StartTime.tsx
@@ -3,8 +3,6 @@ import { TimePicker } from "../TimePicker";
 
 const StartTime = styled(TimePicker)(({ theme }) => ({
   marginLeft: theme.space.x1,
-  display: "flex",
-  alignItems: "flex-end",
 }));
 
 export default StartTime;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4733,6 +4733,16 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-datepicker@^4.1.0":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@types/react-datepicker/-/react-datepicker-4.11.2.tgz#44abfc6379faa58d28eb5730a058d6a389d40eac"
+  integrity sha512-ELYyX3lb3K1WltqdlF1hbnaDGgzlF6PIR5T4W38cSEcfrQDIrPE+Ioq5pwRe/KEJ+ihHMjvTVZQkwJx0pWMNHQ==
+  dependencies:
+    "@popperjs/core" "^2.9.2"
+    "@types/react" "*"
+    date-fns "^2.0.1"
+    react-popper "^2.2.5"
+
 "@types/react-dom@<18.0.0", "@types/react-dom@^17.0.6":
   version "17.0.20"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.20.tgz#e0c8901469d732b36d8473b40b679ad899da1b53"


### PR DESCRIPTION
## Description
Includes the following changes:
- Makes the TimePicker in the DateRange to open to the bottom
- Adds an onFocus and onBlur callbacks to the DatePicker

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [x] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [x] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
