### PR TITLE
fix: types for React 18

### DIFF
--- a/src/BrandedNavBar/MobileMenu.tsx
+++ b/src/BrandedNavBar/MobileMenu.tsx
@@ -227,7 +227,7 @@ type BaseMobileMenuProps = {
   showNulogyLogo?: boolean;
 };
 
-const BaseMobileMenu: React.FC<BaseMobileMenuProps> = ({
+const BaseMobileMenu: React.FC<React.PropsWithChildren<BaseMobileMenuProps>> = ({
   menuData,
   closeMenu,
   subtext,

--- a/src/BrandedNavBar/NavBar.tsx
+++ b/src/BrandedNavBar/NavBar.tsx
@@ -32,7 +32,7 @@ type MediumNavBarProps = {
   subtext?: string;
 };
 
-const MediumNavBar: React.FC<MediumNavBarProps> = ({
+const MediumNavBar: React.FC<React.PropsWithChildren<MediumNavBarProps>> = ({
   menuData,
   environment,
   logo,

--- a/src/Branding/Branding.tsx
+++ b/src/Branding/Branding.tsx
@@ -39,7 +39,7 @@ const alignments = {
 const getLogoColor = (logoColor) => logoColors[logoColor] || logoColors.blue;
 const getAlignment = (alignment) => alignments[alignment] || alignments.left;
 
-const BrandingWrap: React.FC<any> = styled.div(
+const BrandingWrap: React.FC<React.PropsWithChildren<any>> = styled.div(
   ({ alignment, size }: any): CSSObject => ({
     width: "100%",
     display: "inline-flex",
@@ -50,7 +50,7 @@ const BrandingWrap: React.FC<any> = styled.div(
   })
 );
 
-const Line: React.FC<any> = styled.div(
+const Line: React.FC<React.PropsWithChildren<any>> = styled.div(
   ({ logoColor }: any): CSSObject => ({
     position: "relative",
     width: "100%",

--- a/src/Branding/BrandingText.tsx
+++ b/src/Branding/BrandingText.tsx
@@ -13,22 +13,24 @@ const logoColors = {
 
 const getLogoColor = (logoColor) => logoColors[logoColor] || logoColors.blue;
 
-const BrandingText: React.FC<any> = styled.span(({ logoColor, size }: BrandingTextProps): any => ({
-  color: getLogoColor(logoColor),
-  textDecoration: "none",
-  fontWeight: theme.fontWeights.medium,
-  letterSpacing: "0.0333em",
-  textTransform: "uppercase",
-  fontSize: size === "small" ? "10px" : "11px",
-  lineHeight: "12px",
-  whiteSpace: "nowrap",
-  active: {
+const BrandingText: React.FC<React.PropsWithChildren<any>> = styled.span(
+  ({ logoColor, size }: BrandingTextProps): any => ({
     color: getLogoColor(logoColor),
-  },
-  visited: {
-    color: getLogoColor(logoColor),
-  },
-}));
+    textDecoration: "none",
+    fontWeight: theme.fontWeights.medium,
+    letterSpacing: "0.0333em",
+    textTransform: "uppercase",
+    fontSize: size === "small" ? "10px" : "11px",
+    lineHeight: "12px",
+    whiteSpace: "nowrap",
+    active: {
+      color: getLogoColor(logoColor),
+    },
+    visited: {
+      color: getLogoColor(logoColor),
+    },
+  })
+);
 BrandingText.defaultProps = {
   logoColor: "blue",
 };

--- a/src/Branding/LettermarkLogo.tsx
+++ b/src/Branding/LettermarkLogo.tsx
@@ -18,7 +18,7 @@ type LettermarkLogoProps = {
   letterFill?: string;
   size?: string;
 };
-const LettermarkLogo: React.FC<LettermarkLogoProps> = ({ size, letterFill, ...props }) => (
+const LettermarkLogo: React.FC<React.PropsWithChildren<LettermarkLogoProps>> = ({ size, letterFill, ...props }) => (
   <svg
     {...getSize(size)}
     {...props}

--- a/src/Branding/WordmarkLogo.tsx
+++ b/src/Branding/WordmarkLogo.tsx
@@ -19,7 +19,12 @@ type WordmarkLogoProps = {
   letterFill?: string;
   size?: string;
 };
-const WordmarkLogo: React.FC<WordmarkLogoProps> = ({ size, logoFill, letterFill, ...props }) => (
+const WordmarkLogo: React.FC<React.PropsWithChildren<WordmarkLogoProps>> = ({
+  size,
+  logoFill,
+  letterFill,
+  ...props
+}) => (
   <svg
     {...getSize(size)}
     {...props}

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -85,7 +85,7 @@ const WrapperButton = styled.button<ButtonProps>(
   space
 );
 
-const Button: React.FC<ButtonProps> = React.forwardRef(
+const Button: React.FC<React.PropsWithChildren<ButtonProps>> = React.forwardRef(
   ({ children, iconSide = "right", icon, className, asLink, size, ...props }: ButtonProps, ref) => {
     const {
       lineHeights: { smallTextCompressed },

--- a/src/Button/ControlIcon.tsx
+++ b/src/Button/ControlIcon.tsx
@@ -24,7 +24,7 @@ const getIconColorByState = ({ toggled, disabled, theme }) => {
   return theme.colors.darkGrey;
 };
 
-const StyledButton: React.FC<any> = styled.button(
+const StyledButton: React.FC<React.PropsWithChildren<any>> = styled.button(
   ({ toggled, disabled, theme }: any) => ({
     background: "transparent",
     border: "none",

--- a/src/Button/PrimaryButton.tsx
+++ b/src/Button/PrimaryButton.tsx
@@ -2,7 +2,7 @@ import styled, { CSSObject } from "styled-components";
 import { darken } from "polished";
 import Button, { ButtonProps } from "./Button";
 
-const PrimaryButton: React.FC<any> = styled(Button)(
+const PrimaryButton: React.FC<React.PropsWithChildren<any>> = styled(Button)(
   ({ disabled, theme }: ButtonProps): CSSObject => ({
     color: theme.colors.white,
     borderColor: theme.colors.blue,

--- a/src/ButtonGroup/ButtonGroup.tsx
+++ b/src/ButtonGroup/ButtonGroup.tsx
@@ -32,7 +32,7 @@ const buttonSpacings = (theme) => ({
 const getAlignment = (alignment) => alignments[alignment] || alignments.left;
 const getButtonSpacing = (alignment, theme) => buttonSpacings(theme)[alignment] || buttonSpacings(theme).left;
 
-const ButtonGroup: React.FC<ButtonGroupProps> = styled(Flex)(({ alignment, theme }: any) => ({
+const ButtonGroup: React.FC<React.PropsWithChildren<ButtonGroupProps>> = styled(Flex)(({ alignment, theme }: any) => ({
   flexWrap: "wrap",
   marginBottom: `-${theme.space.x1}`,
   justifyContent: getAlignment(alignment),

--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import { Box } from "../Box";
 import { BoxProps } from "../Box/Box";
 
-const Card: React.FC<BoxProps> = styled(Box)({});
+const Card: React.FC<React.PropsWithChildren<BoxProps>> = styled(Box)({});
 
 Card.defaultProps = {
   children: [],

--- a/src/Checkbox/Checkbox.tsx
+++ b/src/Checkbox/Checkbox.tsx
@@ -127,7 +127,7 @@ const CheckboxInput = styled.input<CheckboxProps>((props) => ({
   },
 }));
 
-const Checkbox: React.FC<CheckboxProps> = forwardRef((props, ref) => {
+const Checkbox: React.FC<React.PropsWithChildren<CheckboxProps>> = forwardRef((props, ref) => {
   const { size, className, labelText, disabled, checked, required, error, indeterminate } = props;
 
   const componentSize = useComponentSize(size);

--- a/src/Checkbox/CheckboxGroup.tsx
+++ b/src/Checkbox/CheckboxGroup.tsx
@@ -51,7 +51,7 @@ const Legend = styled.legend(({ theme }) => ({
   marginBottom: theme.space.x1,
 }));
 
-const CheckboxGroup: React.FC<CheckboxGroupProps> = ({
+const CheckboxGroup: React.FC<React.PropsWithChildren<CheckboxGroupProps>> = ({
   className,
   id,
   errorMessage,

--- a/src/DatePicker/DatePickerHeader.tsx
+++ b/src/DatePicker/DatePickerHeader.tsx
@@ -13,7 +13,7 @@ type DatePickerHeaderProps = {
   locale?: string;
 };
 
-const DatePickerHeader: React.FC<DatePickerHeaderProps> = ({
+const DatePickerHeader: React.FC<React.PropsWithChildren<DatePickerHeaderProps>> = ({
   date,
   decreaseMonth,
   increaseMonth,

--- a/src/DateRange/DateRange.tsx
+++ b/src/DateRange/DateRange.tsx
@@ -46,7 +46,7 @@ type DateRangeProps = FieldProps & {
 
 const DEFAULT_LABEL = "Date Range";
 
-const DateRange: React.FC<DateRangeProps> = forwardRef(
+const DateRange: React.FC<React.PropsWithChildren<DateRangeProps>> = forwardRef(
   (
     {
       dateFormat,

--- a/src/DropdownMenu/DropdownItem.tsx
+++ b/src/DropdownMenu/DropdownItem.tsx
@@ -8,7 +8,7 @@ type DropdownItemProps = {
   bgHoverColor?: string;
 };
 
-const DropdownItem: React.FC<DropdownItemProps> = styled.div(
+const DropdownItem: React.FC<React.PropsWithChildren<DropdownItemProps>> = styled.div(
   ({ theme, color, hoverColor, bgHoverColor }: DropdownItemProps): CSSObject => ({
     "*": {
       color: theme.colors[color],

--- a/src/DropdownMenu/DropdownMenu.tsx
+++ b/src/DropdownMenu/DropdownMenu.tsx
@@ -47,7 +47,10 @@ const transformPropsToModifiers = ({ boundariesElement }) => ({
   boundariesElement,
 });
 
-const DropdownMenu: React.FC<DropdownMenuProps> = React.forwardRef<Reference, DropdownMenuProps>(
+const DropdownMenu: React.FC<React.PropsWithChildren<DropdownMenuProps>> = React.forwardRef<
+  Reference,
+  DropdownMenuProps
+>(
   (
     {
       trigger = () => <IconicButton icon="more" />,

--- a/src/DropdownMenu/DropdownMenuContainer.tsx
+++ b/src/DropdownMenu/DropdownMenuContainer.tsx
@@ -37,7 +37,7 @@ const getMenuMargin = (placement, showArrow) => {
   }
 };
 
-const DropdownMenuContainer: React.FC<DropdownMenuContainerProps> = styled(Box)(
+const DropdownMenuContainer: React.FC<React.PropsWithChildren<DropdownMenuContainerProps>> = styled(Box)(
   color,
   ({ dataPlacement, showArrow = true, backgroundColor = "white", theme }: DropdownMenuContainerProps): any => ({
     borderRadius: theme.radii.medium,

--- a/src/DropdownMenu/DropdownText.tsx
+++ b/src/DropdownMenu/DropdownText.tsx
@@ -4,7 +4,7 @@ import { Text } from "../Type";
 import { TextProps } from "../Type/Text";
 import { addStyledProps } from "../StyledProps";
 
-const DropdownText: React.FC<TextProps> = styled(Text)(
+const DropdownText: React.FC<React.PropsWithChildren<TextProps>> = styled(Text)(
   ({ theme }: TextProps): CSSObject => ({
     color: theme.colors.darkGrey,
     fontWeight: theme.fontWeights.medium,

--- a/src/Form/Fieldset.tsx
+++ b/src/Form/Fieldset.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import { space } from "styled-system";
-const Fieldset: React.FC<any> = styled.fieldset(
+const Fieldset: React.FC<React.PropsWithChildren<any>> = styled.fieldset(
   {
     padding: 0,
     border: 0,

--- a/src/Form/FormSection.tsx
+++ b/src/Form/FormSection.tsx
@@ -12,7 +12,7 @@ const FormSectionTitle = styled(Heading3).attrs({
   as: "legend",
 })({});
 
-const BaseFormSection: React.FC<BaseFormSectionProps> = ({ title, children, ...props }) => (
+const BaseFormSection: React.FC<React.PropsWithChildren<BaseFormSectionProps>> = ({ title, children, ...props }) => (
   <fieldset {...props}>
     {title != null && <FormSectionTitle>{title}</FormSectionTitle>}
     {children}

--- a/src/Icon/LoadingIcon.tsx
+++ b/src/Icon/LoadingIcon.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 type LoadingIconProps = React.ComponentPropsWithoutRef<"svg">;
 
-const LoadingIcon: React.FC<LoadingIconProps> = (props) => {
+const LoadingIcon: React.FC<React.PropsWithChildren<LoadingIconProps>> = (props) => {
   return (
     <svg
       viewBox="0 0 24px 24px"

--- a/src/Layout/Header.tsx
+++ b/src/Layout/Header.tsx
@@ -22,7 +22,7 @@ type HeaderProps = BoxProps & {
   };
 };
 
-const Header: React.FC<HeaderProps> = ({
+const Header: React.FC<React.PropsWithChildren<HeaderProps>> = ({
   background,
   renderBreadcrumbs,
   title,

--- a/src/Layout/Page.tsx
+++ b/src/Layout/Page.tsx
@@ -13,7 +13,7 @@ type PageProps = FlexProps & {
   renderHeader?: () => JSX.Element;
 };
 
-export const Page: React.FC<PageProps> = ({
+export const Page: React.FC<React.PropsWithChildren<PageProps>> = ({
   breadcrumbs,
   title,
   children,

--- a/src/List/List.tsx
+++ b/src/List/List.tsx
@@ -11,7 +11,7 @@ type ListProps = React.ComponentPropsWithRef<"ul"> &
     leftAlign?: boolean;
     listStyle?: string;
   };
-const List: React.FC<ListProps> = styled.ul(
+const List: React.FC<React.PropsWithChildren<ListProps>> = styled.ul(
   ({ compact, theme, leftAlign, listStyle }: ListProps) => ({
     margin: 0,
     paddingLeft: leftAlign ? "18px" : undefined,

--- a/src/List/ListItem.tsx
+++ b/src/List/ListItem.tsx
@@ -6,7 +6,7 @@ type ListItemProps = React.ComponentPropsWithRef<"li"> &
   TypographyProps & {
     className?: string;
   };
-const ListItem: React.FC<ListItemProps> = styled.li(space, color, typography, {
+const ListItem: React.FC<React.PropsWithChildren<ListItemProps>> = styled.li(space, color, typography, {
   "&:last-child": {
     marginBottom: 0,
   },

--- a/src/LoadingAnimation/LoadingAnimation.tsx
+++ b/src/LoadingAnimation/LoadingAnimation.tsx
@@ -4,7 +4,7 @@ import { useTheme } from "styled-components";
 type LoadingAnimationProps = React.ComponentPropsWithRef<"svg"> & {
   inactive?: boolean;
 };
-const LoadingAnimation: React.FC<LoadingAnimationProps> = ({ inactive }) => {
+const LoadingAnimation: React.FC<React.PropsWithChildren<LoadingAnimationProps>> = ({ inactive }) => {
   const { colors } = useTheme();
 
   const color1 = inactive ? colors.grey : colors.blue;

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -82,7 +82,9 @@ type ModalProps = {
   parentSelector?: (...args: any) => HTMLElement;
 };
 
-const Modal: React.FC<ModalProps> & { setAppElement: (element: string | HTMLElement) => void } = ({
+const Modal: React.FC<React.PropsWithChildren<ModalProps>> & {
+  setAppElement: (element: string | HTMLElement) => void;
+} = ({
   isOpen,
   children,
   title,

--- a/src/Modal/ModalContent.tsx
+++ b/src/Modal/ModalContent.tsx
@@ -7,14 +7,16 @@ type ModalContentProps = React.ComponentPropsWithRef<"div"> & {
   theme?: DefaultNDSThemeType;
 };
 
-const ModalContent: React.FC<ModalContentProps> = styled.div(({ hasFooter, theme }: ModalContentProps) => ({
-  marginTop: "-64px",
-  marginBottom: hasFooter ? "-72px" : 0,
-  overflow: "auto",
-  paddingTop: "88px",
-  paddingBottom: hasFooter ? "96px" : theme.space.x2,
-  paddingLeft: theme.space.x3,
-  paddingRight: theme.space.x3,
-}));
+const ModalContent: React.FC<React.PropsWithChildren<ModalContentProps>> = styled.div(
+  ({ hasFooter, theme }: ModalContentProps) => ({
+    marginTop: "-64px",
+    marginBottom: hasFooter ? "-72px" : 0,
+    overflow: "auto",
+    paddingTop: "88px",
+    paddingBottom: hasFooter ? "96px" : theme.space.x2,
+    paddingLeft: theme.space.x3,
+    paddingRight: theme.space.x3,
+  })
+);
 
 export default ModalContent;

--- a/src/NDSProvider/ComponentSizeContext.tsx
+++ b/src/NDSProvider/ComponentSizeContext.tsx
@@ -17,7 +17,10 @@ export function useComponentSize(selectedSize?: ComponentSize) {
   return selectedSize ?? context.size;
 }
 
-const ComponentSizeContextProvider: React.FC<ComponentSizeContextValue> = ({ size, children }) => {
+const ComponentSizeContextProvider: React.FC<React.PropsWithChildren<ComponentSizeContextValue>> = ({
+  size,
+  children,
+}) => {
   return <ComponentSizeContext.Provider value={{ size }}>{children}</ComponentSizeContext.Provider>;
 };
 

--- a/src/NDSProvider/NDSProvider.tsx
+++ b/src/NDSProvider/NDSProvider.tsx
@@ -48,7 +48,7 @@ const AllNDSGlobalStyles = ({ theme, locale, disableGlobalStyles, children }: Al
     children
   );
 
-const NDSProvider: React.FC<NDSProviderProps> = ({
+const NDSProvider: React.FC<React.PropsWithChildren<NDSProviderProps>> = ({
   theme,
   children,
   disableGlobalStyles = false,

--- a/src/NavBar/NavBar.tsx
+++ b/src/NavBar/NavBar.tsx
@@ -62,7 +62,7 @@ type MediumNavBarProps = {
   environment?: "development" | "training";
 };
 
-const MediumNavBar: React.FC<MediumNavBarProps> = ({
+const MediumNavBar: React.FC<React.PropsWithChildren<MediumNavBarProps>> = ({
   menuData,
   themeColor,
   subtext,

--- a/src/Overlay/Overlay.tsx
+++ b/src/Overlay/Overlay.tsx
@@ -10,14 +10,16 @@ type OverlayProps = FlexProps & {
   theme?: DefaultNDSThemeType;
 };
 
-const Overlay: React.FC<OverlayProps> = styled(Flex)<OverlayProps>(({ dark, theme }: OverlayProps) => ({
-  top: 0,
-  left: 0,
-  right: 0,
-  bottom: 0,
-  zIndex: theme.zIndices.overlay,
-  backgroundColor: dark ? transparentize(0.5, theme.colors.blackBlue) : transparentize(0.05, theme.colors.white),
-}));
+const Overlay: React.FC<React.PropsWithChildren<OverlayProps>> = styled(Flex)<OverlayProps>(
+  ({ dark, theme }: OverlayProps) => ({
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    zIndex: theme.zIndices.overlay,
+    backgroundColor: dark ? transparentize(0.5, theme.colors.blackBlue) : transparentize(0.05, theme.colors.white),
+  })
+);
 Overlay.defaultProps = {
   position: "fixed",
   justifyContent: "center",

--- a/src/Popper/Popper.tsx
+++ b/src/Popper/Popper.tsx
@@ -28,7 +28,7 @@ type PopperProps = {
   openAriaLabel?: string;
   closeAriaLabel?: string;
 };
-const Popper: React.FC<PopperProps> = React.forwardRef(
+const Popper: React.FC<React.PropsWithChildren<PopperProps>> = React.forwardRef(
   (
     {
       popperPlacement,

--- a/src/Radio/Radio.tsx
+++ b/src/Radio/Radio.tsx
@@ -113,7 +113,7 @@ type RadioProps = NativeInputProps &
     error?: boolean;
   };
 
-const Radio: React.FC<RadioProps> = forwardRef(
+const Radio: React.FC<React.PropsWithChildren<RadioProps>> = forwardRef(
   ({ className, labelText, disabled, checked, required, error, size, ...props }, ref) => {
     const componentSize = useComponentSize(size);
     const spaceProps = getSubset(props, propTypes.space);

--- a/src/RangeContainer/RangeContainer.tsx
+++ b/src/RangeContainer/RangeContainer.tsx
@@ -16,7 +16,7 @@ type RangeContainerProps = {
   errorMessages?: (string | undefined)[];
 };
 
-const RangeContainer: React.FC<RangeContainerProps> = ({
+const RangeContainer: React.FC<React.PropsWithChildren<RangeContainerProps>> = ({
   labelProps,
   startComponent,
   endComponent,

--- a/src/Summary/Summary.tsx
+++ b/src/Summary/Summary.tsx
@@ -32,7 +32,11 @@ const SummaryWrapper = styled(Box)<{ breakpoint: number }>(({ theme, breakpoint 
 
 const DEFAULT_BREAKPOINT = theme.breakpoints.medium;
 
-const Summary: React.FC<SummaryProps> = ({ breakpoint = DEFAULT_BREAKPOINT, children, ...rest }) => {
+const Summary: React.FC<React.PropsWithChildren<SummaryProps>> = ({
+  breakpoint = DEFAULT_BREAKPOINT,
+  children,
+  ...rest
+}) => {
   const breakpointPx = numberFromDimension(breakpoint);
 
   return (

--- a/src/Summary/SummaryContext.tsx
+++ b/src/Summary/SummaryContext.tsx
@@ -14,7 +14,10 @@ export function useSummaryContext() {
   return context;
 }
 
-export const SummaryContextProvider: React.FC<SummaryContextValue> = ({ breakpoint, children }) => {
+export const SummaryContextProvider: React.FC<React.PropsWithChildren<SummaryContextValue>> = ({
+  breakpoint,
+  children,
+}) => {
   return (
     <SummaryContext.Provider
       value={{

--- a/src/Summary/SummaryItem.tsx
+++ b/src/Summary/SummaryItem.tsx
@@ -20,7 +20,7 @@ const SummaryItemWrapper = styled(Flex)<{ breakpoint: number }>(({ theme, breakp
   },
 }));
 
-const SummaryItem: React.FC<SummaryItemProps> = ({ value, status, ...rest }) => {
+const SummaryItem: React.FC<React.PropsWithChildren<SummaryItemProps>> = ({ value, status, ...rest }) => {
   const { breakpoint } = useSummaryContext();
   const matches = useMediaQuery(`(max-width: ${breakpoint}px)`);
 

--- a/src/Switcher/Switcher.tsx
+++ b/src/Switcher/Switcher.tsx
@@ -13,7 +13,7 @@ type SwitcherProps = {
   onChange?: (value: string) => void;
 };
 
-const Switcher: React.FC<SwitcherProps> = ({ size, selected, onChange, ...rest }) => {
+const Switcher: React.FC<React.PropsWithChildren<SwitcherProps>> = ({ size, selected, onChange, ...rest }) => {
   const componentSize = useComponentSize(size);
 
   const optionRefs = [];

--- a/src/Table/TableBody.tsx
+++ b/src/Table/TableBody.tsx
@@ -18,7 +18,7 @@ type StyledTrProps = React.ComponentProps<"tr"> & {
   className?: string;
 };
 
-const StyledTr: React.FC<StyledTrProps> = styled.tr(({ rowHovers, theme }: StyledTrProps) => ({
+const StyledTr: React.FC<React.PropsWithChildren<StyledTrProps>> = styled.tr(({ rowHovers, theme }: StyledTrProps) => ({
   "&:hover": {
     backgroundColor: rowHovers ? theme.colors.whiteGrey : null,
   },

--- a/src/Table/TableCell.tsx
+++ b/src/Table/TableCell.tsx
@@ -7,7 +7,7 @@ type StyledTableCellProps = {
   compact?: boolean;
   theme?: DefaultNDSThemeType;
 };
-const StyledTableCell: React.FC<StyledTableCellProps> = styled.td(
+const StyledTableCell: React.FC<React.PropsWithChildren<StyledTableCellProps>> = styled.td(
   ({ align, compact, theme }: StyledTableCellProps): CSSObject => {
     const padding = compact ? theme.space.x1 : theme.space.x2;
     return {
@@ -28,7 +28,7 @@ type TableCellProps = {
   cellData?: object | React.ReactNode | boolean;
   compact?: boolean;
 };
-const TableCell: React.FC<TableCellProps> = ({ row, column, colSpan, cellData, compact }) => {
+const TableCell: React.FC<React.PropsWithChildren<TableCellProps>> = ({ row, column, colSpan, cellData, compact }) => {
   const cellRenderer = row.cellRenderer || column.cellRenderer;
   const { cellFormatter } = column;
   const isCustomCell = Boolean(cellRenderer);

--- a/src/Tabs/Tab.tsx
+++ b/src/Tabs/Tab.tsx
@@ -101,7 +101,7 @@ type TabProps = TabButtonProps & {
   label?: React.ReactNode;
 };
 
-const Tab: React.FC<TabProps> = React.forwardRef(({ label, ...props }, ref) => (
+const Tab: React.FC<React.PropsWithChildren<TabProps>> = React.forwardRef(({ label, ...props }, ref) => (
   <TabButton role="tab" type="button" ref={ref} {...props}>
     {label}
   </TabButton>

--- a/src/Tabs/TabScrollIndicator.tsx
+++ b/src/Tabs/TabScrollIndicator.tsx
@@ -47,7 +47,7 @@ type TabScrollIndicatorProps = {
   ariaLabelLeft?: string;
   ariaLabelRight?: string;
 };
-const TabScrollIndicator: React.FC<TabScrollIndicatorProps> = ({
+const TabScrollIndicator: React.FC<React.PropsWithChildren<TabScrollIndicatorProps>> = ({
   onClick,
   side,
   ariaLabelLeft,

--- a/src/TimePicker/TimePicker.tsx
+++ b/src/TimePicker/TimePicker.tsx
@@ -126,7 +126,7 @@ export const getTimeOptions = (interval, timeFormat, minTime, maxTime, locale) =
     .slice(startingInterval, finalInterval);
 };
 
-const TimePicker: React.FC<TimePickerProps> = forwardRef(
+const TimePicker: React.FC<React.PropsWithChildren<TimePickerProps>> = forwardRef(
   (
     {
       timeFormat,

--- a/src/ToastContainer/ToastFunction.tsx
+++ b/src/ToastContainer/ToastFunction.tsx
@@ -21,7 +21,7 @@ type ToastFunctions = {
 
 type CustomToastProps = { id: string; isVisible: boolean } & AlertProps;
 
-const CustomToast: React.FC<CustomToastProps> = ({ isVisible, id, children, ...props }) => {
+const CustomToast: React.FC<React.PropsWithChildren<CustomToastProps>> = ({ isVisible, id, children, ...props }) => {
   const handleClose = () => {
     _toast.dismiss(id);
   };

--- a/src/Toggle/Toggle.tsx
+++ b/src/Toggle/Toggle.tsx
@@ -25,7 +25,7 @@ type MaybeToggleTitleProps = React.ComponentPropsWithRef<"div"> & {
   helpText?: string;
   children?: any;
 };
-const MaybeToggleTitle: React.FC<MaybeToggleTitleProps> = ({
+const MaybeToggleTitle: React.FC<React.PropsWithChildren<MaybeToggleTitleProps>> = ({
   labelText,
   requirementText,
   helpText,

--- a/src/Toggle/ToggleButton.tsx
+++ b/src/Toggle/ToggleButton.tsx
@@ -48,7 +48,7 @@ const animationConfig: AnimationConfig = {
   scale: 1.08,
 };
 
-const Switch: React.FC<SwitchProps> = ({ children, disabled, toggled, onClick }) => (
+const Switch: React.FC<React.PropsWithChildren<SwitchProps>> = ({ children, disabled, toggled, onClick }) => (
   <AnimatedBox
     position="relative"
     height="24px"
@@ -66,7 +66,7 @@ const Switch: React.FC<SwitchProps> = ({ children, disabled, toggled, onClick })
   </AnimatedBox>
 );
 
-const Slider: React.FC<SliderProps> = ({ disabled, children }) => (
+const Slider: React.FC<React.PropsWithChildren<SliderProps>> = ({ disabled, children }) => (
   <motion.div
     className="slider"
     initial={false}
@@ -110,7 +110,7 @@ const ToggleInput = styled.input(
   })
 );
 
-const ToggleButton: React.FC<ToggleButtonProps> = React.forwardRef((props, ref) => {
+const ToggleButton: React.FC<React.PropsWithChildren<ToggleButtonProps>> = React.forwardRef((props, ref) => {
   const { disabled, defaultToggled, toggled } = props;
   const inputRef = useRef(null);
 

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -26,7 +26,7 @@ export type TooltipProps = {
   children?: React.ReactNode;
 };
 
-const Tooltip: React.FC<TooltipProps> = React.forwardRef(
+const Tooltip: React.FC<React.PropsWithChildren<TooltipProps>> = React.forwardRef(
   ({ className, tooltip, maxWidth, children, placement, showDelay, hideDelay, defaultOpen }, ref) => (
     <Popper
       ref={ref}

--- a/src/Validation/InlineValidation.tsx
+++ b/src/Validation/InlineValidation.tsx
@@ -22,7 +22,7 @@ type InlineValidationProps = SpaceProps & {
   children?: React.ReactNode;
 };
 
-const InlineValidation: React.FC<InlineValidationProps> = ({
+const InlineValidation: React.FC<React.PropsWithChildren<InlineValidationProps>> = ({
   className,
   errorMessage,
   errorList,

--- a/src/utils/PopperArrow.tsx
+++ b/src/utils/PopperArrow.tsx
@@ -118,7 +118,7 @@ const drawArrow = (placement, borderColor, backgroundColor) => {
   }
 };
 
-const PopperArrow: React.FC<PopperArrowProps> = styled.div(
+const PopperArrow: React.FC<React.PropsWithChildren<PopperArrowProps>> = styled.div(
   {
     position: "absolute",
     height: theme.space.x1,

--- a/src/utils/ts/FocusManager.tsx
+++ b/src/utils/ts/FocusManager.tsx
@@ -17,7 +17,11 @@ type FocusManagerProps = {
   children: (handlers: ChildrenHandlers) => ReactNode;
 };
 
-const FocusManager: React.FC<FocusManagerProps> = ({ children, refs = undefined, defaultFocusedIndex }) => {
+const FocusManager: React.FC<React.PropsWithChildren<FocusManagerProps>> = ({
+  children,
+  refs = undefined,
+  defaultFocusedIndex,
+}) => {
   const [focusedIndex, setFocusedIndex] = useState<number>(defaultFocusedIndex ?? 0);
   const prevFocusedIndex = useRef<number>(focusedIndex);
 


### PR DESCRIPTION
Result of running: 

```
npx types-react-codemod preset-18 ./src

Pick transforms to apply (Press <space> to select, <a> to toggle all, <i> to invert selection, and <enter> to proceed)
 ◯ context-any
 ◉ deprecated-react-type
 ◉ deprecated-sfc-element
 ◉ deprecated-sfc
 ◉ deprecated-stateless-component
 ◉ implicit-children
 ◯ useCallback-implicit-any
```

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
