### PR TITLE
Column metadata fixes

### DIFF
--- a/src/Alert/Alert.story.tsx
+++ b/src/Alert/Alert.story.tsx
@@ -1,16 +1,24 @@
 import { boolean, text } from "@storybook/addon-knobs";
 import React from "react";
-import { Alert } from "../index";
+import { Alert, Flex } from "../index";
 import { Link } from "../Link";
 
 export default {
   title: "Components/Alert",
 };
 
-export const Danger = () => <Alert type="danger">{text("Alert Text", "Danger alert")}</Alert>;
-export const Informative = () => <Alert>{text("Alert Text", "Informative alert")}</Alert>;
-export const Success = () => <Alert type="success">{text("Alert Text", "Success alert")}</Alert>;
-export const Warning = () => <Alert type="warning">{text("Alert Text", "Warning alert")}</Alert>;
+const alertTypes = ["danger", "informative", "success", "warning"] as const;
+
+export const AlertTypes = () => (
+  <Flex flexDirection="column" gap="x1">
+    {alertTypes.map((type) => (
+      <Alert key={type} type={type} title={type}>
+        This is an alert with type &quot;{type}&quot;
+      </Alert>
+    ))}
+  </Flex>
+);
+
 export const WithACloseButton = () => (
   <Alert isCloseable={boolean("isCloseable", true)}>{text("Alert Text", "Warning alert")}</Alert>
 );

--- a/src/Table/Table.tsx
+++ b/src/Table/Table.tsx
@@ -5,10 +5,10 @@ import SortingColumnHeader from "./SortingColumnHeader";
 import { StatefulTableProps } from "./StatefulTable";
 import { ColumnType, RowType, CellInfoType } from "./Table.types";
 
-export type TableProps<ColumnMetadata> = StatefulTableProps<ColumnMetadata>;
-export type TableColumnType<ColumnMetadata> = ColumnType<ColumnMetadata>;
+export type TableProps<ColumnMetadata = unknown> = StatefulTableProps<ColumnMetadata>;
+export type TableColumnType<ColumnMetadata = unknown> = ColumnType<ColumnMetadata>;
 export type TableRowType = RowType;
-export type TableCellInfoType<ColumnMetadata> = CellInfoType<ColumnMetadata>;
+export type TableCellInfoType<ColumnMetadata = unknown> = CellInfoType<ColumnMetadata>;
 
 function Table<ColumnMetadata>({
   hasSelectableRows,


### PR DESCRIPTION
## Description
Default all exported table props types to use unknown for the `ColumnMetadata` generic.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
