### PR TITLE
refactor: convert Tabs class components to functional components

### DIFF
--- a/src/BrandedNavBar/NavBar.tsx
+++ b/src/BrandedNavBar/NavBar.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { styled } from "styled-components";
-import ReactResizeDetector from "react-resize-detector";
+import { useResizeDetector } from "react-resize-detector";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "styled-components";
 import { Flex } from "../Flex";
@@ -121,19 +121,18 @@ type BaseNavBarProps = {
   logoSrc?: string;
 };
 
-const BaseNavBar = ({ environment, breakpointUpper = "medium", ...props }: BaseNavBarProps) => {
+const BaseNavBar = ({ environment, breakpointUpper = "medium", className, ...props }: BaseNavBarProps) => {
   const { breakpoints } = useTheme();
+  const { width, ref } = useResizeDetector<HTMLDivElement>({ handleHeight: false });
   return (
-    <ReactResizeDetector handleWidth>
-      {({ width }) => (
-        <SelectNavBarBasedOnWidth
-          breakpointUpper={breakpoints[breakpointUpper] || breakpointUpper}
-          width={width}
-          environment={environment}
-          {...props}
-        />
-      )}
-    </ReactResizeDetector>
+    <div ref={ref} className={className}>
+      <SelectNavBarBasedOnWidth
+        breakpointUpper={breakpoints[breakpointUpper] || breakpointUpper}
+        width={width}
+        environment={environment}
+        {...props}
+      />
+    </div>
   );
 };
 

--- a/src/Tabs/TabScrollIndicators.tsx
+++ b/src/Tabs/TabScrollIndicators.tsx
@@ -1,159 +1,118 @@
-// @ts-nocheck
+import React, { useCallback, useEffect, useState } from "react";
 import { styled } from "styled-components";
-import React from "react";
+import { useResizeDetector } from "react-resize-detector";
 import TabScrollIndicator from "./TabScrollIndicator";
-const TabScrollIndicatorContainer = styled.div(({ width, theme }) => ({
+
+const TabScrollIndicatorContainer = styled.div<{ width: number }>(({ width, theme }) => ({
   position: "absolute",
   width,
   height: theme.space.x5,
 }));
-type TabScrollIndicatorsProps = {
-  tabRefs?: {
-    offsetWidth?: number;
-  }[];
-  tabContainerRef?: {
-    current?: object;
-  };
+
+interface TabScrollIndicatorsProps {
+  tabRefs?: Array<HTMLButtonElement | null>;
+  tabContainerRef?: React.RefObject<HTMLDivElement>;
   indicatorWidth?: number;
-};
-type TabScrollIndicatorsState = {
-  contentHiddenLeft: boolean;
-  contentHiddenRight: boolean;
-};
-class TabScrollIndicators extends React.Component<TabScrollIndicatorsProps, TabScrollIndicatorsState> {
-  constructor(props) {
-    super(props);
-    this.state = {
-      contentHiddenLeft: this.contentHiddenLeft(),
-      contentHiddenRight: this.contentHiddenRight(),
-    };
-    this.handleIndicatorClick = this.handleIndicatorClick.bind(this);
-    this.getScrollLeftValueByTabIndex = this.getScrollLeftValueByTabIndex.bind(this);
-    this.contentHiddenLeft = this.contentHiddenLeft.bind(this);
-    this.contentHiddenRight = this.contentHiddenRight.bind(this);
-    this.handleScroll = this.handleScroll.bind(this);
-    this.handleResize = this.handleResize.bind(this);
-  }
-  componentDidMount() {
-    this.conditionallyUpdateState();
-  }
-  getScrollLeftValueByTabIndex(index) {
-    const { tabRefs } = this.props;
-    let scrollLeftSum = 0;
-    for (let i = 0; i < index; i += 1) {
-      scrollLeftSum += tabRefs[i].offsetWidth;
-    }
-    return scrollLeftSum;
-  }
-  contentHiddenRight() {
-    const { tabContainerRef } = this.props;
-    if (!tabContainerRef.current) {
-      return false;
-    }
-    return (
-      tabContainerRef.current.scrollLeft + tabContainerRef.current.offsetWidth < tabContainerRef.current.scrollWidth
-    );
-  }
-  contentHiddenLeft() {
-    const { tabContainerRef } = this.props;
-    if (!tabContainerRef.current) {
-      return false;
-    }
-    return (
-      tabContainerRef.current.scrollLeft !== 0 &&
-      tabContainerRef.current.offsetWidth < tabContainerRef.current.scrollWidth
-    );
-  }
-  findLastVisibleTab() {
-    const { tabContainerRef, tabRefs, indicatorWidth } = this.props;
-    const rightMarker = tabContainerRef.current.scrollLeft + tabContainerRef.current.offsetWidth - indicatorWidth;
-    let scrollLeftSum = 0;
-    for (let i = 0; i < tabRefs.length; i += 1) {
-      scrollLeftSum += tabRefs[i].offsetWidth;
-      if (rightMarker <= scrollLeftSum) {
-        return i;
-      }
-    }
-    return null;
-  }
-  findFirstVisibleTab() {
-    const { tabContainerRef, tabRefs, indicatorWidth } = this.props;
-    const leftMarker = tabContainerRef.current.scrollLeft + indicatorWidth;
-    let scrollLeftSum = 0;
-    for (let i = 0; i < tabRefs.length; i += 1) {
-      scrollLeftSum += tabRefs[i].offsetWidth;
-      if (leftMarker <= scrollLeftSum) {
-        return i;
-      }
-    }
-    return null;
-  }
-  handleScroll() {
-    this.conditionallyUpdateState();
-  }
-  handleResize() {
-    this.setState({
-      contentHiddenLeft: this.contentHiddenLeft(),
-      contentHiddenRight: this.contentHiddenRight(),
-    });
-  }
-  conditionallyUpdateState() {
-    const { contentHiddenLeft, contentHiddenRight } = this.state;
-    const currentContentHiddenLeft = this.contentHiddenLeft();
-    const currentContentHiddenRight = this.contentHiddenRight();
-    if (currentContentHiddenLeft !== contentHiddenLeft) {
-      this.setState({ contentHiddenLeft: currentContentHiddenLeft });
-    }
-    if (currentContentHiddenRight !== contentHiddenRight) {
-      this.setState({ contentHiddenRight: currentContentHiddenRight });
-    }
-  }
-  handleIndicatorClick(side) {
-    const { tabRefs, tabContainerRef, indicatorWidth } = this.props;
-    if (side === "right") {
-      const lastVisibleTab = this.findLastVisibleTab();
-      const scrollLeft = this.getScrollLeftValueByTabIndex(lastVisibleTab) - indicatorWidth;
-      this.applyScrollLeft(scrollLeft);
-    } else {
-      const firstVisibleTab = this.findFirstVisibleTab();
-      const scrollLeft =
-        this.getScrollLeftValueByTabIndex(firstVisibleTab) +
-        indicatorWidth +
-        tabRefs[firstVisibleTab].offsetWidth -
-        tabContainerRef.current.offsetWidth;
-      this.applyScrollLeft(scrollLeft);
-    }
-  }
-  applyScrollLeft(scrollLeft) {
-    const { tabContainerRef } = this.props;
-    tabContainerRef.current.scroll({ left: scrollLeft, behavior: "smooth" });
-  }
-  render() {
-    const { tabContainerRef, indicatorWidth, children } = this.props;
-    const { contentHiddenLeft, contentHiddenRight } = this.state;
-    return (
-      <>
-        <TabScrollIndicatorContainer width={tabContainerRef.current ? tabContainerRef.current.offsetWidth : 0}>
-          {contentHiddenLeft && (
-            <TabScrollIndicator width={indicatorWidth} side="left" onClick={this.handleIndicatorClick} />
-          )}
-          {contentHiddenRight && (
-            <TabScrollIndicator width={indicatorWidth} side="right" onClick={this.handleIndicatorClick} />
-          )}
-        </TabScrollIndicatorContainer>
-        {children({
-          handleScroll: this.handleScroll,
-          handleResize: this.handleResize,
-        })}
-      </>
-    );
-  }
+  children: (handlers: { handleScroll: () => void; handleResize: () => void }) => React.ReactNode;
 }
 
-TabScrollIndicators.defaultProps = {
-  tabRefs: undefined,
-  tabContainerRef: undefined,
-  indicatorWidth: 40,
-};
+function TabScrollIndicators({ tabRefs, tabContainerRef, indicatorWidth = 40, children }: TabScrollIndicatorsProps) {
+  const [hiddenLeft, setHiddenLeft] = useState(false);
+  const [hiddenRight, setHiddenRight] = useState(false);
+
+  const isHiddenLeft = useCallback(() => {
+    const container = tabContainerRef?.current;
+    if (!container) return false;
+    return container.scrollLeft !== 0 && container.offsetWidth < container.scrollWidth;
+  }, [tabContainerRef]);
+
+  const isHiddenRight = useCallback(() => {
+    const container = tabContainerRef?.current;
+    if (!container) return false;
+    return container.scrollLeft + container.offsetWidth < container.scrollWidth;
+  }, [tabContainerRef]);
+
+  const updateVisibility = useCallback(() => {
+    setHiddenLeft(isHiddenLeft());
+    setHiddenRight(isHiddenRight());
+  }, [isHiddenLeft, isHiddenRight]);
+
+  useEffect(() => {
+    updateVisibility();
+  }, [updateVisibility]);
+
+  useResizeDetector({
+    targetRef: tabContainerRef as React.MutableRefObject<HTMLDivElement | null>,
+    onResize: updateVisibility,
+  });
+
+  const handleScroll = useCallback(() => {
+    updateVisibility();
+  }, [updateVisibility]);
+
+  function getScrollLeftByTabIndex(index: number) {
+    let sum = 0;
+    for (let i = 0; i < index; i++) {
+      sum += tabRefs[i]?.offsetWidth ?? 0;
+    }
+    return sum;
+  }
+
+  function findLastVisibleTab() {
+    const container = tabContainerRef.current;
+    const rightMarker = container.scrollLeft + container.offsetWidth - indicatorWidth;
+    let sum = 0;
+    for (let i = 0; i < tabRefs.length; i++) {
+      sum += tabRefs[i]?.offsetWidth ?? 0;
+      if (rightMarker <= sum) return i;
+    }
+    return null;
+  }
+
+  function findFirstVisibleTab() {
+    const container = tabContainerRef.current;
+    const leftMarker = container.scrollLeft + indicatorWidth;
+    let sum = 0;
+    for (let i = 0; i < tabRefs.length; i++) {
+      sum += tabRefs[i]?.offsetWidth ?? 0;
+      if (leftMarker <= sum) return i;
+    }
+    return null;
+  }
+
+  function handleIndicatorClick(side: "left" | "right") {
+    const container = tabContainerRef.current;
+    if (side === "right") {
+      const lastVisible = findLastVisibleTab();
+      container.scroll({ left: getScrollLeftByTabIndex(lastVisible) - indicatorWidth, behavior: "smooth" });
+    } else {
+      const firstVisible = findFirstVisibleTab();
+      container.scroll({
+        left:
+          getScrollLeftByTabIndex(firstVisible) +
+          indicatorWidth +
+          (tabRefs[firstVisible]?.offsetWidth ?? 0) -
+          container.offsetWidth,
+        behavior: "smooth",
+      });
+    }
+  }
+
+  const containerWidth = tabContainerRef?.current?.offsetWidth ?? 0;
+
+  return (
+    <>
+      <TabScrollIndicatorContainer width={containerWidth}>
+        {hiddenLeft && (
+          <TabScrollIndicator width={indicatorWidth} side="left" onClick={() => handleIndicatorClick("left")} />
+        )}
+        {hiddenRight && (
+          <TabScrollIndicator width={indicatorWidth} side="right" onClick={() => handleIndicatorClick("right")} />
+        )}
+      </TabScrollIndicatorContainer>
+      {children({ handleScroll, handleResize: updateVisibility })}
+    </>
+  );
+}
 
 export default TabScrollIndicators;

--- a/src/Tabs/Tabs.tsx
+++ b/src/Tabs/Tabs.tsx
@@ -1,157 +1,124 @@
-// @ts-nocheck
-import React from "react";
+import React, { useCallback, useRef, useState } from "react";
 import propTypes from "@styled-system/prop-types";
-import ReactResizeDetector from "react-resize-detector";
 import { getSubset } from "../utils/subset";
 import FocusManager from "../utils/ts/FocusManager";
 import { Box } from "../Box";
-import { ComponentVariant, ComponentVariantContext } from "../NDSProvider/ComponentVariantContext";
+import { ComponentVariant, useComponentVariant } from "../NDSProvider/ComponentVariantContext";
 import TabContainer from "./TabContainer";
 import TabScrollIndicators from "./TabScrollIndicators";
 
-export type TabsProps = React.PropsWithChildren<{
+export interface TabsProps {
+  children?: React.ReactNode;
   className?: string;
   selectedIndex?: number;
   variant?: ComponentVariant;
-  defaultSelectedIndex?: number;
+  defaultSelectedIndex?: number | null;
   renderTabContentOnlyWhenSelected?: boolean;
   fitted?: boolean;
   onTabClick?: (...args: any[]) => any;
-}>;
+}
 
-export type TabsState = {
-  selectedIndex: any;
-};
+// Exported for consuming story/test files
+export interface TabsState {
+  selectedIndex: number | null;
+}
 
-class Tabs extends React.Component<TabsProps, TabsState> {
-  static contextType = ComponentVariantContext;
+function Tabs(props: TabsProps) {
+  const {
+    children,
+    className,
+    selectedIndex: controlledSelectedIndex,
+    variant,
+    defaultSelectedIndex = null,
+    renderTabContentOnlyWhenSelected = false,
+    fitted = false,
+    onTabClick,
+  } = props;
 
-  constructor(props) {
-    super(props);
-    const { defaultSelectedIndex } = this.props;
-    this.state = {
-      selectedIndex: defaultSelectedIndex === null ? null : defaultSelectedIndex,
-    };
-    this.tabContent = [];
-    this.tabContainerRef = React.createRef();
-    this.tabRefs = [];
-    this.handleTabClick = this.handleTabClick.bind(this);
-    this.getTabs = this.getTabs.bind(this);
+  const [uncontrolledSelectedIndex, setUncontrolledSelectedIndex] = useState<number | null>(defaultSelectedIndex);
+  const componentVariant = useComponentVariant(variant);
+  const tabContainerRef = useRef<HTMLDivElement>(null);
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  const selectedIndex = controlledSelectedIndex !== undefined ? controlledSelectedIndex : uncontrolledSelectedIndex;
+  const spaceProps = getSubset(props, propTypes.space);
+
+  const handleTabClick = useCallback((index: number) => {
+    setUncontrolledSelectedIndex(index);
+  }, []);
+
+  function getTabs(
+    setFocusToTab: (index: number) => void,
+    focusedIndex: number,
+    handleArrowNavigation: (e: React.KeyboardEvent) => void
+  ) {
+    const tabs = React.Children.toArray(children) as React.ReactElement[];
+
+    return tabs.filter(Boolean).map((tab, index) =>
+      React.cloneElement(tab, {
+        onClick: (e: React.MouseEvent) => {
+          setFocusToTab(index);
+          tab.props.onClick?.(e);
+          if (onTabClick) {
+            onTabClick(e, index);
+          } else {
+            handleTabClick(index);
+          }
+        },
+        onFocus: (e: React.FocusEvent) => {
+          e.stopPropagation();
+        },
+        onKeyDown: handleArrowNavigation,
+        index,
+        variant: componentVariant,
+        tabIndex: index === focusedIndex ? 0 : -1,
+        selected: index === selectedIndex,
+        "aria-selected": index === selectedIndex,
+        fullWidth: fitted,
+        ref: (ref: HTMLButtonElement | null) => {
+          tabRefs.current[index] = ref;
+        },
+      })
+    );
   }
 
-  getSelectedIndex() {
-    const { selectedIndex: controlledSelectedIndex } = this.props;
-    const { selectedIndex: uncontrolledSelectedIndex } = this.state;
-    return controlledSelectedIndex === undefined ? uncontrolledSelectedIndex : controlledSelectedIndex;
-  }
+  function getTabContent() {
+    const tabs = React.Children.toArray(children) as React.ReactElement[];
 
-  getTabs(setFocusToTab, focusedIndex, handleArrowNavigation) {
-    const { fitted, children, onTabClick, variant } = this.props;
-
-    const componentVariant = variant ?? this.context.size;
-
-    const selectedIndex = this.getSelectedIndex();
-    const tabs = React.Children.toArray(children);
-
-    return tabs
-      .filter((tab) => Boolean(tab))
-      .map((tab, index) => {
-        return React.cloneElement(tab, {
-          onClick: (e) => {
-            setFocusToTab(index);
-            if (tab?.props?.onClick) {
-              tab?.props?.onClick(e);
-            }
-            if (onTabClick) {
-              onTabClick(e, index);
-            } else {
-              this.handleTabClick(index);
-            }
-          },
-          onFocus: (e) => {
-            e.stopPropagation();
-          },
-          onKeyDown: handleArrowNavigation,
-          index,
-          variant: componentVariant,
-          tabIndex: index === focusedIndex ? 0 : -1,
-          selected: index === selectedIndex,
-          "aria-selected": index === selectedIndex,
-          fullWidth: fitted,
-          ref: (ref) => {
-            this.tabRefs[index] = ref;
-          },
-        });
-      });
-  }
-
-  getTabContent() {
-    const { children, renderTabContentOnlyWhenSelected } = this.props;
-    const selectedIndex = this.getSelectedIndex();
-
-    const tabs = React.Children.toArray(children);
-
-    const tabContent = tabs
-      .filter((tab) => Boolean(tab))
-      .map((tab, index) => {
-        const selected = index === selectedIndex;
-        if (renderTabContentOnlyWhenSelected && !selected) {
-          return null;
-        } else {
-          return (
-            <div aria-hidden={!selected} hidden={!selected} selected={selected} key={tab.key || tab.label}>
-              {tab?.props?.children}
-            </div>
-          );
-        }
-      });
-
-    return tabContent;
-  }
-
-  handleTabClick(index) {
-    this.setState({
-      selectedIndex: index,
+    return tabs.filter(Boolean).map((tab, index) => {
+      const selected = index === selectedIndex;
+      if (renderTabContentOnlyWhenSelected && !selected) return null;
+      return (
+        <div aria-hidden={!selected} hidden={!selected} key={tab.key ?? tab.props.label}>
+          {tab.props.children}
+        </div>
+      );
     });
   }
 
-  render() {
-    const { className } = this.props;
-    const spaceProps = getSubset(this.props, propTypes.space);
-    return (
-      <Box position="relative">
-        <FocusManager refs={this.tabRefs} defaultFocusedIndex={this.getSelectedIndex()}>
-          {({ focusedIndex, setFocusedIndex, handleArrowNavigation }) => (
-            <TabScrollIndicators tabRefs={this.tabRefs} tabContainerRef={this.tabContainerRef}>
-              {({ handleScroll, handleResize }) => (
-                <TabContainer
-                  className={className}
-                  role="tablist"
-                  onScroll={handleScroll}
-                  ref={this.tabContainerRef}
-                  {...spaceProps}
-                >
-                  <ReactResizeDetector handleWidth onResize={handleResize} />
-                  {this.getTabs(setFocusedIndex, focusedIndex, handleArrowNavigation)}
-                </TabContainer>
-              )}
-            </TabScrollIndicators>
-          )}
-        </FocusManager>
-        {this.getTabContent()}
-      </Box>
-    );
-  }
+  return (
+    <Box position="relative">
+      {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+      <FocusManager refs={tabRefs.current as any} defaultFocusedIndex={selectedIndex}>
+        {({ focusedIndex, setFocusedIndex, handleArrowNavigation }) => (
+          <TabScrollIndicators tabRefs={tabRefs.current} tabContainerRef={tabContainerRef}>
+            {({ handleScroll }) => (
+              <TabContainer
+                className={className}
+                role="tablist"
+                onScroll={handleScroll}
+                ref={tabContainerRef}
+                {...spaceProps}
+              >
+                {getTabs(setFocusedIndex, focusedIndex, handleArrowNavigation)}
+              </TabContainer>
+            )}
+          </TabScrollIndicators>
+        )}
+      </FocusManager>
+      {getTabContent()}
+    </Box>
+  );
 }
-
-Tabs.defaultProps = {
-  children: null,
-  className: undefined,
-  selectedIndex: undefined,
-  defaultSelectedIndex: null,
-  renderTabContentOnlyWhenSelected: false,
-  fitted: false,
-  onTabClick: undefined,
-};
 
 export default Tabs;


### PR DESCRIPTION
## Description

Converts `Tabs` and `TabScrollIndicators` from legacy class components to function components, removing all `// @ts-nocheck` suppressions and tightening types throughout.

As part of this, `react-resize-detector`'s removed render-prop component API was also replaced with the `useResizeDetector` hook in both `TabScrollIndicators` and `BrandedNavBar/NavBar` (the broken default import was previously hidden by a stale Vite dep cache).

**Bug fixed:** Both scroll indicator buttons previously passed the class method directly as an `onClick` handler, so `handleIndicatorClick` always received a `MouseEvent` — meaning `side === "right"` was always `false` and both buttons ran the left-scroll logic. Each button now passes the correct side string.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [ ] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [x] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [x] Appropriate tests have been added
- [ ] Documentation has been updated
- [x] Accessibility has been considered