### PR TITLE
feat: add predefined widths to the Sidebar

### DIFF
--- a/src/Layout/Sidebar.story.tsx
+++ b/src/Layout/Sidebar.story.tsx
@@ -410,3 +410,32 @@ export const WithALongTitle = () => {
     </ApplicationFrame>
   );
 };
+
+export const WithDifferentWidths = () => {
+  const [width, setWidth] = useState({ value: "xs", label: "Extra small (xs)" });
+
+  const options = [
+    { value: "xs", label: "Extra small (xs) - Default" },
+    { value: "s", label: "Small (s)" },
+    { value: "m", label: "Medium (m)" },
+    { value: "l", label: "Large (l)" },
+    { value: "xl", label: "Extra large (xl)" },
+    { value: "700px", label: "Custom value (700px)" },
+    { value: "75ch", label: "Custom value (75ch)" },
+    { value: "100%", label: "Custom value (100%)" },
+  ];
+
+  return (
+    <Sidebar hideCloseButton top={0} height="100%" width={width.value} isOpen title={`${width.label} sidebar`}>
+      <Select
+        value={width.value}
+        options={options}
+        onChange={(s: string) => {
+          const [option] = options.filter(({ value }) => value === s);
+          setWidth(option);
+        }}
+        labelText="Sidebar size"
+      />
+    </Sidebar>
+  );
+};

--- a/src/Layout/Sidebar.story.tsx
+++ b/src/Layout/Sidebar.story.tsx
@@ -11,6 +11,11 @@ import {
   Select,
   PrimaryButton,
   Box,
+  Textarea,
+  Text,
+  Flex,
+  Button,
+  Heading3,
 } from "..";
 
 const primaryMenu = [
@@ -437,5 +442,63 @@ export const WithDifferentWidths = () => {
         labelText="Sidebar size"
       />
     </Sidebar>
+  );
+};
+
+export const WithHelpText = () => {
+  const [helpText, setHelpText] = useState(
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus tempor lacus nec finibus egestas."
+  );
+
+  return (
+    <Sidebar hideCloseButton top={0} height="100%" isOpen title="With help text" helpText={helpText}>
+      <Textarea
+        value={helpText}
+        labelText="Help Text"
+        placeholder="Enter some text..."
+        onChange={(event) => {
+          setHelpText(event.target.value);
+        }}
+      />
+    </Sidebar>
+  );
+};
+export const WithOtherElementsInHelpText = () => {
+  return (
+    <Sidebar
+      hideCloseButton
+      top={0}
+      height="100%"
+      isOpen
+      title="With help text"
+      helpText={
+        <>
+          Carry over remaining quantity to a future PO line item.{" "}
+          <Link underline={false} href="/">
+            Learn more
+          </Link>{" "}
+        </>
+      }
+    ></Sidebar>
+  );
+};
+
+export const WithARenderedHelpText = () => {
+  return (
+    <Sidebar
+      hideCloseButton
+      top={0}
+      height="100%"
+      isOpen
+      title="With help text"
+      renderHelpText={() => (
+        <Heading3 color="red" fontWeight="bold">
+          This is a custom help text{" "}
+          <Link href="/" underline={false}>
+            Learn more
+          </Link>
+        </Heading3>
+      )}
+    ></Sidebar>
   );
 };

--- a/src/Layout/Sidebar.tsx
+++ b/src/Layout/Sidebar.tsx
@@ -4,10 +4,11 @@ import { useTranslation } from "react-i18next";
 import { Box } from "../Box";
 import { Flex } from "../Flex";
 import { IconicButton } from "../Button";
-import { Heading3 } from "../Type";
+import { Heading3, Text } from "../Type";
 import { AnimatedBoxProps, AnimatedBox } from "../Box/Box";
 import { NAVBAR_HEIGHT } from "../BrandedNavBar/NavBar";
 import { PreventBodyElementScrolling } from "../utils";
+import { Divider } from "../Divider";
 
 type PredefinedSidebarWidth = "xs" | "s" | "m" | "l" | "xl";
 
