### PR TITLE
Resolve upstream problems after Vite port

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start:cypress": "start-server-and-test start 9999 'cypress open'",
     "start:storybook": "storybook dev -p 9999",
     "clean:storybook": "rm -rf node_modules/.cache/storybook && rm -rf ./storybook-static",
-    "build": "tsc -p tsconfig.build.json && vite build",
+    "build": "rm -rf dist && tsc -p tsconfig.build.json && vite build",
     "build:verify": "node scripts/verify-build.js",
     "build:watch": "vite build --watch",
     "build:storybook": "storybook build --stats-json",
@@ -51,6 +51,13 @@
   "main": "dist/main.js",
   "module": "dist/main.module.js",
   "typings": "dist/src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/main.module.js",
+      "require": "./dist/main.js"
+    }
+  },
   "files": [
     "/dist"
   ],

--- a/src/Alert/Alert.tsx
+++ b/src/Alert/Alert.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { FlexProps } from "../Flex/Flex";
 import { useComponentVariant } from "../NDSProvider/ComponentVariantContext";
 import { Box } from "../Box";

--- a/src/AppTag/AppTag.tsx
+++ b/src/AppTag/AppTag.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled, { useTheme } from "styled-components";
+import { styled, useTheme } from "styled-components";
 import { Text } from "../Type";
 import { APP_ABBREVIATIONS, APP_DISPLAY_NAMES, NulogyAppName } from "../types/NulogyApp";
 import { MiniTooltip } from "../MiniTooltip";

--- a/src/AppTag/components/LogoWrapper.tsx
+++ b/src/AppTag/components/LogoWrapper.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { AppTagType } from "../types";
 import { appTagColors } from "../constants";
 

