### PR TITLE
Improve Pagination Types

### DIFF
--- a/src/Pagination/Pagination.spec.tsx
+++ b/src/Pagination/Pagination.spec.tsx
@@ -41,7 +41,7 @@ describe("Pagination", () => {
           onSelectPage={onSelectPageCallback}
         />
       );
-      const clickPage = (pageNum) => {
+      const clickPage = (pageNum: number) => {
         fireEvent.click(getAllByLabelText("Go to page {{count}}")[pageNum]);
       };
       clickPage(2);

--- a/src/Pagination/Pagination.tsx
+++ b/src/Pagination/Pagination.tsx
@@ -26,7 +26,7 @@ export const getPageItemsToDisplay = (totalPages: number, currentPage: number): 
   return [1, SEPARATOR, ...pages.slice(currentPage - 2, currentPage + 2), SEPARATOR, totalPages];
 };
 
-type PaginationProps = FlexProps & {
+interface PaginationProps extends FlexProps {
   currentPage: number;
   totalPages: number;
   onNext?: () => void;
@@ -38,7 +38,7 @@ type PaginationProps = FlexProps & {
   previousAriaLabel?: string;
   scrollToTopAfterPagination?: boolean;
   scrollTargetRef?: RefObject<HTMLElement>;
-};
+}
 
 function Pagination({
   currentPage,

--- a/src/Pagination/Pagination.tsx
+++ b/src/Pagination/Pagination.tsx
@@ -9,9 +9,9 @@ import PageNumber from "./PageNumber";
 import PreviousButton from "./PreviousButton";
 import NextButton from "./NextButton";
 
-const SEPARATOR = "...";
+const SEPARATOR = "..." as const;
 
-export const getPageItemsToDisplay = (totalPages: number, currentPage: number) => {
+export const getPageItemsToDisplay = (totalPages: number, currentPage: number): Array<typeof SEPARATOR | number> => {
   const MAX_PAGES_TO_SHOW = 6;
 
   const pages = Array.from({ length: totalPages }, (v, i) => i + 1);
@@ -31,7 +31,7 @@ type PaginationProps = FlexProps & {
   totalPages: number;
   onNext?: () => void;
   onPrevious?: () => void;
-  onSelectPage?: (page: string | number) => void;
+  onSelectPage?: (page: number) => void;
   nextLabel?: ReactNode;
   nextAriaLabel?: string;
   previousLabel?: ReactNode;


### PR DESCRIPTION
## Description

The previous iteration of these type was accounting for the generated
page numbers being either a string (`SEPARATOR`) or numbers.

In this commit I introduce a much narrower type for the
`getPageItemsToDisplay` function. In doing so we more closely map to the
reality of the implementation and can use a more appropriately narrow
type for `onSelectPage`.

This resolves some challenges with ECO.

## Changes include

- [x] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [x] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
