### PR TITLE
fix: re-add select default props

### DIFF
--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, ReactNode, MutableRefObject } from "react";
 import Select from "react-select/base";
-import ReactSelect, { PropsValue } from "react-select";
+import ReactSelect, { MenuPlacement, MenuPosition, PropsValue } from "react-select";
 import type { GroupBase, Props, StylesConfig } from "react-select";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "styled-components";
@@ -10,6 +10,7 @@ import { InlineValidation } from "../Validation";
 import customStyles from "../Select/customReactSelectStyles";
 import { useComponentVariant } from "../NDSProvider/ComponentVariantContext";
 import { getSubset } from "../utils/subset";
+import numberFromDimension from "../utils/numberFromDimension";
 import { addStyledProps, StyledProps } from "../StyledProps";
 import {
   SelectControl,
@@ -68,12 +69,10 @@ const NDSSelect = forwardRef(
     Group extends GroupBase<Option> = GroupBase<Option>,
   >(
     {
-      autocomplete,
       value,
       onChange,
       defaultValue,
       labelText,
-      required,
       requirementText,
       helpText,
       disabled,
@@ -81,13 +80,19 @@ const NDSSelect = forwardRef(
       errorList,
       id,
       initialIsOpen,
-      maxHeight,
       multiselect,
       placeholder,
       components,
-      windowThreshold,
       options,
       styles,
+      windowThreshold = 300,
+      autocomplete = true,
+      maxHeight = "248px",
+      required = false,
+      menuPosition = "absolute" as MenuPosition,
+      menuPlacement = "bottom" as MenuPlacement,
+      classNamePrefix = "ndsSelect",
+      closeMenuOnSelect = true,
       ...props
     }: NDSSelectProps<Option, IsMulti, Group>,
     ref:
@@ -153,6 +158,11 @@ const NDSSelect = forwardRef(
               ...(isWindowed ? { MenuList } : {}),
               ...components,
             }}
+            closeMenuOnSelect={closeMenuOnSelect}
+            classNamePrefix={classNamePrefix}
+            menuPosition={menuPosition}
+            menuPlacement={menuPlacement}
+            maxMenuHeight={numberFromDimension(maxHeight)}
             {...props}
           />
           <InlineValidation mt="x1" errorMessage={errorMessage} errorList={errorList} />

--- a/src/Select/customReactSelectStyles.spec.tsx
+++ b/src/Select/customReactSelectStyles.spec.tsx
@@ -51,38 +51,38 @@ describe("custom react-select styles", () => {
 
     it("has border radius when empty", () => {
       const expected = theme.radii.medium;
-      const results = [];
+      const configs = [
+        {
+          border: "bottom",
+          isMenuOpen: true,
+          menuLength: 0,
+          menuPlacement: "bottom",
+          theme,
+        },
+        {
+          border: "top",
+          isMenuOpen: true,
+          menuLength: 0,
+          menuPlacement: "bottom",
+          theme,
+        },
+        {
+          border: "bottom",
+          isMenuOpen: true,
+          menuLength: 0,
+          menuPlacement: "top",
+          theme,
+        },
+        {
+          border: "top",
+          isMenuOpen: true,
+          menuLength: 0,
+          menuPlacement: "top",
+          theme,
+        },
+      ] as const;
 
-      results.push(
-        getControlBorderRadius({
-          border: "bottom",
-          isMenuOpen: true,
-          menuLength: 0,
-          menuPlacement: "bottom",
-          theme,
-        }),
-        getControlBorderRadius({
-          border: "top",
-          isMenuOpen: true,
-          menuLength: 0,
-          menuPlacement: "bottom",
-          theme,
-        }),
-        getControlBorderRadius({
-          border: "bottom",
-          isMenuOpen: true,
-          menuLength: 0,
-          menuPlacement: "top",
-          theme,
-        }),
-        getControlBorderRadius({
-          border: "top",
-          isMenuOpen: true,
-          menuLength: 0,
-          menuPlacement: "top",
-          theme,
-        })
-      );
+      const results = configs.map(getControlBorderRadius);
 
       for (const result of results) {
         expect(result).toEqual(expected);

--- a/src/Select/customReactSelectStyles.tsx
+++ b/src/Select/customReactSelectStyles.tsx
@@ -3,6 +3,7 @@ import type { GroupBase, MenuPlacement, StylesConfig } from "react-select";
 import type { CSSProperties } from "react";
 import type { DefaultNDSThemeType } from "../theme";
 import type { ComponentVariant } from "../NDSProvider/ComponentVariantContext";
+import numberFromDimension from "../utils/numberFromDimension";
 
 const getBorderColor = ({
   errored,
@@ -263,7 +264,7 @@ const customStyles: <Option, IsMulti extends boolean, Group extends GroupBase<Op
       ...provided,
       minWidth: "fit-content",
       padding: 0,
-      maxHeight: parseInt(maxHeight, 10),
+      maxHeight: numberFromDimension(maxHeight),
       borderRadius: theme.radii.medium,
       marginTop: windowed ? "-4px" : 0,
       marginBottom: windowed ? "-4px" : 0,


### PR DESCRIPTION
## Description
In v13, some of the default props of the Select component changed inadvertently. This PR fixes the mistake. 

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
