### PR TITLE
fix: allow NDS users to typecheck style-system props

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "@types/react-datepicker": "^4.1.0",
     "@types/react-dom": "^17.0.20",
     "@types/styled-components": "^5.1.9",
-    "@types/styled-system": "^5.1.11",
     "@typescript-eslint/eslint-plugin": "^4.0.0",
     "@typescript-eslint/parser": "^5.30.5",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.8.0",
@@ -164,7 +163,8 @@
     "react-resize-detector": "^9.1.0",
     "react-windowed-select": "2.0.5",
     "smoothscroll-polyfill": "^0.4.4",
-    "styled-system": "^5.1.4"
+    "styled-system": "^5.1.4",
+    "@types/styled-system": "5.1.22"
   },
   "husky": {
     "hooks": {

--- a/src/Table/BaseTable.story.tsx
+++ b/src/Table/BaseTable.story.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from "react";
+import styled from "styled-components";
 import { boolean, text } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
 import { Box, DropdownButton, DropdownMenu, Button, Text } from "..";
@@ -280,7 +281,7 @@ export const WithData = () => (
 );
 
 WithData.story = {
-  name: " with data",
+  name: "with data",
 };
 
 export const WithNoData = () => (
@@ -392,3 +393,24 @@ WithAFooter.story = {
   name: "with a footer",
 };
 /* eslint-enable react/prop-types */
+
+const TableWithBorderedRows = styled(Table)`
+  border-collapse: collapse;
+
+  > tbody > tr {
+    border-bottom: 1px solid;
+    border-color: ${({ theme }) => theme.colors.lightGrey};
+    border-collapse: collapse;
+  }
+`;
+
+export const WithRowBorder = () => (
+  <TableWithBorderedRows
+    columns={columns}
+    rows={rowData}
+    rowHovers={boolean("Show row hovers", true)}
+    compact={boolean("Show with compact styling", false)}
+    loading={boolean("Show loading state", false)}
+    className="Table"
+  />
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5079,10 +5079,10 @@
     "@types/react" "*"
     csstype "^3.0.2"
 
-"@types/styled-system@^5.1.11":
-  version "5.1.11"
-  resolved "https://registry.yarnpkg.com/@types/styled-system/-/styled-system-5.1.11.tgz#158849f3b14cdf8bf27a10f0cf87a2c3a89eb680"
-  integrity sha512-R+JxEZYa5T0HD2urViR/mdklVaGhwbNOtDoWWGQ1+z1CGs/gF1UAKCaS//YwsUwterEKpyaKxgaXyFNKF04GCA==
+"@types/styled-system@5.1.22":
+  version "5.1.22"
+  resolved "https://registry.yarnpkg.com/@types/styled-system/-/styled-system-5.1.22.tgz#508499f4c68bb86dde3454693e92f5771edf177f"
+  integrity sha512-NbRp37zWcrf/+Qf2NumdyZfhSx1dzJ50zgfKvnezYJx1HTRUMVYY8jtWvK1eoIAa6F5sXwHLhE8oXNu15ThBAA==
   dependencies:
     csstype "^3.0.2"
 


### PR DESCRIPTION
## Description

- fix: allow NDS users to typecheck style-system props
- chore: add a story for a row with border

Fixes: #1350

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