--- a/src/BottomSheet/BottomSheet.styled.tsx
+++ b/src/BottomSheet/BottomSheet.styled.tsx
@@ -6,7 +6,7 @@ import {
 import type { AnimationProps } from "framer-motion";
 import { motion } from "framer-motion";
 import { transparentize } from "polished";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { compose, height, layout, maxHeight, maxWidth, space, width } from "styled-system";
 import type { HeightProps, LayoutProps, MaxHeightProps, MaxWidthProps, SpaceProps, WidthProps } from "styled-system";
 import { Heading2, Text } from "../Type";

--- a/src/Box/Box.story.tsx
+++ b/src/Box/Box.story.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { Button } from "../Button";
 import { Box, Flex } from "../index";
 import { AnimatedBox } from "./Box";

--- a/src/Box/Box.tsx
+++ b/src/Box/Box.tsx
@@ -1,5 +1,5 @@
 import { ComponentPropsWithRef } from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { motion, MotionProps } from "framer-motion";
 import { addStyledProps, StyledProps } from "../StyledProps";
 

--- a/src/BrandedNavBar/DesktopMenu.tsx
+++ b/src/BrandedNavBar/DesktopMenu.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import type { CSSObject } from "styled-components";
 import { Icon } from "../Icon";
 import { DefaultNDSThemeType } from "../theme";

--- a/src/BrandedNavBar/MenuTriggerButton.tsx
+++ b/src/BrandedNavBar/MenuTriggerButton.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { themeGet } from "@styled-system/theme-get";
 import { Icon } from "../Icon";
 import { DefaultNDSThemeType } from "../theme";

--- a/src/BrandedNavBar/MobileMenu.tsx
+++ b/src/BrandedNavBar/MobileMenu.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import type { CSSObject } from "styled-components";
 import { display } from "styled-system";
 import { Text } from "../Type";

--- a/src/BrandedNavBar/NavBar.story.tsx
+++ b/src/BrandedNavBar/NavBar.story.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import type { Meta, StoryObj } from "@storybook/react";
 import { BrowserRouter, Link as ReactRouterLink } from "react-router-dom";
 import { Heading1 } from "../Type";

--- a/src/BrandedNavBar/NavBar.tsx
+++ b/src/BrandedNavBar/NavBar.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import ReactResizeDetector from "react-resize-detector";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "styled-components";

--- a/src/BrandedNavBar/NavBarBackground.tsx
+++ b/src/BrandedNavBar/NavBarBackground.tsx
@@ -1,4 +1,4 @@
-import styled, { CSSObject } from "styled-components";
+import { styled, CSSObject } from "styled-components";
 import { DefaultNDSThemeType } from "../theme";
 import { Flex } from "../Flex";
 import { addStyledProps, StyledProps } from "../StyledProps";

--- a/src/BrandedNavBar/SmallNavBar.story.tsx
+++ b/src/BrandedNavBar/SmallNavBar.story.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { Branding } from "../Branding";
 import { Button, SmallNavBarProps } from "../index";
 import { Link } from "../Link";

--- a/src/BrandedNavBar/SmallNavBar.tsx
+++ b/src/BrandedNavBar/SmallNavBar.tsx
@@ -1,4 +1,4 @@
-import styled, { CSSObject, useTheme } from "styled-components";
+import { styled, CSSObject, useTheme } from "styled-components";
 import { useTranslation } from "react-i18next";
 import React, { useEffect } from "react";
 import { Icon } from "../Icon";

--- a/src/BrandedNavBar/SubMenuTrigger.tsx
+++ b/src/BrandedNavBar/SubMenuTrigger.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled, { useTheme } from "styled-components";
+import { styled, useTheme } from "styled-components";
 import { addStyledProps } from "../StyledProps";
 import NavBarDropdownMenu from "./NavBarDropdownMenu";
 import renderSubMenuItems from "./renderSubMenuItems";

--- a/src/BrandedNavBar/SubMenuTriggerButton.tsx
+++ b/src/BrandedNavBar/SubMenuTriggerButton.tsx
@@ -1,4 +1,4 @@
-import styled, { CSSObject } from "styled-components";
+import { styled, CSSObject } from "styled-components";
 import React from "react";
 import { DropdownButton } from "../DropdownMenu";
 import { Icon } from "../Icon";

--- a/src/BrandedNavBar/renderSubMenuItems.tsx
+++ b/src/BrandedNavBar/renderSubMenuItems.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled, { CSSObject } from "styled-components";
+import { styled, CSSObject } from "styled-components";
 import { DropdownText, DropdownLink } from "../DropdownMenu";
 import { Icon } from "../Icon";
 

--- a/src/Branding/Branding.tsx
+++ b/src/Branding/Branding.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled, { useTheme } from "styled-components";
+import { styled, useTheme } from "styled-components";
 import { Flex } from "../Flex";
 import { DefaultNDSThemeType } from "../theme";
 import BrandingText from "./BrandingText";

--- a/src/Branding/BrandingText.tsx
+++ b/src/Branding/BrandingText.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 
 type BrandingTextProps = {
   logoColor?: "blue" | "white";

--- a/src/Breadcrumbs/BreadcrumbsList.tsx
+++ b/src/Breadcrumbs/BreadcrumbsList.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 
 const BreadcrumbsList = styled.ol(() => ({
   margin: 0,

--- a/src/Breadcrumbs/BreadcrumbsListItem.tsx
+++ b/src/Breadcrumbs/BreadcrumbsListItem.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { space, color, flexbox, layout, variant } from "styled-system";
 import { ComponentVariant } from "../NDSProvider/ComponentVariantContext";
 

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled, { useTheme } from "styled-components";
+import { styled, useTheme } from "styled-components";
 import type { IconName } from "@nulogy/icons";
 import { space, SpaceProps, variant } from "styled-system";
 import { Icon } from "../Icon";

--- a/src/Button/CloseButton.tsx
+++ b/src/Button/CloseButton.tsx
@@ -1,5 +1,5 @@
 import React, { ComponentPropsWithRef } from "react";
-import styled, { useTheme } from "styled-components";
+import { styled, useTheme } from "styled-components";
 import { useTranslation } from "react-i18next";
 import { Icon } from "../Icon";
 

--- a/src/Button/ControlIcon.tsx
+++ b/src/Button/ControlIcon.tsx
@@ -1,6 +1,6 @@
 import type { IconName } from "@nulogy/icons";
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { layout, LayoutProps, space, SpaceProps } from "styled-system";
 import { Icon } from "../Icon";
 

--- a/src/Button/DangerButton.tsx
+++ b/src/Button/DangerButton.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { darken } from "polished";
 import Button, { ButtonProps } from "./Button";
 import { DefaultNDSThemeType } from "../theme";

--- a/src/Button/IconicButton.tsx
+++ b/src/Button/IconicButton.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { space, SpaceProps, variant } from "styled-system";
 import { Manager, Reference, Popper } from "react-popper-2";
 import { transparentize } from "polished";

--- a/src/Button/PrimaryButton.tsx
+++ b/src/Button/PrimaryButton.tsx
@@ -1,4 +1,4 @@
-import styled, { CSSObject } from "styled-components";
+import { styled, CSSObject } from "styled-components";
 import { darken } from "polished";
 import Button, { ButtonProps } from "./Button";
 

--- a/src/Button/QuietButton.tsx
+++ b/src/Button/QuietButton.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import Button, { ButtonProps } from "./Button";
 const QuietButton = styled(Button)(({ theme }: ButtonProps) => ({
   color: theme.colors.blue,

--- a/src/ButtonGroup/ButtonGroup.tsx
+++ b/src/ButtonGroup/ButtonGroup.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { Flex } from "../Flex";
 import { FlexProps } from "../Flex/Flex";
 

--- a/src/Card/CardSet.tsx
+++ b/src/Card/CardSet.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { addStyledProps } from "../StyledProps";
 import { Flex } from "../Flex";
 

--- a/src/Checkbox/Checkbox.tsx
+++ b/src/Checkbox/Checkbox.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import styled, { CSSObject } from "styled-components";
+import { styled, CSSObject } from "styled-components";
 import propTypes from "@styled-system/prop-types";
 import { SpaceProps } from "styled-system";
 import { Box } from "../Box";

--- a/src/Checkbox/CheckboxGroup.tsx
+++ b/src/Checkbox/CheckboxGroup.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { HelpText, RequirementText } from "../FieldLabel";
 import { InlineValidation } from "../Validation";
 import { Fieldset } from "../Form";

--- a/src/DateRange/EndTime.tsx
+++ b/src/DateRange/EndTime.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { TimePicker } from "../TimePicker";
 
 const EndTime = styled(TimePicker)(({ theme }) => ({

--- a/src/DateRange/StartTime.tsx
+++ b/src/DateRange/StartTime.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { TimePicker } from "../TimePicker";
 
 const StartTime = styled(TimePicker)(({ theme }) => ({

--- a/src/Decorations/index.tsx
+++ b/src/Decorations/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useTheme } from "styled-components";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { Box, BoxProps } from "../Box";
 
 const RightAngleTriangle = styled(Box)`

--- a/src/DescriptionList/DescriptionList.parts.tsx
+++ b/src/DescriptionList/DescriptionList.parts.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { DefaultNDSThemeType } from "../theme";
 import { useDescriptionListContext } from "./DescriptionListContext";
 import { BaseDescriptionListProps, Columns, Density, GroupMinWidth } from "./lib/types";

--- a/src/DescriptionList/stories/fixtures.tsx
+++ b/src/DescriptionList/stories/fixtures.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { transparentize } from "polished";
 import { Box } from "../../Box";
 import { Flex } from "../../Flex";

--- a/src/Divider/Divider.tsx
+++ b/src/Divider/Divider.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { addStyledProps, StyledProps } from "../StyledProps";
 
 export interface DividerProps extends StyledProps, React.HTMLAttributes<HTMLHRElement> {

--- a/src/DropdownMenu/DropdownButton.tsx
+++ b/src/DropdownMenu/DropdownButton.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { variant } from "styled-system";
 import { DefaultNDSThemeType } from "../theme";
 import { addStyledProps, StyledProps } from "../StyledProps";

--- a/src/DropdownMenu/DropdownItem.tsx
+++ b/src/DropdownMenu/DropdownItem.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { variant } from "../StyledProps";
 
 type Props = {

--- a/src/DropdownMenu/DropdownLink.tsx
+++ b/src/DropdownMenu/DropdownLink.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { variant } from "styled-system";
 import { addStyledProps, StyledProps } from "../StyledProps";
 import { ComponentVariant } from "../NDSProvider/ComponentVariantContext";

--- a/src/DropdownMenu/DropdownMenuContainer.tsx
+++ b/src/DropdownMenu/DropdownMenuContainer.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { color } from "styled-system";
 import { Box } from "../Box";
 import { DefaultNDSThemeType } from "../theme";

--- a/src/DropdownMenu/DropdownText.tsx
+++ b/src/DropdownMenu/DropdownText.tsx
@@ -1,4 +1,4 @@
-import styled, { CSSObject } from "styled-components";
+import { styled, CSSObject } from "styled-components";
 import { Text } from "../Type";
 import type { TextProps } from "../Type";
 import { addStyledProps } from "../StyledProps";

--- a/src/FieldLabel/HelpText.tsx
+++ b/src/FieldLabel/HelpText.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { Text } from "../Type";
 import { Link } from "../Link";
 

--- a/src/FieldLabel/Label.tsx
+++ b/src/FieldLabel/Label.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { space, color, display, DisplayProps } from "styled-system";
 import type { SpaceProps } from "styled-system";
 import type { ComponentPropsWithRef } from "react";

--- a/src/FieldLabel/LabelText.tsx
+++ b/src/FieldLabel/LabelText.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 
 export const LabelContent = styled.span(({ theme }) => ({
   display: "flex",

--- a/src/Flex/Flex.story.tsx
+++ b/src/Flex/Flex.story.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Box, Flex as NDSFlex } from "../index";
-import styled from "styled-components";
+import { styled } from "styled-components";
 
 const Flex = ({ children, ...props }) => (
   <NDSFlex

--- a/src/Flex/Flex.tsx
+++ b/src/Flex/Flex.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { Box } from "../Box";
 import { BoxProps } from "../Box/Box";
 import { gap } from "../StyledProps";

--- a/src/Form/Field.tsx
+++ b/src/Form/Field.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { Box } from "../Box";
 import { BoxProps } from "../Box/Box";
 import { addStyledProps } from "../StyledProps";

--- a/src/Form/Fieldset.tsx
+++ b/src/Form/Fieldset.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { space } from "styled-system";
 
 const Fieldset = styled.fieldset(

--- a/src/Form/Form.tsx
+++ b/src/Form/Form.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { space } from "styled-system";
 import type { SpaceProps } from "styled-system";
 import { Heading2 } from "../Type";

--- a/src/Form/FormSection.tsx
+++ b/src/Form/FormSection.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { Heading3 } from "../Type";
 import Field from "./Field";
 import Fieldset from "./Fieldset";

--- a/src/Icon/Icon.tsx
+++ b/src/Icon/Icon.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled, { useTheme } from "styled-components";
+import { styled, useTheme } from "styled-components";
 import { position, PositionProps, space, SpaceProps } from "styled-system";
 import icons from "@nulogy/icons";
 import { IconName } from "@nulogy/icons";

--- a/src/Input/InputField.tsx
+++ b/src/Input/InputField.tsx
@@ -1,6 +1,6 @@
 import { IconName } from "@nulogy/icons";
 import React, { forwardRef } from "react";
-import styled, { CSSObject, useTheme } from "styled-components";
+import { styled, CSSObject, useTheme } from "styled-components";
 import { space, SpaceProps, variant } from "styled-system";
 import { Box, BoxProps } from "../Box";
 import { MaybeFieldLabel } from "../FieldLabel";

--- a/src/Link/Link.tsx
+++ b/src/Link/Link.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { darken } from "polished";
 import { themeGet } from "@styled-system/theme-get";
 import React from "react";

--- a/src/List/List.tsx
+++ b/src/List/List.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { addStyledProps, StyledProps } from "../StyledProps";
 import ListItem from "./ListItem";
 

--- a/src/List/ListItem.tsx
+++ b/src/List/ListItem.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { space, color, typography, SpaceProps, ColorProps, TypographyProps } from "styled-system";
 
 type Props = React.ComponentPropsWithRef<"li"> & SpaceProps & ColorProps & TypographyProps;

--- a/src/MiniTooltip/index.tsx
+++ b/src/MiniTooltip/index.tsx
@@ -1,5 +1,5 @@
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
-import styled, { keyframes } from "styled-components";
+import { styled, keyframes } from "styled-components";
 import { transparentize } from "polished";
 import React, { ReactNode } from "react";
 

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from "react";
-import styled, { ThemeContext, CSSObject, useTheme } from "styled-components";
+import { styled, ThemeContext, CSSObject, useTheme } from "styled-components";
 import ReactModal from "react-modal";
 import { transparentize } from "polished";
 import { Heading2 } from "../Type";

--- a/src/Modal/ModalCloseButton.tsx
+++ b/src/Modal/ModalCloseButton.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { CloseButton } from "../Button";
 
 const ModalCloseButton = styled(CloseButton)(({ theme }) => ({

--- a/src/Modal/ModalContent.tsx
+++ b/src/Modal/ModalContent.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { DefaultNDSThemeType } from "../theme";
 
 type ModalContentProps = React.ComponentPropsWithRef<"div"> & {

--- a/src/Modal/ModalFooter.tsx
+++ b/src/Modal/ModalFooter.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { transparentize } from "polished";
 
 const ModalFooter = styled.div(({ theme }) => ({

--- a/src/Modal/ModalHeader.tsx
+++ b/src/Modal/ModalHeader.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { transparentize } from "polished";
 import { DefaultNDSThemeType } from "../theme";
 

--- a/src/NDSProvider/GlobalStyles.tsx
+++ b/src/NDSProvider/GlobalStyles.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 
 const GlobalStyles = styled.div<{
   locale?: string;

--- a/src/NavBarSearch/NavBarSearch.jsx
+++ b/src/NavBarSearch/NavBarSearch.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { darken, transparentize } from "polished";
 import { useTranslation } from "react-i18next";
 import { Flex } from "../Flex";

--- a/src/Navigation/components/AppSwitcher/parts/index.tsx
+++ b/src/Navigation/components/AppSwitcher/parts/index.tsx
@@ -1,5 +1,5 @@
 import * as RadixNavigationMenu from "@radix-ui/react-navigation-menu";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { Heading4, Text } from "../../../../Type";
 import Content from "../../shared/NavigationMenuContent";
 import Link from "./Link";

--- a/src/Navigation/components/DesktopNav/parts/MoreMenuItem.tsx
+++ b/src/Navigation/components/DesktopNav/parts/MoreMenuItem.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import type { MenuItem, MenuItems } from "../../../types";
 import { NavigationMenuItem } from "../../shared/NavigationMenuItem";
 

--- a/src/Navigation/components/MenuSubItem/parts/styled.tsx
+++ b/src/Navigation/components/MenuSubItem/parts/styled.tsx
@@ -1,5 +1,5 @@
 import * as RadixNavigationMenu from "@radix-ui/react-navigation-menu";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { addStyledProps, StyledProps } from "../../../../StyledProps";
 import { NAVIGATION_SUB_MENU_MIN_WIDTH_PX } from "../../shared/constants";
 import { disableHoverEvents } from "../../shared/disableHoverEvents";

--- a/src/Navigation/components/MobileNav/parts/styled.tsx
+++ b/src/Navigation/components/MobileNav/parts/styled.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import * as RadixNavigationMenu from "@radix-ui/react-navigation-menu";
 import { Box } from "../../../../Box";
 import { Text } from "../../../../Type";

--- a/src/Navigation/components/UserMenu/UserMenu.tsx
+++ b/src/Navigation/components/UserMenu/UserMenu.tsx
@@ -1,5 +1,5 @@
 import * as RadixNavigationMenu from "@radix-ui/react-navigation-menu";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { addStyledProps, StyledProps } from "../../../StyledProps";
 import { Header } from "./parts/Header";
 import Item from "./parts/Item";

--- a/src/Navigation/components/UserMenu/parts/Header.tsx
+++ b/src/Navigation/components/UserMenu/parts/Header.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { UserMenuInfo } from "../../../types";
 import { Text } from "../../../../Type";
 import { Flex } from "../../../../Flex";

--- a/src/Navigation/components/UserMenu/parts/styled.tsx
+++ b/src/Navigation/components/UserMenu/parts/styled.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import * as RadixNavigationMenu from "@radix-ui/react-navigation-menu";
 import { addStyledProps } from "../../../../StyledProps";
 import { DefaultNDSThemeType } from "../../../../theme/theme.type";

--- a/src/Navigation/components/shared/NavigationLogo.tsx
+++ b/src/Navigation/components/shared/NavigationLogo.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 
 const LogoContainer = styled.div<{ $maxWidth?: string; $maxHeight?: string }>(({ $maxWidth, $maxHeight }) => ({
   display: "flex",

--- a/src/Navigation/components/shared/NavigationLogoLink.tsx
+++ b/src/Navigation/components/shared/NavigationLogoLink.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import type { NavigationMenuLinkProps } from "@radix-ui/react-navigation-menu";
 import { NavigationMenuLink as BaseNavigationMenuLink } from "./components";
 

--- a/src/Navigation/components/shared/NavigationMenuContent.tsx
+++ b/src/Navigation/components/shared/NavigationMenuContent.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import * as RadixNavigationMenu from "@radix-ui/react-navigation-menu";
 import { addStyledProps, StyledProps } from "../../../StyledProps";
 import { NAVIGATION_MENU_CONTENT_WIDTH_MAX_WIDTH_PX, NAVIGATION_MENU_HEIGHT_STYLED_UNITS } from "./constants";

--- a/src/Navigation/components/shared/NavigationMenuItem.tsx
+++ b/src/Navigation/components/shared/NavigationMenuItem.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import * as RadixNavigationMenu from "@radix-ui/react-navigation-menu";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { Text } from "../../../Type";
 import type { MenuItem } from "../../types";
 import { Icon } from "../../../Icon";

--- a/src/Navigation/components/shared/components.tsx
+++ b/src/Navigation/components/shared/components.tsx
@@ -1,5 +1,5 @@
 import * as RadixNavigationMenu from "@radix-ui/react-navigation-menu";
-import styled, { CSSProperties } from "styled-components";
+import { styled, CSSProperties } from "styled-components";
 import { Icon } from "../../../Icon";
 import { DefaultNDSThemeType } from "../../../theme";
 import { IconProps } from "../../../Icon/Icon";

--- a/src/Overlay/Overlay.tsx
+++ b/src/Overlay/Overlay.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { transparentize } from "polished";
 import { Flex } from "../Flex";
 import { FlexProps } from "../Flex/Flex";

--- a/src/Pagination/PageNumber.tsx
+++ b/src/Pagination/PageNumber.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import PaginationButton from "./PaginationButton";
 
 type PageNumberProps = {

--- a/src/Pagination/PaginationButton.tsx
+++ b/src/Pagination/PaginationButton.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { DefaultNDSThemeType } from "../theme";
 
 const getHoverBackground = (currentPage: boolean, disabled: boolean, theme: DefaultNDSThemeType) => {

--- a/src/Primitives/index.tsx
+++ b/src/Primitives/index.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { addStyledProps, StyledProps } from "../StyledProps";
 
 const Ul = styled.ul<StyledProps>(addStyledProps);

--- a/src/Radio/Radio.tsx
+++ b/src/Radio/Radio.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, ReactNode } from "react";
-import styled, { CSSObject } from "styled-components";
+import { styled, CSSObject } from "styled-components";
 import propTypes from "@styled-system/prop-types";
 import { SpaceProps } from "styled-system";
 import { Box } from "../Box";

--- a/src/Select/Select.story.fixture.tsx
+++ b/src/Select/Select.story.fixture.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { GroupBase } from "react-select";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { SelectOption, SelectOptionProps } from "./SelectOption";
 import { NDSOption } from "./Select";
 

--- a/src/Select/SelectOption.tsx
+++ b/src/Select/SelectOption.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { components, GroupBase, OptionProps } from "react-select";
 import { typography } from "styled-system";
 import { subPx } from "../utils";

--- a/src/StatusIndicator/StatusIndicator.tsx
+++ b/src/StatusIndicator/StatusIndicator.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { space, typography, flexbox, SpaceProps, TypographyProps, FlexboxProps } from "styled-system";
 import { DefaultNDSThemeType } from "../theme";
 

--- a/src/Summary/Summary.tsx
+++ b/src/Summary/Summary.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled, { useTheme } from "styled-components";
+import { styled, useTheme } from "styled-components";
 import numberFromDimension from "../utils/numberFromDimension";
 import { Box } from "../Box";
 import { BoxProps } from "../Box/Box";

--- a/src/Summary/SummaryDivider.tsx
+++ b/src/Summary/SummaryDivider.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { Box } from "../Box";
 import numberFromDimension from "../utils/numberFromDimension";
 import { useSummaryContext } from "./SummaryContext";

--- a/src/Summary/SummaryItem.tsx
+++ b/src/Summary/SummaryItem.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { Flex } from "../Flex";
 import { Text } from "../Type";
 import useMediaQuery from "../hooks/useMediaQuery";

--- a/src/Switcher/Switch.tsx
+++ b/src/Switcher/Switch.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { variant } from "styled-system";
 import numberFromDimension from "../utils/numberFromDimension";
 import { ComponentVariant } from "../NDSProvider/ComponentVariantContext";

--- a/src/Table/BaseTable.tsx
+++ b/src/Table/BaseTable.tsx
@@ -1,5 +1,5 @@
 import React, { type ReactNode } from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { space } from "styled-system";
 import TableHead from "./TableHead";
 import TableBody from "./TableBody";

--- a/src/Table/StyledTh.tsx
+++ b/src/Table/StyledTh.tsx
@@ -1,4 +1,4 @@
-import styled, { CSSObject } from "styled-components";
+import { styled, CSSObject } from "styled-components";
 import { DefaultNDSThemeType } from "../theme";
 
 const stickyStyles = (theme: DefaultNDSThemeType): CSSObject => ({

--- a/src/Table/TableBody.tsx
+++ b/src/Table/TableBody.tsx
@@ -1,5 +1,5 @@
 import React, { type ReactNode } from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { Box } from "../Box";
 import { DefaultNDSThemeType } from "../theme";
 import TableCell from "./TableCell";

--- a/src/Table/TableCell.tsx
+++ b/src/Table/TableCell.tsx
@@ -1,5 +1,5 @@
 import React, { CSSProperties } from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { DefaultNDSThemeType } from "../theme";
 
 interface StyledTableCellProps {

--- a/src/Table/TableFoot.tsx
+++ b/src/Table/TableFoot.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import TableCell from "./TableCell";
 import StyledTh from "./StyledTh";
 import { RowType, Columns } from "./Table.types";

--- a/src/Table/TableHead.tsx
+++ b/src/Table/TableHead.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import StyledTh from "./StyledTh";
 import type { ColumnType, Columns } from "./Table.types";
 

--- a/src/Tabs/Tab.tsx
+++ b/src/Tabs/Tab.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled, { CSSObject } from "styled-components";
+import { styled, CSSObject } from "styled-components";
 import { variant } from "styled-system";
 import { ComponentVariant } from "../NDSProvider/ComponentVariantContext";
 

--- a/src/Tabs/TabContainer.tsx
+++ b/src/Tabs/TabContainer.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { Box } from "../Box";
 
 const TabContainer = styled(Box)(({ theme }) => ({

--- a/src/Tabs/TabScrollIndicator.tsx
+++ b/src/Tabs/TabScrollIndicator.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { Icon } from "../Icon";

--- a/src/Tabs/TabScrollIndicators.tsx
+++ b/src/Tabs/TabScrollIndicators.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import styled from "styled-components";
+import { styled } from "styled-components";
 import React from "react";
 import TabScrollIndicator from "./TabScrollIndicator";
 const TabScrollIndicatorContainer = styled.div(({ width, theme }) => ({

--- a/src/Textarea/StyledTextarea.tsx
+++ b/src/Textarea/StyledTextarea.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { transparentize } from "polished";
 import { SpaceProps, variant } from "styled-system";
 import { space } from "styled-system";

--- a/src/TimePicker/TimePickerDropdown.tsx
+++ b/src/TimePicker/TimePickerDropdown.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import styled from "styled-components";
+import { styled } from "styled-components";
 
 const TimePickerDropdown = styled.ul(({ theme, isOpen }) => {
   return {

--- a/src/TimePicker/TimePickerInput.tsx
+++ b/src/TimePicker/TimePickerInput.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { InputField, InputFieldProps } from "../Input/InputField";
 
 type TimePickerInputProps = InputFieldProps & { dropdownIsOpen: boolean };

--- a/src/TimePicker/TimePickerOption.tsx
+++ b/src/TimePicker/TimePickerOption.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { variant } from "styled-system";
 import { ComponentVariant } from "../NDSProvider/ComponentVariantContext";
 

--- a/src/Toggle/ToggleButton.tsx
+++ b/src/Toggle/ToggleButton.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { motion } from "framer-motion";
 import type { Transition } from "framer-motion";
-import styled, { useTheme } from "styled-components";
+import { styled, useTheme } from "styled-components";
 import { DefaultNDSThemeType } from "../theme";
 import { AnimatedBox } from "../Box";
 import { useComponentVariant } from "../NDSProvider/ComponentVariantContext";

--- a/src/Tooltip/TooltipContainer.tsx
+++ b/src/Tooltip/TooltipContainer.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { PositionProps } from "styled-system";
 import { Box } from "../Box";
 import { DefaultNDSThemeType } from "../theme";

--- a/src/Tooltip/components/TooltipComponents.tsx
+++ b/src/Tooltip/components/TooltipComponents.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
-import styled, { keyframes, useTheme } from "styled-components";
+import { styled, keyframes, useTheme } from "styled-components";
 import { maxWidth } from "styled-system";
 import { MaxWidthProps } from "styled-system";
 

--- a/src/TopBar/TopBar.styled.tsx
+++ b/src/TopBar/TopBar.styled.tsx
@@ -1,7 +1,7 @@
 import { DialogOverlay } from "@reach/dialog";
 import { motion } from "framer-motion";
 import { transparentize } from "polished";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { addStyledProps, StyledProps } from "../StyledProps";
 import { TOPBAR } from "./constants";
 

--- a/src/Type/Headings.tsx
+++ b/src/Type/Headings.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { addStyledProps, variant } from "../StyledProps";
 import Text, { TextProps } from "./Text";
 

--- a/src/Type/Text.tsx
+++ b/src/Type/Text.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { ComponentVariant } from "../NDSProvider/ComponentVariantContext";
 import { addStyledProps, StyledProps } from "../StyledProps";
 

--- a/src/Validation/InlineValidation.tsx
+++ b/src/Validation/InlineValidation.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { SpaceProps } from "styled-system";
 import { Text } from "../Type";
 import { Icon } from "../Icon";

--- a/src/VerticalDivider/VerticalDivider.tsx
+++ b/src/VerticalDivider/VerticalDivider.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { addStyledProps, StyledProps } from "../StyledProps";
 
 export interface DividerProps extends StyledProps, React.HTMLAttributes<HTMLDivElement> {

--- a/src/utils/ClickInputLabel.tsx
+++ b/src/utils/ClickInputLabel.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { ComponentVariant } from "../NDSProvider/ComponentVariantContext";
 
 const ClickInputLabel = styled.label<{ variant?: ComponentVariant; disabled?: boolean }>(({ disabled, theme }) => ({

--- a/src/utils/PopperArrow.tsx
+++ b/src/utils/PopperArrow.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { PopperArrowProps as ReactPopperArrowProps } from "react-popper";
 import { PropsWithChildren } from "react";
 

--- a/src/utils/ScrollIndicators.jsx
+++ b/src/utils/ScrollIndicators.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { position } from "styled-system";
 import { Icon } from "../Icon";
 

--- a/src/utils/story/code.tsx
+++ b/src/utils/story/code.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { transparentize } from "polished";
 
 /**

--- a/src/utils/story/dashed.tsx
+++ b/src/utils/story/dashed.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { ComponentType } from "react";
 
 /**

--- a/src/utils/story/placeholder.tsx
+++ b/src/utils/story/placeholder.tsx
@@ -1,6 +1,6 @@
 import { transparentize } from "polished";
 import React from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { BoxProps } from "../../Box";
 import { addStyledProps } from "../../StyledProps";
 

--- a/src/utils/story/resizable.tsx
+++ b/src/utils/story/resizable.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { Resizable as ReResizable } from "re-resizable";
-import styled from "styled-components";
+import { styled } from "styled-components";
 import { Box } from "../../Box";
 import { DashedBox } from "../../DescriptionList/stories/fixtures";
 import { Text } from "../../Type";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,6 +24,17 @@ const GLOBALS = {
 
 const externals = Object.keys(GLOBALS);
 
+// External function - all peer dependencies are externalized
+// Also externalize react/jsx-runtime in case any dependencies use automatic JSX
+const external = (id: string) => {
+  // Externalize react/jsx-runtime and react/jsx-dev-runtime
+  // This ensures that if any dependencies use automatic JSX, they'll use the consumer's React
+  if (id === "react/jsx-runtime" || id === "react/jsx-dev-runtime") {
+    return true;
+  }
+  return externals.includes(id);
+};
+
 export default defineConfig({
   plugins: [react()],
   define: {
@@ -46,7 +57,7 @@ export default defineConfig({
       },
     },
     rollupOptions: {
-      external: externals,
+      external,
       output: {
         globals: GLOBALS,
       },


### PR DESCRIPTION
## Description

Porting to Vite resulted in two problems:

1. React was complaining about its runtime missing, and being out of order
2. "`styled.div` is not a function" — required a change to how we're import styled components

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
