### PR TITLE
fix: use modal z-index for the BottomSheet

### DIFF
--- a/src/BottomSheet/BottomSheet.styled.tsx
+++ b/src/BottomSheet/BottomSheet.styled.tsx
@@ -19,6 +19,7 @@ const Overlay = styled(motion(ReachDialogOverlay))(({ theme }) => ({
   alignItems: "flex-end",
   justifyContent: "center",
   backgroundColor: transparentize(0.5, theme.colors.blackBlue),
+  zIndex: theme.zIndices.overlay,
 }));
 
 interface SheetProps

--- a/src/BottomSheet/stories/BottomSheet.features.story.tsx
+++ b/src/BottomSheet/stories/BottomSheet.features.story.tsx
@@ -10,6 +10,9 @@ import { toast, ToastContainer } from "../../ToastContainer";
 import { Text } from "../../Type";
 import { Placeholder } from "../../utils/story/placeholder";
 import BottomSheet from "../BottomSheet";
+import { ApplicationFrame, Page } from "../../Layout";
+import { menuItems } from "../../TopBar/stories/fixtures";
+import { TopBar } from "../../TopBar";
 
 export default {
   title: "Components/BottomSheet/Features",
@@ -36,6 +39,42 @@ export const WithCustomWidths = () => {
       </BottomSheet>
     </>
   );
+};
+
+export const WithAnApplicationFrame = () => {
+  const [isOpen, setIsOpen] = React.useState(true);
+
+  const navBar = (
+    <TopBar.Root>
+      <TopBar.BackLink href="/cycle-counts">Cycle counts</TopBar.BackLink>
+      <TopBar.PageTitle>Cycle count #3992</TopBar.PageTitle>
+      <TopBar.Menu>
+        <TopBar.MenuItem>
+          <TopBar.MenuItemLink title="Home" description="Go to the home page" icon="home" href="/home" />
+        </TopBar.MenuItem>
+      </TopBar.Menu>
+    </TopBar.Root>
+  );
+  return (
+    <ApplicationFrame navBar={navBar}>
+      <Page>
+        <Button onClick={() => setIsOpen(true)}>Open Sheet</Button>
+        <BottomSheet
+          aria-label="Example BottomSheet"
+          title="Edit Profile"
+          helpText="Update your profile information to access exclusive features."
+          isOpen={isOpen}
+          onClose={() => setIsOpen(false)}
+        >
+          <Placeholder />
+        </BottomSheet>
+      </Page>
+    </ApplicationFrame>
+  );
+};
+
+WithAnApplicationFrame.parameters = {
+  layout: "fullscreen",
 };
 
 export const DisableCloseOnOverlayClick = () => {


### PR DESCRIPTION
## Description
Use modal z-index for the BottomSheet and its overlay.

## Testing notes:

- **Affected components**: BottomSheet
- **Expected change**: BottomSheet will be on top of the navigation elements on the page, like the BrandedNavBar or the TopBar.
- **Fixes**: #1526

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
