### PR TITLE
Improve toggle component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 ## [15.1.4](https://github.com/nulogy/design-system/compare/v15.1.3...v15.1.4) (2025-11-20)
 
-
 ### Bug Fixes
 
-* Toggle should have field label ([8024eb5](https://github.com/nulogy/design-system/commit/8024eb5d040bf3faae68562e8f47149b7853fbb7))
+- Toggle should have field label ([8024eb5](https://github.com/nulogy/design-system/commit/8024eb5d040bf3faae68562e8f47149b7853fbb7))
 
 ## [15.1.3](https://github.com/nulogy/design-system/compare/v15.1.2...v15.1.3) (2025-11-19)
 

--- a/cypress/e2e/components/Toggle.spec.ts
+++ b/cypress/e2e/components/Toggle.spec.ts
@@ -21,14 +21,4 @@ describe("Tooltip", () => {
       getToggleInput().should("have.value", "off");
     });
   });
-  describe("Controlled", () => {
-    beforeEach(() => {
-      cy.renderFromStorybook("toggle--controlled-toggle");
-    });
-    it("does not change the value on click", () => {
-      getToggleInput().should("have.value", "off");
-      getToggle().click();
-      getToggleInput().should("have.value", "off");
-    });
-  });
 });

--- a/src/FieldLabel/FieldLabel.story.tsx
+++ b/src/FieldLabel/FieldLabel.story.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Field, FieldLabel, Input, Select, Toggle, RadioGroup, Radio, Flex } from "../index";
+import { FieldLabel, Input, Select, Toggle, RadioGroup, Radio, Flex } from "../index";
 import { Link } from "../Link";
 
 const helpTextWithLink = (
@@ -82,7 +82,7 @@ export const WithRangeOfInputComponents = () => (
     </FieldLabel>
 
     <FieldLabel labelText="Label with hint" hint="This is a hint for the input field" requirementText="(Required)">
-      <Toggle onText="on" offText="off" defaultToggled />
+      <Toggle onText="on" offText="off" toggled={true} />
     </FieldLabel>
     <FieldLabel labelText="Label with hint" hint="This is a hint for the input field" requirementText="(Required)">
       <RadioGroup name="settingSelection">

--- a/src/FieldLabel/Label.tsx
+++ b/src/FieldLabel/Label.tsx
@@ -2,13 +2,18 @@ import styled from "styled-components";
 import { space, color, display, DisplayProps } from "styled-system";
 import type { SpaceProps } from "styled-system";
 import type { ComponentPropsWithRef } from "react";
+import { ComponentVariant } from "../NDSProvider/ComponentVariantContext";
 
-export interface LabelProps extends SpaceProps, DisplayProps, Omit<ComponentPropsWithRef<"label">, "color"> {}
+export interface LabelProps extends SpaceProps, DisplayProps, Omit<ComponentPropsWithRef<"label">, "color"> {
+  disabled?: boolean;
+  variant?: ComponentVariant;
+}
 
 const Label = styled.label<LabelProps>(
-  ({ color = "black" }) => ({
+  ({ color = "black", disabled }) => ({
     color: color,
     display: "inline-block",
+    cursor: disabled ? undefined : "pointer",
   }),
   display,
   space,

--- a/src/Toggle/Toggle.spec.tsx
+++ b/src/Toggle/Toggle.spec.tsx
@@ -6,16 +6,12 @@ import { Toggle } from ".";
 describe("Toggle", () => {
   describe("calls event handlers", () => {
     const onChange = jest.fn();
-    const onClick = jest.fn();
 
     it("returns the selected time when the selection has changed", () => {
-      const { container } = renderWithNDSProvider(
-        <Toggle onChange={onChange} onClick={onClick} data-testid="toggle" />
-      );
+      const { container } = renderWithNDSProvider(<Toggle onChange={onChange} data-testid="toggle" />);
       fireEvent.click(container.querySelectorAll("[data-testid='toggle'] input")[0]);
 
       expect(onChange).toHaveBeenCalled();
-      expect(onClick).toHaveBeenCalled();
     });
   });
 });

--- a/src/Toggle/Toggle.story.tsx
+++ b/src/Toggle/Toggle.story.tsx
@@ -1,6 +1,5 @@
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
 import { action } from "@storybook/addon-actions";
-import { boolean } from "@storybook/addon-knobs";
 import { Toggle, Button, Box } from "../index";
 import { dashed } from "../utils/story/dashed";
 
@@ -10,124 +9,138 @@ export default {
   title: "Components/Toggle",
 };
 
-export const _Toggle = () => <Toggle data-testid="toggle-example" onChange={action("on change")} />;
+export const _Toggle = () => {
+  const [toggled, setToggled] = useState(false);
 
-export const ToggleWithAllProps = () => (
-  <Toggle
-    labelText="Toggle"
-    helpText="Turns setting on/off"
-    onText="on"
-    offText="off"
-    defaultToggled
-    required
-    requirementText="(Required)"
-    onChange={action("on change")}
-  />
-);
-
-ToggleWithAllProps.story = {
-  name: "Toggle with all props",
+  return <Toggle data-testid="toggle-example" toggled={toggled} onChange={(e) => setToggled(e.target.checked)} />;
 };
 
-export const ToggleSetToDefaultToggled = () => (
-  <Toggle labelText="Toggle" defaultToggled onChange={action("on change")} />
-);
+export const ToggleWithAllProps = () => {
+  const [toggled, setToggled] = useState(true);
 
-ToggleSetToDefaultToggled.story = {
-  name: "Toggle set to defaultToggled",
-};
-
-export const ToggleSetToDisabled = () => (
-  <>
+  return (
     <Toggle
       labelText="Toggle"
-      disabled
+      helpText="Turns setting on/off"
       onText="on"
       offText="off"
-      onChange={action("on change")}
-      data-testid="toggle-example"
+      toggled={toggled}
+      required
+      requirementText="(Required)"
+      onChange={(e) => setToggled(e.target.checked)}
     />
+  );
+};
+ToggleWithAllProps.storyName = "Toggle with all props";
+
+export const ToggleSetToDisabled = () => {
+  return (
+    <>
+      <Toggle
+        labelText="Toggle"
+        disabled
+        onText="on"
+        offText="off"
+        onChange={action("on change")}
+        data-testid="toggle-example"
+      />
+      <Toggle
+        id="toggle-2"
+        disabled
+        onText="on"
+        offText="off"
+        toggled={true}
+        labelText="Toggle"
+        onChange={action("on change")}
+      />
+    </>
+  );
+};
+ToggleSetToDisabled.storyName = "Toggle set to disabled";
+
+export const WithCustomId = () => {
+  const [toggled, setToggled] = useState(true);
+
+  return (
     <Toggle
-      id="toggle-2"
-      disabled
+      id="my-custom-id"
+      labelText="Toggle"
       onText="on"
       offText="off"
-      defaultToggled
-      labelText="Toggle"
-      onChange={action("on change")}
+      toggled={toggled}
+      onChange={(e) => setToggled(e.target.checked)}
     />
-  </>
-);
-
-ToggleSetToDisabled.story = {
-  name: "Toggle set to disabled",
+  );
 };
+WithCustomId.storyName = "With custom id";
 
-export const WithCustomId = () => (
-  <Toggle id="my-custom-id" labelText="Toggle" onText="on" offText="off" onChange={action("on change")} />
-);
+export const WithText = () => {
+  const [toggled, setToggled] = useState(true);
 
-WithCustomId.story = {
-  name: "With custom id",
-};
-
-export const WithText = () => <Toggle labelText="Toggle" onText="on" offText="off" onChange={action("on change")} />;
-
-WithText.story = {
-  name: "With text",
-};
-
-export const WithLongText = () => (
-  <Toggle
-    labelText="Toggle"
-    defaultToggled
-    onText="this state has a very long text label to explain it's state"
-    offText="not this one"
-    onChange={action("on change")}
-  />
-);
-
-WithLongText.story = {
-  name: "With long text",
-};
-
-export const WithContraintWidth = () => (
-  <DashedBox width="200px" padding="x2">
+  return (
     <Toggle
       labelText="Toggle"
-      onText="This is a long On label for the toggle component."
-      offText="This is a long Off label for the toggle component."
-      defaultToggled
-      onChange={action("on change")}
+      onText="on"
+      offText="off"
+      toggled={toggled}
+      onChange={(e) => setToggled(e.target.checked)}
     />
-  </DashedBox>
-);
+  );
+};
+WithText.storyName = "With text";
 
-export const ControlledToggle = () => (
-  <Toggle
-    labelText="Controlled Toggle"
-    toggled={boolean("Toggled", false)}
-    onText="on"
-    offText="off"
-    onChange={action("on change")}
-    data-testid="toggle-example"
-  />
-);
+export const WithLongText = () => {
+  const [toggled, setToggled] = useState(true);
+
+  return (
+    <Toggle
+      labelText="Toggle"
+      toggled={toggled}
+      onText="this state has a very long text label to explain it's state"
+      offText="not this one"
+      onChange={(e) => setToggled(e.target.checked)}
+    />
+  );
+};
+WithLongText.storyName = "With long text";
+
+export const WithContraintWidth = () => {
+  const [toggled, setToggled] = useState(true);
+
+  return (
+    <DashedBox width="200px" padding="x2">
+      <Toggle
+        labelText="Toggle"
+        onText="This is a long On label for the toggle component."
+        offText="This is a long Off label for the toggle component."
+        toggled={toggled}
+        onChange={(e) => setToggled(e.target.checked)}
+      />
+    </DashedBox>
+  );
+};
+WithContraintWidth.storyName = "With constraint width";
 
 export const UsingRefToControlFocus = () => {
-  const ref = useRef(null);
+  const [toggled, setToggled] = useState(true);
+  const ref = useRef<HTMLInputElement>(null);
   const handleClick = () => {
     ref.current.focus();
   };
 
   return (
     <>
-      <Toggle id="my-custom-id" labelText="Toggle" onText="on" offText="off" onChange={action("on change")} ref={ref} />
+      <Toggle
+        id="my-custom-id"
+        labelText="Toggle"
+        onText="on"
+        offText="off"
+        toggled={toggled}
+        onChange={(e) => setToggled(e.target.checked)}
+        ref={ref}
+      />
       <Button onClick={handleClick}>Focus the Toggle</Button>
     </>
   );
 };
-
-UsingRefToControlFocus.story = {
-  name: "using ref to control focus",
-};
+UsingRefToControlFocus.storyName = "Using ref to control focus";

--- a/src/Toggle/Toggle.tsx
+++ b/src/Toggle/Toggle.tsx
@@ -1,20 +1,34 @@
-import React, { useState } from "react";
+import React, { useCallback, useEffect } from "react";
 import { SpaceProps } from "styled-system";
 import propTypes from "@styled-system/prop-types";
-import { MaybeFieldLabel } from "../FieldLabel";
+import { FieldLabel } from "../FieldLabel";
 import { Field } from "../Form";
 import { Text } from "../Type";
 import { ComponentVariant, useComponentVariant } from "../NDSProvider/ComponentVariantContext";
-import { ClickInputLabel } from "../utils";
 import { DefaultNDSThemeType } from "../theme";
 import { getSubset, omitSubset } from "../utils/subset";
-import { noop } from "../utils/noop";
+import { Flex } from "../Flex";
 import ToggleButton from "./ToggleButton";
 
-type BaseToggleProps = SpaceProps & {
+interface ToggleProps extends SpaceProps {
+  /**
+   * @see FieldLabel
+   */
   hint?: string;
+  /**
+   * @note This prop is required when checked is set. It will not be optional in
+   * a future version.
+   */
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   variant?: ComponentVariant;
+  /**
+   * Controls whether the toggle is checked or not.
+   * @note This prop will be required in a future version.
+   */
+  checked?: boolean;
+  /**
+   * @deprecated use checked instead
+   */
   toggled?: boolean;
   disabled?: boolean;
   onText?: string;
@@ -22,101 +36,127 @@ type BaseToggleProps = SpaceProps & {
   id?: string;
   className?: string;
   required?: boolean;
+  /**
+   * @see FieldLabel
+   */
   helpText?: string;
+  /**
+   * @see FieldLabel
+   */
   labelText?: string;
   requirementText?: string;
   error?: boolean;
-  onClick?: (e: React.MouseEvent) => void;
-  innerRef?: React.Ref<HTMLInputElement>;
+  ref?: React.Ref<HTMLInputElement>;
   name?: string;
   theme?: DefaultNDSThemeType;
   "data-testid"?: string;
-};
+  /**
+   * @deprecated use onChange instead
+   */
+  onClick?: (e: React.MouseEvent<HTMLInputElement>) => void;
+  /**
+   * @deprecated set the default state through the checked prop instead
+   */
+  defaultToggled?: boolean;
+}
 
-const BaseToggle = ({
-  disabled,
-  onChange,
-  onText,
-  offText,
-  className,
-  required,
-  error,
-  id,
-  labelText,
-  requirementText,
-  helpText,
-  hint,
-  toggled,
-  onClick = noop,
-  variant,
-  "data-testid": dataTestId,
-  ...props
-}: BaseToggleProps) => {
-  const handleClick = (e: React.MouseEvent) => {
-    onClick(e);
-  };
+const Toggle = React.forwardRef<HTMLInputElement, ToggleProps>(
+  (
+    {
+      checked,
+      variant,
+      className,
+      labelText,
+      requirementText,
+      helpText,
+      hint,
+      disabled,
+      toggled,
+      onChange,
+      onText,
+      offText,
+      required,
+      error,
+      id,
+      defaultToggled,
+      onClick,
+      "data-testid": dataTestId,
+      ...props
+    },
+    ref
+  ) => {
+    const componentVariant = useComponentVariant(variant);
+    const spaceProps = getSubset(props, propTypes.space);
+    const restProps = omitSubset(props, propTypes.space);
 
-  const componentVariant = useComponentVariant(variant);
-  const spaceProps = getSubset(props, propTypes.space);
-  const restProps = omitSubset(props, propTypes.space);
+    useEffect(() => {
+      if (defaultToggled) {
+        console.warn("defaultToggled is deprecated. Use checked instead.");
+      }
+      if (checked) {
+        console.warn("checked is deprecated. Use checked instead.");
+      }
+      if (onClick) {
+        console.warn("onClick is deprecated. Use onChange instead.");
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
-  return (
-    <Field className={className} alignItems="flex-start" py="half" {...spaceProps}>
-      <MaybeFieldLabel labelText={labelText} requirementText={requirementText} helpText={helpText} hint={hint}>
-        <ClickInputLabel
-          variant={componentVariant}
-          as="div"
-          onClick={onClick}
+    const _checked = checked ?? defaultToggled ?? toggled;
+
+    const _onChange = useCallback(
+      (e: React.ChangeEvent<HTMLInputElement>) => {
+        if (onClick) {
+          onClick(e as unknown as React.MouseEvent<HTMLInputElement>);
+        }
+        if (onChange) {
+          onChange(e);
+        }
+      },
+      [onClick, onChange]
+    );
+
+    useEffect(() => {
+      if (_checked !== undefined && !(onChange || onClick)) {
+        console.warn("onChange or onClick is required when checked is set.");
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    return (
+      <Field className={className} alignItems="flex-start" py="half" {...spaceProps}>
+        <FieldLabel
+          htmlFor={id}
+          labelText={labelText}
+          requirementText={requirementText}
+          helpText={helpText}
+          hint={hint}
           disabled={disabled}
+          variant={componentVariant}
           data-testid={dataTestId}
         >
-          <ToggleButton
-            id={id}
-            checked={toggled}
-            onChange={onChange}
-            disabled={disabled}
-            required={required}
-            aria-required={required}
-            aria-invalid={error}
-            aria-labelledby={labelText && `${labelText}-label`}
-            onClick={handleClick}
-            toggled={toggled}
-            {...restProps}
-            ref={props.innerRef}
-          />
-          {(onText || offText) && (
-            <Text disabled={disabled} mb="none" ml="x1">
-              {toggled ? onText : offText}
-            </Text>
-          )}
-        </ClickInputLabel>
-      </MaybeFieldLabel>
-    </Field>
-  );
-};
+          <Flex flexDirection="row" alignItems="center">
+            <ToggleButton
+              id={id}
+              checked={_checked}
+              onChange={_onChange}
+              disabled={disabled}
+              required={required}
+              aria-required={required}
+              aria-invalid={error}
+              {...restProps}
+              ref={ref}
+            />
+            {(onText || offText) && (
+              <Text disabled={disabled} mb="none" ml="x1" aria-hidden>
+                {_checked ? onText : offText}
+              </Text>
+            )}
+          </Flex>
+        </FieldLabel>
+      </Field>
+    );
+  }
+);
 
-type StatefulToggleProps = BaseToggleProps & {
-  defaultToggled?: boolean;
-};
-
-const StatefulToggle = ({ defaultToggled, onClick = noop, disabled, ...props }: StatefulToggleProps) => {
-  const [toggled, setToggled] = useState(defaultToggled);
-
-  const handleClick = (e: React.MouseEvent) => {
-    if (!disabled) setToggled(!toggled);
-    onClick(e);
-  };
-
-  return <BaseToggle toggled={toggled} onClick={handleClick} disabled={disabled} {...props} />;
-};
-
-type ToggleProps = StatefulToggleProps;
-
-const Toggle = ({ toggled, ...props }: ToggleProps) =>
-  toggled === undefined ? <StatefulToggle {...props} /> : <BaseToggle toggled={toggled} {...props} />;
-
-const ToggleComponent = React.forwardRef<HTMLInputElement, ToggleProps>((props, ref) => (
-  <Toggle innerRef={ref} {...props} />
-));
-
-export default ToggleComponent;
+export default Toggle;

--- a/src/Toggle/ToggleButton.tsx
+++ b/src/Toggle/ToggleButton.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useImperativeHandle } from "react";
+import React from "react";
 import { motion } from "framer-motion";
 import type { Transition } from "framer-motion";
 import styled, { useTheme } from "styled-components";
@@ -6,31 +6,28 @@ import { DefaultNDSThemeType } from "../theme";
 import { AnimatedBox } from "../Box";
 import { useComponentVariant } from "../NDSProvider/ComponentVariantContext";
 
-type SwitchProps = {
+interface SwitchProps {
   children?: React.ReactNode;
   disabled?: boolean;
-  toggled?: boolean;
-  onClick?: (event: React.MouseEvent) => void;
-};
+  checked?: boolean;
+}
 
-type SliderProps = {
+interface SliderProps {
   disabled?: boolean;
-};
+}
 
-type ToggleButtonProps = React.ComponentPropsWithRef<"input"> & {
-  defaultToggled?: boolean;
-  toggled?: boolean;
+interface ToggleButtonProps extends React.ComponentPropsWithRef<"input"> {
   disabled?: boolean;
   name?: string;
   theme?: DefaultNDSThemeType;
-};
+}
 
-type AnimationConfig = {
+interface AnimationConfig {
   transition: Transition;
   scale: string | number;
-};
+}
 
-const getSwitchBackground = (toggled) => (toggled ? "darkBlue" : "darkGrey");
+const getSwitchBackground = (checked: boolean) => (checked ? "darkBlue" : "darkGrey");
 
 const animationConfig: AnimationConfig = {
   transition: {
@@ -42,7 +39,7 @@ const animationConfig: AnimationConfig = {
   scale: 1.08,
 };
 
-function Switch({ children, disabled, toggled, onClick }: SwitchProps) {
+function Switch({ children, disabled, checked }: SwitchProps) {
   const componentVariant = useComponentVariant();
 
   return (
@@ -52,14 +49,13 @@ function Switch({ children, disabled, toggled, onClick }: SwitchProps) {
       flexShrink={0}
       height="24px"
       width="48px"
-      bg={disabled ? "grey" : getSwitchBackground(toggled)}
+      bg={disabled ? "grey" : getSwitchBackground(checked)}
       borderRadius="20px"
       padding="2px"
       boxShadow="small"
-      animate={toggled ? "toggled" : "initial"}
+      animate={checked ? "toggled" : "initial"}
       whileHover="active"
       whileFocus="active"
-      onClick={onClick}
     >
       {children}
     </AnimatedBox>
@@ -112,26 +108,15 @@ const ToggleInput = styled.input<ToggleButtonProps>(({ disabled, theme }) => ({
   },
 }));
 
-const ToggleButton = React.forwardRef<HTMLInputElement, ToggleButtonProps>((props, ref) => {
-  const { disabled, defaultToggled, toggled } = props;
-  const inputRef = useRef(null);
-
-  useImperativeHandle(ref, () => inputRef.current);
-
-  const handleClick = () => {
-    if (inputRef.current) {
-      // triggers the onChange event on a checkbox input
-      inputRef.current.click();
-    }
-  };
-
+const ToggleButton = React.forwardRef<HTMLInputElement, ToggleButtonProps>(({ disabled, checked, ...props }, ref) => {
   return (
-    <Switch disabled={disabled} toggled={toggled} onClick={handleClick}>
+    <Switch disabled={disabled} checked={checked}>
       <ToggleInput
-        ref={inputRef}
         type="checkbox"
-        defaultChecked={defaultToggled}
-        value={toggled ? "on" : "off"}
+        role="switch"
+        checked={checked}
+        ref={ref}
+        value={checked ? "on" : "off"}
         {...props}
       />
       <Slider disabled={disabled} />


### PR DESCRIPTION
## Description

The goal of this refactor is to make this component more a11y friendly,
and, by extension, friendly to use with a11y-forward testing libraries.

The first challenge was to ensure we always had a label present. An
earlier attempt to fix this missed that we were effectively wrapping
the field in two labels. This change ensures we use our FieldLabel
component, and that it behaves correctly.

An extension of the above is to ensure the component is never controlled.
Toggling the state of the component ought to be done via its `toggle`
prop. You still have access to its ref, but this isn't suggested.

Per the above the `onClick` handler has been aliased to `onChange`. We
log if `onClick` has been used and you will be warned that it is
deprecated in favour of `onChange`.

`defaultToggled` is also aliased to the `toggle` prop. You will be
again be warned that this prop is deprecated.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [x] Accessibility has been considered
