### PR TITLE
feat: IconicButton can have complex tooltips

### DIFF
--- a/src/Button/IconicButton.story.tsx
+++ b/src/Button/IconicButton.story.tsx
@@ -84,6 +84,16 @@ WithATooltipAndLabel.story = {
   name: "with a tooltip and label",
 };
 
+export const WithAComplicatedTooltipAndLabel = () => (
+  <IconicButton tooltip={<Box>Hello</Box>} icon="close">
+    Please stop
+  </IconicButton>
+);
+
+WithAComplicatedTooltipAndLabel.story = {
+  name: "with a complicated tooltip and label",
+};
+
 export const rightAligned = () => (
   <Flex px="x3" height="150px">
     <Flex justifyContent="flex-end" alignItems="flex-start" width="100%">

--- a/src/Button/IconicButton.tsx
+++ b/src/Button/IconicButton.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import styled from "styled-components";
-import PropTypes from "prop-types";
 import { space, SpaceProps, variant } from "styled-system";
 import { Manager, Reference, Popper } from "react-popper-2";
 import { transparentize } from "polished";
@@ -10,18 +9,21 @@ import { Text } from "../Type";
 import { DefaultNDSThemeType } from "../theme.type";
 import { ComponentSize, useComponentSize } from "../NDSProvider/ComponentSizeContext";
 
-type BaseProps = {
+interface BaseProps {
   size?: ComponentSize;
   color?: string;
   labelHidden?: boolean;
-  icon?: any;
+  icon?: string;
   iconSize?: string;
   hoverBackgroundColor?: string;
   fontSize?: string;
-  tooltip?: string;
-};
+  tooltip?: React.ReactNode;
+}
 
-type IconicButtonProps = BaseProps & SpaceProps & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseProps>;
+interface IconicButtonProps
+  extends BaseProps,
+    SpaceProps,
+    Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseProps> {}
 
 const IconWrapper = styled.span(({ theme, size }: { theme: DefaultNDSThemeType; size: string }) => ({
   display: "inline-flex",
@@ -34,7 +36,7 @@ const IconWrapper = styled.span(({ theme, size }: { theme: DefaultNDSThemeType; 
   transition: ".2s",
 }));
 
-const HoverText: React.FC<any> = styled.div(({ theme }) => ({
+const HoverText = styled.div(({ theme }) => ({
   whiteSpace: "nowrap",
   ontSize: theme.fontSizes.small,
   lineHeight: theme.lineHeights.smallTextCompressed,
@@ -47,7 +49,7 @@ const HoverText: React.FC<any> = styled.div(({ theme }) => ({
 }));
 
 const WrapperButton = styled.button<IconicButtonProps>(
-  ({ disabled, hoverBackgroundColor, theme }: any) => ({
+  ({ disabled, hoverBackgroundColor, theme }) => ({
     background: "transparent",
     border: "none",
     position: "relative",
@@ -165,9 +167,9 @@ const IconicButton = React.forwardRef<HTMLButtonElement, IconicButtonProps>(
               },
             ]}
           >
-            {({ ref, style, placement }) =>
+            {({ ref, style }) =>
               labelHidden || tooltip ? (
-                <HoverText ref={ref} style={style} placement={placement}>
+                <HoverText ref={ref} style={style}>
                   {tooltip ? tooltip : children}
                 </HoverText>
               ) : null
@@ -189,16 +191,5 @@ const IconicButton = React.forwardRef<HTMLButtonElement, IconicButtonProps>(
 );
 
 export const iconNames = Object.keys(icons);
-
-IconicButton.propTypes = {
-  className: PropTypes.string,
-  color: PropTypes.string,
-  disabled: PropTypes.bool,
-  onClick: PropTypes.func,
-  icon: PropTypes.string,
-  iconSize: PropTypes.string,
-  tooltip: PropTypes.string,
-  children: PropTypes.node,
-};
 
 export default IconicButton;

--- a/src/Icon/Icon.tsx
+++ b/src/Icon/Icon.tsx
@@ -6,7 +6,7 @@ import icons from "@nulogy/icons";
 import theme from "../theme";
 import LoadingIcon from "./LoadingIcon";
 
-type IconProps = SpaceProps & {
+interface IconProps extends SpaceProps {
   icon: string;
   className?: string;
   size?: string;
@@ -14,7 +14,7 @@ type IconProps = SpaceProps & {
   color?: string;
   focusable?: boolean;
   style?: React.CSSProperties;
-};
+}
 
 /* eslint-disable react/no-array-index-key */
 const getPathElements = (icon: any) => (


### PR DESCRIPTION
## Description
Modify the types for the Tooltip component to allow passing any React node and not just strings.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [x] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
