### PR TITLE
fix: AppTag not displaying in touch mode

### DIFF
--- a/src/AppTag/AppTag.tsx
+++ b/src/AppTag/AppTag.tsx
@@ -23,7 +23,7 @@ export default function AppTag({ app, type = "active", hideTooltip = false }: Ap
     <Tooltip content={displayName} hideTooltip={hideTooltip}>
       <Wrapper $type={type}>
         <LogoWrapper $type={type}>
-          <NulogyLogo width={8} height={8} />
+          <NulogyLogo width={theme.space.x1} height={theme.space.x1} />
         </LogoWrapper>
         <Text
           fontSize="smaller"

--- a/src/AppTag/components/LogoWrapper.tsx
+++ b/src/AppTag/components/LogoWrapper.tsx
@@ -9,7 +9,7 @@ export const LogoWrapper = styled.span<{ $type?: AppTagType }>(({ theme, $type }
     background: color,
     display: "inline-block",
     padding: theme.space.half,
-    borderRadius: theme.radii.rounded,
+    borderRadius: theme.radii.circle,
     lineHeight: 0,
   };
 });

--- a/src/Icon/LoadingIcon.tsx
+++ b/src/Icon/LoadingIcon.tsx
@@ -12,7 +12,7 @@ const LoadingIcon = React.forwardRef<SVGSVGElement, LoadingIconProps>(({ size, .
   return (
     <svg
       ref={ref}
-      viewBox="0 0 24px 24px"
+      viewBox="0 0 24 24"
       width={size}
       height={size}
       fill="none"


### PR DESCRIPTION
## Description

The AppTag was not properly sized in touch mode. This PR fixes it.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [x] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
