### PR TITLE
fix: restore close dropdown render prop

### DIFF
--- a/cypress/integration/components/Alert.spec.js
+++ b/cypress/integration/components/Alert.spec.js
@@ -2,10 +2,12 @@ describe("Alert", () => {
   before(() => {
     cy.renderFromStorybook("alert--with-a-close-button");
   });
+
   it("shows an alert", () => {
     cy.get('[role="alert"]').should("be.visible");
     cy.isInViewport('[role="alert"]');
   });
+
   it("hides the alert when closed", () => {
     cy.get('[aria-label="Close"]').click();
     cy.get('[role="alert"]').should("not.be.visible");

--- a/cypress/integration/components/DropdownMenu.spec.js
+++ b/cypress/integration/components/DropdownMenu.spec.js
@@ -70,24 +70,47 @@ describe("DropdownMenu", () => {
       getDropdownLink().should("be.focused");
     });
   });
-  it("can be opened with a different element", () => {
-    cy.renderFromStorybook("dropdownmenu--with-custom-trigger");
 
-    getOpenButton().click();
+  describe("with custom trigger", () => {
+    beforeEach(() => {
+      cy.renderFromStorybook("dropdownmenu--with-custom-trigger");
+    });
 
-    assertDropdownIsOpen();
+    it("can be opened with a different element", () => {
+      getOpenButton().click();
+
+      assertDropdownIsOpen();
+    });
   });
 
-  it("handles submenus that open on hover", () => {
-    cy.renderFromStorybook("dropdownmenu--with-submenu");
+  describe("with button closing menu", () => {
+    beforeEach(() => {
+      cy.renderFromStorybook("dropdownmenu--with-button-closing-menu");
+    });
 
-    getOpenButton().click();
-    assertDropdownIsOpen();
+    it("can be closed with a callback function", () => {
+      getOpenButton().click();
+      assertDropdownIsOpen();
 
-    getSubmenuButton().trigger('mouseover')
-    assertSubDropdownIsOpen();
+      getCloseButton().click();
+      assertDropdownIsClosed();
+    });
+  });
 
-    getSubCloseButton().trigger('mouseout')
-    assertSubDropdownIsClosed();
+  describe("with submenu", () => {
+    beforeEach(() => {
+      cy.renderFromStorybook("dropdownmenu--with-submenu");
+    });
+
+    it("handles submenus that open on hover", () => {
+      getOpenButton().click();
+      assertDropdownIsOpen();
+
+      getSubmenuButton().trigger("mouseover");
+      assertSubDropdownIsOpen();
+
+      getSubCloseButton().trigger("mouseout");
+      assertSubDropdownIsClosed();
+    });
   });
 });

--- a/src/DropdownMenu/DropdownMenu.tsx
+++ b/src/DropdownMenu/DropdownMenu.tsx
@@ -1,20 +1,19 @@
-// @ts-nocheck
 import React, { useMemo } from "react";
 import propTypes from "@styled-system/prop-types";
 import { Reference } from "react-popper";
 import { IconicButton } from "../Button";
+import { ComponentSize, useComponentSize } from "../NDSProvider/ComponentSizeContext";
 import { Popper } from "../Popper";
 import { getSubset, omitSubset } from "../utils/subset";
 import { StyledProps } from "../StyledProps";
 import DropdownMenuContainer from "./DropdownMenuContainer";
-import { ComponentSize, useComponentSize } from "../NDSProvider/ComponentSizeContext";
 
 type DropdownMenuProps = {
   className?: string;
   size?: ComponentSize;
   id?: string;
   disabled?: boolean;
-  trigger?: React.ReactNode | ((...args: any[]) => any);
+  trigger?: () => React.FunctionComponentElement<unknown>;
   backgroundColor?: string;
   showArrow?: boolean;
   placement?:
@@ -48,7 +47,7 @@ const transformPropsToModifiers = ({ boundariesElement }) => ({
   boundariesElement,
 });
 
-const DropdownMenu: React.FC<DropdownMenuProps> = React.forwardRef<DropdownMenuProps, Reference>(
+const DropdownMenu: React.FC<DropdownMenuProps> = React.forwardRef<Reference, DropdownMenuProps>(
   (
     {
       trigger = () => <IconicButton icon="more" />,
@@ -108,9 +107,13 @@ const DropdownMenu: React.FC<DropdownMenuProps> = React.forwardRef<DropdownMenuP
           showArrow={showArrow}
           {...restProps}
         >
-          {React.Children.map(children, (child) =>
-            React.cloneElement(child, { size: componentSize, ...child.props }, child.props.children)
-          )}
+          {typeof children === "function"
+            ? children
+            : React.Children.map(children, (child) => {
+                if (React.isValidElement(child)) {
+                  return React.cloneElement(child, { size: componentSize, ...child.props }, child.props.children);
+                }
+              })}
         </DropdownMenuContainer>
       </Popper>
     );

--- a/src/DropdownMenu/DropdownMenuContainer.tsx
+++ b/src/DropdownMenu/DropdownMenuContainer.tsx
@@ -4,6 +4,7 @@ import { Box } from "../Box";
 import { DefaultNDSThemeType } from "../theme.type";
 
 type DropdownMenuContainerProps = {
+  id?: string;
   className?: string;
   backgroundColor?: string;
   showArrow?: boolean;

--- a/src/Table/Table.spec.tsx
+++ b/src/Table/Table.spec.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { fireEvent } from "@testing-library/react";
-
 import { Pagination } from "../Pagination";
 import { renderWithNDSProvider } from "../NDSProvider/renderWithNDSProvider.spec-utils";
 import { mountWithNDSProvider } from "../NDSProvider/mountWithNDSProvider.spec-utils";
@@ -23,6 +22,7 @@ describe("Table", () => {
 
         expect(callback).toHaveBeenCalledWith([rowData[0].c1]);
       });
+
       it("returns an empty array if no rows are selected", () => {
         const columns = [{ label: "Column 1", dataKey: "c1" }];
         const rowData = [{ c1: "r1c1" }, { c1: "r2c1" }];
@@ -39,6 +39,7 @@ describe("Table", () => {
       });
     });
   });
+
   describe("expandedRows", () => {
     describe("onRowExpansionChange:", () => {
       it("returns the expanded rows when the a row was expanded or collapsed", () => {
@@ -72,6 +73,7 @@ describe("Table", () => {
 
         expect(callback).toHaveBeenCalledWith(["2"]);
       });
+
       it("returns an empty array if no rows are expanded", () => {
         const expandedContent = () => <p>Expands!</p>;
         const rowData = [
@@ -109,6 +111,7 @@ describe("Table", () => {
       });
     });
   });
+
   describe("pagination", () => {
     describe("onPageChange:", () => {
       it("called when a new page is selected", () => {
@@ -149,6 +152,7 @@ describe("Table", () => {
         expect(pageChangeCallback).toHaveBeenCalledWith(2);
       });
     });
+
     describe("rowsPerPage", () => {
       it("displays the correct number of rows", () => {
         const pageChangeCallback = jest.fn();
@@ -166,6 +170,7 @@ describe("Table", () => {
         const rows = wrapper.find("tbody tr");
         expect(rows.length).toEqual(ROWS_PER_PAGE);
       });
+
       it("renders the inner Pagination with correct props", () => {
         const wrapper = mountWithNDSProvider(
           <Table columns={mockColumns} rows={getMockRows(20)} hasSelectableRows keyField="c1" rowsPerPage={6} />
@@ -175,6 +180,7 @@ describe("Table", () => {
         expect(pagination.props().totalPages).toEqual(4);
         expect(pagination.props().currentPage).toEqual(1);
       });
+
       it("does not display pagination when rowsPerPage is falsy", () => {
         const wrapper = mountWithNDSProvider(
           <Table columns={mockColumns} rows={getMockRows(20)} hasSelectableRows keyField="c1" />
@@ -186,6 +192,7 @@ describe("Table", () => {
       });
     });
   });
+
   describe("loading", () => {
     it("shows only loading text when loading", () => {
       const wrapper = mountWithNDSProvider(
@@ -196,6 +203,7 @@ describe("Table", () => {
       expect(loadingCell.text()).toEqual("Loading...");
       expect(rows.length).toEqual(1);
     });
+
     it("shows rows when not loading", () => {
       const rowData = getMockRows(20);
       const wrapper = mountWithNDSProvider(
@@ -207,6 +215,7 @@ describe("Table", () => {
       expect(rows.length).toEqual(20);
     });
   });
+
   describe("row hovers", () => {
     describe("onRowMouseEnter", () => {
       it("is called with the row when mouse enters a row", () => {
@@ -224,6 +233,7 @@ describe("Table", () => {
       });
     });
   });
+
   describe("row hovers", () => {
     describe("onRowMouseLeave", () => {
       it("is called with the row when mouse leaves a row", () => {


### PR DESCRIPTION
## Description

This PR restores functionality that was removed when introducing the `size` prop. 

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [x] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
