### PR TITLE
fix(Navigation): keep dropdown menus within the viewport and scroll

### DIFF
--- a/src/Navigation/components/DesktopNav/DesktopNav.tsx
+++ b/src/Navigation/components/DesktopNav/DesktopNav.tsx
@@ -66,7 +66,7 @@ export default function DesktopNav({
       {/* ----------------------- Secondary ------------------------------ */}
       <NavigationMenuList ref={secondaryMenuRef}>
         {secondaryNavigation.map((item) => (
-          <NavigationMenuItem key={item.key} item={item} />
+          <NavigationMenuItem key={item.key} item={item} align="end" />
         ))}
 
         {secondaryNavigation.length > 0 && userMenuExists && <VerticalDivider />}

--- a/src/Navigation/components/MenuSubItem/MenuSubItem.tsx
+++ b/src/Navigation/components/MenuSubItem/MenuSubItem.tsx
@@ -1,3 +1,4 @@
+import { autoUpdate, flip, offset, shift, size, useFloating } from "@floating-ui/react";
 import * as RadixNavigationMenu from "@radix-ui/react-navigation-menu";
 import React from "react";
 import { useTheme } from "styled-components";
@@ -15,6 +16,30 @@ type Props = {
 
 export function MenuSubItem({ item, level }: Props) {
   const theme = useTheme();
+
+  // Position the submenu flyout with floating-ui so it stays within the
+  // viewport: flip/shift off the edges and cap its height to the available
+  // space (it scrolls via overflow-y) instead of running off-screen.
+  const { refs, floatingStyles } = useFloating({
+    placement: "right-start",
+    strategy: "fixed",
+    // Position via top/left rather than a transform so the flyout is not a
+    // containing block for deeper (fixed) flyouts — they need to escape its
+    // overflow-x: hidden.
+    transform: false,
+    middleware: [
+      offset({ crossAxis: -parseFloat(theme.space.x1), mainAxis: -parseFloat(theme.space.half) }),
+      flip({ fallbackAxisSideDirection: "start" }),
+      shift({ padding: parseFloat(theme.space.x1) }),
+      size({
+        padding: parseFloat(theme.space.x1),
+        apply({ availableHeight, elements }) {
+          elements.floating.style.maxHeight = `${availableHeight}px`;
+        },
+      }),
+    ],
+    whileElementsMounted: autoUpdate,
+  });
 
   /* ---------------------------------------------------------------------
    * Separator
@@ -69,9 +94,14 @@ export function MenuSubItem({ item, level }: Props) {
         </SubMenuItemLink>
       ) : (
         <>
-          <SubMenuItemButton {...item.props}>{content}</SubMenuItemButton>
+          <SubMenuItemButton ref={refs.setReference} {...item.props}>
+            {content}
+          </SubMenuItemButton>
           {hasSubMenu && (
-            <SubMenuContent left={`calc(100% - ${theme.space.half})`} top={`calc(-1 * ${theme.space.x1})`}>
+            <SubMenuContent
+              ref={refs.setFloating}
+              style={{ ...floatingStyles, overflowX: "hidden", overflowY: "auto" }}
+            >
               <RadixNavigationMenu.Sub orientation="vertical">
                 <SubMenuList>
                   {item.items?.map((subItem) => (

--- a/src/Navigation/components/MenuSubItem/parts/styled.tsx
+++ b/src/Navigation/components/MenuSubItem/parts/styled.tsx
@@ -2,7 +2,7 @@ import * as RadixNavigationMenu from "@radix-ui/react-navigation-menu";
 import { styled } from "styled-components";
 import { addStyledProps, type StyledProps } from "../../../../StyledProps";
 import type { DefaultNDSThemeType } from "../../../../theme";
-import { NAVIGATION_SUB_MENU_MIN_WIDTH_PX } from "../../shared/constants";
+import { NAVIGATION_MENU_HEIGHT_STYLED_UNITS, NAVIGATION_SUB_MENU_MIN_WIDTH_PX } from "../../shared/constants";
 import { disableHoverEvents } from "../../shared/disableHoverEvents";
 
 const getSharedPaddingStyles = (theme: DefaultNDSThemeType) => ({
@@ -71,6 +71,12 @@ export const SubMenuContent = styled(RadixNavigationMenu.Content).attrs(disableH
     position: "absolute",
     top: `calc(100% + ${theme.space.half})`,
     left: 0,
+    // Cap to the viewport so a long top-level menu scrolls rather than running
+    // off the bottom. Nested flyouts override this via floating-ui (see
+    // MenuSubItem); they are fixed-positioned so overflow here does not clip them.
+    maxHeight: `calc(100dvh - ${theme.space.x2} - ${theme.space[NAVIGATION_MENU_HEIGHT_STYLED_UNITS]})`,
+    overflowX: "hidden",
+    overflowY: "auto",
     minWidth: NAVIGATION_SUB_MENU_MIN_WIDTH_PX,
     display: "flex",
     flexDirection: "column",

--- a/src/Navigation/components/shared/NavigationMenuItem.tsx
+++ b/src/Navigation/components/shared/NavigationMenuItem.tsx
@@ -14,13 +14,15 @@ import { CaretDown, NavigationMenuLink, NavigationMenuTrigger, RadixNavigationMe
 export interface NavigationMenuItemProps extends RadixNavigationMenu.NavigationMenuItemProps {
   item: MenuItem;
   level?: number;
+  /** Which edge the dropdown aligns to. Secondary (right-hand) menus use "end" so they don't run off-screen. */
+  align?: "start" | "end";
 }
 
 /**
  * A single Radix <NavigationMenu.Item> that can represent any MenuItem variant.
  */
 export const NavigationMenuItem = React.forwardRef<HTMLLIElement, NavigationMenuItemProps>(
-  ({ item, level = 0, ...props }, forwardedRef) => {
+  ({ item, level = 0, align = "start", ...props }, forwardedRef) => {
     if (item.type === "separator") {
       return (
         <RadixNavigationMenuItem ref={forwardedRef} {...props}>
@@ -107,7 +109,7 @@ export const NavigationMenuItem = React.forwardRef<HTMLLIElement, NavigationMenu
         </NavigationMenuTrigger>
 
         {hasSubMenu && (
-          <SubMenuContent>
+          <SubMenuContent style={align === "end" ? { left: "auto", right: 0 } : undefined}>
             <RadixNavigationMenu.Sub orientation="vertical">
               <NavigationMenuSubList>
                 {item.items?.map((sub) => (

--- a/src/Navigation/stories/Navigation.navigationMenus.subMenus.story.tsx
+++ b/src/Navigation/stories/Navigation.navigationMenus.subMenus.story.tsx
@@ -125,6 +125,47 @@ export const SubMenus = () => {
   );
 };
 
+const manyItems = (prefix: string, count: number) =>
+  Array.from({ length: count }, (_, index) => ({
+    key: `${prefix}-${index}`,
+    label: `${prefix} item ${index + 1}`,
+    type: "button" as const,
+  }));
+
+export const TallMenus = () => {
+  return (
+    <Navigation
+      primaryNavigation={[
+        {
+          key: "reports",
+          label: "Reports",
+          type: "button",
+          items: [
+            ...manyItems("Category", 4),
+            {
+              key: "tall-submenu",
+              label: "Tall submenu",
+              type: "button",
+              // More items than fit on screen: the flyout should cap to the
+              // viewport and scroll rather than run off the bottom.
+              items: manyItems("Report", 30),
+            },
+          ],
+        },
+      ]}
+      secondaryNavigation={[
+        {
+          key: "create",
+          label: "Create",
+          type: "button",
+          // A tall top-level menu, to exercise overflow at the top level too.
+          items: manyItems("Create", 30),
+        },
+      ]}
+    />
+  );
+};
+
 export const SubMenuSeparator = () => {
   return (
     <Navigation


### PR DESCRIPTION
## What

Makes `Navigation` dropdown menus stay within the viewport:

- **Top-level panels** are capped to the viewport (`max-height` + `overflow-y: auto`, `overflow-x: hidden`) so a long menu scrolls instead of running off the bottom.
- **Submenu flyouts** are positioned with `@floating-ui/react` (`flip` / `shift` / `size`) so they flip away from screen edges and cap their height to the actual available space — a tall submenu that opens mid-screen now scrolls and stays reachable, rather than running off the bottom. They use `strategy: "fixed"` with `transform: false` so deeper flyouts escape the parent's overflow.
- **Secondary (right-hand) menus** right-align (`align="end"`) so a tall/wide menu doesn't spill off the right edge.

## Why

Long menus (e.g. a Reports menu with a deep Production submenu, or a tall Create menu) currently render off the bottom or right of the page with no way to reach the clipped items. The static `position: absolute` submenu had no knowledge of the space below it, so it couldn't cap/scroll correctly.

## Changes

- `MenuSubItem.tsx` — floating-ui positioning + scroll for nested submenu flyouts.
- `MenuSubItem/parts/styled.tsx` — `SubMenuContent` caps to the viewport and scrolls (top-level usage; nested usage overrides via floating-ui inline styles).
- `shared/NavigationMenuItem.tsx` — new `align?: "start" | "end"` prop for the dropdown edge.
- `DesktopNav.tsx` — passes `align="end"` for secondary nav items.
- `stories/Navigation.navigationMenus.subMenus.story.tsx` — new `TallMenus` story exercising a tall top-level menu and a tall nested submenu.

## Testing

- `pnpm check:types` and `biome check` pass.
- Verified in Storybook (new `TallMenus` story + existing `SubMenus`): top-level menus cap/scroll, nested submenus flip/shift/scroll and stay reachable, secondary menus right-align, primary menus unchanged, and short menus anchor correctly.
