### PR TITLE
fix: do not shrink the toggle when put in a small container

### DIFF
--- a/src/Toggle/Toggle.story.tsx
+++ b/src/Toggle/Toggle.story.tsx
@@ -1,11 +1,12 @@
 import React, { useRef } from "react";
 import { action } from "@storybook/addon-actions";
 import { boolean } from "@storybook/addon-knobs";
-import { Toggle, Button } from "../index";
+import { Toggle, Button, Box } from "../index";
 import { Flex } from "../Flex";
 import dashed from "../utils/dashed";
 
 const DashedToggle = dashed(Toggle);
+const DashedBox = dashed(Box);
 
 export const WithDifferentSizes = () => (
   <Flex gap="x2" alignItems="flex-start">
@@ -111,6 +112,18 @@ export const WithLongText = () => (
 WithLongText.story = {
   name: "With long text",
 };
+
+export const WithContraintWidth = () => (
+  <DashedBox width="200px" padding="x2">
+    <Toggle
+      labelText="Toggle"
+      onText="This is a long On label for the toggle component."
+      offText="This is a long Off label for the toggle component."
+      defaultToggled
+      onChange={action("on change")}
+    />
+  </DashedBox>
+);
 
 export const ControlledToggle = () => (
   <Toggle

--- a/src/Toggle/ToggleButton.tsx
+++ b/src/Toggle/ToggleButton.tsx
@@ -53,6 +53,7 @@ function Switch({ children, disabled, toggled, onClick }: SwitchProps) {
   return (
     <AnimatedBox
       position="relative"
+      flexShrink={0}
       height="24px"
       width="48px"
       bg={disabled ? "grey" : getSwitchBackground(toggled)}


### PR DESCRIPTION
## Description

Fixes: #1449 

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [x] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
