### PR TITLE
feat: add IBM Plex Sans JP custom font for ja_JP locale

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,3 +1,4 @@
 <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans:300,400,500,600" rel="stylesheet" />
 <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono" rel="stylesheet" />
 <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;500&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+JP:wght@300;400;500;600&display=swap" rel="stylesheet" />

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,4 +1,7 @@
 <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans:300,400,500,600" rel="stylesheet" />
 <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono" rel="stylesheet" />
 <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;500&display=swap" rel="stylesheet" />
-<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+JP:wght@300;400;500;600&display=swap" rel="stylesheet" />
+<link
+  href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+JP:wght@300;400;500;600&display=swap"
+  rel="stylesheet"
+/>

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ If your application supports Simplified Chinese, you'll also need to load [Noto 
 <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;500&display=swap" rel="stylesheet" />
 ```
 
+If your application supports Japanese, you'll also need to load [IBM Plex Sans JP](https://fonts.google.com/specimen/IBM+Plex+Sans+JP).
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+JP:wght@300;400;500;600&display=swap" rel="stylesheet" />
+```
+
 Note that loading fonts from Google API is just an example and not the most performant way to load fonts for your application. You'll most likely want to include the font's inside your existing asset pipeline.
 
 ### 2. Wrap your application in our theme provider

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
   },
   "dependencies": {
     "@emotion/is-prop-valid": "^1.3.1",
-    "@nulogy/tokens": "^6.1.1",
+    "@nulogy/tokens": "^6.2.0",
     "@radix-ui/react-dialog": "^1.1.0",
     "@radix-ui/react-navigation-menu": "^1.1.4",
     "@radix-ui/react-tooltip": "1.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^1.3.1
         version: 1.4.0
       '@nulogy/tokens':
-        specifier: ^6.1.1
-        version: 6.1.1
+        specifier: ^6.2.0
+        version: 6.2.0
       '@radix-ui/react-dialog':
         specifier: ^1.1.0
         version: 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -852,8 +852,8 @@ packages:
   '@nulogy/icons@4.38.1':
     resolution: {integrity: sha512-qDTUCuvc5RSxygXHw3QLt9duXdRYNUjNJIvGeKj9mUoi/5ekMhii9jrMO4EaGtfYLz3s1Ij4cqKAZQWw+zuwGA==}
 
-  '@nulogy/tokens@6.1.1':
-    resolution: {integrity: sha512-5UqGPU+/sgf40owem02HG6HnVMcG9PvG/p/jL8T3CJjnfJeVRHubFfcqJeWXlwMutgR2jOFnS/yfH/YUdfzzrw==}
+  '@nulogy/tokens@6.2.0':
+    resolution: {integrity: sha512-LzpHnSjU38p/U0/0dWVTG/hPgQ31TRGvWUQBByIpUG4N0sAD/50TW+YJJANpAyDVec+IbC4xkXcsnjNxE5Yjww==}
 
   '@octokit/auth-token@3.0.4':
     resolution: {integrity: sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==}
@@ -6457,7 +6457,7 @@ snapshots:
 
   '@nulogy/icons@4.38.1': {}
 
-  '@nulogy/tokens@6.1.1': {}
+  '@nulogy/tokens@6.2.0': {}
 
   '@octokit/auth-token@3.0.4': {}
 

--- a/src/NDSProvider/GlobalStyles.tsx
+++ b/src/NDSProvider/GlobalStyles.tsx
@@ -3,7 +3,11 @@ import { styled } from "styled-components";
 const GlobalStyles = styled.div<{
   locale?: string;
 }>(({ theme, locale }) => {
-  const fontFamily = locale === "zh_CN" ? theme.fonts.sc : theme.fonts.base;
+  const localeFontMap: Record<string, string> = {
+    zh_CN: theme.fonts.sc,
+    ja_JP: theme.fonts.jp,
+  };
+  const fontFamily = (locale && localeFontMap[locale]) || theme.fonts.base;
   return {
     color: theme.colors.black,
     fontFamily,

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -3,6 +3,8 @@ import { DefaultNDSThemeType } from "./theme.type";
 
 type ThemeKey = "legacy" | "experimental" | "tablet" | "phone";
 
+const IBM_PLEX_SANS_JP = "'IBM Plex Sans JP', sans-serif";
+
 export const themes: Record<ThemeKey, DefaultNDSThemeType> = {
   legacy: {
     colors: {
@@ -40,6 +42,7 @@ export const themes: Record<ThemeKey, DefaultNDSThemeType> = {
       base: tokens.DESKTOP_FONT_FAMILY_BASE,
       mono: tokens.DESKTOP_FONT_FAMILY_MONO,
       sc: tokens.DESKTOP_FONT_FAMILY_SC,
+      jp: IBM_PLEX_SANS_JP,
     },
     shadows: {
       small: tokens.DESKTOP_SHADOW_SMALL,
@@ -202,6 +205,7 @@ export const themes: Record<ThemeKey, DefaultNDSThemeType> = {
       base: tokens.DESKTOP_FONT_FAMILY_BASE,
       mono: tokens.DESKTOP_FONT_FAMILY_MONO,
       sc: tokens.DESKTOP_FONT_FAMILY_SC,
+      jp: IBM_PLEX_SANS_JP,
     },
     shadows: {
       small: tokens.DESKTOP_SHADOW_SMALL,
@@ -364,6 +368,7 @@ export const themes: Record<ThemeKey, DefaultNDSThemeType> = {
       base: tokens.TABLET_FONT_FAMILY_BASE,
       mono: tokens.TABLET_FONT_FAMILY_MONO,
       sc: tokens.TABLET_FONT_FAMILY_SC,
+      jp: IBM_PLEX_SANS_JP,
     },
     shadows: {
       small: tokens.TABLET_SHADOW_SMALL,
@@ -526,6 +531,7 @@ export const themes: Record<ThemeKey, DefaultNDSThemeType> = {
       base: tokens.PHONE_FONT_FAMILY_BASE,
       mono: tokens.PHONE_FONT_FAMILY_MONO,
       sc: tokens.PHONE_FONT_FAMILY_SC,
+      jp: IBM_PLEX_SANS_JP,
     },
     shadows: {
       small: tokens.PHONE_SHADOW_SMALL,

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -3,8 +3,6 @@ import { DefaultNDSThemeType } from "./theme.type";
 
 type ThemeKey = "legacy" | "experimental" | "tablet" | "phone";
 
-const IBM_PLEX_SANS_JP = "'IBM Plex Sans JP', sans-serif";
-
 export const themes: Record<ThemeKey, DefaultNDSThemeType> = {
   legacy: {
     colors: {
@@ -42,7 +40,7 @@ export const themes: Record<ThemeKey, DefaultNDSThemeType> = {
       base: tokens.DESKTOP_FONT_FAMILY_BASE,
       mono: tokens.DESKTOP_FONT_FAMILY_MONO,
       sc: tokens.DESKTOP_FONT_FAMILY_SC,
-      jp: IBM_PLEX_SANS_JP,
+      jp: tokens.DESKTOP_FONT_FAMILY_JP,
     },
     shadows: {
       small: tokens.DESKTOP_SHADOW_SMALL,
@@ -205,7 +203,7 @@ export const themes: Record<ThemeKey, DefaultNDSThemeType> = {
       base: tokens.DESKTOP_FONT_FAMILY_BASE,
       mono: tokens.DESKTOP_FONT_FAMILY_MONO,
       sc: tokens.DESKTOP_FONT_FAMILY_SC,
-      jp: IBM_PLEX_SANS_JP,
+      jp: tokens.DESKTOP_FONT_FAMILY_JP,
     },
     shadows: {
       small: tokens.DESKTOP_SHADOW_SMALL,
@@ -368,7 +366,7 @@ export const themes: Record<ThemeKey, DefaultNDSThemeType> = {
       base: tokens.TABLET_FONT_FAMILY_BASE,
       mono: tokens.TABLET_FONT_FAMILY_MONO,
       sc: tokens.TABLET_FONT_FAMILY_SC,
-      jp: IBM_PLEX_SANS_JP,
+      jp: tokens.TABLET_FONT_FAMILY_JP,
     },
     shadows: {
       small: tokens.TABLET_SHADOW_SMALL,
@@ -531,7 +529,7 @@ export const themes: Record<ThemeKey, DefaultNDSThemeType> = {
       base: tokens.PHONE_FONT_FAMILY_BASE,
       mono: tokens.PHONE_FONT_FAMILY_MONO,
       sc: tokens.PHONE_FONT_FAMILY_SC,
-      jp: IBM_PLEX_SANS_JP,
+      jp: tokens.PHONE_FONT_FAMILY_JP,
     },
     shadows: {
       small: tokens.PHONE_SHADOW_SMALL,

--- a/src/theme/theme.type.ts
+++ b/src/theme/theme.type.ts
@@ -100,6 +100,7 @@ interface Fonts {
   base: string;
   mono: string;
   sc: string;
+  jp: string;
 }
 
 type Borders = Array<any>;


### PR DESCRIPTION
## Description

Adds IBM Plex Sans JP as the custom font for the `ja_JP` locale, following the same pattern as Simplified Chinese (Noto Sans SC). The font family token is sourced from `@nulogy/tokens` v6.2.0 (via [nds-tokens PR #72](https://github.com/nulogy/nds-tokens/pull/72)), which was bumped as part of this change. README has been updated to instruct consumers to load the font if their application supports Japanese.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [x] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added
- [x] Documentation has been updated
- [x] Accessibility has been considered