### PR TITLE
fix: portal the tooltip in the AppTag and TruncatedText

### DIFF
--- a/src/AppTag/components/Tooltip.tsx
+++ b/src/AppTag/components/Tooltip.tsx
@@ -18,7 +18,9 @@ export function Tooltip({ children, content, hideTooltip = false }: TooltipProps
     <TooltipPrimitive.Provider>
       <TooltipPrimitive.Root>
         <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
-        <TooltipContent sideOffset={4}>{content}</TooltipContent>
+        <TooltipPrimitive.Portal>
+          <TooltipContent sideOffset={4}>{content}</TooltipContent>
+        </TooltipPrimitive.Portal>
       </TooltipPrimitive.Root>
     </TooltipPrimitive.Provider>
   );
@@ -70,7 +72,6 @@ const slideLeftAndFade = keyframes`
 
 const TooltipContent = styled(TooltipPrimitive.Content)`
   font-family: ${({ theme }) => theme.fonts.base};
-  font-weight: ${({ theme }) => theme.fontWeights.medium};
   white-space: nowrap;
   font-size: ${({ theme }) => theme.fontSizes.smaller};
   line-height: ${({ theme }) => theme.lineHeights.smallerText};
@@ -79,6 +80,7 @@ const TooltipContent = styled(TooltipPrimitive.Content)`
   border-radius: ${({ theme }) => theme.radii.medium};
   margin-top: ${({ theme }) => theme.space.half};
   padding: ${({ theme }) => `${theme.space.x0_25} ${theme.space.x0_75}`};
+  z-index: ${({ theme }) => theme.zIndices.aboveOverlay};
   pointer-events: none;
   animation-duration: 400ms;
   animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);

--- a/src/TruncatedText/components/MaybeTooltip.tsx
+++ b/src/TruncatedText/components/MaybeTooltip.tsx
@@ -1,5 +1,6 @@
 import React, { PropsWithChildren } from "react";
 import { MaxWidthProps } from "styled-system";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "./TooltipComponents";
 
 export type MaybeTooltipProps = PropsWithChildren<{
@@ -32,9 +33,11 @@ function MaybeTooltip({
     <TooltipProvider>
       <Tooltip defaultOpen={defaultOpen} delayDuration={showDelay} supportMobileTap={supportMobileTap}>
         <TooltipTrigger asChild>{children}</TooltipTrigger>
-        <TooltipContent side={placement} className={className} maxWidth={maxWidth}>
-          {tooltip}
-        </TooltipContent>
+        <TooltipPrimitive.Portal>
+          <TooltipContent side={placement} className={className} maxWidth={maxWidth}>
+            {tooltip}
+          </TooltipContent>
+        </TooltipPrimitive.Portal>
       </Tooltip>
     </TooltipProvider>
   );

--- a/src/TruncatedText/components/TooltipComponents.tsx
+++ b/src/TruncatedText/components/TooltipComponents.tsx
@@ -141,6 +141,7 @@ const StyledContent = styled(TooltipPrimitive.Content)`
   background-color: ${({ theme }) => theme.colors.white};
   border: 1px solid ${({ theme }) => theme.colors.grey};
   box-shadow: ${({ theme }) => theme.shadows.medium};
+  z-index: ${({ theme }) => theme.zIndices.aboveOverlay};
   animation-duration: 400ms;
   animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
   will-change: transform, opacity;


### PR DESCRIPTION
## Description

Portal the Tooltip so that it doesn't go under elements with lower z-index, but a a different CSS stacking context.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
