### PR TITLE
chore(deps): upgrade framer-motion v6 → v12

### DIFF
--- a/.storybook/vitest.setup.ts
+++ b/.storybook/vitest.setup.ts
@@ -1,6 +1,10 @@
 import { beforeAll } from "vitest";
 import { setProjectAnnotations } from "@storybook/react-vite";
+import { MotionGlobalConfig } from "framer-motion";
 import * as previewAnnotations from "./preview";
+
+// Skip framer-motion animations in tests so assertions don't race against WAAPI transitions
+MotionGlobalConfig.skipAnimations = true;
 
 // Apply Storybook's global decorators/parameters (NDSProvider, etc.) to all story tests
 const annotations = setProjectAnnotations([previewAnnotations]);

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "date-fns": "2.23.0",
     "debounce": "^3.0.0",
     "deep-equal": "^2.2.1",
-    "framer-motion": "6.5.1",
+    "framer-motion": "^12.35.0",
     "i18next": "^19.3.1",
     "polished": "4.3.1",
     "react-datepicker": "^4.25.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: ^2.2.1
         version: 2.2.3
       framer-motion:
-        specifier: 6.5.1
-        version: 6.5.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^12.35.0
+        version: 12.35.0(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       i18next:
         specifier: ^19.3.1
         version: 19.9.2
@@ -432,17 +432,11 @@ packages:
   '@emotion/hash@0.9.1':
     resolution: {integrity: sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==}
 
-  '@emotion/is-prop-valid@0.8.8':
-    resolution: {integrity: sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==}
-
   '@emotion/is-prop-valid@1.2.2':
     resolution: {integrity: sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==}
 
   '@emotion/is-prop-valid@1.4.0':
     resolution: {integrity: sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==}
-
-  '@emotion/memoize@0.7.4':
-    resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
 
   '@emotion/memoize@0.8.1':
     resolution: {integrity: sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==}
@@ -771,24 +765,6 @@ packages:
     peerDependencies:
       '@types/react': ^18.0.0
       react: '>=16'
-
-  '@motionone/animation@10.18.0':
-    resolution: {integrity: sha512-9z2p5GFGCm0gBsZbi8rVMOAJCtw1WqBTIPw3ozk06gDvZInBPIsQcHgYogEJ4yuHJ+akuW8g1SEIOpTOvYs8hw==}
-
-  '@motionone/dom@10.12.0':
-    resolution: {integrity: sha512-UdPTtLMAktHiqV0atOczNYyDd/d8Cf5fFsd1tua03PqTwwCe/6lwhLSQ8a7TbnQ5SN0gm44N1slBfj+ORIhrqw==}
-
-  '@motionone/easing@10.18.0':
-    resolution: {integrity: sha512-VcjByo7XpdLS4o9T8t99JtgxkdMcNWD3yHU/n6CLEz3bkmKDRZyYQ/wmSf6daum8ZXqfUAgFeCZSpJZIMxaCzg==}
-
-  '@motionone/generators@10.18.0':
-    resolution: {integrity: sha512-+qfkC2DtkDj4tHPu+AFKVfR/C30O1vYdvsGYaR13W/1cczPrrcjdvYCj0VLFuRMN+lP1xvpNZHCRNM4fBzn1jg==}
-
-  '@motionone/types@10.17.1':
-    resolution: {integrity: sha512-KaC4kgiODDz8hswCrS0btrVrzyU2CSQKO7Ps90ibBVSQmjkrt2teqta6/sOG59v7+dPnKMAg13jyqtMKV2yJ7A==}
-
-  '@motionone/utils@10.18.0':
-    resolution: {integrity: sha512-3XVF7sgyTSI2KWvTf6uLlBJ5iAgRgmvp3bpuOiQJvInd4nZ19ET8lX5unn30SlmRH7hXbBbH+Gxd0m0klJ3Xtw==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1290,66 +1266,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -2953,14 +2942,19 @@ packages:
     resolution: {integrity: sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==}
     engines: {node: '>=0.10.0'}
 
-  framer-motion@6.5.1:
-    resolution: {integrity: sha512-o1BGqqposwi7cgDrtg0dNONhkmPsUFDaLcKXigzuTFC5x58mE8iyTazxSudFzmT6MEyJKfjjU8ItoMe3W+3fiw==}
+  framer-motion@12.35.0:
+    resolution: {integrity: sha512-w8hghCMQ4oq10j6aZh3U2yeEQv5K69O/seDI/41PK4HtgkLrcBovUNc0ayBC3UyyU7V1mrY2yLzvYdWJX9pGZQ==}
     peerDependencies:
-      react: '>=16.8 || ^17.0.0 || ^18.0.0'
-      react-dom: '>=16.8 || ^17.0.0 || ^18.0.0'
-
-  framesync@6.0.1:
-    resolution: {integrity: sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==}
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   from2@2.3.0:
     resolution: {integrity: sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==}
@@ -3192,9 +3186,6 @@ packages:
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
-
-  hey-listen@1.0.8:
-    resolution: {integrity: sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==}
 
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
@@ -3901,6 +3892,12 @@ packages:
     resolution: {integrity: sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==}
     engines: {node: '>=0.10.0'}
 
+  motion-dom@12.35.0:
+    resolution: {integrity: sha512-FFMLEnIejK/zDABn+vqGVAUN4T0+3fw+cVAY8MMT65yR+j5uMuvWdd4npACWhh94OVWQs79CrBBuwOwGRZAQiA==}
+
+  motion-utils@12.29.2:
+    resolution: {integrity: sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==}
+
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -4391,9 +4388,6 @@ packages:
   polished@4.3.1:
     resolution: {integrity: sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==}
     engines: {node: '>=10'}
-
-  popmotion@11.0.3:
-    resolution: {integrity: sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==}
 
   popper.js@1.16.1:
     resolution: {integrity: sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==}
@@ -5114,9 +5108,6 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
-
-  style-value-types@5.0.0:
-    resolution: {integrity: sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==}
 
   styled-components@6.1.19:
     resolution: {integrity: sha512-1v/e3Dl1BknC37cXMhwGomhO8AkYmN41CqyX9xhUDxry1ns3BFQy2lLDRQXJRdVVWB9OHemv/53xaStimvWyuA==}
@@ -5971,11 +5962,6 @@ snapshots:
 
   '@emotion/hash@0.9.1': {}
 
-  '@emotion/is-prop-valid@0.8.8':
-    dependencies:
-      '@emotion/memoize': 0.7.4
-    optional: true
-
   '@emotion/is-prop-valid@1.2.2':
     dependencies:
       '@emotion/memoize': 0.8.1
@@ -5983,9 +5969,6 @@ snapshots:
   '@emotion/is-prop-valid@1.4.0':
     dependencies:
       '@emotion/memoize': 0.9.0
-
-  '@emotion/memoize@0.7.4':
-    optional: true
 
   '@emotion/memoize@0.8.1': {}
 
@@ -6245,41 +6228,6 @@ snapshots:
       '@types/mdx': 2.0.13
       '@types/react': 18.3.28
       react: 18.3.1
-
-  '@motionone/animation@10.18.0':
-    dependencies:
-      '@motionone/easing': 10.18.0
-      '@motionone/types': 10.17.1
-      '@motionone/utils': 10.18.0
-      tslib: 2.8.1
-
-  '@motionone/dom@10.12.0':
-    dependencies:
-      '@motionone/animation': 10.18.0
-      '@motionone/generators': 10.18.0
-      '@motionone/types': 10.17.1
-      '@motionone/utils': 10.18.0
-      hey-listen: 1.0.8
-      tslib: 2.8.1
-
-  '@motionone/easing@10.18.0':
-    dependencies:
-      '@motionone/utils': 10.18.0
-      tslib: 2.8.1
-
-  '@motionone/generators@10.18.0':
-    dependencies:
-      '@motionone/types': 10.17.1
-      '@motionone/utils': 10.18.0
-      tslib: 2.8.1
-
-  '@motionone/types@10.17.1': {}
-
-  '@motionone/utils@10.18.0':
-    dependencies:
-      '@motionone/types': 10.17.1
-      hey-listen: 1.0.8
-      tslib: 2.8.1
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -8865,22 +8813,15 @@ snapshots:
     dependencies:
       map-cache: 0.2.2
 
-  framer-motion@6.5.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  framer-motion@12.35.0(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@motionone/dom': 10.12.0
-      framesync: 6.0.1
-      hey-listen: 1.0.8
-      popmotion: 11.0.3
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      style-value-types: 5.0.0
+      motion-dom: 12.35.0
+      motion-utils: 12.29.2
       tslib: 2.8.1
     optionalDependencies:
-      '@emotion/is-prop-valid': 0.8.8
-
-  framesync@6.0.1:
-    dependencies:
-      tslib: 2.8.1
+      '@emotion/is-prop-valid': 1.4.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   from2@2.3.0:
     dependencies:
@@ -9116,8 +9057,6 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
-
-  hey-listen@1.0.8: {}
 
   highlight.js@10.7.3: {}
 
@@ -9795,6 +9734,12 @@ snapshots:
 
   modify-values@1.0.1: {}
 
+  motion-dom@12.35.0:
+    dependencies:
+      motion-utils: 12.29.2
+
+  motion-utils@12.29.2: {}
+
   mrmime@2.0.1: {}
 
   ms@2.0.0: {}
@@ -10128,13 +10073,6 @@ snapshots:
   polished@4.3.1:
     dependencies:
       '@babel/runtime': 7.28.4
-
-  popmotion@11.0.3:
-    dependencies:
-      framesync: 6.0.1
-      hey-listen: 1.0.8
-      style-value-types: 5.0.0
-      tslib: 2.8.1
 
   popper.js@1.16.1: {}
 
@@ -11030,11 +10968,6 @@ snapshots:
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
-
-  style-value-types@5.0.0:
-    dependencies:
-      hey-listen: 1.0.8
-      tslib: 2.8.1
 
   styled-components@6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:

--- a/src/BottomSheet/BottomSheet.parts.tsx
+++ b/src/BottomSheet/BottomSheet.parts.tsx
@@ -1,8 +1,18 @@
-import { DialogContentProps, DialogOverlayProps } from "@reach/dialog";
+import { DialogOverlayProps } from "@reach/dialog";
 import { AnimatePresence, AnimatePresenceProps } from "framer-motion";
 import React from "react";
 import { HeightProps, LayoutProps, MaxHeightProps, MaxWidthProps, SpaceProps, WidthProps } from "styled-system";
-import { Overlay, Sheet, ContentContainer, Footer, Header, Title, HelpText } from "./BottomSheet.styled";
+import {
+  OverlayDialog,
+  Overlay,
+  SheetDialog,
+  Sheet,
+  ContentContainer,
+  Footer,
+  Header,
+  Title,
+  HelpText,
+} from "./BottomSheet.styled";
 import { BottomSheetProvider, useBottomSheet } from "./BottomSheetProvider";
 
 const overlayVariants = {
@@ -17,7 +27,7 @@ const sheetVariants = {
 
 const transition = {
   duration: 0.5,
-  ease: [0.32, 0.72, 0, 1],
+  ease: [0.32, 0.72, 0, 1] as [number, number, number, number],
 };
 
 interface RootProps extends AnimatePresenceProps {
@@ -30,7 +40,7 @@ function Root({ isOpen, onClose, children, ...props }: RootProps) {
   return (
     <AnimatePresence {...props}>
       {isOpen && (
-        <BottomSheetProvider isOpen={isOpen} onClose={onClose}>
+        <BottomSheetProvider key="bottom-sheet" isOpen={isOpen} onClose={onClose}>
           {children}
         </BottomSheetProvider>
       )}
@@ -47,35 +57,34 @@ function OverlayPart({ closeOnClick, children, ...props }: OverlayPartProps) {
   const [isAnimationComplete, setAnimationComplete] = React.useState(false);
 
   return (
-    <Overlay
-      data-testid="bottom-sheet-overlay"
-      data-visible={isAnimationComplete ? true : undefined}
-      variants={overlayVariants}
-      initial="hidden"
-      animate="visible"
-      exit="hidden"
-      transition={transition}
-      onAnimationComplete={() => {
-        if (isOpen) {
-          setAnimationComplete(true);
-        }
-      }}
-      onClick={closeOnClick ? onClose : undefined}
-      isOpen={isOpen}
-      {...props}
-    >
-      {children}
-    </Overlay>
+    <OverlayDialog isOpen={isOpen} {...props}>
+      <Overlay
+        data-testid="bottom-sheet-overlay"
+        data-visible={isAnimationComplete ? true : undefined}
+        variants={overlayVariants}
+        initial="hidden"
+        animate="visible"
+        exit="hidden"
+        transition={transition}
+        onAnimationComplete={() => {
+          if (isOpen) {
+            setAnimationComplete(true);
+          }
+        }}
+        onClick={closeOnClick ? onClose : undefined}
+      >
+        {children}
+      </Overlay>
+    </OverlayDialog>
   );
 }
 
-interface SheetPartProps
-  extends DialogContentProps, WidthProps, MaxWidthProps, HeightProps, MaxHeightProps, SpaceProps, LayoutProps {
+interface SheetPartProps extends WidthProps, MaxWidthProps, HeightProps, MaxHeightProps, SpaceProps, LayoutProps {
   children: React.ReactNode;
   "aria-label": string;
 }
 
-function SheetPart({ children, ...props }: SheetPartProps) {
+function SheetPart({ children, "aria-label": ariaLabel, ...props }: SheetPartProps) {
   const { isOpen } = useBottomSheet();
   const [isAnimationComplete, setAnimationComplete] = React.useState(false);
 
@@ -84,25 +93,26 @@ function SheetPart({ children, ...props }: SheetPartProps) {
   }
 
   return (
-    <Sheet
-      data-testid="bottom-sheet-body"
-      aria-label={props["aria-label"]}
-      data-visible={isAnimationComplete ? true : undefined}
-      variants={sheetVariants}
-      initial="hidden"
-      animate="visible"
-      exit="hidden"
-      transition={transition}
-      onAnimationComplete={() => {
-        if (isOpen) {
-          setAnimationComplete(true);
-        }
-      }}
-      onClick={handleSheetClick}
-      {...props}
-    >
-      {children}
-    </Sheet>
+    <SheetDialog aria-label={ariaLabel}>
+      <Sheet
+        data-testid="bottom-sheet-body"
+        data-visible={isAnimationComplete ? true : undefined}
+        variants={sheetVariants}
+        initial="hidden"
+        animate="visible"
+        exit="hidden"
+        transition={transition}
+        onAnimationComplete={() => {
+          if (isOpen) {
+            setAnimationComplete(true);
+          }
+        }}
+        onClick={handleSheetClick}
+        {...props}
+      >
+        {children}
+      </Sheet>
+    </SheetDialog>
   );
 }
 

--- a/src/BottomSheet/BottomSheet.styled.tsx
+++ b/src/BottomSheet/BottomSheet.styled.tsx
@@ -2,8 +2,10 @@ import {
   DialogContent as ReachDialogContent,
   DialogContentProps,
   DialogOverlay as ReachDialogOverlay,
+  DialogOverlayProps,
 } from "@reach/dialog";
-import type { AnimationProps } from "framer-motion";
+import React from "react";
+import type { MotionProps } from "framer-motion";
 import { motion } from "framer-motion";
 import { transparentize } from "polished";
 import { styled } from "styled-components";
@@ -12,7 +14,11 @@ import type { HeightProps, LayoutProps, MaxHeightProps, MaxWidthProps, SpaceProp
 import { Heading2, Text } from "../Type";
 import { excludeStyledProps } from "../StyledProps";
 
-const Overlay = styled(motion(ReachDialogOverlay))(({ theme }) => ({
+// Portal + focus-lock + scroll-lock wrapper (no visual styles)
+const OverlayDialog = styled(ReachDialogOverlay as React.ComponentType<DialogOverlayProps>)({});
+
+// Animated backdrop
+const Overlay = styled(motion.div)(({ theme }) => ({
   position: "fixed",
   inset: 0,
   display: "flex",
@@ -22,20 +28,21 @@ const Overlay = styled(motion(ReachDialogOverlay))(({ theme }) => ({
   zIndex: theme.zIndices.overlay,
 }));
 
+// Transparent a11y wrapper (role="dialog", aria-modal, focus containment)
+const SheetDialog = styled(ReachDialogContent as React.ComponentType<DialogContentProps>)({
+  width: "100%",
+  display: "flex",
+  justifyContent: "center",
+  padding: 0,
+  background: "none",
+});
+
 interface SheetProps
-  extends
-    DialogContentProps,
-    AnimationProps,
-    WidthProps,
-    MaxWidthProps,
-    HeightProps,
-    MaxHeightProps,
-    SpaceProps,
-    LayoutProps {}
+  extends MotionProps, WidthProps, MaxWidthProps, HeightProps, MaxHeightProps, SpaceProps, LayoutProps {}
 
 const styleFns = [width, maxWidth, height, maxHeight, space, layout];
 
-const Sheet = styled(motion(ReachDialogContent)).withConfig({
+const Sheet = styled(motion.div).withConfig({
   shouldForwardProp: excludeStyledProps(...styleFns),
 })<SheetProps>(
   ({ theme }) => ({
@@ -113,4 +120,4 @@ const HelpText = styled(Text)(({ theme }) => ({
   },
 }));
 
-export { Overlay, Sheet, ContentContainer, Footer, Header, Title, HelpText };
+export { OverlayDialog, Overlay, SheetDialog, Sheet, ContentContainer, Footer, Header, Title, HelpText };

--- a/src/BottomSheet/stories/BottomSheet.actions.story.tsx
+++ b/src/BottomSheet/stories/BottomSheet.actions.story.tsx
@@ -14,7 +14,7 @@ export default {
 
 export const WithAHiddenCloseButton = {
   render: () => {
-    const [isOpen, setIsOpen] = React.useState(true);
+    const [isOpen, setIsOpen] = React.useState(false);
 
     return (
       <>
@@ -35,7 +35,8 @@ export const WithAHiddenCloseButton = {
   name: "With a hidden close button",
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
-    await step("is open initially without a close button", async () => {
+    await step("opens when trigger button is clicked without a close button", async () => {
+      await userEvent.click(canvas.getByText("Open Sheet"));
       await waitFor(() => expect(screen.getByRole("dialog")).toBeVisible());
       await expect(screen.queryByText("Close")).not.toBeInTheDocument();
     });
@@ -43,7 +44,7 @@ export const WithAHiddenCloseButton = {
       await userEvent.click(screen.getByText("Submit"));
       await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
     });
-    await step("opens when trigger button is clicked", async () => {
+    await step("can be reopened", async () => {
       await userEvent.click(canvas.getByText("Open Sheet"));
       await waitFor(() => expect(screen.getByRole("dialog")).toBeVisible());
     });

--- a/src/BottomSheet/stories/BottomSheet.features.story.tsx
+++ b/src/BottomSheet/stories/BottomSheet.features.story.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { expect, screen, userEvent, waitFor } from "storybook/test";
+import { expect, screen, userEvent, waitFor, within } from "storybook/test";
 import { Box } from "../../Box";
 import { Button, IconicButton } from "../../Button";
 import { Flex } from "../../Flex";
@@ -81,7 +81,7 @@ export const WithAnApplicationFrame = {
 
 export const DisableCloseOnOverlayClick = {
   render: () => {
-    const [isOpen, setIsOpen] = React.useState(true);
+    const [isOpen, setIsOpen] = React.useState(false);
     return (
       <Box>
         <Button onClick={() => setIsOpen(true)}>Open Sheet</Button>
@@ -102,13 +102,19 @@ export const DisableCloseOnOverlayClick = {
   },
 
   name: "Disable close on overlay click",
-  play: async ({ canvasElement: _canvasElement, step }) => {
-    await step("is open initially", async () => {
-      await waitFor(() => expect(screen.getByRole("dialog")).toBeVisible(), { timeout: 3000 });
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    await step("opens when trigger button is clicked", async () => {
+      await userEvent.click(canvas.getByText("Open Sheet"));
+      await waitFor(() => expect(screen.getByRole("dialog")).toBeVisible());
     });
     await step("closes when close button is clicked", async () => {
       await userEvent.click(screen.getByText("Close"));
       await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    });
+    await step("can be reopened", async () => {
+      await userEvent.click(canvas.getByText("Open Sheet"));
+      await waitFor(() => expect(screen.getByRole("dialog")).toBeVisible());
     });
   },
 };

--- a/src/BottomSheet/stories/BottomSheet.story.tsx
+++ b/src/BottomSheet/stories/BottomSheet.story.tsx
@@ -14,7 +14,7 @@ export default {
 
 export const BasicUsage = {
   render: () => {
-    const [isOpen, setIsOpen] = React.useState(true);
+    const [isOpen, setIsOpen] = React.useState(false);
 
     return (
       <>
@@ -27,14 +27,15 @@ export const BasicUsage = {
   },
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
-    await step("is open initially", async () => {
+    await step("opens when trigger button is clicked", async () => {
+      await userEvent.click(canvas.getByText("Open Sheet"));
       await waitFor(() => expect(screen.getByRole("dialog")).toBeVisible());
     });
     await step("closes when Close button is clicked", async () => {
       await userEvent.click(screen.getByText("Close"));
       await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
     });
-    await step("opens when trigger button is clicked", async () => {
+    await step("can be reopened", async () => {
       await userEvent.click(canvas.getByText("Open Sheet"));
       await waitFor(() => expect(screen.getByRole("dialog")).toBeVisible());
     });

--- a/src/Box/Box.tsx
+++ b/src/Box/Box.tsx
@@ -12,7 +12,7 @@ const Box = styled.div<BoxProps>(addStyledProps);
 export interface AnimatedBoxProps
   extends
     MotionProps,
-    Omit<BoxProps, "onAnimationStart" | "onDrag" | "onDragStart" | "onDragEnd" | "style" | "transition"> {}
+    Omit<BoxProps, "onAnimationStart" | "onDrag" | "onDragStart" | "onDragEnd" | "style" | "transition" | "children"> {}
 
 export const AnimatedBox = styled(motion.div)<AnimatedBoxProps>(addStyledProps);
 

--- a/src/Toast/Toast.tsx
+++ b/src/Toast/Toast.tsx
@@ -23,12 +23,12 @@ export const toastAnimationConfig = {
   animate: {
     opacity: 1,
     y: -30,
-    transition: { type: "spring", bounce: 0.4, duration: 0.6 },
+    transition: { type: "spring" as const, bounce: 0.4, duration: 0.6 },
   },
   exit: {
     y: 50,
     opacity: 0,
-    transition: { ease: "easeOut", duration: 0.15 },
+    transition: { ease: "easeOut" as const, duration: 0.15 },
   },
 };
 

--- a/src/TopBar/components/Menu.tsx
+++ b/src/TopBar/components/Menu.tsx
@@ -16,7 +16,7 @@ const blurVariants = {
     WebkitBackdropFilter: "blur(8px)",
     transition: {
       duration: 0.5,
-      ease: "easeInOut",
+      ease: "easeInOut" as const,
     },
   },
   exit: {
@@ -24,7 +24,7 @@ const blurVariants = {
     WebkitBackdropFilter: "blur(0px)",
     transition: {
       duration: 0.5,
-      ease: "easeOut",
+      ease: "easeOut" as const,
     },
   },
 };

--- a/src/TopBar/components/MenuItem.tsx
+++ b/src/TopBar/components/MenuItem.tsx
@@ -8,7 +8,7 @@ const fadeInVariants = {
     y: -16,
     scale: 0.95,
     transition: {
-      ease: "easeOut",
+      ease: "easeOut" as const,
       duration: 0.25,
     },
   },
@@ -18,7 +18,7 @@ const fadeInVariants = {
     y: 0,
     scale: 1,
     transition: {
-      type: "spring",
+      type: "spring" as const,
       duration: 0.75,
     },
   },

--- a/src/utils/story/resizable.tsx
+++ b/src/utils/story/resizable.tsx
@@ -4,7 +4,6 @@ import { Resizable as ReResizable } from "re-resizable";
 import { styled } from "styled-components";
 import { Box } from "../../Box";
 import { DashedBox } from "../../DescriptionList/stories/fixtures";
-import { Text } from "../../Type";
 
 const CONTAINER_BORDER_WIDTH = 2 * 2; // 2px * 2 sides (left and right)
 
@@ -27,13 +26,7 @@ export const Resizable = ({
   const WidthIndicator = (
     <AnimatePresence>
       {showWidth && (
-        <WidthText
-          fontSize="sm"
-          color="midGrey"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-        >
+        <WidthText initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
           {width}
         </WidthText>
       )}
@@ -68,12 +61,14 @@ export const Resizable = ({
   );
 };
 
-export const WidthText = styled(motion(Text))`
-  position: absolute;
-  right: 0;
-  transform: translateX(50%);
-  bottom: -${(props) => props.theme.space.x3};
-`;
+export const WidthText = styled(motion.span)(({ theme }) => ({
+  position: "absolute",
+  right: 0,
+  transform: "translateX(50%)",
+  bottom: `-${theme.space.x3}`,
+  fontSize: theme.fontSizes.small,
+  color: theme.colors.midGrey,
+}));
 
 export const ResizeHandle = styled.div`
   position: absolute;


### PR DESCRIPTION
- Resolves React 18 StrictMode compatibility issues in v6
- Fixes WAAPI animation failures: replace motion(ReachComponent) wrappers in BottomSheet with motion.div inside Reach a11y containers so WAAPI gets direct DOM element access
- Add as const casts for string literal ease/type values (stricter v11+ types)
- Fix AnimatedBox children type conflict (add "children" to Omit)
- Replace styled(motion(Text)) with styled(motion.span) in resizable util
- Skip framer-motion animations in Storybook browser test runner (vitest.setup.ts)
- Start BottomSheet stories closed so play() drives the full lifecycle

## Description

**Describe the change you're making, the motivations behind it, and any thing else a reviewer may need to know to approve this PR.**

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
