### PR TITLE
fix: Dropdown props account for higher order component children

### DIFF
--- a/src/DropdownMenu/DropdownMenu.story.tsx
+++ b/src/DropdownMenu/DropdownMenu.story.tsx
@@ -9,7 +9,6 @@ import {
   Flex,
   Text,
   Icon,
-  IconicButton,
 } from "../index";
 
 const customColors = {
@@ -165,3 +164,18 @@ export const WithConditionallyRenderedMenuItems = () => (
     {true && <DropdownButton onClick={() => {}}>Conditional Item C</DropdownButton>}
   </DropdownMenu>
 );
+
+export const WithHigherOrderChild = () => (
+  <DropdownMenu>
+    {({ closeMenu, openMenu }) => (
+      <>
+        <DropdownButton onClick={(e) => closeMenu(e)}>Close menu</DropdownButton>
+        <DropdownButton onClick={(e) => openMenu(e)}>Open menu</DropdownButton>
+      </>
+    )}
+  </DropdownMenu>
+);
+
+WithHigherOrderChild.story = {
+  name: "with higher order child",
+};

--- a/src/DropdownMenu/DropdownMenu.story.tsx
+++ b/src/DropdownMenu/DropdownMenu.story.tsx
@@ -165,7 +165,7 @@ export const WithConditionallyRenderedMenuItems = () => (
   </DropdownMenu>
 );
 
-export const WithHigherOrderChild = () => (
+export const WithRenderProps = () => (
   <DropdownMenu>
     {({ closeMenu, openMenu }) => (
       <>
@@ -176,6 +176,6 @@ export const WithHigherOrderChild = () => (
   </DropdownMenu>
 );
 
-WithHigherOrderChild.story = {
-  name: "with higher order child",
+WithRenderProps.story = {
+  name: "With render props",
 };

--- a/src/DropdownMenu/DropdownMenu.tsx
+++ b/src/DropdownMenu/DropdownMenu.tsx
@@ -7,8 +7,16 @@ import { getSubset, omitSubset } from "../utils/subset";
 import { StyledProps } from "../StyledProps";
 import DropdownMenuContainer from "./DropdownMenuContainer";
 
-type DropdownMenuProps = {
-  children?: React.ReactNode;
+type HigherOrderChild = ({
+  closeMenu,
+  openMenu,
+}: {
+  closeMenu: (e: unknown) => void;
+  openMenu: (e: unknown) => void;
+}) => React.ReactNode;
+
+interface DropdownMenuProps extends StyledProps {
+  children?: React.ReactNode | HigherOrderChild;
   className?: string;
   variant?: ComponentVariant;
   id?: string;
@@ -36,7 +44,7 @@ type DropdownMenuProps = {
   openAriaLabel?: string;
   closeAriaLabel?: string;
   openOnHover?: boolean;
-} & StyledProps;
+}
 
 const DEFAULT_POPPER_MODIFIERS = {
   preventOverflow: { enabled: true, padding: 8, boundariesElement: "viewport" },

--- a/src/DropdownMenu/DropdownMenu.tsx
+++ b/src/DropdownMenu/DropdownMenu.tsx
@@ -7,21 +7,21 @@ import { getSubset, omitSubset } from "../utils/subset";
 import { StyledProps } from "../StyledProps";
 import DropdownMenuContainer from "./DropdownMenuContainer";
 
-type HigherOrderChild = ({
-  closeMenu,
-  openMenu,
-}: {
-  closeMenu: (e: unknown) => void;
-  openMenu: (e: unknown) => void;
-}) => React.ReactNode;
+/*
+ * These render props are defined in the `transformInnerChildren`
+ * function in /src/Popper/Popper.tsx
+ */
+type DropdownMenuRenderProps = {
+  closeMenu: (e: React.MouseEvent) => void;
+  openMenu: (e: React.MouseEvent) => void;
+};
 
 interface DropdownMenuProps extends StyledProps {
-  children?: React.ReactNode | HigherOrderChild;
-  className?: string;
+  children?: React.ReactNode | ((props: DropdownMenuRenderProps) => React.ReactElement);
   variant?: ComponentVariant;
   id?: string;
   disabled?: boolean;
-  trigger?: () => React.FunctionComponentElement<unknown>;
+  trigger?: () => React.ReactElement;
   backgroundColor?: string;
   showArrow?: boolean;
   placement?:
@@ -44,6 +44,7 @@ interface DropdownMenuProps extends StyledProps {
   openAriaLabel?: string;
   closeAriaLabel?: string;
   openOnHover?: boolean;
+  className?: string;
 }
 
 const DEFAULT_POPPER_MODIFIERS = {

--- a/src/Popper/Popper.tsx
+++ b/src/Popper/Popper.tsx
@@ -133,11 +133,11 @@ const Popper = React.forwardRef<React.Ref<unknown>, PopperProps>(
     const transformInnerChildren = (elements) =>
       makeArray(elements).map((element, i) => {
         const transformedElement = wrapInFunction(element)({
-          closeMenu: (e) => {
+          closeMenu: (e: React.MouseEvent) => {
             closePopUp();
             e.stopPropagation();
           },
-          openMenu: (e) => {
+          openMenu: (e: React.MouseEvent) => {
             openPopUp();
             e.stopPropagation();
           },


### PR DESCRIPTION
## Description

Amends the type for DropdownMenu to account for higher order children.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
