### PR TITLE
chore: extra small storybook viewports

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -6,7 +6,7 @@ const newViewports = {
   extraSmall: {
     name: "Extra small",
     styles: {
-      width: theme.breakpoints.extraSmall,
+      width: "320px",
       height: "100%",
     },
   },
@@ -39,6 +39,7 @@ const newViewports = {
     },
   },
 };
+
 export const parameters = {
   viewport: { viewports: newViewports },
   layout: "padded",

--- a/src/DropdownMenu/DropdownMenu.story.tsx
+++ b/src/DropdownMenu/DropdownMenu.story.tsx
@@ -20,6 +20,9 @@ const customColors = {
 
 export default {
   title: "Components/DropdownMenu",
+  parameters: {
+    chromatic: { diffThreshold: 0.4 },
+  },
 };
 
 export const _DropdownMenu = () => (


### PR DESCRIPTION
## Description
Fix the small storybook viewport which is currently using 0px.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [x] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
