### PR TITLE
SPAR-444: consume @nulogy dependencies from GitHub Packages

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -3,6 +3,11 @@
 name: Chromatic
 on:
   push:
+
+env:
+  # Install @nulogy/tokens + @nulogy/icons from GitHub Packages
+  GITHUB_NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,6 +9,10 @@ on:
       - next
       - beta
 
+env:
+  # Install @nulogy/tokens + @nulogy/icons from GitHub Packages
+  GITHUB_NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
       - main
       - next
       - beta
+
+env:
+  # Install @nulogy/tokens + @nulogy/icons from GitHub Packages
+  GITHUB_NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   release:
     name: Release

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
 ignore-workspace-root-check=true
+@nulogy:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_NPM_AUTH_TOKEN}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,14 @@ Additionally, verify that the new component has already been added to the design
 
 1. Download and install the Node version in the `.tool-versions` file.
 2. Download and install the package manager [pnpm](https://pnpm.io/installation)
+3. `@nulogy/*` dependencies install from GitHub Packages, which requires authentication — no personal access token
+   needed. mise exports a read token from your GitHub CLI login automatically; you just need the `read:packages`
+   scope on that login once (if you authenticated `gh` with a bare token rather than the web flow, ensure it carries
+   `read:packages`):
+
+   ```sh
+   gh auth refresh -h github.com -s read:packages
+   ```
 
 ### Cloning the repo
 

--- a/mise.toml
+++ b/mise.toml
@@ -8,6 +8,10 @@ node = "24.15.0"
 # This must be enabled to make the hooks work
 experimental = true
 
+[env]
+# Local dev: derive a GitHub Packages read token from the gh CLI (see the script for the guard).
+_.source = "scripts/github-packages-token.sh"
+
 [hooks]
 postinstall = 'corepack enable'
 

--- a/scripts/github-packages-token.sh
+++ b/scripts/github-packages-token.sh
@@ -1,0 +1,7 @@
+# shellcheck shell=bash
+# Local-dev convenience: hand pnpm a GitHub Packages read token from the gh CLI so the private
+# @nulogy/* deps resolve without a hand-made PAT. Guarded so CI (which sets GITHUB_NPM_AUTH_TOKEN
+# explicitly) and shells without gh are left untouched.
+if [ -z "${GITHUB_NPM_AUTH_TOKEN:-}" ] && command -v gh >/dev/null 2>&1; then
+  export GITHUB_NPM_AUTH_TOKEN="$(gh auth token 2>/dev/null || true)"
+fi


### PR DESCRIPTION
## What

Point design-system's own `@nulogy/tokens` + `@nulogy/icons` installs at **GitHub Packages** (private `@nulogy` scope), matching where the NDS family now publishes.

Part of [SPAR-444](https://nulogy-go.atlassian.net/browse/SPAR-444). **Stacked on** #1832 (the publish PR) — review/merge that first; this PR retargets to `main` automatically once it lands.

## Changes

- `.npmrc`: `@nulogy` scope → `https://npm.pkg.github.com`, auth via `${GITHUB_NPM_AUTH_TOKEN}`.
- `release.yml` / `pull-request.yml` / `chromatic.yml`: set `GITHUB_NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` at the workflow level so every `pnpm install` authenticates.
- `CONTRIBUTING.md`: local-dev prerequisite — **no PAT needed**, uses the GitHub CLI: `gh auth refresh -s read:packages` + `export GITHUB_NPM_AUTH_TOKEN=$(gh auth token)`.

## Blocked until (do NOT merge before)

1. `@nulogy/tokens@6.2.0` + `@nulogy/icons@4.39.0` are **mirrored to GitHub Packages** (the mirror workflow from #1832).
2. The **design-system repo is granted Actions Read** on the `@nulogy/tokens` and `@nulogy/icons` packages (Manage Actions access) — otherwise CI `pnpm install` 401s.

Until then this PR's CI will be red — expected.

## Watch on first release

design-system publishes via semantic-release. This adds a committed `.npmrc` auth line; the first real release after merge should confirm the publish step still authenticates cleanly (install and publish both resolve to the built-in token, so no conflict is expected).

[SPAR-444]: https://nulogy-go.atlassian.net/browse/SPAR-444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