### PR TITLE
fix: sub-menu link items rendering in browser-default blue when unvisited

### DIFF
--- a/src/Navigation/components/MenuSubItem/parts/styled.tsx
+++ b/src/Navigation/components/MenuSubItem/parts/styled.tsx
@@ -28,6 +28,7 @@ export const SubMenuItemLink = styled(RadixNavigationMenu.Link)<StyledProps>(
     alignItems: "flex-start",
     alignSelf: "stretch",
     width: "100%",
+    color: theme.colors.darkGrey,
     textDecoration: "none",
     "&:hover, &:focus": {
       backgroundColor: theme.colors.lightBlue,

--- a/src/Navigation/stories/Navigation.story.tsx
+++ b/src/Navigation/stories/Navigation.story.tsx
@@ -228,7 +228,18 @@ export const WithACustomBreakpoint = () => {
       navBar={
         <Navigation
           primaryNavigation={[{ key: "dashboard", label: "Dashboard", type: "link" }]}
-          secondaryNavigation={[{ key: "settings", icon: "settings", tooltip: "Settings", type: "button" }]}
+          secondaryNavigation={[
+            {
+              key: "settings",
+              icon: "settings",
+              tooltip: "Settings",
+              type: "button",
+              items: [
+                { key: "boms", label: "BOMs", type: "link", props: { href: "/admin/bom_visualizer" } },
+                { key: "other", label: "Other Page", type: "link", props: { href: "/admin/other_page" } },
+              ],
+            },
+          ]}
           breakpoint={breakpoint}
         />
       }


### PR DESCRIPTION
## Description

`SubMenuItemLink` was missing a base `color` style, so unvisited `<a>` elements fell through to the browser's user-agent stylesheet (blue). Visited links appeared correct only because the existing `:visited { color: inherit }` rule happened to mask the issue by inheriting `darkGrey` from the parent.

The fix mirrors what `SubMenuItemButton` already does: explicitly set `color: theme.colors.darkGrey` on the base state.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [ ] Appropriate tests have been added
- [ ] Documentation has been updated
- [x] Accessibility has been considered