### PR TITLE
fix: move EnvironmentBanner to the Navigation

### DIFF
--- a/src/BrandedNavBar/NavBar.tsx
+++ b/src/BrandedNavBar/NavBar.tsx
@@ -8,7 +8,7 @@ import { Box } from "../Box";
 import numberFromDimension from "../utils/numberFromDimension";
 import DesktopMenu from "./DesktopMenu";
 import { NulogyLogoContainer } from "./NulogyLogoContainer";
-import EnvironmentBanner from "./EnvironmentBanner";
+import EnvironmentBanner from "../Navigation/components/EnvironmentBanner/EnvironmentBanner";
 import BrandLogoContainer from "./BrandLogoContainer";
 import SmallNavBar from "./SmallNavBar";
 import NavBarBackground from "./NavBarBackground";

--- a/src/BrandedNavBar/SmallNavBar.tsx
+++ b/src/BrandedNavBar/SmallNavBar.tsx
@@ -6,7 +6,7 @@ import { DefaultNDSThemeType } from "../theme";
 import { Flex } from "../Flex";
 import NavBarSearch from "../NavBarSearch/NavBarSearch";
 import { withMenuState, WithMenuStateProps, AcceptsMenuStateProps } from "../utils";
-import EnvironmentBanner from "./EnvironmentBanner";
+import EnvironmentBanner from "../Navigation/components/EnvironmentBanner/EnvironmentBanner";
 import MobileMenu from "./MobileMenu";
 import NavBarBackground from "./NavBarBackground";
 

--- a/src/BrandedNavBar/index.ts
+++ b/src/BrandedNavBar/index.ts
@@ -1,8 +1,6 @@
 export { default as BrandedNavBar } from "./NavBar";
 export { default as MenuTrigger } from "./MenuTrigger";
 export type { MenuTriggerProps } from "./MenuTrigger";
-export { default as EnvironmentBanner } from "./EnvironmentBanner";
-export type { EnvironmentBannerProps } from "./EnvironmentBanner";
 export { default as NavBarBackground } from "./NavBarBackground";
 export type { NavBarBackgroundProps } from "./NavBarBackground";
 export { default as BrandLogoContainer } from "./BrandLogoContainer";

--- a/src/Layout/ApplicationFrame.tsx
+++ b/src/Layout/ApplicationFrame.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { ZIndexProps } from "styled-system";
 import Box from "../Box/Box";
 import Flex, { FlexProps } from "../Flex/Flex";
