### PR TITLE
fix: Table's `noRowsContent` type improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,14 @@
 ## [15.1.1](https://github.com/nulogy/design-system/compare/v15.1.0...v15.1.1) (2025-11-10)
 
-
 ### Bug Fixes
 
-* Add temporary params to DatePicker ([b414899](https://github.com/nulogy/design-system/commit/b41489958c085babb351f6bd678980b2751adff0))
+- Add temporary params to DatePicker ([b414899](https://github.com/nulogy/design-system/commit/b41489958c085babb351f6bd678980b2751adff0))
 
 # [15.1.0](https://github.com/nulogy/design-system/compare/v15.0.1...v15.1.0) (2025-08-21)
 
-
 ### Features
 
-* Improved Header title prop ([b9f8a9d](https://github.com/nulogy/design-system/commit/b9f8a9d3d96067e66d2f37f326077ff867f83c4c))
+- Improved Header title prop ([b9f8a9d](https://github.com/nulogy/design-system/commit/b9f8a9d3d96067e66d2f37f326077ff867f83c4c))
 
 ## [15.0.1](https://github.com/nulogy/design-system/compare/v15.0.0...v15.0.1) (2025-06-26)
 

--- a/src/Table/BaseTable.tsx
+++ b/src/Table/BaseTable.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { type ReactNode } from "react";
 import styled from "styled-components";
 import { space } from "styled-system";
 import TableHead from "./TableHead";
@@ -9,7 +9,7 @@ import { RowType, Columns, RowBorder } from "./Table.types";
 export type BaseTableProps<ColumnMetaData> = {
   columns: Columns<ColumnMetaData>;
   rows: RowType[];
-  noRowsContent?: string;
+  noRowsContent?: ReactNode;
   keyField?: string;
   id?: string;
   loading?: boolean;

--- a/src/Table/TableBody.tsx
+++ b/src/Table/TableBody.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { type ReactNode } from "react";
 import styled from "styled-components";
 import { Box } from "../Box";
 import { DefaultNDSThemeType } from "../theme";
@@ -31,15 +31,15 @@ const StyledTr = styled.tr<StyledTrProps>(({ rowHovers, rowBorder, theme }: Styl
 }));
 
 const renderRows = (
-  rows,
-  columns,
-  keyField,
-  noRowsContent,
-  rowHovers,
-  compact,
-  onRowMouseLeave,
-  onRowMouseEnter,
-  rowBorder
+  rows: any[],
+  columns: any[],
+  keyField?: string,
+  rowHovers?: boolean,
+  noRowsContent?: ReactNode,
+  compact?: boolean,
+  onRowMouseLeave?: ({ row, e }: { row: any; e: React.MouseEvent<HTMLTableRowElement> }) => void,
+  onRowMouseEnter?: ({ row, e }: { row: any; e: React.MouseEvent<HTMLTableRowElement> }) => void,
+  rowBorder?: RowBorder
 ) =>
   rows.length > 0 ? (
     rows.map((row, rowIndex) => {
@@ -64,7 +64,7 @@ const renderRows = (
     <TableMessageContainer colSpan={columns.length}>{noRowsContent}</TableMessageContainer>
   );
 
-type TableBodyRowProps = {
+interface TableBodyRowProps {
   row: any;
   columns: any[];
   rowHovers?: boolean;
@@ -74,7 +74,7 @@ type TableBodyRowProps = {
   onMouseEnter?: any;
   onMouseLeave?: any;
   rowBorder?: RowBorder;
-};
+}
 
 const TableBodyRow = ({
   row,
@@ -121,7 +121,7 @@ const TableBodyRow = ({
   );
 };
 
-const TableMessageContainer = ({ colSpan, children }: { colSpan: number; children: React.ReactNode }) => (
+const TableMessageContainer = ({ colSpan, children }: { colSpan: number; children: ReactNode }) => (
   <tr data-testid="table-message-container">
     <td colSpan={colSpan}>
       <StyledMessageContainer className="nds-table__no-rows-content">{children}</StyledMessageContainer>
@@ -133,18 +133,18 @@ const LoadingContent = ({ colSpan }: { colSpan: number }) => (
   <TableMessageContainer colSpan={colSpan}>Loading...</TableMessageContainer>
 );
 
-type TableBodyProps = {
+interface TableBodyProps {
   rows: any[];
   columns: any[];
   keyField?: string;
-  noRowsContent?: any;
+  noRowsContent: ReactNode;
   loading?: boolean;
   rowHovers?: boolean;
   compact?: boolean;
-  onRowMouseLeave?: any;
-  onRowMouseEnter?: any;
+  onRowMouseLeave?: (...args: any[]) => any;
+  onRowMouseEnter?: (...args: any[]) => any;
   rowBorder?: RowBorder;
-};
+}
 
 const TableBody = ({
   rows,
@@ -164,8 +164,8 @@ const TableBody = ({
         rows,
         columns,
         keyField,
-        noRowsContent,
         rowHovers,
+        noRowsContent,
         compact,
         onRowMouseLeave,
         onRowMouseEnter,


### PR DESCRIPTION
## Description

This can be a ReactNode.

I've added some additional types that are admittedly awful, but they ensure I don't need to break any method signatures. Long term we need to refactor away from this entire library.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
