### PR TITLE
feat: support tree-shaking via preserveModules ESM build

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,12 +48,13 @@
     "component library"
   ],
   "main": "dist/main.js",
-  "module": "dist/main.module.js",
+  "module": "dist/esm/index.js",
   "typings": "dist/src/index.d.ts",
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/main.module.js",
+      "import": "./dist/esm/index.js",
       "require": "./dist/main.js"
     }
   },

--- a/src/NDSProvider/NDSProvider.tsx
+++ b/src/NDSProvider/NDSProvider.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import { I18nextProvider } from "react-i18next";
-import i18n from "../i18n";
+import i18n, { initI18n } from "../i18n";
 import { ThemeType } from "../theme";
 import NDSThemeProvider from "../theme/NDSThemeProvider";
 import ComponentVariantContextProvider, { ComponentVariant } from "./ComponentVariantContext";
@@ -27,6 +27,8 @@ function NDSProvider({
     experimentalDesktopTypographyScale: false,
   },
 }: NDSProviderProps) {
+  initI18n();
+
   useEffect(() => {
     i18n.changeLanguage(locale);
   }, [locale]);

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -47,17 +47,26 @@ const resources = {
     nds: zh_CN,
   },
 };
-i18n.init({
-  ns: ["nds"],
-  defaultNS: "nds",
-  resources,
-  lng: "en_US",
+let initialized = false;
 
-  keySeparator: false, // we do not use keys in form messages.welcome
+export function initI18n() {
+  if (initialized) return i18n;
+  initialized = true;
 
-  interpolation: {
-    escapeValue: false, // react already safes from xss
-  },
-});
+  i18n.init({
+    ns: ["nds"],
+    defaultNS: "nds",
+    resources,
+    lng: "en_US",
+
+    keySeparator: false, // we do not use keys in form messages.welcome
+
+    interpolation: {
+      escapeValue: false, // react already safes from xss
+    },
+  });
+
+  return i18n;
+}
 
 export default i18n;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -47,22 +47,30 @@ export default defineConfig({
   },
   build: {
     emptyOutDir: false,
-    lib: {
-      entry: resolve(__dirname, "src/index.ts"),
-      name: "NDSComponents",
-      formats: ["umd", "es"],
-      fileName: (format) => {
-        if (format === "umd") {
-          return "main.js";
-        }
-        return "main.module.js";
-      },
-    },
     rollupOptions: {
+      input: resolve(__dirname, "src/index.ts"),
       external,
-      output: {
-        globals: GLOBALS,
-      },
+      preserveEntrySignatures: "strict",
+      output: [
+        // ESM with preserved modules — enables tree-shaking in consumers
+        {
+          format: "es",
+          dir: "dist/esm",
+          preserveModules: true,
+          preserveModulesRoot: "src",
+          entryFileNames: "[name].js",
+          exports: "named",
+        },
+        // UMD monolith — retained for legacy/CDN use
+        {
+          format: "umd",
+          dir: "dist",
+          entryFileNames: "main.js",
+          name: "NDSComponents",
+          globals: GLOBALS,
+          exports: "named",
+        },
+      ],
     },
     sourcemap: true,
     minify: false,


### PR DESCRIPTION
Switch from a monolithic ESM bundle to a per-module ESM output (preserveModules: true), enabling consumers' bundlers to eliminate unused components from their production bundles.

- Add `"sideEffects": false` to package.json
- Replace `build.lib` with explicit rollupOptions: ESM output uses preserveModules into dist/esm/, UMD monolith retained in dist/main.js
- Refactor i18n.init() from module-level side effect into lazy initI18n() function, making "sideEffects": false safe for the entire package
- NDSProvider calls initI18n() on first render (idempotent)

BREAKING CHANGE: The ESM entry point has moved from dist/main.module.js to dist/esm/index.js. Consumers relying on the `module` or `exports.import` fields will pick this up automatically via package.json. Consumers with hardcoded paths to dist/main.module.js must update to dist/esm/index.js.

## Description

**Describe the change you're making, the motivations behind it, and any thing else a reviewer may need to know to approve this PR.**

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added 
- [ ] Documentation has been updated
- [ ] Accessibility has been considered
