### PR TITLE
refactor: replace @reach/dialog with @radix-ui/react-dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
     "@radix-ui/react-dialog": "^1.1.0",
     "@radix-ui/react-navigation-menu": "^1.1.4",
     "@radix-ui/react-tooltip": "1.2.8",
-    "@reach/dialog": "0.18.0",
     "@styled-system/prop-types": "^5.1.4",
     "@styled-system/theme-get": "^5.1.2",
     "@types/react-window": "^1.8.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: 1.2.8
         version: 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@reach/dialog':
-        specifier: 0.18.0
-        version: 0.18.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@styled-system/prop-types':
         specifier: ^5.1.4
         version: 5.1.5(styled-system@5.1.5)
@@ -1266,29 +1263,6 @@ packages:
 
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
-
-  '@reach/dialog@0.18.0':
-    resolution: {integrity: sha512-hWhzmBK8VJj+yf6OivFqHFZIV4q9TISZrkPaglKE5oFYtrr75lxWjrBTA+BshL0r/FfKodvNtdT8yq4vj/6Gcw==}
-    peerDependencies:
-      react: ^16.8.0 || 17.x
-      react-dom: ^16.8.0 || 17.x
-
-  '@reach/polymorphic@0.18.0':
-    resolution: {integrity: sha512-N9iAjdMbE//6rryZZxAPLRorzDcGBnluf7YQij6XDLiMtfCj1noa7KyLpEc/5XCIB/EwhX3zCluFAwloBKdblA==}
-    peerDependencies:
-      react: ^16.8.0 || 17.x
-
-  '@reach/portal@0.18.0':
-    resolution: {integrity: sha512-TImozRapd576ofRk30Le2L3lRTFXF1p47B182wnp5eMTdZa74JX138BtNGEPJFOyrMaVmguVF8SSwZ6a0fon1Q==}
-    peerDependencies:
-      react: ^16.8.0 || 17.x
-      react-dom: ^16.8.0 || 17.x
-
-  '@reach/utils@0.18.0':
-    resolution: {integrity: sha512-KdVMdpTgDyK8FzdKO9SCpiibuy/kbv3pwgfXshTI6tEcQT1OOwj7BAksnzGC0rPz0UholwC+AgkqEl3EJX3M1A==}
-    peerDependencies:
-      react: ^16.8.0 || 17.x
-      react-dom: ^16.8.0 || 17.x
 
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
@@ -2543,10 +2517,6 @@ packages:
     resolution: {integrity: sha512-2kCCtc+JvcZ86IGAz3Z2Y0A1baIz9fL31pH/0S1IqZr9Iwnjq8izfPtrCyQKO6TLMPELLsQMre7VDqeIKCsHkA==}
     engines: {node: '>=18'}
 
-  focus-lock@0.9.2:
-    resolution: {integrity: sha512-YtHxjX7a0IC0ZACL5wsX8QdncXofWpGPNoVMuI/nZUrPGp6LmNI6+D5j0pPj+v8Kw5EpweA+T5yImK0rnWf7oQ==}
-    engines: {node: '>=10'}
-
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
@@ -3703,11 +3673,6 @@ packages:
       react: ^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  react-clientside-effect@1.2.8:
-    resolution: {integrity: sha512-ma2FePH0z3px2+WOu6h+YycZcEvFmmxIlAb62cF52bG86eMySciO/EQZeQMXd07kPCYB0a1dWDT5J+KE9mCDUw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-
   react-color@2.19.3:
     resolution: {integrity: sha512-LEeGE/ZzNLIsFWa1TMe8y5VYqr7bibneWmvJwm1pCn/eNmrabWDh659JSPn9BuaMpEfU83WTOJfnCcjDZwNQTA==}
     peerDependencies:
@@ -3735,11 +3700,6 @@ packages:
 
   react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
-
-  react-focus-lock@2.5.2:
-    resolution: {integrity: sha512-WzpdOnEqjf+/A3EH9opMZWauag7gV0BxFl+EY4ElA4qFqYsUsBLnmo2sELbN5OC30S16GAWMy16B9DLPpdJKAQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
 
   react-hot-toast@2.6.0:
     resolution: {integrity: sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==}
@@ -3807,16 +3767,6 @@ packages:
     peerDependencies:
       '@types/react': '*'
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  react-remove-scroll@2.4.3:
-    resolution: {integrity: sha512-lGWYXfV6jykJwbFpsuPdexKKzp96f3RbvGapDSIdcyGvHb7/eqyn46C7/6h+rUzYar1j5mdU+XECITHXCKBk9Q==}
-    engines: {node: '>=8.5.0'}
-    peerDependencies:
-      '@types/react': ^16.8.0 || ^17.0.0
-      react: ^16.8.0 || ^17.0.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -4410,9 +4360,6 @@ packages:
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
-
-  tslib@1.14.1:
-    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -5677,33 +5624,6 @@ snapshots:
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
   '@radix-ui/rect@1.1.1': {}
-
-  '@reach/dialog@0.18.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@reach/polymorphic': 0.18.0(react@18.3.1)
-      '@reach/portal': 0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@reach/utils': 0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-focus-lock: 2.5.2(@types/react@18.3.28)(react@18.3.1)
-      react-remove-scroll: 2.4.3(@types/react@18.3.28)(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/react'
-
-  '@reach/polymorphic@0.18.0(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
-
-  '@reach/portal@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@reach/utils': 0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
-  '@reach/utils@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
@@ -7083,10 +7003,6 @@ snapshots:
       semver-regex: 4.0.5
       super-regex: 1.1.0
 
-  focus-lock@0.9.2:
-    dependencies:
-      tslib: 2.8.1
-
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
@@ -8120,11 +8036,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  react-clientside-effect@1.2.8(react@18.3.1):
-    dependencies:
-      '@babel/runtime': 7.29.2
-      react: 18.3.1
-
   react-color@2.19.3(react@18.3.1):
     dependencies:
       '@icons/material': 0.2.4(react@18.3.1)
@@ -8173,18 +8084,6 @@ snapshots:
       scheduler: 0.23.2
 
   react-fast-compare@3.2.2: {}
-
-  react-focus-lock@2.5.2(@types/react@18.3.28)(react@18.3.1):
-    dependencies:
-      '@babel/runtime': 7.29.2
-      focus-lock: 0.9.2
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-clientside-effect: 1.2.8(react@18.3.1)
-      use-callback-ref: 1.3.3(@types/react@18.3.28)(react@18.3.1)
-      use-sidecar: 1.1.3(@types/react@18.3.28)(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/react'
 
   react-hot-toast@2.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -8250,17 +8149,6 @@ snapshots:
       react: 18.3.1
       react-style-singleton: 2.2.3(@types/react@18.3.28)(react@18.3.1)
       tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 18.3.28
-
-  react-remove-scroll@2.4.3(@types/react@18.3.28)(react@18.3.1):
-    dependencies:
-      react: 18.3.1
-      react-remove-scroll-bar: 2.3.8(@types/react@18.3.28)(react@18.3.1)
-      react-style-singleton: 2.2.3(@types/react@18.3.28)(react@18.3.1)
-      tslib: 1.14.1
-      use-callback-ref: 1.3.3(@types/react@18.3.28)(react@18.3.1)
-      use-sidecar: 1.1.3(@types/react@18.3.28)(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.28
 
@@ -8987,8 +8875,6 @@ snapshots:
       json5: 2.2.3
       minimist: 1.2.8
       strip-bom: 3.0.0
-
-  tslib@1.14.1: {}
 
   tslib@2.8.1: {}
 

--- a/src/BottomSheet/BottomSheet.parts.tsx
+++ b/src/BottomSheet/BottomSheet.parts.tsx
@@ -1,18 +1,9 @@
-import type { DialogOverlayProps } from "@reach/dialog";
+import * as Dialog from "@radix-ui/react-dialog";
 import { AnimatePresence, type AnimatePresenceProps } from "framer-motion";
 import React from "react";
 import type { HeightProps, LayoutProps, MaxHeightProps, MaxWidthProps, SpaceProps, WidthProps } from "styled-system";
-import {
-  ContentContainer,
-  Footer,
-  Header,
-  HelpText,
-  Overlay,
-  OverlayDialog,
-  Sheet,
-  SheetDialog,
-  Title,
-} from "./BottomSheet.styled";
+import { useScrollLock } from "../utils/useScrollLock";
+import { ContentContainer, Footer, Header, HelpText, Overlay, Sheet, Title } from "./BottomSheet.styled";
 import { BottomSheetProvider, useBottomSheet } from "./BottomSheetProvider";
 
 const overlayVariants = {
@@ -38,44 +29,54 @@ interface RootProps extends AnimatePresenceProps {
 
 function Root({ isOpen, onClose, children, ...props }: RootProps) {
   return (
-    <AnimatePresence {...props}>
-      {isOpen && (
-        <BottomSheetProvider key="bottom-sheet" isOpen={isOpen} onClose={onClose}>
-          {children}
-        </BottomSheetProvider>
-      )}
-    </AnimatePresence>
+    <Dialog.Root
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <AnimatePresence {...props}>
+        {isOpen && (
+          <BottomSheetProvider key="bottom-sheet" isOpen={isOpen} onClose={onClose}>
+            {children}
+          </BottomSheetProvider>
+        )}
+      </AnimatePresence>
+    </Dialog.Root>
   );
 }
 
-interface OverlayPartProps extends DialogOverlayProps {
+interface OverlayPartProps {
   closeOnClick?: boolean;
+  children: React.ReactNode;
 }
 
-function OverlayPart({ closeOnClick, children, ...props }: OverlayPartProps) {
+function OverlayPart({ closeOnClick, children }: OverlayPartProps) {
   const { onClose, isOpen } = useBottomSheet();
   const [isAnimationComplete, setAnimationComplete] = React.useState(false);
 
   return (
-    <OverlayDialog isOpen={isOpen} {...props}>
-      <Overlay
-        data-testid="bottom-sheet-overlay"
-        data-visible={isAnimationComplete ? true : undefined}
-        variants={overlayVariants}
-        initial="hidden"
-        animate="visible"
-        exit="hidden"
-        transition={transition}
-        onAnimationComplete={() => {
-          if (isOpen) {
-            setAnimationComplete(true);
-          }
-        }}
-        onClick={closeOnClick ? onClose : undefined}
-      >
-        {children}
-      </Overlay>
-    </OverlayDialog>
+    <Dialog.Portal forceMount>
+      <Dialog.Overlay asChild forceMount>
+        <Overlay
+          data-testid="bottom-sheet-overlay"
+          data-visible={isAnimationComplete ? true : undefined}
+          variants={overlayVariants}
+          initial="hidden"
+          animate="visible"
+          exit="hidden"
+          transition={transition}
+          onAnimationComplete={() => {
+            if (isOpen) {
+              setAnimationComplete(true);
+            }
+          }}
+          onClick={closeOnClick ? onClose : undefined}
+        >
+          {children}
+        </Overlay>
+      </Dialog.Overlay>
+    </Dialog.Portal>
   );
 }
 
@@ -87,13 +88,20 @@ interface SheetPartProps extends WidthProps, MaxWidthProps, HeightProps, MaxHeig
 function SheetPart({ children, "aria-label": ariaLabel, ...props }: SheetPartProps) {
   const { isOpen } = useBottomSheet();
   const [isAnimationComplete, setAnimationComplete] = React.useState(false);
+  useScrollLock();
 
   function handleSheetClick(e: React.MouseEvent<HTMLDivElement, MouseEvent>) {
     e.stopPropagation();
   }
 
   return (
-    <SheetDialog aria-label={ariaLabel}>
+    <Dialog.Content
+      asChild
+      forceMount
+      aria-label={ariaLabel}
+      onEscapeKeyDown={(e) => e.preventDefault()}
+      onPointerDownOutside={(e) => e.preventDefault()}
+    >
       <Sheet
         data-testid="bottom-sheet-body"
         data-visible={isAnimationComplete ? true : undefined}
@@ -112,7 +120,7 @@ function SheetPart({ children, "aria-label": ariaLabel, ...props }: SheetPartPro
       >
         {children}
       </Sheet>
-    </SheetDialog>
+    </Dialog.Content>
   );
 }
 

--- a/src/BottomSheet/BottomSheet.styled.tsx
+++ b/src/BottomSheet/BottomSheet.styled.tsx
@@ -1,23 +1,13 @@
-import {
-  type DialogContentProps,
-  type DialogOverlayProps,
-  DialogContent as ReachDialogContent,
-  DialogOverlay as ReachDialogOverlay,
-} from "@reach/dialog";
 import type { MotionProps } from "framer-motion";
 import { motion } from "framer-motion";
 import { transparentize } from "polished";
-import type React from "react";
 import { styled } from "styled-components";
 import type { HeightProps, LayoutProps, MaxHeightProps, MaxWidthProps, SpaceProps, WidthProps } from "styled-system";
 import { compose, height, layout, maxHeight, maxWidth, space, width } from "styled-system";
 import { excludeStyledProps } from "../StyledProps";
 import { Heading2, Text } from "../Type";
 
-// Portal + focus-lock + scroll-lock wrapper (no visual styles)
-const OverlayDialog = styled(ReachDialogOverlay as React.ComponentType<DialogOverlayProps>)({});
-
-// Animated backdrop
+// Animated backdrop (composed with Dialog.Overlay via asChild at the call site)
 const Overlay = styled(motion.div)(({ theme }) => ({
   position: "fixed",
   inset: 0,
@@ -27,15 +17,6 @@ const Overlay = styled(motion.div)(({ theme }) => ({
   backgroundColor: transparentize(0.5, theme.colors.blackBlue),
   zIndex: theme.zIndices.overlay,
 }));
-
-// Transparent a11y wrapper (role="dialog", aria-modal, focus containment)
-const SheetDialog = styled(ReachDialogContent as React.ComponentType<DialogContentProps>)({
-  width: "100%",
-  display: "flex",
-  justifyContent: "center",
-  padding: 0,
-  background: "none",
-});
 
 interface SheetProps
   extends MotionProps,
@@ -126,4 +107,4 @@ const HelpText = styled(Text)(({ theme }) => ({
   },
 }));
 
-export { ContentContainer, Footer, Header, HelpText, Overlay, OverlayDialog, Sheet, SheetDialog, Title };
+export { ContentContainer, Footer, Header, HelpText, Overlay, Sheet, Title };

--- a/src/NDSProvider/ModalStyleOverride.tsx
+++ b/src/NDSProvider/ModalStyleOverride.tsx
@@ -3,10 +3,7 @@ import { createGlobalStyle } from "styled-components";
 const ModalStyleOverride = createGlobalStyle<{ locale?: string }>(({ theme, locale }) => {
   const fontFamily = locale === "zh_CN" ? theme.fonts.sc : theme.fonts.base;
   return {
-    ":root": {
-      "--reach-dialog": 1,
-    },
-    ".ReactModal__Content, [data-reach-dialog-content]": {
+    '.ReactModal__Content, [role="dialog"]': {
       "-webkit-font-smoothing": "antialiased",
       "-moz-osx-font-smoothing": "grayscale",
       "*": { boxSizing: "border-box" },

--- a/src/TopBar/TopBar.styled.tsx
+++ b/src/TopBar/TopBar.styled.tsx
@@ -1,4 +1,3 @@
-import { DialogOverlay } from "@reach/dialog";
 import { motion } from "framer-motion";
 import { transparentize } from "polished";
 import { styled } from "styled-components";
@@ -112,7 +111,7 @@ const StyledPageTitle = styled.li(({ theme }) => ({
   overflow: "hidden",
 }));
 
-const Overlay = styled(motion(DialogOverlay))(({ theme }) => ({
+const Overlay = styled(motion.div)(({ theme }) => ({
   position: "fixed",
   top: theme.space[TOPBAR.themedHeight],
   bottom: theme.space.none,

--- a/src/TopBar/components/Menu.tsx
+++ b/src/TopBar/components/Menu.tsx
@@ -1,4 +1,4 @@
-import { DialogContent } from "@reach/dialog";
+import * as Dialog from "@radix-ui/react-dialog";
 import { AnimatePresence } from "framer-motion";
 import React from "react";
 import { useTranslation } from "react-i18next";
@@ -42,50 +42,50 @@ export function Menu({
   const [animationComplete, setAnimationComplete] = React.useState(false);
   const { t } = useTranslation();
 
-  function close() {
-    setShowMenu(false);
-    setAnimationComplete(false);
-  }
-
-  function toggle() {
-    if (!showMenu) {
-      setAnimationComplete(false);
-    }
-    setShowMenu((s) => !s);
-  }
-
   return (
     <Flex justifyContent="flex-end" as="li" color="black" flex="1 1">
-      <MenuButton onClick={toggle} data-testid="topbar-menu-button">
-        <Icon size="x3" color="midGrey" icon={showMenu ? "close" : "apps"} />
-      </MenuButton>
-      <AnimatePresence>
-        {showMenu && (
-          <Overlay
-            data-testid="topbar-menu-overlay"
-            data-visible={animationComplete ? "true" : undefined}
-            initial="hidden"
-            animate="visible"
-            exit="exit"
-            variants={blurVariants}
-            isOpen={showMenu}
-            onAnimationComplete={() => {
-              if (showMenu) {
-                setAnimationComplete(true);
-              }
-            }}
-            onDismiss={close}
-          >
-            <DialogContent
-              data-testid="topbar-menu"
-              data-visible={animationComplete ? true : undefined}
-              aria-label={props["aria-label"] ?? t("menu options")}
-            >
-              <MenuItemList>{children}</MenuItemList>
-            </DialogContent>
-          </Overlay>
-        )}
-      </AnimatePresence>
+      <Dialog.Root
+        open={showMenu}
+        onOpenChange={(open) => {
+          if (!open) setAnimationComplete(false);
+          setShowMenu(open);
+        }}
+      >
+        <Dialog.Trigger asChild>
+          <MenuButton data-testid="topbar-menu-button">
+            <Icon size="x3" color="midGrey" icon={showMenu ? "close" : "apps"} />
+          </MenuButton>
+        </Dialog.Trigger>
+        <AnimatePresence>
+          {showMenu && (
+            <Dialog.Portal forceMount>
+              <Dialog.Overlay asChild forceMount>
+                <Overlay
+                  data-testid="topbar-menu-overlay"
+                  data-visible={animationComplete ? "true" : undefined}
+                  initial="hidden"
+                  animate="visible"
+                  exit="exit"
+                  variants={blurVariants}
+                  onAnimationComplete={() => {
+                    if (showMenu) {
+                      setAnimationComplete(true);
+                    }
+                  }}
+                >
+                  <Dialog.Content
+                    data-testid="topbar-menu"
+                    data-visible={animationComplete ? true : undefined}
+                    aria-label={props["aria-label"] ?? t("menu options")}
+                  >
+                    <MenuItemList>{children}</MenuItemList>
+                  </Dialog.Content>
+                </Overlay>
+              </Dialog.Overlay>
+            </Dialog.Portal>
+          )}
+        </AnimatePresence>
+      </Dialog.Root>
     </Flex>
   );
 }


### PR DESCRIPTION
## Summary

- Migrates the two remaining `@reach/dialog` consumers (`TopBar.Menu` and `BottomSheet`) onto `@radix-ui/react-dialog`, matching the pattern already used by `Modal`.
- Uses `Dialog.Root` + `Dialog.Portal` + `Dialog.Overlay`/`Content` with `asChild` + `forceMount` so framer-motion's `AnimatePresence` keeps owning enter/exit animations. Drops the discouraged `motion(DialogOverlay)` HOC pattern in `TopBar.styled.tsx`.
- Removes `@reach/dialog` from `package.json` and updates the stale `[data-reach-dialog-content]` selector in `NDSProvider/ModalStyleOverride.tsx` to `[role="dialog"]`.

Behaviour preserved: all existing test IDs (`topbar-menu-button`, `topbar-menu-overlay`, `topbar-menu`, `bottom-sheet-overlay`, `bottom-sheet-body`), the `data-visible` animation-completion attribute, and the historical close-paths (BottomSheet's overlay-click-only-when-`closeOnClick` and no-escape-key behaviour are both held via explicit `onEscapeKeyDown` / `onPointerDownOutside` `preventDefault` on `Dialog.Content`). `useScrollLock()` replaces Reach's built-in body-scroll lock inside `BottomSheet`.

One narrowing: `BottomSheetParts.Overlay`'s prop type changes from `extends DialogOverlayProps` to `{ closeOnClick?, children }`. The previous extension exposed Reach-only props that no consumer used and that conflict with `motion.div`'s `onDrag` typing.

## Test plan

- [x] `pnpm check` (tsc + biome)
- [x] `pnpm test:components` (Vitest unit tests)
- [ ] `pnpm start` — Storybook walkthrough:
  - [ ] `TopBar/Default` and `TopBar/Menu/*` — open via button, close via overlay click, close via escape, focus returns to trigger, button icon swaps `apps`↔`close`, blur backdrop animates in/out
  - [ ] `BottomSheet/Basic Usage` — open/close via close button, overlay click closes, escape does NOT close (parity with prior behaviour)
  - [ ] `BottomSheet/Features/Disable Close On Overlay Click` — overlay click and escape both suppressed, primary action still closes (existing `play()` test covers open/close-button/reopen)
  - [ ] `BottomSheet/Features/With An Application Frame` — TopBar Menu + BottomSheet together
  - [ ] `BottomSheet/Parts/Rendered Using Compositional API` — compositional Parts API still renders
  - [ ] `Modal/Example Controlled Modal` — regression check that the `[role="dialog"]` selector change in `ModalStyleOverride` doesn't visually break the existing Modal
- [ ] Chromatic snapshots green

🤖 Generated with [Claude Code](https://claude.com/claude-code)