### PR TITLE
feat: disable strict date parsing

### DIFF
--- a/src/DatePicker/DatePicker.tsx
+++ b/src/DatePicker/DatePicker.tsx
@@ -155,7 +155,6 @@ const DatePicker: React.FC<DatePickerProps> = forwardRef(
               customInput={customInput}
               renderCustomHeader={renderHeader({ locale })}
               disabledKeyboardNavigation
-              strictParsing
               minDate={minDate}
               maxDate={maxDate}
               highlightDates={highlightDates}


### PR DESCRIPTION
## Description
Disable strict date parsing in the `DatePicker`

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [x] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
