### PR TITLE
Fix StatusIndicator types

### DIFF
--- a/src/StatusIndicator/StatusIndicator.story.tsx
+++ b/src/StatusIndicator/StatusIndicator.story.tsx
@@ -96,7 +96,7 @@ export const InsideFlex = () => (
       <Heading2 inline mr="x1" mb="0">
         Label
       </Heading2>
-      <StatusIndicator>Status</StatusIndicator>
+      <StatusIndicator className="my-test-classname">Status</StatusIndicator>
     </Flex>
     <Flex mb="x3">
       <Heading3 inline mr="x1" mb="0">

--- a/src/StatusIndicator/StatusIndicator.tsx
+++ b/src/StatusIndicator/StatusIndicator.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styled from "styled-components";
 import { space, typography, flexbox, SpaceProps, TypographyProps, FlexboxProps } from "styled-system";
 import { DefaultNDSThemeType } from "../theme.type";
@@ -54,25 +53,18 @@ const statusIndicatorStyles = (theme: DefaultNDSThemeType) => ({
   },
 });
 
-type StatusIndicatorProps = SpaceProps &
-  TypographyProps &
-  FlexboxProps & {
-    type?: StatusIndicatorType;
-  };
+interface Props extends SpaceProps, TypographyProps, FlexboxProps {
+  type?: StatusIndicatorType;
+}
 
-const StatusIndicator: React.FC<StatusIndicatorProps> = styled.span(
-  space,
-  typography,
-  flexbox,
-  ({ theme, type }: { theme: DefaultNDSThemeType; type: StatusIndicatorType }) => ({
-    display: "inline-block",
-    fontWeight: theme.fontWeights.bold,
-    textTransform: "uppercase",
-    letterSpacing: ".05em",
-    borderRadius: theme.space.x1,
-    ...statusIndicatorStyles(theme)[type],
-  })
-);
+const StatusIndicator = styled.span<Props>(space, typography, flexbox, ({ theme, type }) => ({
+  display: "inline-block",
+  fontWeight: theme.fontWeights.bold,
+  textTransform: "uppercase",
+  letterSpacing: ".05em",
+  borderRadius: theme.space.x1,
+  ...statusIndicatorStyles(theme)[type],
+}));
 
 StatusIndicator.defaultProps = {
   type: StatusIndicatorValues.neutral,


### PR DESCRIPTION
## Description

`className` wasn't a recognized prop type

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
