### PR TITLE
fix(DateRange): stop onRangeChange infinite loop with inline callbacks

### DIFF
--- a/src/DateRange/DateRange.story.tsx
+++ b/src/DateRange/DateRange.story.tsx
@@ -1,6 +1,6 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { action } from "storybook/actions";
-import { expect, userEvent, waitFor, within } from "storybook/test";
+import { expect, fn, userEvent, waitFor, within } from "storybook/test";
 
 import { Box, Button, Flex, PrimaryButton } from "..";
 import DateRange from "./DateRange";
@@ -243,4 +243,99 @@ export const UsingRefToControlFocus = () => {
       </Flex>
     </Flex>
   );
+};
+
+// Regression test for the onRangeChange infinite loop (GO-11207). The wrapper passes a fresh
+// inline callback every render that also setStates — the exact consumer pattern that used to
+// re-fire the effect on every render and peg the CPU. The module-scoped spy is shared with
+// the play() function, which measures how many times the callback fires in a quiet window.
+const dateRangeLoopSpy = fn();
+export const DoesNotLoopWithInlineCallback = {
+  render: () => {
+    const [, setTick] = useState(0);
+    return (
+      <DateRange
+        onRangeChange={(value) => {
+          dateRangeLoopSpy(value);
+          setTick((tick) => tick + 1);
+        }}
+      />
+    );
+  },
+  name: "does not loop with an inline onRangeChange",
+  play: async () => {
+    await waitFor(() => expect(dateRangeLoopSpy).toHaveBeenCalled());
+    const before = dateRangeLoopSpy.mock.calls.length;
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    const after = dateRangeLoopSpy.mock.calls.length;
+    // Pre-fix the effect re-fired every render, so this quiet window captured hundreds of
+    // calls (the loop was measured at ~1000 in 1.5s). Post-fix it fires once on mount and
+    // then stays quiescent — no growth.
+    expect(after - before).toBeLessThan(3);
+  },
+};
+
+// Mount fire: the parent learns the initial/default range + validation error exactly once.
+const mountFireSpy = fn();
+export const FiresOnceOnMountWithDefaults = {
+  render: () => (
+    <DateRange
+      defaultStartDate={new Date("2019-01-01T05:00:00.000Z")}
+      defaultEndDate={new Date("2019-01-05T05:00:00.000Z")}
+      onRangeChange={mountFireSpy}
+    />
+  ),
+  name: "fires onRangeChange once on mount with defaults",
+  play: async () => {
+    await waitFor(() => expect(mountFireSpy).toHaveBeenCalledTimes(1));
+    const payload = mountFireSpy.mock.calls[0][0];
+    expect(payload.startDate).toEqual(new Date("2019-01-01T05:00:00.000Z"));
+    expect(payload.endDate).toEqual(new Date("2019-01-05T05:00:00.000Z"));
+    expect(payload.error).toBeUndefined();
+  },
+};
+
+// Invalid defaults: an end date before the start date is reported in the mount payload's error.
+const invalidDefaultsSpy = fn();
+export const ReportsErrorForInvalidDefaultsOnMount = {
+  render: () => (
+    <DateRange
+      defaultStartDate={new Date("2019-01-05T05:00:00.000Z")}
+      defaultEndDate={new Date("2019-01-01T05:00:00.000Z")}
+      onRangeChange={invalidDefaultsSpy}
+    />
+  ),
+  name: "reports error for invalid defaults on mount",
+  play: async () => {
+    await waitFor(() => expect(invalidDefaultsSpy).toHaveBeenCalledTimes(1));
+    expect(invalidDefaultsSpy.mock.calls[0][0].error).toBe("end date is before start date");
+  },
+};
+
+// C1 behavior: toggling the display-only `showTimes` prop must NOT fire onRangeChange — the
+// range didn't change. (Pre-refactor it fired because `showTimes` was in the effect deps.)
+const toggleSpy = fn();
+export const TogglingShowTimesDoesNotFire = {
+  render: () => {
+    const [showTimes, setShowTimes] = useState(false);
+    return (
+      <>
+        <DateRange
+          defaultStartDate={new Date("2019-01-01T05:00:00.000Z")}
+          defaultEndDate={new Date("2019-01-05T05:00:00.000Z")}
+          showTimes={showTimes}
+          onRangeChange={toggleSpy}
+        />
+        <Button onClick={() => setShowTimes((value) => !value)}>Toggle times</Button>
+      </>
+    );
+  },
+  name: "toggling showTimes does not fire onRangeChange",
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(() => expect(toggleSpy).toHaveBeenCalledTimes(1)); // mount fire
+    await userEvent.click(canvas.getByText("Toggle times"));
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(toggleSpy).toHaveBeenCalledTimes(1); // no extra fire for the toggle
+  },
 };

