### PR TITLE
fix: a more accurate type for the Select onChange prop

### DIFF
--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -22,7 +22,7 @@ import {
 } from "./SelectComponents";
 import { SelectOption } from "./SelectOption";
 import MenuList from "./MenuList";
-import { calcOptionsLength, checkOptionsAreValid, extractValue, getReactSelectValue } from "./lib";
+import { calcOptionsLength, checkOptionsAreValid, CustomOnChangeValue, extractValue, getReactSelectValue } from "./lib";
 
 export type NDSOptionValue = string | number | boolean | null;
 
@@ -46,7 +46,7 @@ interface CustomProps<Option extends NDSOption, IsMulti extends boolean, Group e
   defaultValue?: PropsValue<Option["value"]>;
   value?: PropsValue<Option["value"]>;
   options: readonly Option[];
-  onChange?: (newValue: PropsValue<Option["value"]>) => void;
+  onChange?: (newValue: CustomOnChangeValue<IsMulti>) => void;
   windowThreshold?: number;
   styles?: (selectStyles: StylesConfig<Option, IsMulti, Group>) => StylesConfig<Option, IsMulti, Group>;
 }

--- a/src/Select/lib.ts
+++ b/src/Select/lib.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Options, PropsValue } from "react-select";
+import { OnChangeValue, Options, PropsValue } from "react-select";
 import { NDSOption, NDSOptionValue } from "./Select";
 
 export function calcOptionsLength(options) {
@@ -92,20 +92,22 @@ export function getReactSelectValue(options: Options<NDSOption>, input: PropsVal
   return getOption(options, input);
 }
 
-export function extractValue(
-  options: Options<NDSOption> | NDSOption,
-  isMulti: boolean
-): NDSOptionValue[] | NDSOptionValue {
+export type CustomOnChangeValue<IsMulti extends boolean> = IsMulti extends true ? NDSOptionValue[] : NDSOptionValue;
+
+export function extractValue<IsMulti extends boolean>(
+  options: OnChangeValue<NDSOption, IsMulti>,
+  isMulti: IsMulti
+): CustomOnChangeValue<IsMulti> {
   if (options === null) {
     return null;
   }
 
   if (!Array.isArray(options)) {
-    return (options as NDSOption).value;
+    return (options as NDSOption).value as CustomOnChangeValue<IsMulti>;
   }
 
   if (isMulti) {
-    return options && options.length ? options.map((o) => o.value) : [];
+    return (options && options.length ? options.map((o) => o.value) : []) as CustomOnChangeValue<IsMulti>;
   }
 
   throw new Error("UNEXPECTED ERROR: don't forget to enable isMulti");


### PR DESCRIPTION
## Description

Consider this example:
```tsx
export const options = [{ value: "accepted", label: "Accepted" }];

function WithMulti() {
  return (
    <Select
      options={options}
      multiselect
      // value here is of type NDSOptionValue[]
      onChange={(value) => {
        // Do something with the value
      }}
    />
  );
}

function WithSingle() {
  return (
    <Select
      options={options}
      // value here is of type NDSOptionValue
      onChange={(value) => {
        // Do something with the value
      }}
    />
  );
}
```

TypeScript will infer the right type depending on whether multiselect is true or false. 

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
