### PR TITLE
fix(DatePickers): localize header from context and portal the calendar to escape modals

### DIFF
--- a/src/DatePickers/shared/components/BasePicker.tsx
+++ b/src/DatePickers/shared/components/BasePicker.tsx
@@ -145,6 +145,7 @@ export const BasePicker = forwardRef<ReactDatePicker, BasePickerProps>(
           onEnterKeyPress={onEnterKeyPress}
           popperPlacement="bottom-start"
           popperProps={getPopperProps(disableFlipping)}
+          portalId="nds-date-picker-portal"
           disabledKeyboardNavigation={disabledKeyboardNavigation}
         />
         <InlineValidation mt="x1" errorMessage={errorMessage} errorList={errorList} />

--- a/src/DatePickers/shared/components/DatePickerHeader.tsx
+++ b/src/DatePickers/shared/components/DatePickerHeader.tsx
@@ -3,6 +3,7 @@ import type { ReactDatePickerCustomHeaderProps } from "react-datepicker";
 import { useTranslation } from "react-i18next";
 import { ControlIcon } from "../../../Button";
 import { Flex } from "../../../Flex";
+import { useLocale } from "../../../NDSProvider/LocaleContext";
 import { Text } from "../../../Type";
 import { localizedFormat } from "../../../utils/localized-date-fns";
 
@@ -24,6 +25,8 @@ export function DatePickerHeader({
   locale,
 }: Props) {
   const { t } = useTranslation();
+  const { locale: contextLocale } = useLocale();
+  const resolvedLocale = locale ?? contextLocale;
 
   return (
     <Flex justifyContent="space-between" alignItems="center" py="half" px="x1">
@@ -41,7 +44,7 @@ export function DatePickerHeader({
         fontSize="large"
         style={{ textTransform: "capitalize" }}
       >
-        {localizedFormat(date, "MMMM yyyy", locale)}
+        {localizedFormat(date, "MMMM yyyy", resolvedLocale)}
       </Text>
       <ControlIcon
         icon="rightArrow"
@@ -62,6 +65,8 @@ export function MonthDatePickerHeader({
   locale,
 }: ReactDatePickerCustomHeaderProps & { locale?: string }) {
   const { t } = useTranslation();
+  const { locale: contextLocale } = useLocale();
+  const resolvedLocale = locale ?? contextLocale;
 
   return (
     <Flex justifyContent="space-between" alignItems="center" pb="x1_5">
@@ -72,7 +77,7 @@ export function MonthDatePickerHeader({
         disabled={prevMonthButtonDisabled}
       />
       <Text fontWeight="bold" color="blackBlue" px="x8" fontSize="large" style={{ textTransform: "capitalize" }}>
-        {localizedFormat(date, "yyyy", locale)}
+        {localizedFormat(date, "yyyy", resolvedLocale)}
       </Text>
       <ControlIcon
         icon="rightArrow"

--- a/src/DatePickers/shared/styles.ts
+++ b/src/DatePickers/shared/styles.ts
@@ -10,6 +10,10 @@ export const DatePickerStyles = createGlobalStyle(({ theme }) => ({
         position: "relative",
       },
     },
+  },
+  // The calendar renders in a portal (`portalId` in BasePicker), so its styles are
+  // scoped to that portal node.
+  "#nds-date-picker-portal": {
     ".react-datepicker__header": {
       backgroundColor: theme.colors.white,
       borderBottom: "none",
@@ -20,7 +24,7 @@ export const DatePickerStyles = createGlobalStyle(({ theme }) => ({
       display: "none",
     },
     ".react-datepicker-popper": {
-      zIndex: theme.zIndices.openControl,
+      zIndex: theme.zIndices.aboveOverlay,
     },
     ".react-datepicker-popper[data-placement^='bottom']": {
       marginTop: "0",

--- a/src/Modal/Modal.story.tsx
+++ b/src/Modal/Modal.story.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useState } from "react";
-import { expect, userEvent, within } from "storybook/test";
+import { expect, userEvent, waitFor, within } from "storybook/test";
 import {
   Button,
   ButtonGroup,
@@ -206,6 +206,39 @@ export const WithSelectAndScrollingContent: Story = {
     ),
   },
   name: "with select and scrolling content",
+};
+
+// Guards the date picker's portal behaviour: in a short modal the open calendar
+// extends past the modal body, so it must render in a portal to avoid being clipped
+// by the modal's overflow.
+export const WithDatePicker: Story = {
+  args: {
+    title: "Schedule delivery",
+    footerContent: (
+      <ButtonGroup>
+        <PrimaryButton>Schedule</PrimaryButton>
+        <QuietButton>Cancel</QuietButton>
+      </ButtonGroup>
+    ),
+    maxWidth: "456px",
+    onRequestClose: () => {},
+    children: (
+      <Form id="myForm" mb="x2">
+        <DatePicker
+          selected={new Date("2019-01-01T05:00:00.000Z")}
+          dateFormat="MMMM d, yyyy"
+          onChange={(val) => val}
+          onInputChange={(val) => val}
+        />
+      </Form>
+    ),
+  },
+  name: "with date picker",
+  play: async () => {
+    const body = within(document.body);
+    await userEvent.click(body.getByLabelText("select a date"));
+    await waitFor(() => expect(document.querySelector(".react-datepicker-popper")).toBeInTheDocument());
+  },
 };
 
 export const WithParentSelector: Story = {


### PR DESCRIPTION
## Description

Two fixes to the `DatePicker`, both surfaced while localizing date pickers into a new locale.

**1. The month/year header didn't localize from context.** The custom header rendered its caption from the explicit `locale` prop, which is `undefined` when a consumer relies on the `NDSProvider` context (the common case). So the caption fell back to English (e.g. "June 2026") while the rest of the calendar — weekday headers, etc. — localized correctly. `DatePickerHeader` / `MonthDatePickerHeader` now fall back to the `LocaleContext` locale (`locale ?? useLocale().locale`), mirroring what `BasePicker` already does for the picker itself.

**2. The calendar was clipped inside modals.** The calendar popper rendered inline, so a `Modal`'s `overflow: hidden` plus its `transform` containing block clipped the popup (a `strategy: "fixed"` popper can't escape a transformed ancestor). The calendar now renders in a portal (`portalId="nds-date-picker-portal"`); the popper/calendar styles were moved off `.nds-date-picker` onto the portal node so they still apply, and the popper's `z-index` was raised from `openControl` to `aboveOverlay` so it stacks above modals.

A new Modal story (**"with date picker"**) opens a calendar inside a short modal and leaves it open, so Chromatic captures the calendar escaping the modal — both as visual proof and as a regression guard.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [x] Appropriate tests have been added — new Modal "with date picker" story with a `play` that opens the calendar; existing DatePicker/MonthPicker/WeekPicker (21) and Modal (11) story play-tests pass; `tsc` and `biome` clean.
- [x] Documentation has been updated — the new Storybook story documents the date-picker-in-modal case.
- [x] Accessibility has been considered — portal keeps the calendar in the DOM and reachable; arrow-button labels unchanged; z-index raised so the open calendar isn't obscured by the modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
