### PR TITLE
Truncated text allows font size

### DIFF
--- a/src/TruncatedText/TruncatedText.story.tsx
+++ b/src/TruncatedText/TruncatedText.story.tsx
@@ -7,7 +7,9 @@ export default {
   title: "Components/TruncatedText",
 };
 
-export const _TruncatedText = () => <TruncatedText>Special instructions are provided for the shipment</TruncatedText>;
+export const _TruncatedText = () => (
+  <TruncatedText fontSize="small">Special instructions are provided for the shipment</TruncatedText>
+);
 
 _TruncatedText.story = {
   name: "TruncatedText",

--- a/src/TruncatedText/TruncatedText.tsx
+++ b/src/TruncatedText/TruncatedText.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import { Text } from "../Type";
 import { TruncatedTextProps } from "./TruncatedTextProps";

--- a/src/TruncatedText/TruncatedTextMaxCharacters.tsx
+++ b/src/TruncatedText/TruncatedTextMaxCharacters.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Text } from "../Type";
 import { TruncatedTextProps } from "./TruncatedTextProps";
-import { TooltipProps } from "../Tooltip/Tooltip";
 import MaybeTooltip from "./MaybeTooltip";
 
 const TruncatedTextMaxCharacters = ({

--- a/src/TruncatedText/TruncatedTextProps.ts
+++ b/src/TruncatedText/TruncatedTextProps.ts
@@ -1,6 +1,7 @@
 import { TooltipProps } from "../Tooltip/Tooltip";
+import { TextProps } from "../Type";
 
-export type TruncatedTextProps = {
+export interface TruncatedTextProps extends TextProps {
   children?: string;
   indicator?: string;
   element?: any;
@@ -9,4 +10,4 @@ export type TruncatedTextProps = {
   fullWidth?: boolean;
   "data-testid"?: string;
   tooltipProps?: TooltipProps;
-};
+}


### PR DESCRIPTION
## Description

Even though `<TruncatedText` allows for font size in practice, the types don't indicate as such. This fixes the associated type.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