-import EnvironmentBanner from "../BrandedNavBar/EnvironmentBanner";
+import EnvironmentBanner from "../Navigation/components/EnvironmentBanner/EnvironmentBanner";
 
 type ApplicationFrameProps = FlexProps & {
   navBar?: React.ReactNode;

--- a/src/Navigation/README.md
+++ b/src/Navigation/README.md
@@ -74,7 +74,7 @@ function ApplicationHeader() {
 
 Use `Navigation` on every Nulogy application to provide a single, consistent entry point for navigation, cross-app switching, and account-level actions.
 
-Do **not** use it for in‑page or section navigation; use tabs or secondary menus instead. The `Navigation` component is not designed to be used for applications meant to be used primarily on touch devices. For those use cases, see the `TopBar` component.
+Do **not** use it for in‑page or section navigation; use tabs or a switcher instead. The `Navigation` component is not designed for applications meant to be used primarily on touch devices. For those use cases, use the `TopBar` component.
 
 ---
 
@@ -292,7 +292,7 @@ Change the `breakpoint` prop to control when the component switches to the deskt
 ## Technical Details
 
 - Powered by [Radix UI Navigation Menu](https://www.radix-ui.com/primitives/docs/components/navigation-menu).
-- For client‑side routing, pass `renderAsFragment` to `NavigationLogoLink` **or** supply an `element` to `MenuItemLink` / `LinkUserMenuItem`.
+- For client‑side routing, pass `renderAsFragment` to `NavigationLogoLink` **or** supply an `element` to link items.
 - Type definitions are located in `src/Navigation/types.ts`.
 
 ---
@@ -302,7 +302,13 @@ Change the `breakpoint` prop to control when the component switches to the deskt
 1. Keep navigation consistent across all pages.
 2. Write short, descriptive labels.
 3. Always provide the `tooltip` prop for icon‑only buttons.
-4. Make sure to set a width and height for the secondary logo to prevent overflow.
-5. Prefer nested sub‑menus and logical **separators** over long, flat lists.
+4. Make sure to set a width and height for the secondary logo to prevent overflow, or use the `NavigationLogo` helper component.
+5. Prefer nested sub‑menus and logical separators over long, flat lists.
 6. Test custom items on mobile and with a screen reader.
 7. Use the `mobileVisibility` prop to fine‑tune what appears in the collapsed layout.
+
+---
+
+## Migration from `BrandedNavBar`
+
+- The height of the new `Navigation` component is `64px` vs `56px` for `BrandedNavBar`. You need to adjust the `top` of the SideBar or any content (such as Pendo content) that is positioned relative to the page by `8px`.

--- a/src/Navigation/components/EnvironmentBanner/EnvironmentBanner.tsx
+++ b/src/Navigation/components/EnvironmentBanner/EnvironmentBanner.tsx
@@ -1,8 +1,7 @@
 import React from "react";
-import { Box } from "../Box";
-import { Text } from "../Type";
+import { Box } from "../../../Box";
+import { Text } from "../../../Type";
 
-/** @deprecated The BrandedNavBar component is deprecated. Use the Navigation component instead. */
 export type EnvironmentBannerProps = {
   children?: React.ReactNode;
 };
@@ -15,5 +14,4 @@ const EnvironmentBanner = ({ children }: EnvironmentBannerProps) => (
   </Box>
 );
 
-/** @deprecated The BrandedNavBar component is deprecated. Use the Navigation component instead. */
 export default EnvironmentBanner;

--- a/src/Navigation/components/EnvironmentBanner/index.ts
+++ b/src/Navigation/components/EnvironmentBanner/index.ts
@@ -1,0 +1,2 @@
+export { default as EnvironmentBanner } from "./EnvironmentBanner";
+export type { EnvironmentBannerProps } from "./EnvironmentBanner";

--- a/src/Navigation/index.ts
+++ b/src/Navigation/index.ts
@@ -2,6 +2,9 @@ export { default as Navigation } from "./Navigation";
 export { NulogyLogo } from "./components/NulogyLogo/NulogyLogo";
 export { NavigationLogoLink } from "./components/shared/NavigationLogoLink";
 export { NavigationLogo } from "./components/shared/NavigationLogo";
+export { EnvironmentBanner } from "./components/EnvironmentBanner";
+
 export type { NavigationProps } from "./Navigation";
 export type { MenuItems, MenuItem, UserMenu, UserMenuItem, UserMenuInfo } from "./types";
 export type { AppSwitcherConfig } from "./components/AppSwitcher/NulogyAppSwitcher";
+export type { EnvironmentBannerProps } from "./components/EnvironmentBanner";

--- a/src/Navigation/stories/Navigation.story.tsx
+++ b/src/Navigation/stories/Navigation.story.tsx
@@ -7,6 +7,7 @@ import { Select } from "../../Select";
 import { Flex } from "../../Flex";
 import { Text } from "../../Type";
 import { Code } from "../../utils/story/code";
+import { Banner } from "../../Banner";
 import CustomLogo3 from "./fixtures/logos/CustomLogo3";
 
 export default {
@@ -244,6 +245,39 @@ export const WithACustomBreakpoint = () => {
             </Text>
           </Flex>
         </Sidebar>
+      </Page>
+    </ApplicationFrame>
+  );
+};
+
+export const WithBanners = () => {
+  return (
+    <ApplicationFrame
+      environment="production"
+      navBar={
+        <>
+          <Banner title="Action required">
+            We have detected unauthorized access attempts on your account. Please change your password immediately to
+            secure your account.
+          </Banner>
+          <Navigation
+            primaryNavigation={[{ key: "dashboard", label: "Dashboard", type: "link" }]}
+            secondaryNavigation={[{ key: "settings", icon: "settings", tooltip: "Settings", type: "button" }]}
+          />
+        </>
+      }
+    >
+      <Page fullHeight>
+        <Sidebar
+          height="100%"
+          width="350px"
+          hideCloseButton
+          isOpen
+          title="Story information"
+          overlay="hide"
+          top="83px"
+          bottom="0px"
+        />
       </Page>
     </ApplicationFrame>
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,6 @@ export {
   BrandedNavBar,
   BrandLogoContainer,
   DesktopMenu,
-  EnvironmentBanner,
   MenuTrigger,
   NavBarBackground,
   SmallNavBar,
@@ -21,7 +20,6 @@ export {
 export type {
   BrandLogoContainerProps,
   DesktopMenuProps,
-  EnvironmentBannerProps,
   MenuTriggerProps,
   NavBarBackgroundProps,
   RenderMenuButtonProps,
@@ -51,7 +49,7 @@ export { List, ListItem } from "./List";
 export { LoadingAnimation } from "./LoadingAnimation";
 export { ALL_NDS_LOCALES } from "./locales.const";
 export { Modal } from "./Modal";
-export { Navigation, NulogyLogo, NavigationLogoLink, NavigationLogo } from "./Navigation";
+export { Navigation, NulogyLogo, NavigationLogoLink, NavigationLogo, EnvironmentBanner } from "./Navigation";
 export type {
   NavigationProps,
   MenuItems,
@@ -60,6 +58,7 @@ export type {
   UserMenuItem,
   UserMenuInfo,
   AppSwitcherConfig,
+  EnvironmentBannerProps,
 } from "./Navigation";
 export { NDSProvider } from "./NDSProvider";
 export { Overlay } from "./Overlay";


### PR DESCRIPTION
## Description
Undeprecate the EnvironmentBanner and move it out of the old BrandedNavBar

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
