### PR TITLE
chore(deps): upgrade react-datepicker to v6.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
   },
   "dependencies": {
     "@emotion/is-prop-valid": "^1.3.1",
-    "@floating-ui/react": "^0.26.28",
+    "@floating-ui/react": "^0.27.0",
     "@nulogy/tokens": "^6.2.0",
     "@radix-ui/react-dialog": "^1.1.0",
     "@radix-ui/react-navigation-menu": "^1.1.4",
@@ -127,7 +127,7 @@
     "framer-motion": "^12.38.0",
     "i18next": "^26.0.3",
     "polished": "4.3.1",
-    "react-datepicker": "^5.1.0",
+    "react-datepicker": "^6.9.0",
     "react-fast-compare": "^3.2.0",
     "react-hot-toast": "^2.6.0",
     "react-i18next": "^17.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.3.1
         version: 1.4.0
       '@floating-ui/react':
-        specifier: ^0.26.28
-        version: 0.26.28(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^0.27.0
+        version: 0.27.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@nulogy/tokens':
         specifier: ^6.2.0
         version: 6.2.0
@@ -60,8 +60,8 @@ importers:
         specifier: 4.3.1
         version: 4.3.1
       react-datepicker:
-        specifier: ^5.1.0
-        version: 5.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^6.9.0
+        version: 6.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-fast-compare:
         specifier: ^3.2.0
         version: 3.2.2
@@ -862,6 +862,12 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
+
+  '@floating-ui/react@0.27.19':
+    resolution: {integrity: sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==}
+    peerDependencies:
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
@@ -2085,9 +2091,6 @@ packages:
     resolution: {integrity: sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==}
     engines: {node: '>=0.10.0'}
 
-  classnames@2.5.1:
-    resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
-
   clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
@@ -2119,6 +2122,10 @@ packages:
   clone@2.1.2:
     resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
     engines: {node: '>=0.8'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   collection-visit@1.0.0:
     resolution: {integrity: sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw==}
@@ -2243,10 +2250,6 @@ packages:
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-
-  date-fns@2.30.0:
-    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
-    engines: {node: '>=0.11'}
 
   date-fns@3.6.0:
     resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
@@ -3718,8 +3721,8 @@ packages:
     peerDependencies:
       react: '*'
 
-  react-datepicker@5.1.0:
-    resolution: {integrity: sha512-elwEnHpd9dQ4U/u7f2vsFdK1CchrOkPPR6rRDQWIzOgqM+Dty43c0tK/IPumrcPSMpRcyDu1okHmbs5m3xlz7w==}
+  react-datepicker@6.9.0:
+    resolution: {integrity: sha512-QTxuzeem7BUfVFWv+g5WuvzT0c5BPo+XTCNbMTZKSZQLU+cMMwSUHwspaxuIcDlwNcOH0tiJ+bh1fJ2yxOGYWA==}
     peerDependencies:
       react: ^16.9.0 || ^17 || ^18
       react-dom: ^16.9.0 || ^17 || ^18
@@ -5280,6 +5283,14 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       tabbable: 6.4.0
 
+  '@floating-ui/react@0.27.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/utils': 0.2.11
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tabbable: 6.4.0
+
   '@floating-ui/utils@0.2.11': {}
 
   '@floating-ui/utils@0.2.9': {}
@@ -6516,8 +6527,6 @@ snapshots:
       isobject: 3.0.1
       static-extend: 0.1.2
 
-  classnames@2.5.1: {}
-
   clean-stack@2.2.0: {}
 
   clean-stack@5.3.0:
@@ -6558,6 +6567,8 @@ snapshots:
       wrap-ansi: 9.0.2
 
   clone@2.1.2: {}
+
+  clsx@2.1.1: {}
 
   collection-visit@1.0.0:
     dependencies:
@@ -6689,10 +6700,6 @@ snapshots:
       whatwg-url: 16.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
-
-  date-fns@2.30.0:
-    dependencies:
-      '@babel/runtime': 7.29.2
 
   date-fns@3.6.0: {}
 
@@ -8117,11 +8124,11 @@ snapshots:
       reactcss: 1.2.3(react@18.3.1)
       tinycolor2: 1.4.2
 
-  react-datepicker@5.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-datepicker@6.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@floating-ui/react': 0.26.28(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      classnames: 2.5.1
-      date-fns: 2.30.0
+      clsx: 2.1.1
+      date-fns: 3.6.0
       prop-types: 15.8.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)


### PR DESCRIPTION
## Summary
- Bumps \`react-datepicker\` from \`^5.1.0\` to \`^6.9.0\`. **Zero source changes** — v6's only major change from v5 was bumping its date-fns peer to v3, which we already landed in #1788.
- Bumps \`@floating-ui/react\` from \`^0.26.28\` to \`^0.27.0\` — forward step, API-compatible for our \`offset()\` usage, reduces churn if we revisit v7+ later.
- All 567 storybook tests + 38 unit tests pass.

## Why not v7?
v7's TypeScript rewrite is mechanical (renamed type exports, dropped \`<string>\` generic, tightened \`popperProps\` type), but two more impactful changes block a clean upgrade:

1. **Real regression**: v7 drops \`react-onclickoutside\` and reworks focus management. The MonthPicker \`Default\` story breaks — clicking a month no longer closes the popper when paired with our \`customInput\`. Needs deeper investigation, possibly upstream.
2. **DatePicker test was a false positive**: \`.react-datepicker__day--002\` was never a valid class (v4 onwards only emits day-of-week classes like \`__day--mon\`). The test was accidentally passing in v5/v6 because clicking the null target fell through to \`react-onclickoutside\`'s body-click handler, which v7 removed. Fixing this is straightforward (aria-label query) but should land alongside the regression fix.

v8+ require React 19, which is outside our peer range (\`react: <19.0.0\`).

## Test plan
- [x] \`pnpm check && pnpm test\` (567/567 storybook + 38/38 unit)
- [x] \`pnpm build\`
- [ ] Eyeball DatePicker, MonthPicker, WeekPicker, DateRange stories in Storybook
- [ ] Review Chromatic snapshots — no popper or rendering diffs expected since the v5→v6 source delta is zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)