### PR TITLE
(fix): Change Table Key type

### DIFF
--- a/src/Table/Table.types.ts
+++ b/src/Table/Table.types.ts
@@ -1,5 +1,4 @@
-import type { Key } from "react";
-
+type Key = string | number;
 export type RowType = any;
 
 export interface CellInfoType<ColumnMetadata> {


### PR DESCRIPTION
In React v18 this type is defined as follows:

```
type Key = string | number | bigint;
```

This, however, conflicts with Typescript's allowed index types:

https://github.com/microsoft/TypeScript/issues/46395

## Description

**Describe the change you're making, the motivations behind it, and any thing else a reviewer may need to know to approve this PR.**

## Changes include

- [x] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
