### PR TITLE
Fixes around types and toasts

### DIFF
--- a/src/Link/Link.tsx
+++ b/src/Link/Link.tsx
@@ -1,4 +1,4 @@
-import styled, { CSSObject } from "styled-components";
+import styled from "styled-components";
 import { darken } from "polished";
 import { themeGet } from "@styled-system/theme-get";
 import { variant } from "styled-system";
@@ -9,17 +9,11 @@ import { ComponentSize, useComponentSize } from "../NDSProvider/ComponentSizeCon
 
 export type LinkProps = React.ComponentPropsWithRef<"a"> &
   StyledProps & {
-    className?: string;
     underline?: boolean;
     hover?: string;
-    as?: React.ElementType | string;
     size?: ComponentSize;
     to?: string;
-    color?: string;
-    fontSize?: string;
-    theme?: DefaultNDSThemeType;
-    children: JSX.Element | JSX.Element[] | React.ReactNode;
-    "aria-label"?: string;
+    as?: React.ElementType | string;
   };
 
 const resetButtonStyles = {
@@ -27,20 +21,22 @@ const resetButtonStyles = {
   border: "none",
 };
 
-function getColorFromProps(props: LinkProps) {
+type StyledLinkProps = LinkProps & {
+  theme: DefaultNDSThemeType;
+};
+
+function getColorFromProps(props: StyledLinkProps) {
   return themeGet(`colors.${props.color}`, props.color)(props);
 }
 
-function getColor(props: LinkProps) {
+function getColor(props: StyledLinkProps) {
   return getColorFromProps(props) || props.theme.colors.blue;
 }
 
-const getHoverColor = (props: LinkProps) => (props.hover ? getColor(props) : darken("0.1", getColor(props)));
+const getHoverColor = (props: StyledLinkProps) => (props.hover ? getColor(props) : darken("0.1", getColor(props)));
 
-const StyledLink = styled.a.withConfig<LinkProps>({
-  shouldForwardProp: (prop, defaultValidatorFn) => !["underline", "hover"].includes(prop) && defaultValidatorFn(prop),
-})(
-  ({ underline, as, ...props }): CSSObject => ({
+const StyledLink = styled.a<LinkProps>(
+  ({ underline, as, ...props }) => ({
     ...resetButtonStyles,
     padding: as === "button" ? "0" : undefined,
     textDecoration: underline ? "underline" : "none",
@@ -64,10 +60,10 @@ const StyledLink = styled.a.withConfig<LinkProps>({
   addStyledProps
 );
 
-const Link = React.forwardRef(({ size, ...props }: LinkProps, ref) => {
+const Link = React.forwardRef<HTMLLinkElement, LinkProps>(({ size, ...props }, ref) => {
   const componentSize = useComponentSize(size);
 
-  return <StyledLink size={componentSize} ref={ref} {...props} />;
+  return <StyledLink size={componentSize} {...props} />;
 });
 
 Link.defaultProps = {

--- a/src/Toast/Toast.tsx
+++ b/src/Toast/Toast.tsx
@@ -12,7 +12,7 @@ type ToastProps = AlertProps & {
   onHidden?: () => void;
 };
 
-export const TOAST_SHOW_DURATION = 2000; // in ms
+export const TOAST_SHOW_DURATION = 5000; // in ms
 const ANIMATE_OUT_DURATION = 1000;
 
 export const toastAnimationConfig = {


### PR DESCRIPTION
## Description
* fix: allow toasts to stay longer on the screen
* fix: improve the type for the Link component

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
