### PR TITLE
fix: Show tooltips above other content

### DIFF
--- a/cypress/e2e/components/AppTag.spec.ts
+++ b/cypress/e2e/components/AppTag.spec.ts
@@ -1,0 +1,19 @@
+describe("AppTag ", () => {
+  it("inside a modal", () => {
+    cy.renderFromStorybook("apptag-usecases--inside-a-modal");
+
+    cy.get('[role="dialog"]').should("be.visible");
+
+    cy.contains("Modal Title").should("be.visible");
+
+    cy.contains(
+      "The point of this test is to see if the tooltip is visible and shown over the modal and its overlay"
+    ).should("be.visible");
+
+    cy.contains("DQI").should("be.visible");
+
+    cy.contains("DQI").realHover();
+
+    cy.get('[role="tooltip"]').should("be.visible").and("contain", "Digital Quality Inspection");
+  });
+});

--- a/src/AppTag/components/Tooltip.tsx
+++ b/src/AppTag/components/Tooltip.tsx
@@ -1,7 +1,7 @@
-import * as RadixTooltip from "@radix-ui/react-tooltip";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import styled, { keyframes } from "styled-components";
 import { transparentize } from "polished";
-import React, { Fragment, ReactNode } from "react";
+import React, { ReactNode } from "react";
 
 type TooltipProps = {
   children: ReactNode;
@@ -11,20 +11,16 @@ type TooltipProps = {
 
 export function Tooltip({ children, content, hideTooltip = false }: TooltipProps) {
   if (hideTooltip) {
-    return <Fragment>{children}</Fragment>;
+    return <>{children}</>;
   }
 
   return (
-    <Fragment>
-      <RadixTooltip.Provider>
-        <RadixTooltip.Root>
-          <RadixTooltip.Trigger asChild>{children}</RadixTooltip.Trigger>
-          <RadixTooltip.Portal>
-            <TooltipContent sideOffset={4}>{content}</TooltipContent>
-          </RadixTooltip.Portal>
-        </RadixTooltip.Root>
-      </RadixTooltip.Provider>
-    </Fragment>
+    <TooltipPrimitive.Provider>
+      <TooltipPrimitive.Root>
+        <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
+        <TooltipContent sideOffset={4}>{content}</TooltipContent>
+      </TooltipPrimitive.Root>
+    </TooltipPrimitive.Provider>
   );
 }
 
@@ -72,8 +68,9 @@ const slideLeftAndFade = keyframes`
   }
 `;
 
-const TooltipContent = styled(RadixTooltip.Content)`
+const TooltipContent = styled(TooltipPrimitive.Content)`
   font-family: ${({ theme }) => theme.fonts.base};
+  font-weight: ${({ theme }) => theme.fontWeights.medium};
   white-space: nowrap;
   font-size: ${({ theme }) => theme.fontSizes.smaller};
   line-height: ${({ theme }) => theme.lineHeights.smallerText};
@@ -83,7 +80,6 @@ const TooltipContent = styled(RadixTooltip.Content)`
   margin-top: ${({ theme }) => theme.space.half};
   padding: ${({ theme }) => `${theme.space.x0_25} ${theme.space.x0_75}`};
   pointer-events: none;
-  z-index: 1000;
   animation-duration: 400ms;
   animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
   will-change: transform, opacity;

--- a/src/AppTag/stories/AppTag.usecases.story.tsx
+++ b/src/AppTag/stories/AppTag.usecases.story.tsx
@@ -9,6 +9,7 @@ import { Heading1, Text } from "../../Type";
 import { Code } from "../../utils/story/code";
 import { Table } from "../../Table";
 import { Tooltip } from "../../Tooltip";
+import { Modal } from "../../Modal";
 
 export default {
   title: "Components/AppTag/Usecases",
@@ -163,3 +164,16 @@ export const WithTooltip = () => {
 };
 
 WithTooltip.storyName = "With Tooltip";
+
+export const InsideAModal = () => {
+  return (
+    <Modal title="Modal Title">
+      <Flex flexDirection="column" gap="half">
+        <Text>The point of this test is to see if the tooltip is visible and shown over the modal and its overlay</Text>
+        <AppTag app="digital-quality-inspection" type="active" />
+      </Flex>
+    </Modal>
+  );
+};
+
+InsideAModal.storyName = "Inside a Modal";

--- a/src/Icon/Icon.tsx
+++ b/src/Icon/Icon.tsx
@@ -5,7 +5,7 @@ import icons from "@nulogy/icons";
 import { IconName } from "@nulogy/icons";
 import LoadingIcon from "./LoadingIcon";
 
-interface IconProps extends SpaceProps {
+export interface IconProps extends SpaceProps {
   icon: IconName | "loading";
   className?: string;
   size?: string;

--- a/src/TruncatedText/TruncatedText.story.tsx
+++ b/src/TruncatedText/TruncatedText.story.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Heading1 } from "../Type";
 import { Box } from "../Box";
+import { Modal } from "../Modal";
 import { TruncatedText } from ".";
 
 export default {
@@ -76,3 +77,15 @@ export const WithoutChildren = () => (
 WithoutChildren.story = {
   name: "Without children",
 };
+
+export const TooltipInsideModal = () => {
+  return (
+    <Modal title="Modal Title">
+      <TruncatedText tooltipProps={{ defaultOpen: true }}>
+        The point of this test is to see if the tooltip is visible and shown over the modal and its overlay
+      </TruncatedText>
+    </Modal>
+  );
+};
+
+TooltipInsideModal.storyName = "Tooltip inside modal";

--- a/src/TruncatedText/TruncatedText.tsx
+++ b/src/TruncatedText/TruncatedText.tsx
@@ -12,30 +12,22 @@ const TruncatedText = ({
   showTooltip = true,
   "data-testid": dataTestId = "truncated-text",
   children,
-  ...props
-}: TruncatedTextProps) =>
-  fullWidth ? (
-    <TruncatedTextFillWidth
-      indicator={indicator}
-      element={element}
-      maxCharacters={maxCharacters}
-      showTooltip={showTooltip}
-      data-testid={dataTestId}
-      {...props}
-    >
-      {children}
-    </TruncatedTextFillWidth>
+  ...rest
+}: TruncatedTextProps) => {
+  const props = {
+    indicator,
+    element,
+    maxCharacters,
+    showTooltip,
+    "data-testid": dataTestId,
+    ...rest,
+  };
+
+  return fullWidth ? (
+    <TruncatedTextFillWidth {...props}>{children}</TruncatedTextFillWidth>
   ) : (
-    <TruncatedTextMaxCharacters
-      indicator={indicator}
-      element={element}
-      maxCharacters={maxCharacters}
-      showTooltip={showTooltip}
-      data-testid={dataTestId}
-      {...props}
-    >
-      {children}
-    </TruncatedTextMaxCharacters>
+    <TruncatedTextMaxCharacters {...props}>{children}</TruncatedTextMaxCharacters>
   );
+};
 
 export default TruncatedText;

--- a/src/TruncatedText/components/MaybeTooltip.tsx
+++ b/src/TruncatedText/components/MaybeTooltip.tsx
@@ -1,5 +1,4 @@
 import React, { PropsWithChildren } from "react";
-import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import { MaxWidthProps } from "styled-system";
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "./TooltipComponents";
 
@@ -14,7 +13,7 @@ export type MaybeTooltipProps = PropsWithChildren<{
   supportMobileTap?: boolean;
 }>;
 
-const MaybeTooltip: React.FC<MaybeTooltipProps> = ({
+function MaybeTooltip({
   tooltip,
   children,
   placement = "bottom",
@@ -24,7 +23,7 @@ const MaybeTooltip: React.FC<MaybeTooltipProps> = ({
   showTooltip = true,
   supportMobileTap = true,
   className,
-}) => {
+}: MaybeTooltipProps) {
   if (!showTooltip) {
     return <>{children}</>;
   }
@@ -33,14 +32,12 @@ const MaybeTooltip: React.FC<MaybeTooltipProps> = ({
     <TooltipProvider>
       <Tooltip defaultOpen={defaultOpen} delayDuration={showDelay} supportMobileTap={supportMobileTap}>
         <TooltipTrigger asChild>{children}</TooltipTrigger>
-        <TooltipPrimitive.Portal>
-          <TooltipContent side={placement} className={className} maxWidth={maxWidth}>
-            {tooltip}
-          </TooltipContent>
-        </TooltipPrimitive.Portal>
+        <TooltipContent side={placement} className={className} maxWidth={maxWidth}>
+          {tooltip}
+        </TooltipContent>
       </Tooltip>
     </TooltipProvider>
   );
-};
+}
 
 export default MaybeTooltip;

--- a/src/TruncatedText/components/TooltipComponents.tsx
+++ b/src/TruncatedText/components/TooltipComponents.tsx
@@ -32,7 +32,7 @@ type TooltipProps = TooltipPrimitive.TooltipProps & {
   supportMobileTap?: boolean;
 };
 
-const Tooltip: React.FC<TooltipProps> = ({ children, ...props }) => {
+function Tooltip({ children, ...props }: TooltipProps) {
   const [open, setOpen] = React.useState<boolean>(props.defaultOpen ?? false);
   const hasHover = useHasHover();
 
@@ -53,7 +53,8 @@ const Tooltip: React.FC<TooltipProps> = ({ children, ...props }) => {
       </TooltipTriggerContext.Provider>
     </TooltipPrimitive.Root>
   );
-};
+}
+
 Tooltip.displayName = TooltipPrimitive.Root.displayName;
 
 const TooltipTrigger = React.forwardRef<
@@ -83,6 +84,7 @@ const TooltipTrigger = React.forwardRef<
     </TooltipPrimitive.Trigger>
   );
 });
+
 TooltipTrigger.displayName = TooltipPrimitive.Trigger.displayName;
 
 const slideUpAndFade = keyframes`
@@ -139,7 +141,6 @@ const StyledContent = styled(TooltipPrimitive.Content)`
   background-color: ${({ theme }) => theme.colors.white};
   border: 1px solid ${({ theme }) => theme.colors.grey};
   box-shadow: ${({ theme }) => theme.shadows.medium};
-  z-index: ${({ theme }) => theme.zIndices.content};
   animation-duration: 400ms;
   animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
   will-change: transform, opacity;

--- a/src/TruncatedText/types.ts
+++ b/src/TruncatedText/types.ts
@@ -10,5 +10,5 @@ export interface TruncatedTextProps extends TextProps {
   showTooltip?: boolean;
   fullWidth?: boolean;
   "data-testid"?: string;
-  tooltipProps?: MaybeTooltipProps;
+  tooltipProps?: Partial<MaybeTooltipProps>;
 }


### PR DESCRIPTION
## Description

Fixes an issue with the tooltip of the AppTag and the TruncatedText showing behind the Modal and the overlay.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
