### PR TITLE
Move truncated text away from popper

### DIFF
--- a/cypress/e2e/components/TruncatedText.spec.ts
+++ b/cypress/e2e/components/TruncatedText.spec.ts
@@ -1,15 +1,9 @@
 describe("TruncatedText", () => {
-  const assertNoTooltip = () => cy.get('[role="tooltip"]').should("not.exist");
+  const triggerSelector = '[data-testid="truncated-text"]';
   const assertText = (text, el = "p") => {
-    cy.get(el).should("be.visible");
-    cy.get(el).contains(text);
+    cy.get(el).should("be.visible").contains(text);
   };
-  const assertTooltip = (text) => {
-    cy.get('[aria-haspopup="true"]').trigger("mouseover");
-    cy.get('[role="tooltip"]').should("be.visible");
-    cy.isInViewport('[role="tooltip"]');
-    cy.get('[role="tooltip"]').contains(text);
-  };
+
   describe("default", () => {
     beforeEach(() => {
       cy.renderFromStorybook("truncatedtext--truncated-text");
@@ -18,9 +12,10 @@ describe("TruncatedText", () => {
       assertText("Special instructions...");
     });
     it("shows a tooltip with full content on hover", () => {
-      assertTooltip("Special instructions are provided for the shipment");
+      cy.assertTooltip(triggerSelector, "Special instructions are provided for the shipment");
     });
   });
+
   describe("without tooltip", () => {
     beforeEach(() => {
       cy.renderFromStorybook("truncatedtext--without-tooltip");
@@ -29,9 +24,10 @@ describe("TruncatedText", () => {
       assertText("Special instructions...");
     });
     it("does not show a tooltip", () => {
-      assertNoTooltip();
+      cy.assertNoTooltip(triggerSelector);
     });
   });
+
   describe("under max characters", () => {
     beforeEach(() => {
       cy.renderFromStorybook("truncatedtext--under-max-characters");
@@ -40,9 +36,10 @@ describe("TruncatedText", () => {
       assertText("Item is available");
     });
     it("does not show a tooltip", () => {
-      assertNoTooltip();
+      cy.assertNoTooltip(triggerSelector);
     });
   });
+
   describe("with max characters 10", () => {
     beforeEach(() => {
       cy.renderFromStorybook("truncatedtext--with-max-characters-10");
@@ -51,9 +48,10 @@ describe("TruncatedText", () => {
       assertText("Item is av...");
     });
     it("does not show a tooltip", () => {
-      assertNoTooltip();
+      cy.assertNoTooltip(triggerSelector);
     });
   });
+
   describe("with custom truncation indicator", () => {
     beforeEach(() => {
       cy.renderFromStorybook("truncatedtext--with-custom-truncation-indicator");
@@ -62,9 +60,10 @@ describe("TruncatedText", () => {
       assertText("Special instructions + 2...");
     });
     it("shows a tooltip with full content on hover", () => {
-      assertTooltip("Special instructions are provided for the shipment");
+      cy.assertTooltip(triggerSelector, "Special instructions are provided for the shipment");
     });
   });
+
   describe("as title", () => {
     beforeEach(() => {
       cy.renderFromStorybook("truncatedtext--as-title");
@@ -73,28 +72,36 @@ describe("TruncatedText", () => {
       assertText("Special instructions...", "h1");
     });
   });
+
   describe("with fullWidth setting", () => {
     beforeEach(() => {
       cy.renderFromStorybook("truncatedtext--full-width");
     });
     it("shows the tooltip when there is overflow", () => {
-      cy.get("[data-testid='truncated-text']").first().trigger("mouseover");
-      cy.get('[role="tooltip"]').contains(
-        "Special instructions are truncated because there is not enough space to show them."
-      );
+      cy.get(triggerSelector)
+        .first()
+        .should("have.attr", "aria-describedby")
+        .then((tooltipId) => {
+          cy.get(`#${tooltipId}`)
+            .should("exist")
+            .should("have.css", "visibility", "visible")
+            .and("have.css", "opacity", "1")
+            .contains("Special instructions are truncated because there is not enough space to show them.");
+        });
     });
     it("doesn't show a tooltip when there's no overflow", () => {
-      cy.get("[data-testid='truncated-text']").eq(1).trigger("mouseover");
-      cy.get('[role="tooltip"]').should("not.exist");
-      cy.get("[data-testid='truncated-text']").eq(1).contains("Instructions fit here.");
+      cy.get(triggerSelector).eq(1).realHover();
+      cy.get(triggerSelector).eq(1).should("not.have.attr", "aria-describedby");
+      cy.get(triggerSelector).eq(1).contains("Instructions fit here.");
     });
   });
+
   describe("without children", () => {
     beforeEach(() => {
       cy.renderFromStorybook("truncatedtext--without-children");
     });
     it("renders without crashing", () => {
-      cy.get("[data-testid='truncated-text']").should("exist");
+      cy.get(triggerSelector).should("exist");
     });
   });
 });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -28,6 +28,7 @@
 // The plugin overrides the type command and manually triggers a click
 
 import "cypress-enter-plugin";
+import "cypress-real-events";
 
 Cypress.Commands.add("renderFromStorybook", (component, props) => {
   const baseUrl = `/iframe.html?path=/story/components-${component}`;
@@ -38,6 +39,23 @@ Cypress.Commands.add("renderFromStorybook", (component, props) => {
   } else {
     cy.visit(baseUrl);
   }
+});
+
+Cypress.Commands.add("assertTooltip", (triggerSelector, expectedText) => {
+  cy.get(triggerSelector).realHover();
+  cy.get(triggerSelector)
+    .should("have.attr", "aria-describedby")
+    .then((tooltipId) => {
+      cy.get(`#${tooltipId}`)
+        .should("exist")
+        .should("have.css", "visibility", "visible")
+        .and("have.css", "opacity", "1")
+        .contains(expectedText);
+    });
+});
+
+Cypress.Commands.add("assertNoTooltip", (triggerSelector) => {
+  cy.get(triggerSelector).should("not.have.attr", "aria-describedby");
 });
 
 Cypress.Commands.add("pressEscapeKey", () => {

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -2,6 +2,8 @@
 
 declare namespace Cypress {
   interface Chainable {
+    assertTooltip(triggerSelector: string, expectedText: string): Chainable<Element>;
+    assertNoTooltip(triggerSelector: string): Chainable<Element>;
     isNotInViewport(element: string): Chainable<Element>;
     isInViewport(element: string): Chainable<Element>;
     renderFromStorybook(component: string, props?: Record<string, unknown>): Chainable<Element>;

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es5",
     "lib": ["es5", "dom"],
-    "types": ["cypress", "node"]
+    "types": ["cypress", "node", "cypress-real-events"]
   },
   "include": ["**/*.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "cypress": "^13.2.0",
     "cypress-enter-plugin": "^1.0.1",
     "cypress-plugin-tab": "^1.0.1",
+    "cypress-real-events": "^1.14.0",
     "enzyme": "3.11.0",
     "enzyme-to-json": "3.4.4",
     "eslint": "6.8.0",

--- a/src/Card/Card.story.tsx
+++ b/src/Card/Card.story.tsx
@@ -1,5 +1,19 @@
 import React from "react";
-import { Card, CardSet } from "../index";
+import {
+  Card,
+  CardSet,
+  DescriptionDetails,
+  DescriptionGroup,
+  DescriptionList,
+  DescriptionTerm,
+  Flex,
+  Icon,
+  Link,
+  StatusIndicator,
+  Tooltip,
+} from "../index";
+import { Heading1, Heading4, Text } from "../Type";
+import TruncatedText from "../TruncatedText/TruncatedText";
 
 export default {
   title: "Components/Card",
@@ -23,4 +37,66 @@ export const Cardset = () => (
     <Card>I am a 2nd card in a cardset.</Card>
     <Card>I am a 3rd card in a cardset.</Card>
   </CardSet>
+);
+
+function AdvancedCard() {
+  return (
+    <Card>
+      <Heading4>POLI-2304</Heading4>
+      <DescriptionList>
+        <DescriptionGroup>
+          <DescriptionTerm>Customer</DescriptionTerm>
+          <DescriptionDetails>Nulogy</DescriptionDetails>
+        </DescriptionGroup>
+        <DescriptionGroup>
+          <DescriptionTerm>
+            <Text display="inline-flex" alignItems="center">
+              Order number
+              <Tooltip tooltip="The unique identifier assigned to this order when it was placed by the customer.">
+                <Icon icon="info" size="x3" paddingLeft="half" />
+              </Tooltip>
+            </Text>
+          </DescriptionTerm>
+          <DescriptionDetails>
+            <Link href="/customer-details">P12-90381-2039</Link>
+          </DescriptionDetails>
+        </DescriptionGroup>
+        <DescriptionGroup>
+          <DescriptionTerm>Status</DescriptionTerm>
+          <DescriptionDetails>
+            <StatusIndicator type="success">Paid</StatusIndicator>
+          </DescriptionDetails>
+        </DescriptionGroup>
+        <DescriptionGroup>
+          <DescriptionTerm>Amount</DescriptionTerm>
+          <DescriptionDetails>$202.12</DescriptionDetails>
+        </DescriptionGroup>
+        <DescriptionGroup>
+          <DescriptionTerm>Notes</DescriptionTerm>
+          <DescriptionDetails>
+            <TruncatedText fontSize="small" maxCharacters={200}>
+              Due to severe weather disruptions and unforeseen logistical challenges, this shipment has been
+              significantly delayed. The warehouse manager reported that mechanical issues with the transport vehicles,
+              coupled with a shortage of available staff, have extended processing times at the loading dock.
+              Additionally, mandatory safety inspections and inventory verifications required extra time, further
+              postponing the dispatch schedule. His detailed notes also mention that alternate transportation
+              arrangements are being evaluated and urge all stakeholders to stay in close communication for updated
+              delivery timelines.
+            </TruncatedText>
+          </DescriptionDetails>
+        </DescriptionGroup>
+      </DescriptionList>
+    </Card>
+  );
+}
+
+export const AdvancedUsage = () => (
+  <Flex flexDirection="column" gap="x2">
+    <Heading1 compact>Orders</Heading1>
+    <CardSet>
+      {[...Array(10)].map((_, i) => (
+        <AdvancedCard key={i} />
+      ))}
+    </CardSet>
+  </Flex>
 );

--- a/src/TruncatedText/MaybeTooltip.tsx
+++ b/src/TruncatedText/MaybeTooltip.tsx
@@ -1,13 +1,26 @@
 import React from "react";
-import { Tooltip } from "../Tooltip";
-import { TooltipProps } from "../Tooltip/Tooltip";
+import * as RadixTooltip from "@radix-ui/react-tooltip";
+import TooltipContent from "./TooltipContent";
 
-type MaybeTooltipProps = TooltipProps & {
+type MaybeTooltipProps = React.ComponentProps<typeof RadixTooltip.Root> & {
+  tooltip: React.ReactNode;
   showTooltip?: boolean;
 };
 
-const MaybeTooltip = ({ children = "", showTooltip = true, ...props }: MaybeTooltipProps) => {
-  return showTooltip ? <Tooltip {...props}>{children}</Tooltip> : <>{children}</>;
+const MaybeTooltip = ({ children, tooltip, showTooltip = true, ...rest }: MaybeTooltipProps) => {
+  if (!showTooltip) {
+    return <>{children}</>;
+  }
+  return (
+    <RadixTooltip.Provider>
+      <RadixTooltip.Root {...rest}>
+        <RadixTooltip.Trigger asChild>{children}</RadixTooltip.Trigger>
+        <RadixTooltip.Portal>
+          <TooltipContent>{tooltip}</TooltipContent>
+        </RadixTooltip.Portal>
+      </RadixTooltip.Root>
+    </RadixTooltip.Provider>
+  );
 };
 
 export default MaybeTooltip;

--- a/src/TruncatedText/TooltipContent.tsx
+++ b/src/TruncatedText/TooltipContent.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import * as RadixTooltip from "@radix-ui/react-tooltip";
+import styled, { keyframes } from "styled-components";
+
+const slideUpAndFade = keyframes`
+  from {
+    opacity: 0;
+    transform: translateY(2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
+const slideRightAndFade = keyframes`
+  from {
+    opacity: 0;
+    transform: translateX(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+`;
+
+const slideDownAndFade = keyframes`
+  from {
+    opacity: 0;
+    transform: translateY(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
+const slideLeftAndFade = keyframes`
+  from {
+    opacity: 0;
+    transform: translateX(2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+`;
+
+const StyledContent = styled(RadixTooltip.Content)`
+  font-family: ${({ theme }) => theme.fonts.base};
+  border-radius: ${({ theme }) => theme.radii.medium};
+  padding: ${({ theme }) => theme.space.x1};
+  font-size: ${({ theme }) => theme.fontSizes.small};
+  color: ${({ theme }) => theme.colors.black};
+  background-color: ${({ theme }) => theme.colors.white};
+  border: 1px solid ${({ theme }) => theme.colors.grey};
+  box-shadow: ${({ theme }) => theme.shadows.medium};
+  z-index: ${({ theme }) => theme.zIndices.content};
+  line-height: 1;
+  user-select: none;
+  animation-duration: 400ms;
+  animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: transform, opacity;
+
+  &[data-state="delayed-open"][data-side="top"] {
+    animation-name: ${slideUpAndFade};
+  }
+  &[data-state="delayed-open"][data-side="right"] {
+    animation-name: ${slideRightAndFade};
+  }
+  &[data-state="delayed-open"][data-side="bottom"] {
+    animation-name: ${slideDownAndFade};
+  }
+  &[data-state="delayed-open"][data-side="left"] {
+    animation-name: ${slideLeftAndFade};
+  }
+`;
+
+const StyledArrow = styled(RadixTooltip.Arrow)(({ theme }) => ({
+  fill: theme.colors.white,
+  filter: `drop-shadow(0px 1px 0px ${theme.colors.grey})`,
+  clipPath: "inset(0 -10px -10px -10px)",
+}));
+
+type StyledTooltipContentProps = React.ComponentProps<typeof RadixTooltip.Content> & {
+  children: React.ReactNode;
+};
+
+const StyledTooltipContent = ({ children, ...props }: StyledTooltipContentProps) => (
+  <StyledContent sideOffset={4} {...props}>
+    <StyledArrow />
+    {children}
+  </StyledContent>
+);
+
+export default StyledTooltipContent;

--- a/src/TruncatedText/TruncatedText.tsx
+++ b/src/TruncatedText/TruncatedText.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { Text } from "../Type";
-import { TruncatedTextProps } from "./TruncatedTextProps";
-import TruncatedTextFillWidth from "./TruncatedTextFillWidth";
-import TruncatedTextMaxCharacters from "./TruncatedTextMaxCharacters";
+import { TruncatedTextProps } from "./types";
+import TruncatedTextFillWidth from "./components/TruncatedTextFillWidth";
+import TruncatedTextMaxCharacters from "./components/TruncatedTextMaxCharacters";
 
 const TruncatedText = ({
   indicator = "...",

--- a/src/TruncatedText/components/MaybeTooltip.tsx
+++ b/src/TruncatedText/components/MaybeTooltip.tsx
@@ -1,0 +1,46 @@
+import React, { PropsWithChildren } from "react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import { MaxWidthProps } from "styled-system";
+import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "./TooltipComponents";
+
+export type MaybeTooltipProps = PropsWithChildren<{
+  tooltip: React.ReactNode;
+  showTooltip?: boolean;
+  placement?: "top" | "bottom" | "left" | "right";
+  className?: string;
+  defaultOpen?: boolean;
+  showDelay?: number;
+  maxWidth?: MaxWidthProps["maxWidth"];
+  supportMobileTap?: boolean;
+}>;
+
+const MaybeTooltip: React.FC<MaybeTooltipProps> = ({
+  tooltip,
+  children,
+  placement = "bottom",
+  defaultOpen = false,
+  showDelay = 100,
+  maxWidth = "24em",
+  showTooltip = true,
+  supportMobileTap = true,
+  className,
+}) => {
+  if (!showTooltip) {
+    return <>{children}</>;
+  }
+
+  return (
+    <TooltipProvider>
+      <Tooltip defaultOpen={defaultOpen} delayDuration={showDelay} supportMobileTap={supportMobileTap}>
+        <TooltipTrigger asChild>{children}</TooltipTrigger>
+        <TooltipPrimitive.Portal>
+          <TooltipContent side={placement} className={className} maxWidth={maxWidth}>
+            {tooltip}
+          </TooltipContent>
+        </TooltipPrimitive.Portal>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};
+
+export default MaybeTooltip;

--- a/src/TruncatedText/components/TooltipComponents.tsx
+++ b/src/TruncatedText/components/TooltipComponents.tsx
@@ -1,0 +1,187 @@
+import * as React from "react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import styled, { keyframes, useTheme } from "styled-components";
+import { maxWidth } from "styled-system";
+import { MaxWidthProps } from "styled-system";
+
+// A helper hook to determine if the device supports hover
+function useHasHover() {
+  try {
+    return matchMedia("(hover: hover)").matches;
+  } catch {
+    // Assume that if the browser is too old to support matchMedia, it's likely not a touch device
+    return true;
+  }
+}
+
+type TooltipTriggerContextType = {
+  supportMobileTap: boolean;
+  open: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+const TooltipTriggerContext = React.createContext<TooltipTriggerContextType>({
+  supportMobileTap: false,
+  open: false,
+  setOpen: () => {},
+});
+
+const TooltipProvider = TooltipPrimitive.Provider;
+
+type TooltipProps = TooltipPrimitive.TooltipProps & {
+  supportMobileTap?: boolean;
+};
+
+const Tooltip: React.FC<TooltipProps> = ({ children, ...props }) => {
+  const [open, setOpen] = React.useState<boolean>(props.defaultOpen ?? false);
+  const hasHover = useHasHover();
+
+  return (
+    <TooltipPrimitive.Root
+      delayDuration={!hasHover && props.supportMobileTap ? 0 : props.delayDuration}
+      onOpenChange={setOpen}
+      open={open}
+    >
+      <TooltipTriggerContext.Provider
+        value={{
+          open,
+          setOpen,
+          supportMobileTap: props.supportMobileTap ?? false,
+        }}
+      >
+        {children}
+      </TooltipTriggerContext.Provider>
+    </TooltipPrimitive.Root>
+  );
+};
+Tooltip.displayName = TooltipPrimitive.Root.displayName;
+
+const TooltipTrigger = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Trigger>
+>(({ children, ...props }, ref) => {
+  const hasHover = useHasHover();
+  const { setOpen, supportMobileTap } = React.useContext(TooltipTriggerContext);
+
+  const { onClick: onClickProp } = props;
+
+  const onClick = React.useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      if (!hasHover && supportMobileTap) {
+        e.preventDefault();
+        setOpen(true);
+      } else {
+        onClickProp?.(e);
+      }
+    },
+    [setOpen, hasHover, supportMobileTap, onClickProp]
+  );
+
+  return (
+    <TooltipPrimitive.Trigger ref={ref} {...props} onClick={onClick}>
+      {children}
+    </TooltipPrimitive.Trigger>
+  );
+});
+TooltipTrigger.displayName = TooltipPrimitive.Trigger.displayName;
+
+const slideUpAndFade = keyframes`
+  from {
+    opacity: 0;
+    transform: translateY(2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
+const slideRightAndFade = keyframes`
+  from {
+    opacity: 0;
+    transform: translateX(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+`;
+
+const slideDownAndFade = keyframes`
+  from {
+    opacity: 0;
+    transform: translateY(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
+const slideLeftAndFade = keyframes`
+  from {
+    opacity: 0;
+    transform: translateX(2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+`;
+
+const StyledContent = styled(TooltipPrimitive.Content)`
+  font-family: ${({ theme }) => theme.fonts.base};
+  font-size: ${({ theme }) => theme.fontSizes.small};
+  line-height: ${({ theme }) => theme.lineHeights.smallTextBase};
+  border-radius: ${({ theme }) => theme.radii.medium};
+  padding: ${({ theme }) => theme.space.x1};
+  color: ${({ theme }) => theme.colors.black};
+  background-color: ${({ theme }) => theme.colors.white};
+  border: 1px solid ${({ theme }) => theme.colors.grey};
+  box-shadow: ${({ theme }) => theme.shadows.medium};
+  z-index: ${({ theme }) => theme.zIndices.content};
+  animation-duration: 400ms;
+  animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: transform, opacity;
+
+  &[data-state="delayed-open"][data-side="top"] {
+    animation-name: ${slideDownAndFade};
+  }
+  &[data-state="delayed-open"][data-side="right"] {
+    animation-name: ${slideLeftAndFade};
+  }
+  &[data-state="delayed-open"][data-side="bottom"] {
+    animation-name: ${slideUpAndFade};
+  }
+  &[data-state="delayed-open"][data-side="left"] {
+    animation-name: ${slideRightAndFade};
+  }
+  ${maxWidth}
+`;
+
+const StyledArrow = styled(TooltipPrimitive.Arrow)(({ theme }) => ({
+  fill: theme.colors.white,
+  filter: `drop-shadow(0px 1px 0px ${theme.colors.grey})`,
+}));
+
+interface StyledTooltipContentProps
+  extends React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>,
+    MaxWidthProps {
+  children?: React.ReactNode;
+}
+
+const TooltipContent = React.forwardRef<React.ElementRef<typeof TooltipPrimitive.Content>, StyledTooltipContentProps>(
+  ({ sideOffset = 4, children, ...props }, ref) => {
+    const theme = useTheme();
+    return (
+      <StyledContent ref={ref} sideOffset={sideOffset} {...props}>
+        {children}
+        <StyledArrow width={theme.space.x1_5} height={theme.space.x0_75} />
+      </StyledContent>
+    );
+  }
+);
+
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };

--- a/src/TruncatedText/components/TruncatedTextFillWidth.tsx
+++ b/src/TruncatedText/components/TruncatedTextFillWidth.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
-import { Text } from "../Type";
-import { TruncatedTextProps } from "./TruncatedTextProps";
+import { Text } from "../../Type";
+import { TruncatedTextProps } from "../types";
 import MaybeTooltip from "./MaybeTooltip";
 
 const TruncatedTextFillWidth = ({

--- a/src/TruncatedText/components/TruncatedTextMaxCharacters.tsx
+++ b/src/TruncatedText/components/TruncatedTextMaxCharacters.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { Text } from "../Type";
-import { TruncatedTextProps } from "./TruncatedTextProps";
+import { Text } from "../../Type";
+import { TruncatedTextProps } from "../types";
 import MaybeTooltip from "./MaybeTooltip";
 
 const TruncatedTextMaxCharacters = ({

--- a/src/TruncatedText/types.ts
+++ b/src/TruncatedText/types.ts
@@ -1,6 +1,6 @@
 import { ReactElement } from "react";
-import { TooltipProps } from "../Tooltip/Tooltip";
 import { TextProps } from "../Type";
+import { MaybeTooltipProps } from "./components/MaybeTooltip";
 
 export interface TruncatedTextProps extends TextProps {
   children?: string;
@@ -10,5 +10,5 @@ export interface TruncatedTextProps extends TextProps {
   showTooltip?: boolean;
   fullWidth?: boolean;
   "data-testid"?: string;
-  tooltipProps?: TooltipProps;
+  tooltipProps?: MaybeTooltipProps;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10821,6 +10821,11 @@ cypress-plugin-tab@^1.0.1:
   dependencies:
     ally.js "^1.4.1"
 
+cypress-real-events@^1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/cypress-real-events/-/cypress-real-events-1.14.0.tgz#c5495db50a2bd247f4accde983af7153566945d3"
+  integrity sha512-XmI8y3OZLh6cjRroPalzzS++iv+pGCaD9G9kfIbtspgv7GVsDt30dkZvSXfgZb4rAN+3pOkMVB7e0j4oXydW7Q==
+
 cypress@^13.2.0:
   version "13.2.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.2.0.tgz#10f73d06a0764764ffbb903a31e96e2118dcfc1d"


### PR DESCRIPTION
## Description

This PR is part of an epic to move all NDS components away from Popper and onto more modern primitives. In this PR, we change the underlying tooltip in the TruncatedText to use a custom Radix UI tooltip instead of the Popper-based NDS one. 

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [x] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [x] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
