### PR TITLE
fix: BottomSheet footer blur Firefox bug

### DIFF
--- a/src/BottomSheet/BottomSheet.styled.tsx
+++ b/src/BottomSheet/BottomSheet.styled.tsx
@@ -78,8 +78,10 @@ const ContentContainer = styled.div((_) => ({
 }));
 
 const Footer = styled.div(({ theme }) => ({
-  position: "sticky",
+  position: "fixed",
   bottom: 0,
+  left: 0,
+  right: 0,
   marginLeft: theme.space.x1,
   marginRight: theme.space.x1,
   padding: theme.space.x2,


### PR DESCRIPTION
## Description
Fixes a BottomSheet footer blur bug that occurs in Firefox

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