--- a/src/DateRange/DateRange.tsx
+++ b/src/DateRange/DateRange.tsx
@@ -46,6 +46,29 @@ type DateRangeProps = FieldProps & {
 
 const DEFAULT_LABEL = "Date Range";
 
+type RangeErrorInput = {
+  startDate?: Date | null;
+  endDate?: Date | null;
+  startTime?: string;
+  endTime?: string;
+  showTimes?: boolean;
+};
+
+function computeRangeError({ startDate, endDate, startTime, endTime, showTimes }: RangeErrorInput) {
+  let error: string | undefined;
+  if (endDate && startDate) {
+    if (isBefore(endDate, startDate) && (showTimes || !isSameDay(endDate, startDate))) {
+      error = "end date is before start date";
+    }
+    if (isSameDay(endDate, startDate) && showTimes) {
+      if (getDuration(startTime, endTime) < 0) {
+        error = "end time is before start time";
+      }
+    }
+  }
+  return error;
+}
+
 const DateRange = forwardRef<unknown, DateRangeProps>(
   (
     {
@@ -93,8 +116,19 @@ const DateRange = forwardRef<unknown, DateRangeProps>(
     const [endDate, setEndDate] = useState(defaultEndDate);
     const [startTime, setStartTime] = useState(defaultStartTime);
     const [endTime, setEndTime] = useState(defaultEndTime);
-    const [rangeError, setRangeError] = useState<string | undefined>();
     const { t } = useTranslation();
+
+    // Derived during render — a pure function of the dates/times/showTimes. No state, no effect.
+    const rangeError = computeRangeError({ startDate, endDate, startTime, endTime, showTimes });
+
+    // Notify the parent of the new range + its validation error. Called from the change handlers
+    // (which carry the new value as `overrides`, since the corresponding state setter hasn't
+    // updated the closure yet this render) and once on mount. No effect depends on changing data,
+    // so an inline `onRangeChange` can never re-trigger a loop.
+    const emitRange = (overrides: Partial<RangeErrorInput>) => {
+      const next = { startDate, endDate, startTime, endTime, ...overrides };
+      onRangeChange?.({ ...next, error: computeRangeError({ ...next, showTimes }) });
+    };
 
     const componentVariant = useComponentVariant(variant);
 
@@ -117,41 +151,19 @@ const DateRange = forwardRef<unknown, DateRangeProps>(
       },
     }));
 
-    const validateDateRange = () => {
-      let error: string | undefined;
-      if (endDate && startDate) {
-        if (isBefore(endDate, startDate) && (showTimes || !isSameDay(endDate, startDate))) {
-          error = "end date is before start date";
-        }
-        if (isSameDay(endDate, startDate) && showTimes) {
-          const duration = getDuration(startTime, endTime);
-          if (duration < 0) {
-            error = "end time is before start time";
-          }
-        }
-      }
-      setRangeError(error);
-      if (onRangeChange) {
-        onRangeChange({
-          startDate,
-          endDate,
-          startTime,
-          endTime,
-          error,
-        });
-      }
-    };
-
-    // biome-ignore lint/correctness/useExhaustiveDependencies: validateDateRange captures the listed deps; listing the function would cause infinite re-renders
+    // Mount-only by design — reports the initial/default range + error to the parent once.
+    // Empty deps cannot re-run, so no loop is possible even with an inline onRangeChange.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: emitRange is intentionally excluded so this fires exactly once on mount.
     useEffect(() => {
-      validateDateRange();
-    }, [startDate, endDate, startTime, endTime, showTimes, onRangeChange]);
+      emitRange({});
+    }, []);
 
     const changeStartTimeHandler = (label, value) => {
       setStartTime(value);
       if (onStartTimeChange) {
         onStartTimeChange(label, value);
       }
+      emitRange({ startTime: value });
     };
 
     const changeEndTimeHandler = (label, value) => {
@@ -159,6 +171,7 @@ const DateRange = forwardRef<unknown, DateRangeProps>(
       if (onEndTimeChange) {
         onEndTimeChange(label, value);
       }
+      emitRange({ endTime: value });
     };
 
     const changeStartDateHandler = (date) => {
@@ -166,6 +179,7 @@ const DateRange = forwardRef<unknown, DateRangeProps>(
       if (onStartDateChange) {
         onStartDateChange(date);
       }
+      emitRange({ startDate: date });
     };
 
     const changeEndDateHandler = (date) => {
@@ -173,6 +187,7 @@ const DateRange = forwardRef<unknown, DateRangeProps>(
       if (onEndDateChange) {
         onEndDateChange(date);
       }
+      emitRange({ endDate: date });
     };
 
     const startInputProps = {

--- a/src/TimeRange/TimeRange.story.tsx
+++ b/src/TimeRange/TimeRange.story.tsx
@@ -1,6 +1,6 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { action } from "storybook/actions";
-import { expect, screen, userEvent, within } from "storybook/test";
+import { expect, fn, screen, userEvent, waitFor, within } from "storybook/test";
 
 import { Button, PrimaryButton } from "..";
 import TimeRange from "./TimeRange";
@@ -106,4 +106,45 @@ export const UsingRefToControlFocus = {
   },
 
   name: "using ref to control focus",
+};
+
+// Regression test for the onRangeChange infinite loop (GO-11207) — mirrors the DateRange case.
+// The wrapper passes a fresh inline callback every render that also setStates, the pattern that
+// used to re-fire the effect on every render. The module-scoped spy is shared with the play()
+// function, which measures how many times the callback fires in a quiet window.
+const timeRangeLoopSpy = fn();
+export const DoesNotLoopWithInlineCallback = {
+  render: () => {
+    const [, setTick] = useState(0);
+    return (
+      <TimeRange
+        onRangeChange={(value) => {
+          timeRangeLoopSpy(value);
+          setTick((tick) => tick + 1);
+        }}
+      />
+    );
+  },
+  name: "does not loop with an inline onRangeChange",
+  play: async () => {
+    await waitFor(() => expect(timeRangeLoopSpy).toHaveBeenCalled());
+    const before = timeRangeLoopSpy.mock.calls.length;
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    const after = timeRangeLoopSpy.mock.calls.length;
+    // Pre-fix the effect re-fired every render, so this quiet window captured hundreds of
+    // calls. Post-fix it fires once on mount and then stays quiescent — no growth.
+    expect(after - before).toBeLessThan(3);
+  },
+};
+
+// Mount fire: the parent learns the initial/default range + validation error exactly once.
+// With defaults that are out of order, the error surfaces in the mount payload.
+const timeMountFireSpy = fn();
+export const FiresOnceOnMountWithDefaults = {
+  render: () => <TimeRange defaultStartTime="13:30" defaultEndTime="10:30" onRangeChange={timeMountFireSpy} />,
+  name: "fires onRangeChange once on mount with defaults",
+  play: async () => {
+    await waitFor(() => expect(timeMountFireSpy).toHaveBeenCalledTimes(1));
+    expect(timeMountFireSpy.mock.calls[0][0].error).toBe("end time is before start time");
+  },
 };

--- a/src/TimeRange/TimeRange.tsx
+++ b/src/TimeRange/TimeRange.tsx
@@ -10,6 +10,22 @@ import { getDuration } from "./TimeRange.utils";
 
 const DEFAULT_LABEL = "Time Range";
 
+type TimeRangeErrorInput = {
+  startTime?: string;
+  endTime?: string;
+  defaultStartTime?: string;
+  defaultEndTime?: string;
+};
+
+function computeTimeRangeError({ startTime, endTime, defaultStartTime, defaultEndTime }: TimeRangeErrorInput) {
+  const start = startTime || defaultStartTime;
+  const end = endTime || defaultEndTime;
+  if (start && end && getDuration(start, end) < 0) {
+    return "end time is before start time";
+  }
+  return undefined;
+}
+
 type TimeRangeProps = SpaceProps & {
   variant?: ComponentVariant;
   timeFormat?: string;
@@ -60,7 +76,18 @@ const TimeRange = forwardRef(
   ) => {
     const [startTime, setStartTime] = useState<string | undefined>();
     const [endTime, setEndTime] = useState<string | undefined>();
-    const [rangeError, setRangeError] = useState<string | undefined>();
+
+    // Derived during render — pure function of the times (with the default* fallbacks).
+    const rangeError = computeTimeRangeError({ startTime, endTime, defaultStartTime, defaultEndTime });
+
+    // Notify the parent of the new range + its validation error. Called from the change handlers
+    // (carrying the new value as `overrides`, since the state setter hasn't updated the closure
+    // yet this render) and once on mount. No effect depends on changing data, so an inline
+    // `onRangeChange` can never re-trigger a loop.
+    const emitRange = (overrides: Partial<TimeRangeErrorInput>) => {
+      const next = { startTime, endTime, ...overrides };
+      onRangeChange?.({ ...next, error: computeTimeRangeError({ ...next, defaultStartTime, defaultEndTime }) });
+    };
 
     const inputRef1 = useRef();
     const inputRef2 = useRef();
@@ -90,36 +117,19 @@ const TimeRange = forwardRef(
       },
     }));
 
-    const validateTimeRange = () => {
-      let error: string | undefined;
-      const end = endTime || defaultEndTime;
-      const start = startTime || defaultStartTime;
-      if (start && end) {
-        const duration = getDuration(start, end);
-        if (duration < 0) {
-          error = "end time is before start time";
-        }
-      }
-      setRangeError(error);
-      if (onRangeChange) {
-        onRangeChange({
-          startTime,
-          endTime,
-          error,
-        });
-      }
-    };
-
-    // biome-ignore lint/correctness/useExhaustiveDependencies: validateTimeRange captures the listed deps; listing the function would cause infinite re-renders
+    // Mount-only by design — reports the initial/default range + error to the parent once.
+    // Empty deps cannot re-run, so no loop is possible even with an inline onRangeChange.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: emitRange is intentionally excluded so this fires exactly once on mount.
     useEffect(() => {
-      validateTimeRange();
-    }, [startTime, endTime, defaultStartTime, defaultEndTime, onRangeChange]);
+      emitRange({});
+    }, []);
 
     const changeStartTimeHandler = (label, value) => {
       setStartTime(value);
       if (onStartTimeChange) {
         onStartTimeChange(label);
       }
+      emitRange({ startTime: value });
     };
 
     const changeEndTimeHandler = (label, value) => {
@@ -127,6 +137,7 @@ const TimeRange = forwardRef(
       if (onEndTimeChange) {
         onEndTimeChange(label);
       }
+      emitRange({ endTime: value });
     };
 
     const startInput = (


### PR DESCRIPTION
## Description

`DateRange` and `TimeRange` fired their `onRangeChange` callback from a `useEffect` whose dependency array included `onRangeChange` itself, calling it unconditionally. Consumers passing an inline arrow (`onRangeChange={v => ...}` — the universal React convention) change the prop identity on every render, so the effect re-ran every render and re-fired the callback. When the handler writes state (the normal case) this became an unbounded loop: render → effect → onRangeChange → setState → render → …, manifesting as pegged CPU, "Maximum update depth exceeded", or a hard crash.

This was a real production crash (ECO ticket **GO-11207**, mitigated app-side in ECO PR #7719). The regression was introduced in 17.1.x — `onRangeChange`/`showTimes` were added to the deps to satisfy `useExhaustiveDependencies` — and is still present in the latest release.

**Fix:** refactor the effect out entirely rather than masking it with a ref.

- The validation error is now **derived during render** via a pure `computeRangeError` helper, replacing the `rangeError` state that was set from the effect.
- `onRangeChange` fires from the **four change handlers**, each passing its new value as an override (the state setter hasn't updated the closure yet that render).
- A single **`[]`-deps mount effect** preserves the on-mount fire so the parent still learns the initial range + error. Empty deps can never re-run, so a loop is structurally impossible even with an inline callback.

No ref, no callback in any dependency array. The internal validation display, mount fire, change fire, and payload shape are all preserved.

The single pickers (`DatePicker`, `MonthPicker`, `WeekPicker`) were checked and are clean — their effects only sync `selected` and fire callbacks from change handlers, not effects.

### Behaviour change to note

Toggling the **display-only `showTimes` prop** no longer re-fires `onRangeChange`. It previously did, but only as an accident of the old dependency array. The component's own validation display still updates on toggle; only the parent callback no longer fires for a `showTimes` change that didn't itself change the range. This affects only a consumer that **(a)** toggles `showTimes` at runtime, **(b)** with a same-day range already entered, and **(c)** reads the callback's `error` rather than the component's own display — a narrow intersection. If such a consumer surfaces, the one-line `[showTimes]`-deps variant restores the old behaviour without reintroducing the loop.

## Tests

- The `DoesNotLoopWithInlineCallback` regression story on each component is retained: it mounts with an unstable inline `onRangeChange` that `setState`s and asserts the callback stays quiescent (hangs the suite pre-fix, passes post-fix).
- Added explicit coverage for the mount fire (fires once with defaults; reports the error for invalid defaults) and, for `DateRange`, that toggling `showTimes` does **not** fire the callback.
- `pnpm check`, `pnpm test:components` (38), and `pnpm test:storybook` (556) all pass.

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [ ] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [x] Appropriate tests have been added
- [ ] Documentation has been updated
- [x] Accessibility has been considered

🤖 Generated with [Claude Code](https://claude.com/claude-code)
