### PR TITLE
fix: custom select option props are incorrect

### DIFF
--- a/src/AsyncSelect/AsyncSelect.tsx
+++ b/src/AsyncSelect/AsyncSelect.tsx
@@ -10,7 +10,6 @@ import { Field } from "../Form";
 import { MaybeFieldLabel } from "../FieldLabel";
 import { InlineValidation } from "../Validation";
 import customStyles from "../Select/customReactSelectStyles";
-import { SelectOption } from "../Select/SelectOption";
 import { getSubset } from "../utils/subset";
 import { ComponentSize, useComponentSize } from "../NDSProvider/ComponentSizeContext";
 import {
@@ -21,6 +20,7 @@ import {
   SelectInput,
   SelectDropdownIndicator,
   SelectMenu,
+  SelectOption,
 } from "./AsyncSelectComponents";
 
 type AsyncCustomProps<Option, IsMulti extends boolean, Group extends GroupBase<Option>> = {
@@ -130,7 +130,11 @@ const AsyncSelect = forwardRef(
             onInputChange={onInputChange}
             theme={theme as any}
             components={{
-              Option: (props) => <SelectOption size={componentSize} {...props} />,
+              Option: (props) => (
+                <SelectOption size={componentSize} {...props}>
+                  {props.children}
+                </SelectOption>
+              ),
               Control: SelectControl,
               MultiValue: SelectMultiValue,
               ClearIndicator: SelectClearIndicator,

--- a/src/AsyncSelect/AsyncSelectComponents.tsx
+++ b/src/AsyncSelect/AsyncSelectComponents.tsx
@@ -10,6 +10,9 @@ import {
   MultiValueProps,
 } from "react-select";
 import { components, GroupBase } from "react-select";
+import { OptionProps } from "react-windowed-select";
+import { ComponentSize, useComponentSize } from "../NDSProvider/ComponentSizeContext";
+import { StyledOption } from "../Select/SelectOption";
 
 export const SelectControl = <Option, IsMulti extends boolean, Group extends GroupBase<Option>>(
   props: ControlProps<Option, IsMulti, Group>
@@ -22,7 +25,9 @@ export const SelectControl = <Option, IsMulti extends boolean, Group extends Gro
         className={isFocused ? "nds-select--is-focused" : null}
         isFocused={isFocused}
         {...props}
-      />
+      >
+        {props.children}
+      </selectComponents.Control>
     </div>
   );
 };
@@ -32,7 +37,7 @@ export const SelectMultiValue = <Option, IsMulti extends boolean, Group extends 
 ) => {
   return (
     <div data-testid="select-multivalue">
-      <selectComponents.MultiValue {...props} />
+      <selectComponents.MultiValue {...props}>{props.children}</selectComponents.MultiValue>
     </div>
   );
 };
@@ -42,7 +47,7 @@ export const SelectClearIndicator = <Option, IsMulti extends boolean, Group exte
 ) => {
   return (
     <div data-testid="select-clear">
-      <selectComponents.ClearIndicator {...props} />
+      <selectComponents.ClearIndicator {...props}>{props.children}</selectComponents.ClearIndicator>
     </div>
   );
 };
@@ -52,7 +57,7 @@ export const SelectDropdownIndicator = <Option, IsMulti extends boolean, Group e
 ) => {
   return (
     <div data-testid="select-arrow">
-      <selectComponents.DropdownIndicator {...props} />
+      <selectComponents.DropdownIndicator {...props}>{props.children}</selectComponents.DropdownIndicator>
     </div>
   );
 };
@@ -62,7 +67,7 @@ export const SelectContainer = <Option, IsMulti extends boolean, Group extends G
 ) => {
   return (
     <div data-testid="select-container">
-      <selectComponents.SelectContainer {...props} />
+      <selectComponents.SelectContainer {...props}>{props.children}</selectComponents.SelectContainer>
     </div>
   );
 };
