### PR TITLE
SPAR-444: publish @nulogy/components to GitHub Packages

### DIFF
--- a/.github/workflows/mirror-to-github-packages.yml
+++ b/.github/workflows/mirror-to-github-packages.yml
@@ -1,0 +1,41 @@
+name: Mirror versions to GitHub Packages
+
+# One-off (SPAR-444): republish existing npmjs versions of this package to
+# GitHub Packages. semantic-release only publishes versions forward, so the
+# older versions consumers still pin have to be mirrored for them to install
+# from GitHub Packages.
+
+on:
+  workflow_dispatch:
+    inputs:
+      versions:
+        description: "Space-separated npmjs versions to mirror (e.g. 19.1.3 15.1.4)"
+        required: true
+
+permissions:
+  packages: write
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://npm.pkg.github.com
+          scope: "@nulogy"
+      - name: Mirror npmjs -> GitHub Packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PKG: "@nulogy/components"
+          VERSIONS: ${{ inputs.versions }}
+        run: |
+          set -euo pipefail
+          for v in $VERSIONS; do
+            echo "::group::$PKG@$v"
+            # Pack from npmjs — the @nulogy scope is pointed at GitHub Packages
+            # for publish, so override it back to npmjs just for the fetch.
+            tarball=$(npm pack "$PKG@$v" --@nulogy:registry=https://registry.npmjs.org 2>/dev/null | tail -1)
+            npm publish "$tarball" --access restricted
+            echo "::endgroup::"
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
-      # Required for OIDC to let NPM registry know
-      # that this workflow is trusted
-      id-token: write
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -52,3 +50,5 @@ jobs:
           branch: main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # @semantic-release/npm authenticates via NPM_TOKEN, not NODE_AUTH_TOKEN
+          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -10,11 +10,18 @@
 
 ### 1. Add the package
 
-`@nulogy/components` is published to [GitHub Packages](https://docs.github.com/en/packages) under the `@nulogy` scope. Point the scope at GitHub Packages in your `.npmrc` and authenticate with a token that has `read:packages`:
+`@nulogy/components` is published to [GitHub Packages](https://docs.github.com/en/packages) under the `@nulogy` scope. Point the scope at GitHub Packages in your `.npmrc`:
 
 ```
 @nulogy:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
+//npm.pkg.github.com/:_authToken=${GITHUB_NPM_AUTH_TOKEN}
+```
+
+GitHub Packages requires authentication even for reads. No personal access token is needed — reuse your GitHub CLI login:
+
+```sh
+gh auth refresh -h github.com -s read:packages   # one-time
+export GITHUB_NPM_AUTH_TOKEN=$(gh auth token)     # add to your shell profile
 ```
 
 Then add the package:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@
 
 ### 1. Add the package
 
+`@nulogy/components` is published to [GitHub Packages](https://docs.github.com/en/packages) under the `@nulogy` scope. Point the scope at GitHub Packages in your `.npmrc` and authenticate with a token that has `read:packages`:
+
+```
+@nulogy:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
+```
+
+Then add the package:
+
+`yarn add @nulogy/components`
+
 ## Peer dependencies
 
 @nulogy/components relies on React, ReactDOM and Styled Components. You will need to add these to your projects dependencies if they are not there already.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "Component library for the Nulogy Design System - http://nulogy.design",
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
   },
   "scripts": {
     "ci": "pnpm install && pnpm build && pnpm build:verify && pnpm test && pnpm run check",


### PR DESCRIPTION
## What

Switch `@nulogy/components` publishing from public npmjs to **GitHub Packages** (`npm.pkg.github.com`), keeping the `@nulogy` scope.

Part of [SPAR-444](https://nulogy-go.atlassian.net/browse/SPAR-444). NPM allows only one registry per package scope, so `@nulogy/*` on npmjs and the private `@nulogy/spark-ui` on GitHub Packages cannot both install in PackManager. Consolidating the NDS family (`@nulogy/components`, `@nulogy/icons`, `@nulogy/tokens`) onto GitHub Packages resolves the conflict without exposing spark-ui publicly.

## Changes

- `package.json` → `publishConfig.registry = https://npm.pkg.github.com`, `access: restricted`
- `.github/workflows/release.yml`: add `packages: write`; remove `id-token: write` (npm OIDC trusted publishing is npmjs-only, inert for GitHub Packages); authenticate `@semantic-release/npm` via `NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}` (the plugin reads `NPM_TOKEN`, not `NODE_AUTH_TOKEN`)
- README: install from the `@nulogy` GitHub Packages registry

## Publishing sequencing

- **Merging this does not publish.** The commit is `ci:`-typed, so semantic-release cuts no release on merge. The first GitHub Packages release happens on the next releasable (`feat:`/`fix:`) commit to `main`; the version continues from existing git tags (stays on the current major), satisfying PackManager's current range.
- `npm whoami` is skipped for non-default registries, so verify needs only `NPM_TOKEN` present (@semantic-release/npm `verify-auth.js`).

## Related

- Companion PRs (all three must land together): `nulogy/design-system`, `nulogy/nds-icons`, `nulogy/nds-tokens`
- Follow-up (PackManager): point the `@nulogy` scope at GitHub Packages and drop the `file:` spark-ui dependency.

[SPAR-444]: https://nulogy-go.atlassian.net/browse/SPAR-444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