### PR TITLE
Fix Popper Timeout Tracking

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,15 @@
+{
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "lineWidth": 120
+  },
+  "linter": {
+    "enabled": false
+  },
+  "javascript": {
+    "formatter": {
+      "trailingComma": "es5"
+    }
+  }
+}

--- a/src/Popper/Popper.tsx
+++ b/src/Popper/Popper.tsx
@@ -50,24 +50,29 @@ const Popper: React.FC<PopperProps> = React.forwardRef(
     popperRef
   ) => {
     let timeoutID;
+
     const [isOpen, setIsOpen] = useState(defaultOpen);
-    const conditionallyApplyDelay = (fnc, delay, skipDelay = true) => {
+
+    const conditionallyApplyDelay = (fnc: () => void, delay: number, skipDelay = true) => {
       if (!skipDelay) {
         timeoutID = setTimeout(fnc, delay);
       } else {
         fnc();
       }
     };
-    const setPopUpState = (nextIsOpenState, skipDelay) => {
+
+    const setPopUpState = (nextIsOpenState: boolean, skipDelay: boolean) => {
       clearTimeout(timeoutID);
       conditionallyApplyDelay(() => setIsOpen(nextIsOpenState), nextIsOpenState ? showDelay : hideDelay, skipDelay);
     };
-    const closePopUp = (skipDelay) => {
+
+    const closePopUp = (skipDelay: boolean) => {
       setPopUpState(false, skipDelay);
     };
+
     useEffect(() => {
-      const handleKeyDown = (event) => {
-        switch (event.keyCode) {
+      const handleKeyDown = (event: KeyboardEvent) => {
+        switch (event.code) {
           case keyCodes.ESC:
             closePopUp();
             break;
@@ -75,16 +80,20 @@ const Popper: React.FC<PopperProps> = React.forwardRef(
             break;
         }
       };
+
       document.addEventListener("keydown", handleKeyDown);
+
       const cleanup = () => {
         document.removeEventListener("keydown", handleKeyDown);
         clearTimeout(timeoutID);
       };
       return cleanup;
     }, []);
-    const openPopUp = (skipDelay) => {
+
+    const openPopUp = (skipDelay: boolean) => {
       setPopUpState(true, skipDelay);
     };
+
     const onClickEventHandlers = openOnClick
       ? {
           onClick: () => {
@@ -96,12 +105,14 @@ const Popper: React.FC<PopperProps> = React.forwardRef(
           },
         }
       : null;
+
     const onHoverHandlers = openOnHover
       ? {
           onMouseEnter: () => openPopUp(false),
           onMouseLeave: () => closePopUp(false),
         }
       : null;
+
     const eventHandlers = {
       onFocus: () => openPopUp(false),
       onBlur: () => {
@@ -110,6 +121,7 @@ const Popper: React.FC<PopperProps> = React.forwardRef(
       ...onHoverHandlers,
       ...onClickEventHandlers,
     };
+
     const transformInnerChildren = (elements) =>
       makeArray(elements).map((element, i) => {
         const transformedElement = wrapInFunction(element)({
@@ -127,13 +139,18 @@ const Popper: React.FC<PopperProps> = React.forwardRef(
           key: i,
         });
       });
+
     const renderInnerChildren = () => {
       const innerChildren = children.props.children;
       return typeof innerChildren !== "string" ? transformInnerChildren(innerChildren) : innerChildren;
     };
+
     const { t } = useTranslation();
+
     const openLabel = openAriaLabel || t("open");
+
     const closeLabel = closeAriaLabel || t("close");
+
     return (
       <Manager ref={popperRef}>
         <Reference>

--- a/src/Popper/Popper.tsx
+++ b/src/Popper/Popper.tsx
@@ -3,7 +3,6 @@ import React, { useState, useEffect, useRef } from "react";
 import { Manager, Reference, Popper as ReactPopperPopUp } from "react-popper";
 import { useTranslation } from "react-i18next";
 import { PopperArrow } from "../utils";
-import { keyCodes } from "../constants";
 const makeArray = (children) => {
   if (!Array.isArray(children)) {
     return [children];

--- a/src/Popper/Popper.tsx
+++ b/src/Popper/Popper.tsx
@@ -79,15 +79,11 @@ const Popper: React.FC<PopperProps> = React.forwardRef(
     };
 
     useEffect(() => {
-      const handleKeyDown = (event: KeyboardEvent) => {
-        switch (event.code) {
-          case keyCodes.ESC:
-            closePopUp();
-            break;
-          default:
-            break;
+      function handleKeyDown(event: KeyboardEvent) {
+        if (event.code === "Escape") {
+          closePopUp();
         }
-      };
+      }
 
       document.addEventListener("keydown", handleKeyDown);
 
@@ -95,6 +91,7 @@ const Popper: React.FC<PopperProps> = React.forwardRef(
         document.removeEventListener("keydown", handleKeyDown);
         resetTimeoutId();
       };
+
       return cleanup;
     }, []);
 


### PR DESCRIPTION
## Description

We noticed that Popper was sometimes closing the dorpdown inaccurately.
This was pinned down to timeouts being incorrectly cleared, and thefore
sometimes running when they ought not to. Careful examination of the
code revealed that they weren't being tracked very well, and thus stomped on
or lost.

This approach leverages a ref to track the value to avoid loss during
re-renders, and to also avoid unnecessary re-renders.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [x] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
