### PR TITLE
chore(deps): upgrade date-fns to v3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "@styled-system/theme-get": "^5.1.2",
     "@types/react-window": "^1.8.8",
     "@types/styled-system": "5.1.25",
-    "date-fns": "^2.30.0",
+    "date-fns": "^3.6.0",
     "debounce": "^3.0.0",
     "deep-equal": "^2.2.1",
     "framer-motion": "^12.38.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: 5.1.25
         version: 5.1.25
       date-fns:
-        specifier: ^2.30.0
-        version: 2.30.0
+        specifier: ^3.6.0
+        version: 3.6.0
       debounce:
         specifier: ^3.0.0
         version: 3.0.0
@@ -2247,6 +2247,9 @@ packages:
   date-fns@2.30.0:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
     engines: {node: '>=0.11'}
+
+  date-fns@3.6.0:
+    resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
 
   debounce@3.0.0:
     resolution: {integrity: sha512-64byRbF0/AirwbuHqB3/ZpMG9/nckDa6ZA0yd6UnaQNwbbemCOwvz2sL5sjXLHhZHADyiwLm0M5qMhltUUx+TA==}
@@ -6690,6 +6693,8 @@ snapshots:
   date-fns@2.30.0:
     dependencies:
       '@babel/runtime': 7.29.2
+
+  date-fns@3.6.0: {}
 
   debounce@3.0.0: {}
 


### PR DESCRIPTION
## Summary
- Bumps \`date-fns\` from \`^2.30.0\` to \`^3.6.0\`. **Zero source changes** — every callsite already uses the named-export import style (\`import { format } from \"date-fns\"\`, \`import { es } from \"date-fns/locale\"\`) that v3 standardised, so the flat-package migration was a no-op for us.
- All 567 storybook tests + 38 unit tests pass, including the WeekPicker French-locale story (real Chromium), which confirms the v3 locale objects still work at runtime with react-datepicker v5's \`registerLocale\` despite the v5 peer dep declaring \`^2.30.0\`.

## Why now
This is a prerequisite for upgrading react-datepicker to v6+ in a future PR. v6 declares date-fns v3 as a dependency; consolidating both date-fns versions in our tree at v3 lets us move forward.

## Known noise
\`pnpm peers check\` will continue to flag react-datepicker v5 wanting \`date-fns: ^2.30.0\` — that's a peer-range bug in react-datepicker v5 itself (v3 locales work fine at runtime). It'll resolve when we move to react-datepicker v6+.

## Test plan
- [x] \`pnpm check && pnpm test\` (567/567 storybook + 38/38 unit)
- [x] \`pnpm build\`
- [ ] Eyeball the WeekPicker / DatePicker / MonthPicker stories in Storybook
- [ ] Review Chromatic snapshots — no popper or formatting diffs expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)