@@ -41,6 +42,8 @@ type SidebarProps = Omit<AnimatedBoxProps, "width"> & {
   disableScroll?: boolean;
   hideCloseButton?: boolean;
   width?: SidebarWidth;
+  helpText?: React.ReactNode;
+  renderHelpText?: () => React.ReactNode;
 };
 
 const focusFirstElement = () => {
@@ -69,7 +72,7 @@ const SidebarOverlay = ({ transitionDuration, top, transparent, zIndex = 799 as 
   />
 );
 function Sidebar({
-  p = "x3",
+  p = "x2",
   width = "xs",
   children,
   onClose,
@@ -87,6 +90,8 @@ function Sidebar({
   disableScroll = true,
   hideCloseButton = false,
   zIndex = "sidebar" as any,
+  helpText,
+  renderHelpText,
   ...props
 }: SidebarProps) {
   const closeButton = useRef(null);
@@ -191,24 +196,36 @@ function Sidebar({
           flexDirection="column"
           style={{ overflowBehaviour: "contain" } as any}
         >
-          <Flex justifyContent="space-between" alignItems="flex-start" pb="x3">
-            {title && (
-              <Flex alignItems="center" height="100%">
-                <Heading3 mb={0}>{title}</Heading3>
+          <Flex flexDirection="column" pb="x3">
+            <Flex flexDirection="column" pb="x2">
+              <Flex justifyContent="space-between" alignItems="flex-start">
+                {title && (
+                  <Flex alignItems="center" height="100%">
+                    <Heading3 mb={0}>{title}</Heading3>
+                  </Flex>
+                )}
+                {!hideCloseButton && (
+                  <Box marginLeft="x2">
+                    <IconicButton
+                      type="button"
+                      ref={closeButton}
+                      icon="close"
+                      onClick={onClose}
+                      data-testid={closeButtonTestId}
+                      aria-label={closeButtonAriaLabel || t("close")}
+                    />
+                  </Box>
+                )}
               </Flex>
-            )}
-            {!hideCloseButton && (
-              <Box marginLeft="x2">
-                <IconicButton
-                  type="button"
-                  ref={closeButton}
-                  icon="close"
-                  onClick={onClose}
-                  data-testid={closeButtonTestId}
-                  aria-label={closeButtonAriaLabel || t("close")}
-                />
-              </Box>
-            )}
+              {renderHelpText
+                ? renderHelpText()
+                : helpText && (
+                    <Text pt="x1" color="midGrey">
+                      {helpText}
+                    </Text>
+                  )}
+            </Flex>
+            <Divider m="0 -8px" width="calc(100% + 16px)" />
           </Flex>
           <AnimatedBox
             variants={childVariants}

--- a/src/Layout/Sidebar.tsx
+++ b/src/Layout/Sidebar.tsx
@@ -1,29 +1,46 @@
-import React, { useEffect, useState, useRef, RefObject } from "react";
+import React, { useEffect, useState, useRef, RefObject, CSSProperties } from "react";
 import { AnimatePresence } from "framer-motion";
+import { useTranslation } from "react-i18next";
 import { Box } from "../Box";
 import { Flex } from "../Flex";
 import { IconicButton } from "../Button";
 import { Heading3 } from "../Type";
 import { AnimatedBoxProps, AnimatedBox } from "../Box/Box";
 import { NAVBAR_HEIGHT } from "../BrandedNavBar/NavBar";
-import { useTranslation } from "react-i18next";
 import { PreventBodyElementScrolling } from "../utils";
 
-type SidebarProps = AnimatedBoxProps & {
+type PredefinedSidebarWidth = "xs" | "s" | "m" | "l" | "xl";
+
+// We need (string & {}) to allow passing
+// custom values in addition to the predefined width
+// https://twitter.com/mattpocockuk/status/1671908303918473217
+// eslint-disable-next-line @typescript-eslint/ban-types
+type SidebarWidth = PredefinedSidebarWidth | (string & {});
+
+const sidebarWidths: Record<PredefinedSidebarWidth, CSSProperties["width"]> = {
+  xs: "400px",
+  s: "520px",
+  m: "640px",
+  l: "768px",
+  xl: "1024px",
+} as const;
+
+type SidebarProps = Omit<AnimatedBoxProps, "width"> & {
   children?: React.ReactNode;
-  onClose?: (arg: any) => any;
+  onClose?: () => void;
   title?: string;
   isOpen?: boolean;
   footer?: React.ReactNode;
   closeButtonTestId?: string;
   closeButtonAriaLabel?: string;
   offset?: string;
-  triggerRef?: RefObject<any>;
+  triggerRef?: RefObject<HTMLInputElement | HTMLButtonElement>;
   duration?: number;
   closeOnOutsideClick?: boolean;
   overlay?: boolean;
   disableScroll?: boolean;
   hideCloseButton?: boolean;
+  width?: SidebarWidth;
 };
 
 const focusFirstElement = () => {
@@ -51,10 +68,9 @@ const SidebarOverlay = ({ transitionDuration, top, transparent, zIndex = 799 as 
     onMouseDown={onClick}
   />
 );
-
-const Sidebar: React.FC<SidebarProps> = ({
+function Sidebar({
   p = "x3",
-  width = "400px",
+  width = "xs",
   children,
   onClose,
   title,
@@ -70,14 +86,16 @@ const Sidebar: React.FC<SidebarProps> = ({
   overlay = true,
   disableScroll = true,
   hideCloseButton = false,
-  zIndex,
+  zIndex = "sidebar" as any,
   ...props
-}) => {
+}: SidebarProps) {
   const closeButton = useRef(null);
   const [shouldUpdateFocus, setShouldUpdateFocus] = useState(false);
   const { t } = useTranslation();
   const sideBarRef = useRef(null);
   const contentRef = useRef(null);
+
+  const selectedWidth = sidebarWidths[width] ?? width;
 
   useEffect(() => {
     if (closeButton.current && isOpen) {
@@ -88,7 +106,7 @@ const Sidebar: React.FC<SidebarProps> = ({
       }
     } else if (shouldUpdateFocus) {
       if (triggerRef) {
-        triggerRef.current.focus();
+        triggerRef?.current?.focus();
       } else {
         focusFirstElement();
       }
@@ -160,8 +178,8 @@ const Sidebar: React.FC<SidebarProps> = ({
         position="fixed"
         top={top}
         right={offset}
-        width={typeof width === "string" ? { default: "100%", small: width } : width}
-        zIndex={zIndex || ("sidebar" as any)}
+        width={typeof selectedWidth === "string" ? { default: "100%", small: selectedWidth } : selectedWidth}
+        zIndex={zIndex}
         ref={sideBarRef as any}
         {...props}
       >
@@ -220,6 +238,6 @@ const Sidebar: React.FC<SidebarProps> = ({
       </AnimatedBox>
     </>
   );
-};
+}
 
 export default Sidebar;


### PR DESCRIPTION
## Description

- Allow passing a predefined width ("xs", "s", "m", "l", "xl") when using the Sidebar while preserving the ability to pass any other valid width  value.
- Add a helpText and a renderHelpText props to the Sidebar component.

## Linked issues
Fixes #1293

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [x] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [x] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
