### PR TITLE
chore: allow storybook to load esmodules

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,5 +1,17 @@
 module.exports = {
   stories: ["../src/**/*.story.tsx", "../src/**/*.story.js"],
+  webpackFinal: async (config) => {
+    // Resolve error when webpack-ing storybook:
+    // Can't import the named export 'Children' from non EcmaScript module (only
+    // default export is available)
+    config.module.rules.push({
+      test: /\.mjs$/,
+      include: /node_modules/,
+      type: "javascript/auto",
+    });
+
+    return config;
+  },
   addons: [
     "@storybook/addon-knobs",
     "@storybook/addon-viewport",


### PR DESCRIPTION
## Description
Resolves error when loading packages with .mjs files:
`Can't import the named export 'Children' from non EcmaScript module (only default export is available)`

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [x] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
