### PR TITLE
chore: upgrade NDS icons to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@babel/preset-env": "7.3.1",
     "@babel/preset-typescript": "^7.10.4",
     "@nulogy/eslint-config-nulogy": "^1.0.0",
-    "@nulogy/icons": "^4.26.0",
+    "@nulogy/icons": "4.34.1",
     "@rollup/plugin-babel": "^5.0.0",
     "@rollup/plugin-node-resolve": "^7.1.3",
     "@semantic-release/changelog": "^6.0.2",
@@ -142,6 +142,7 @@
     "@nulogy/tokens": "^5.4.0",
     "@styled-system/prop-types": "^5.1.4",
     "@styled-system/theme-get": "^5.1.2",
+    "@types/styled-system": "5.1.22",
     "body-scroll-lock": "^3.1.5",
     "core-js": "3",
     "create-react-context": "^0.3.0",
@@ -160,11 +161,10 @@
     "react-popper": "1.3.11",
     "react-popper-2": "npm:react-popper@2.2.4",
     "react-resize-detector": "^9.1.0",
+    "react-select": "^5.8.0",
     "react-windowed-select": "^5.2.0",
     "smoothscroll-polyfill": "^0.4.4",
-    "react-select": "^5.8.0",
-    "styled-system": "^5.1.4",
-    "@types/styled-system": "5.1.22"
+    "styled-system": "^5.1.4"
   },
   "husky": {
     "hooks": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2912,10 +2912,10 @@
     eslint-plugin-react-hooks "^4.0.4"
     prettier "^2.0.5"
 
-"@nulogy/icons@^4.26.0":
-  version "4.26.0"
-  resolved "https://registry.yarnpkg.com/@nulogy/icons/-/icons-4.26.0.tgz#d3e179c1b582c83dd82f70f71420fadce9b4d891"
-  integrity sha512-bM6z9FvVPbbYKo0YZwgkqb3KXi7AWXpQbxH1YCa6/InVSSPZP73EL+6k/oL8DmsCnFunx7Y7q8hGeDS3FR4n3A==
+"@nulogy/icons@4.34.1":
+  version "4.34.1"
+  resolved "https://registry.yarnpkg.com/@nulogy/icons/-/icons-4.34.1.tgz#9255e637909b403dd877ad7631879b0b9fff023d"
+  integrity sha512-ZqOMxPcN/ZXFa5yhBY4cV5tMTorMPQ4BhcWpU1y8VmLftxcQS61gGhIg5MfogON4yUZJIZWrGaIRi6r2s6Qr1Q==
 
 "@nulogy/tokens@^5.4.0":
   version "5.4.0"


### PR DESCRIPTION
## Description
Upgrade @nulogy/icons to latest

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [x] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
