### PR TITLE
fix: make the application frame header sticky again

### DIFF
--- a/cypress/e2e/components/NavigationUserMenu.spec.ts
+++ b/cypress/e2e/components/NavigationUserMenu.spec.ts
@@ -67,17 +67,6 @@ describe("NavigationUserMenu", () => {
     });
   });
 
-  describe("Header", () => {
-    beforeEach(() => {
-      cy.viewport(1280, 800);
-      cy.renderFromStorybook("navigation-user-menu--header");
-    });
-
-    it("opens and shows header content", () => {
-      getUserMenu().contains("Haider Alshamma").should("be.visible");
-    });
-  });
-
   describe("Controls", () => {
     beforeEach(() => {
       cy.viewport(1280, 800);
@@ -104,29 +93,6 @@ describe("NavigationUserMenu", () => {
     it("shows button menu items", () => {
       getUserMenuTrigger().click();
       getUserMenu().contains("A menu item can be a button").should("be.visible");
-    });
-
-    it("shows nested menu items", () => {
-      getUserMenuTrigger().click();
-      getUserMenu().contains("A menu item can have nested items").click();
-      getUserMenu().contains("Nested item 1").should("be.visible");
-      getUserMenu().contains("Nested item 2").should("be.visible");
-    });
-
-    it("handles deeply nested menu items", () => {
-      getUserMenuTrigger().click();
-      getUserMenu().contains("A menu item can have nested items").click();
-      getUserMenu().contains("A nested item can have nested items").click();
-      getUserMenu().contains("A menu item can be custom rendered").click();
-      getUserMenu().contains("This is a custom panel inside the user menu").should("be.visible");
-    });
-
-    it("renders custom components in the menu", () => {
-      getUserMenuTrigger().click();
-      getUserMenu().contains("A menu item can have nested items").click();
-      getUserMenu().contains("A nested item can have nested items").click();
-      getUserMenu().contains("A menu item can be custom rendered").click();
-      getUserMenu().contains("Custom button").should("be.visible");
     });
   });
 

--- a/src/Layout/ApplicationFrame.tsx
+++ b/src/Layout/ApplicationFrame.tsx
@@ -13,7 +13,7 @@ type ApplicationFrameProps = FlexProps & {
 const ApplicationFrame = ({ navBar, children, environment, ...props }: ApplicationFrameProps) => {
   return (
     <Flex flexDirection="column" minHeight="100vh" {...props}>
-      <Box zIndex={"navBar" as ZIndexProps["zIndex"]}>
+      <Box position="sticky" top="0" zIndex={"navBar" as ZIndexProps["zIndex"]}>
         {environment && <EnvironmentBanner>{environment}</EnvironmentBanner>}
         {navBar}
       </Box>

--- a/src/Navigation/README.md
+++ b/src/Navigation/README.md
@@ -221,19 +221,18 @@ type UserMenuItem = BaseUserMenuItem & (LinkUserMenuItem | ButtonUserMenuItem | 
 
 ##### ButtonUserMenuItem
 
-| Prop      | Type                                       | Description           |
-| --------- | ------------------------------------------ | --------------------- |
-| **type**  | `"button"`                                 | Discriminator.        |
-| **label** | `string`                                   | Visible text.         |
-| **props** | `React.ComponentPropsWithoutRef<"button">` | Pass‑through props.   |
-| **items** | `UserMenuItem[]`                           | Nested submenu items. |
+| Prop      | Type                                       | Description         |
+| --------- | ------------------------------------------ | ------------------- |
+| **type**  | `"button"`                                 | Discriminator.      |
+| **label** | `string`                                   | Visible text.       |
+| **props** | `React.ComponentPropsWithoutRef<"button">` | Pass‑through props. |
 
 ##### CustomUserMenuItem
 
-| Prop       | Type                                  | Description                                                                                                                                                                                                                                                                             |
-| ---------- | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **type**   | `"custom"`                            | Discriminator.                                                                                                                                                                                                                                                                          |
-| **render** | `(props: RenderProps) => JSX.Element` | A function that returns the JSX to be rendered for this menu item. <br/>**`RenderProps`**: <br/>- `level: number`: The depth of the item (0 for root, 1 for first submenu, etc.). <br/>- `withinMobileNav: boolean`: True if the item is rendered within the mobile navigation context. |
+| Prop       | Type                                  | Description                                                                                                                                                                                      |
+| ---------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **type**   | `"custom"`                            | Discriminator.                                                                                                                                                                                   |
+| **render** | `(props: RenderProps) => JSX.Element` | A function that returns the JSX to be rendered for this menu item. <br/>**`RenderProps`**: <br/>- `withinMobileNav: boolean`: True if the item is rendered within the mobile navigation context. |
 
 ---
 

--- a/src/Navigation/components/UserMenu/parts/Item.tsx
+++ b/src/Navigation/components/UserMenu/parts/Item.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import * as RadixNavigationMenu from "@radix-ui/react-navigation-menu";
 import type { UserMenuItem as UserMenuItemType } from "../../../types";
-import { CaretRight, RadixNavigationMenuItem } from "../../shared/components";
-import { SubMenuList, SubMenuContent, UserMenuLink, UserMenuTrigger } from "./styled";
+import { RadixNavigationMenuItem } from "../../shared/components";
+import { UserMenuLink, UserMenuTrigger } from "./styled";
 
 export interface UserMenuItemProps extends RadixNavigationMenu.NavigationMenuItemProps {
   item: UserMenuItemType;
@@ -24,25 +24,7 @@ const Item = React.forwardRef<HTMLLIElement, UserMenuItemProps & { level?: numbe
             )}
           </UserMenuLink>
         )}
-        {item.type === "button" && (
-          <>
-            <UserMenuTrigger {...item.props}>
-              {item.label}
-              {"items" in item && item.items && item.items.length > 0 && <CaretRight aria-hidden size="x2" />}
-            </UserMenuTrigger>
-            {"items" in item && item.items && item.items.length > 0 && (
-              <SubMenuContent>
-                <RadixNavigationMenu.Sub orientation="vertical">
-                  <SubMenuList>
-                    {item.items.map((subItem) => (
-                      <Item key={subItem.key} item={subItem} level={level + 1} />
-                    ))}
-                  </SubMenuList>
-                </RadixNavigationMenu.Sub>
-              </SubMenuContent>
-            )}
-          </>
-        )}
+        {item.type === "button" && <UserMenuTrigger {...item.props}>{item.label}</UserMenuTrigger>}
         {item.type === "custom" && item.render({ level, withinMobileNav: false })}
       </RadixNavigationMenuItem>
     );

--- a/src/Navigation/components/UserMenu/parts/MobileItem.tsx
+++ b/src/Navigation/components/UserMenu/parts/MobileItem.tsx
@@ -1,15 +1,11 @@
 import React from "react";
-import * as RadixNavigationMenu from "@radix-ui/react-navigation-menu";
 import { RadixNavigationMenuItem } from "../../shared/components";
 import { IndentedContainer } from "../../MobileNav/parts/styled";
-import { SubMenuList } from "../../MenuSubItem/parts/styled";
 import { UserMenuLink, UserMenuTrigger } from "./styled";
 import { UserMenuItemProps } from "./Item";
 
 const MobileItem = React.forwardRef<HTMLLIElement, UserMenuItemProps & { level?: number }>(
   ({ item, level = 0, ...props }, forwardedRef) => {
-    const hasSubItems = "items" in item && item.items && item.items.length > 0;
-
     const content = (
       <>
         {item.type === "link" && (
@@ -36,21 +32,6 @@ const MobileItem = React.forwardRef<HTMLLIElement, UserMenuItemProps & { level?:
         {item.type === "custom" && item.render({ level, withinMobileNav: true })}
       </>
     );
-
-    if (item.type === "button" && hasSubItems) {
-      return (
-        <RadixNavigationMenuItem ref={forwardedRef} {...props}>
-          {content}
-          <RadixNavigationMenu.Sub orientation="vertical">
-            <SubMenuList>
-              {item.items.map((subItem) => (
-                <MobileItem key={subItem.key} item={subItem} level={level + 1} />
-              ))}
-            </SubMenuList>
-          </RadixNavigationMenu.Sub>
-        </RadixNavigationMenuItem>
-      );
-    }
 
     return (
       <RadixNavigationMenuItem ref={forwardedRef} {...props}>

--- a/src/Navigation/components/UserMenu/parts/styled.tsx
+++ b/src/Navigation/components/UserMenu/parts/styled.tsx
@@ -54,25 +54,3 @@ export const UserMenuTrigger = styled(RadixNavigationMenu.Trigger)<{ $isMobile?:
   }),
   addStyledProps
 );
-
-export const SubMenuContent = styled(RadixNavigationMenu.Content)(({ theme }) => ({
-  position: "absolute",
-  top: `calc(-1 * ${theme.space.x1})`,
-  right: `calc(100% - ${theme.space.half})`,
-  width: "max-content",
-  minWidth: "150px",
-  background: theme.colors.white,
-  borderRadius: theme.radii.medium,
-  boxShadow: theme.shadows.medium,
-  padding: theme.space.none,
-  listStyle: "none",
-}));
-
-export const SubMenuList = styled(RadixNavigationMenu.List)(({ theme }) => ({
-  listStyle: "none",
-  paddingLeft: theme.space.none,
-  paddingRight: theme.space.none,
-  paddingTop: theme.space.x1,
-  paddingBottom: theme.space.x1,
-  margin: 0,
-}));

--- a/src/Navigation/components/shared/NavigationMenuContent.tsx
+++ b/src/Navigation/components/shared/NavigationMenuContent.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import * as RadixNavigationMenu from "@radix-ui/react-navigation-menu";
 import { addStyledProps, StyledProps } from "../../../StyledProps";
-import { NAVIGATION_MENU_CONTENT_WIDTH_MAX_WIDTH_PX } from "./constants";
+import { NAVIGATION_MENU_CONTENT_WIDTH_MAX_WIDTH_PX, NAVIGATION_MENU_HEIGHT_STYLED_UNITS } from "./constants";
 import { disableHoverEvents } from "./disableHoverEvents";
 
 export interface NavigationMenuContentProps extends RadixNavigationMenu.NavigationMenuContentProps, StyledProps {}
@@ -10,6 +10,8 @@ const NavigationMenuContent = styled(RadixNavigationMenu.Content).attrs(disableH
   ({ theme }) => ({
     position: "absolute",
     top: `calc(100% + ${theme.space.x1})`,
+    maxHeight: `calc(100dvh - ${theme.space.x2} - ${theme.space[NAVIGATION_MENU_HEIGHT_STYLED_UNITS]})`,
+    overflowY: "auto",
     display: "flex",
     flexDirection: "column",
     borderRadius: theme.radii.large,

--- a/src/Navigation/stories/Navigation.userMenu.story.tsx
+++ b/src/Navigation/stories/Navigation.userMenu.story.tsx
@@ -295,67 +295,6 @@ export const MenuItems = () => {
               key: "nested-items",
               label: "A menu item can have nested items",
               type: "button",
-              items: [
-                {
-                  key: "nested-item-1",
-                  label: "Nested item 1",
-                  type: "button",
-                },
-                {
-                  key: "nested-item-2",
-                  label: "Nested item 2",
-                  type: "button",
-                },
-                {
-                  key: "nested-item-3",
-                  label: "A nested item can have nested items",
-                  type: "button",
-                  items: [
-                    {
-                      key: "nested-item-3-1",
-                      label: "A menu item can be custom rendered",
-                      type: "button",
-                      items: [
-                        {
-                          key: "custom-panel",
-                          type: "custom",
-                          render: () => (
-                            <div style={{ backgroundColor: "beige", padding: 24, borderRadius: 8 }}>
-                              This is a custom panel inside the user menu
-                            </div>
-                          ),
-                        },
-                        {
-                          key: "custom-button",
-                          type: "custom",
-                          render: () => (
-                            <button
-                              style={{
-                                backgroundColor: "#fff000",
-                                borderRadius: 12,
-                                color: "#000",
-                                cursor: "pointer",
-                                fontWeight: "bold",
-                                padding: "10px 15px",
-                                textAlign: "center",
-                                transition: "200ms",
-                                width: "100%",
-                                boxSizing: "border-box",
-                                border: 0,
-                                fontSize: 16,
-                                userSelect: "none",
-                                WebkitUserSelect: "none",
-                              }}
-                            >
-                              Custom button
-                            </button>
-                          ),
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
             },
           ],
         }}

--- a/src/Navigation/types.ts
+++ b/src/Navigation/types.ts
@@ -34,7 +34,6 @@ interface ButtonUserMenuItem {
   label: string;
   type: "button";
   props?: React.ComponentPropsWithoutRef<"button">;
-  items?: UserMenuItem[];
 }
 
 interface CustomUserMenuItem {


### PR DESCRIPTION
## Description
Makes the header in the application frame sticky like it used to be prior to the new Navigation

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
