### PR TITLE
fix(DatePicker): restore calendar font and upgrade react-datepicker to v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "framer-motion": "^12.38.0",
     "i18next": "^26.0.3",
     "polished": "4.3.1",
-    "react-datepicker": "^6.9.0",
+    "react-datepicker": "^9.1.0",
     "react-fast-compare": "^3.2.0",
     "react-hot-toast": "^2.6.0",
     "react-i18next": "^17.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: 4.3.1
         version: 4.3.1
       react-datepicker:
-        specifier: ^6.9.0
-        version: 6.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^9.1.0
+        version: 9.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-fast-compare:
         specifier: ^3.2.0
         version: 3.2.2
@@ -936,12 +936,6 @@ packages:
 
   '@floating-ui/react-dom@2.1.8':
     resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-
-  '@floating-ui/react@0.26.28':
-    resolution: {integrity: sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
@@ -2597,6 +2591,9 @@ packages:
   date-fns@3.6.0:
     resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
 
+  date-fns@4.4.0:
+    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
+
   debounce@3.0.0:
     resolution: {integrity: sha512-64byRbF0/AirwbuHqB3/ZpMG9/nckDa6ZA0yd6UnaQNwbbemCOwvz2sL5sjXLHhZHADyiwLm0M5qMhltUUx+TA==}
     engines: {node: '>=20'}
@@ -4073,11 +4070,15 @@ packages:
     peerDependencies:
       react: '*'
 
-  react-datepicker@6.9.0:
-    resolution: {integrity: sha512-QTxuzeem7BUfVFWv+g5WuvzT0c5BPo+XTCNbMTZKSZQLU+cMMwSUHwspaxuIcDlwNcOH0tiJ+bh1fJ2yxOGYWA==}
+  react-datepicker@9.1.0:
+    resolution: {integrity: sha512-lOp+m5bc+ttgtB5MHEjwiVu4nlp4CvJLS/PG1OiOe5pmg9kV73pEqO8H0Geqvg2E8gjqTaL9eRhSe+ZpeKP3nA==}
     peerDependencies:
-      react: ^16.9.0 || ^17 || ^18
-      react-dom: ^16.9.0 || ^17 || ^18
+      date-fns-tz: ^3.0.0
+      react: ^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc
+    peerDependenciesMeta:
+      date-fns-tz:
+        optional: true
 
   react-docgen-typescript@2.4.0:
     resolution: {integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==}
@@ -4133,12 +4134,6 @@ packages:
     peerDependencies:
       react: ^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19
       react-dom: ^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19
-
-  react-onclickoutside@6.13.2:
-    resolution: {integrity: sha512-h6Hbf1c8b7tIYY4u90mDdBLY4+AGQVMFtIE89HgC0DtVCh/JfKl477gYqUtGLmjZBKK3MJxomP/lFiLbz4sq9A==}
-    peerDependencies:
-      react: ^15.5.x || ^16.x || ^17.x || ^18.x
-      react-dom: ^15.5.x || ^16.x || ^17.x || ^18.x
 
   react-refresh@0.18.0:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
@@ -5761,14 +5756,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@floating-ui/react@0.26.28(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@floating-ui/utils': 0.2.11
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      tabbable: 6.4.0
-
   '@floating-ui/react@0.27.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -7339,6 +7326,8 @@ snapshots:
 
   date-fns@3.6.0: {}
 
+  date-fns@4.4.0: {}
+
   debounce@3.0.0: {}
 
   debug@2.6.9:
@@ -8798,15 +8787,13 @@ snapshots:
       reactcss: 1.2.3(react@18.3.1)
       tinycolor2: 1.4.2
 
-  react-datepicker@6.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-datepicker@9.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@floating-ui/react': 0.26.28(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/react': 0.27.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
-      date-fns: 3.6.0
-      prop-types: 15.8.1
+      date-fns: 4.4.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-onclickoutside: 6.13.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   react-docgen-typescript@2.4.0(typescript@5.9.3):
     dependencies:
@@ -8867,11 +8854,6 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-lifecycles-compat: 3.0.4
       warning: 4.0.3
-
-  react-onclickoutside@6.13.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
 
   react-refresh@0.18.0: {}
 

--- a/src/DatePickers/DatePicker.tsx
+++ b/src/DatePickers/DatePicker.tsx
@@ -1,6 +1,7 @@
 import { addDays, isAfter, isBefore, isSameDay, isValid, subDays } from "date-fns";
 import { forwardRef, useEffect, useState } from "react";
-import type { ReactDatePicker, ReactDatePickerCustomHeaderProps } from "react-datepicker";
+import type ReactDatePicker from "react-datepicker";
+import type { ReactDatePickerCustomHeaderProps } from "react-datepicker";
 import { BasePicker } from "./shared/components/BasePicker";
 import { DatePickerHeader } from "./shared/components/DatePickerHeader";
 import type { DatePickerProps } from "./shared/types";
@@ -11,7 +12,6 @@ const DEFAULT_PLACEHOLDER = "YYYY-Mon-DD";
 const DatePicker = forwardRef<ReactDatePicker, DatePickerProps>(
   ({ selected, dateFormat = DEFAULT_DATE_FORMAT, onChange, ...props }, datePickerRef) => {
     const [selectedDate, setSelectedDate] = useState(selected);
-    const [ref] = useState(null);
 
     useEffect(() => {
       setSelectedDate(selected);
@@ -38,13 +38,6 @@ const DatePicker = forwardRef<ReactDatePicker, DatePickerProps>(
       }
     };
 
-    const handleEnterKey = () => {
-      if (ref) {
-        const isOpen = ref.isCalendarOpen();
-        ref.setOpen(!isOpen);
-      }
-    };
-
     return (
       <BasePicker
         {...props}
@@ -58,7 +51,6 @@ const DatePicker = forwardRef<ReactDatePicker, DatePickerProps>(
         disabledKeyboardNavigation
         onUpKeyPress={handleUpKey}
         onDownKeyPress={handleDownKey}
-        onEnterKeyPress={handleEnterKey}
         renderHeader={(headerProps: ReactDatePickerCustomHeaderProps) => (
           <DatePickerHeader locale={props.locale} {...headerProps} />
         )}

--- a/src/DatePickers/MonthPicker.tsx
+++ b/src/DatePickers/MonthPicker.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, useEffect, useState } from "react";
-import type { ReactDatePicker, ReactDatePickerCustomHeaderProps } from "react-datepicker";
+import type ReactDatePicker from "react-datepicker";
+import type { ReactDatePickerCustomHeaderProps } from "react-datepicker";
 import { noop } from "../utils/noop";
 import { MonthDatePickerHeader } from "./custom/MonthPickerHeader";
 import { BasePicker } from "./shared/components/BasePicker";
@@ -13,7 +14,6 @@ export const DEFAULT_PLACEHOLDER = "YYYY-Mon";
 const MonthPicker = forwardRef<ReactDatePicker, MonthPickerProps>(
   ({ selected, dateFormat = DEFAULT_MONTH_FORMAT, onChange, ...props }, monthPickerRef) => {
     const [selectedDate, setSelectedDate] = useState(selected);
-    const [ref] = useState(null);
 
     useEffect(() => {
       setSelectedDate(selected);
@@ -28,13 +28,6 @@ const MonthPicker = forwardRef<ReactDatePicker, MonthPickerProps>(
 
     const handleUpKey = noop;
     const handleDownKey = noop;
-
-    const handleEnterKey = () => {
-      if (ref) {
-        const isOpen = ref.isCalendarOpen();
-        ref.setOpen(!isOpen);
-      }
-    };
 
     return (
       <BasePicker
@@ -51,7 +44,6 @@ const MonthPicker = forwardRef<ReactDatePicker, MonthPickerProps>(
         )}
         onUpKeyPress={handleUpKey}
         onDownKeyPress={handleDownKey}
-        onEnterKeyPress={handleEnterKey}
       />
     );
   },

--- a/src/DatePickers/WeekPicker.tsx
+++ b/src/DatePickers/WeekPicker.tsx
@@ -176,7 +176,7 @@ const WeekPicker = forwardRef<unknown, WeekPickerProps>(
       return <DatePickerHeader locale={currentLocale} {...props} />;
     };
 
-    const weekPickerRefHandler = (r: ReactDatePicker<string>) => {
+    const weekPickerRefHandler = (r: ReactDatePicker) => {
       if (datePickerRef && typeof datePickerRef !== "function") {
         datePickerRef.current = r;
       }
@@ -206,7 +206,7 @@ const WeekPicker = forwardRef<unknown, WeekPickerProps>(
 
     return (
       <Field className={`${className} nds-date-picker`} {...spaceProps}>
-        <DatePickerStyles />
+        <DatePickerStyles locale={currentLocale} />
         <WeekPickerStyles variant={componentVariant} />
         <ReactDatePicker
           showWeekNumbers

--- a/src/DatePickers/shared/components/BasePicker.tsx
+++ b/src/DatePickers/shared/components/BasePicker.tsx
@@ -25,7 +25,6 @@ interface BasePickerProps extends DatePickerProps {
   renderHeader: (props: ReactDatePickerCustomHeaderProps) => JSX.Element;
   onUpKeyPress?: () => void;
   onDownKeyPress?: () => void;
-  onEnterKeyPress?: () => void;
 }
 
 export const BasePicker = forwardRef<ReactDatePicker, BasePickerProps>(
@@ -52,7 +51,6 @@ export const BasePicker = forwardRef<ReactDatePicker, BasePickerProps>(
       renderHeader,
       onUpKeyPress,
       onDownKeyPress,
-      onEnterKeyPress,
       locale,
       disabledKeyboardNavigation,
       name,
@@ -111,7 +109,7 @@ export const BasePicker = forwardRef<ReactDatePicker, BasePickerProps>(
       />
     );
 
-    const pickerRefHandler = (r: ReactDatePicker<string>) => {
+    const pickerRefHandler = (r: ReactDatePicker) => {
       if (pickerRef && typeof pickerRef !== "function") {
         pickerRef.current = r;
       }
@@ -122,7 +120,7 @@ export const BasePicker = forwardRef<ReactDatePicker, BasePickerProps>(
 
     return (
       <Field className={`${className} nds-date-picker`} {...spaceProps}>
-        <DatePickerStyles />
+        <DatePickerStyles locale={currentLocale} />
         <ReactDatePicker
           highlightDates={highlightDates}
           selected={selected}
@@ -142,7 +140,6 @@ export const BasePicker = forwardRef<ReactDatePicker, BasePickerProps>(
           showWeekNumbers={showWeekNumbers}
           name={name}
           required={required}
-          onEnterKeyPress={onEnterKeyPress}
           popperPlacement="bottom-start"
           popperProps={getPopperProps(disableFlipping)}
           portalId="nds-date-picker-portal"

--- a/src/DatePickers/shared/helpers.ts
+++ b/src/DatePickers/shared/helpers.ts
@@ -1,7 +1,9 @@
-import { offset } from "@floating-ui/react";
+import { offset, type UseFloatingOptions } from "@floating-ui/react";
 
-// react-datepicker spreads `popperProps` over its useFloating config at runtime,
-// so providing `middleware` here replaces the default `[flip, offset, arrow]`
-// array — this is how we disable the built-in flip behaviour.
+// react-datepicker spreads `popperProps` last over its internal useFloating config,
+// so providing `middleware` here still overrides the default `[flip, offset, arrow]`
+// array — this is how we disable the built-in flip behaviour. As of react-datepicker
+// v9 the public `popperProps` type omits `middleware` (custom modifiers are otherwise
+// appended via `popperModifiers`), so we assert the wider shape to keep replacing it.
 export const getPopperProps = (disableFlipping: boolean | undefined) =>
-  disableFlipping ? { middleware: [offset(10)] } : undefined;
+  disableFlipping ? ({ middleware: [offset(10)] } as Partial<UseFloatingOptions>) : undefined;

--- a/src/DatePickers/shared/styles.ts
+++ b/src/DatePickers/shared/styles.ts
@@ -1,6 +1,32 @@
 import { createGlobalStyle } from "styled-components";
+import type { DefaultNDSThemeType } from "../../theme";
 
-export const DatePickerStyles = createGlobalStyle(({ theme }) => ({
+// Mirrors the locale → font resolution in NDSProvider/GlobalStyles.
+const resolveFontFamily = (theme: DefaultNDSThemeType, locale?: string) => {
+  const localeFontMap: Record<string, string> = {
+    zh_CN: theme.fonts.sc,
+    ja_JP: theme.fonts.jp,
+  };
+  return (locale && localeFontMap[locale]) || theme.fonts.base;
+};
+
+export const DatePickerStyles = createGlobalStyle<{ locale?: string }>(({ theme, locale }) => ({
+  // react-datepicker v9 renders each day name as a visible short label plus a
+  // `.react-datepicker__sr-only` span holding the full weekday name for screen
+  // readers. Its own stylesheet hides that span; since NDS ships bespoke styles
+  // (and doesn't import react-datepicker's CSS) we must hide it ourselves,
+  // otherwise the full day names render visibly and overlap the header row.
+  ".react-datepicker__sr-only": {
+    position: "absolute",
+    width: "1px",
+    height: "1px",
+    padding: "0",
+    margin: "-1px",
+    overflow: "hidden",
+    clip: "rect(0, 0, 0, 0)",
+    whiteSpace: "nowrap",
+    borderWidth: "0",
+  },
   ".nds-date-picker": {
     ".react-datepicker-wrapper": {
       width: "fit-content",
@@ -18,6 +44,10 @@ export const DatePickerStyles = createGlobalStyle(({ theme }) => ({
     // calendar is portaled to the body, outside the dialog, so re-enable interaction
     // here — otherwise day clicks pass through to the overlay and close the modal.
     pointerEvents: "auto",
+    // The calendar is portaled to document.body, outside NDSProvider's GlobalStyles
+    // font wrapper, so it can't inherit the NDS font — it must declare it explicitly,
+    // otherwise the calendar falls back to the browser default (serif).
+    fontFamily: resolveFontFamily(theme, locale),
     ".react-datepicker__header": {
       backgroundColor: theme.colors.white,
       borderBottom: "none",

--- a/src/DatePickers/shared/types.ts
+++ b/src/DatePickers/shared/types.ts
@@ -1,4 +1,4 @@
-import type { ReactDatePickerProps } from "react-datepicker";
+import type { DatePickerProps as ReactDatePickerProps } from "react-datepicker";
 import type { FieldProps } from "../../Form/Field";
 import type { InputFieldProps } from "../../Input/InputField";
 

--- a/src/DatePickers/stories/DatePicker.story.tsx
+++ b/src/DatePickers/stories/DatePicker.story.tsx
@@ -51,6 +51,34 @@ export const Default: Story = {
   },
 };
 
+// Opens the calendar and leaves it open so Chromatic captures the open popper.
+// The `Default` story closes the calendar (it selects a date), so no snapshot
+// ever covered the open calendar — which is how a font regression in the
+// portaled calendar (see DatePickers/shared/styles.ts) slipped through.
+export const OpenCalendar: Story = {
+  args: {
+    selected: selectedDateExamples[0],
+    inputProps: { labelText: "Expiry Date" },
+  },
+  parameters: {
+    // Give the portaled popper a beat to position before Chromatic snapshots.
+    chromatic: { delay: 300 },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByLabelText("select a date"));
+    const calendar = await waitFor(() => {
+      const el = document.querySelector(".react-datepicker");
+      expect(el).toBeInTheDocument();
+      return el as HTMLElement;
+    });
+    // Regression guard: the calendar renders in a portal on document.body, outside
+    // NDSProvider's font wrapper, so it must declare the NDS font itself. Without it
+    // the calendar falls back to the browser default (serif).
+    await expect(getComputedStyle(calendar).fontFamily).toContain("IBM Plex Sans");
+  },
+};
+
 export const WithCustomDateFormat: Story = {
   args: {
     selected: selectedDateExamples[0],

--- a/src/DateRange/DateRange.tsx
+++ b/src/DateRange/DateRange.tsx
@@ -1,6 +1,6 @@
 import { isBefore, isSameDay } from "date-fns";
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
-import type { ReactDatePicker } from "react-datepicker";
+import type ReactDatePicker from "react-datepicker";
 import { useTranslation } from "react-i18next";
 import { DatePicker } from "../DatePickers";
 import { FieldLabelDefaultProps } from "../FieldLabel/FieldLabel.type";


### PR DESCRIPTION
## Description

Upgrades `react-datepicker` v6 → v9 and fixes a font regression on the calendar.

**Why the upgrade:** `react-datepicker@6` caps its React peer range at 18, which blocks the React 19 upgrade. v9 spans React 18 **and** 19, so this preserves React 18 support while unblocking React 19. This is the prerequisite tracked in #1821.

**react-datepicker v9 API adaptations:**
- `ReactDatePicker`/`ReactDatePickerProps` type exports were removed; the default export is now the non-generic `DatePicker` class. Updated type imports and dropped the `<string>` generic.
- `popperProps` no longer types `middleware`; kept the flip-disable behaviour by asserting the wider shape (v9 still spreads `popperProps` last over its internal `useFloating` call, so the override still applies).
- Added a visually-hidden rule for v9's new `.react-datepicker__sr-only` element, which was rendering full weekday names on top of the short labels.
- Removed dead `onEnterKeyPress` plumbing — never a real react-datepicker prop (v6 or v9); the live Enter handling runs through the custom input.

**Font regression fix:**
- The calendar renders in a portal on `document.body`, outside NDSProvider's `GlobalStyles` font wrapper, so it can't inherit the NDS font. It now declares the font itself (locale-aware). The regression surfaced with styled-components 6.4.0's global-style injection-order change (bisected to `e7a78a5`), which computed to the browser serif default (`Times`).
- Added an `OpenCalendar` story that leaves the calendar open so Chromatic snapshots it, plus an inline `font-family` assertion. The existing `Default` story closes the calendar before the snapshot — which is how this slipped through. Verified the guard fails without the fix (`expected 'Times' to contain 'IBM Plex Sans'`).

Unblocks #1822 (Support React 19).

Closes #1821

## Changes include

- [ ] breaking change: a change that is not backwards-compatible and/or changes current functionality
- [x] fix: a non-breaking change that solves an issue
- [ ] feature: a non-breaking change that adds functionality
- [x] chore: contains no changes affecting the library, such as documentation or test updates

## Feature checklist

- [x] Appropriate tests have been added
- [ ] Documentation has been updated
- [x] Accessibility has been considered