@@ -72,7 +77,7 @@ export const SelectInput = <Option, IsMulti extends boolean, Group extends Group
 ) => {
   return (
     <div data-testid="select-input">
-      <selectComponents.Input {...props} />
+      <selectComponents.Input {...props}>{props.children}</selectComponents.Input>
     </div>
   );
 };
@@ -86,7 +91,19 @@ export const SelectMenu = <Option, IsMulti extends boolean, Group extends GroupB
 
   return (
     <div data-testid="select-dropdown">
-      <components.Menu {...props} />
+      <components.Menu {...props}>{props.children}</components.Menu>
     </div>
   );
 };
+
+export function SelectOption<Option, IsMulti extends boolean, Group extends GroupBase<Option>>(
+  props: OptionProps<Option, IsMulti, Group> & { size?: ComponentSize }
+) {
+  const size = useComponentSize(props.size);
+
+  return (
+    <StyledOption isSelected={props.isSelected} isFocused={props.isFocused} size={size} data-testid="select-option">
+      <components.Option {...props}>{props.children}</components.Option>
+    </StyledOption>
+  );
+}

--- a/src/Select/Select.story.tsx
+++ b/src/Select/Select.story.tsx
@@ -567,6 +567,7 @@ export const WithCustomOptionComponent = () => {
     height: "10px",
     marginRight: "5px",
   }));
+
   const CustomOption = ({ children, ...props }: OptionProps) => {
     const newChildren = (
       <>
@@ -574,12 +575,9 @@ export const WithCustomOptionComponent = () => {
         {children}
       </>
     );
-    return (
-      <SelectOption size="medium" {...props}>
-        {newChildren}
-      </SelectOption>
-    );
+    return <SelectOption {...props}>{newChildren}</SelectOption>;
   };
+
   return (
     <>
       <Box position="relative" overflow="hidden" width="300px" height="600px">

--- a/src/Select/SelectOption.tsx
+++ b/src/Select/SelectOption.tsx
@@ -2,9 +2,8 @@ import React from "react";
 import styled from "styled-components";
 import { components, OptionProps } from "react-windowed-select";
 import { typography } from "styled-system";
-import { GroupBase } from "react-select";
 import { subPx } from "../utils";
-import { ComponentSize } from "../NDSProvider/ComponentSizeContext";
+import { ComponentSize, useComponentSize } from "../NDSProvider/ComponentSizeContext";
 import { stylesForSize } from "./customReactSelectStyles";
 
 type SelectOptionProps = {
@@ -52,17 +51,16 @@ const StyledOption = styled.div<SelectOptionProps>(
     )
 );
 
-export function SelectOption<Option, IsMulti extends boolean, Group extends GroupBase<Option>>(
-  props: OptionProps<Option, IsMulti, Group> & { size: ComponentSize }
-) {
+interface CustomOptionProps extends OptionProps {
+  size?: ComponentSize;
+}
+
+export function SelectOption(props: CustomOptionProps) {
+  const size = useComponentSize(props.size);
+
   return (
-    <StyledOption
-      isSelected={props.isSelected}
-      isFocused={props.isFocused}
-      size={props.size}
-      data-testid="select-option"
-    >
-      <components.Option {...props} />
+    <StyledOption isSelected={props.isSelected} isFocused={props.isFocused} size={size} data-testid="select-option">
+      <components.Option {...props}>{props.children}</components.Option>
     </StyledOption>
   );
 }

--- a/src/Select/SelectOption.tsx
+++ b/src/Select/SelectOption.tsx
@@ -12,7 +12,7 @@ type SelectOptionProps = {
   size: ComponentSize;
 };
 
-const StyledOption = styled.div<SelectOptionProps>(
+export const StyledOption = styled.div<SelectOptionProps>(
   typography,
   ({ isSelected, isFocused, theme }) => ({
     "&:last-child": {


### PR DESCRIPTION
## Description

follows this example: https://github.com/JedWatson/react-select/blob/master/docs/examples/CustomOption.tsx

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
